### PR TITLE
Add `volumes` declaration in docker-compose file

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -13,3 +13,6 @@ services:
       - POSTGRES_PASSWORD=tobira-dev-db-pw
       - POSTGRES_USER=tobira
       - POSTGRES_DB=tobira
+
+volumes:
+  tobira-dev-postgres:


### PR DESCRIPTION
Without this, when the volume does not exist yet, I get roughly this
error:

    Named volume is used in service but no declaration was found in
    the volumes section.

@lkiesow Is this the correct solution? Or did I just screw up when I got that error? :D