### PR TITLE
Use Default PostgreSQL Port

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -129,8 +129,7 @@ impl Db {
     const DEFAULT_USER: &'static str = "tobira";
     const DEFAULT_PASSWORD: &'static str = "tobira-dev-db-pw";
     const DEFAULT_HOST: &'static str = "localhost";
-    const DEFAULT_PROD_PORT: u16 = 5432;
-    const DEFAULT_DEV_PORT: u16 = 5435;
+    const DEFAULT_PORT: u16 = 5432;
     const DEFAULT_DATABASE: &'static str = "tobira";
 
     pub fn user(&self) -> &str {
@@ -146,17 +145,11 @@ impl Db {
 
 impl Default for Db {
     fn default() -> Self {
-        let port = if cfg!(feature = "prod") {
-            Self::DEFAULT_PROD_PORT
-        } else {
-            Self::DEFAULT_DEV_PORT
-        };
-
         Self {
             user: None,
             password: None,
             host: None,
-            port,
+            port: Self::DEFAULT_PORT,
             database: Self::DEFAULT_DATABASE.into(),
         }
     }


### PR DESCRIPTION
This patch makes Tobira use the default PostgreSQL port by default
instead of choosing a custom port.

The idea of the custom port was to avoid conflicts with PostgreSQL
installation on development machines but this makes it hard to use a
regular PostgreSQL installation (one needs custom configuration) and if
a developer has set-up PostgreSQL, it's actually likely that he wants to
use that.

This also simplifies the defaults since there is no distinction between
development and production builds any longer.

This patch deliberately ignores the documentation since there will be a
larger documentation update shortly anyway.