### PR TITLE
Add backend helper binary to export the API as GraphQL schema file

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 publish = false
 description = "Backend of the Tobira video portal for Opencast"
 
+default-run = "tobira"
 
 [features]
 # Enable this feature for a "production" build. The production builds differ

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,12 @@ Build and run the backend:
 cargo run
 ```
 
+You can export the GraphQL schema of the API as a file with this command:
+
+```rust
+cargo run --bin export_schema -- schema.graphql
+```
+
 
 Configuration
 -------------

--- a/backend/src/bin/export_schema.rs
+++ b/backend/src/bin/export_schema.rs
@@ -1,0 +1,19 @@
+//! This tiny binary just export the GraphQL API Schema from the backend `api`
+//! code. The schema is required for the frontend to compile.
+
+use anyhow::Result;
+
+#[path = "../api/mod.rs"]
+mod api;
+
+fn main() -> Result<()> {
+    let schema = api::root_node().as_schema_language();
+
+    if let Some(target) = std::env::args().nth(1) {
+        std::fs::write(target, schema)?;
+    } else {
+        println!("{}", schema);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This is useful for many reasons, but most importantly: frontend code can use it to check validity of queries.

This might be a bit hacky as the binary just includes a subtree of the main application's module tree. This works as long as the `api` module will not refer to any other modules. We will see. But this solution has the advantage of building significantly faster.