### PR TITLE
Source maps

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -25,5 +25,7 @@ module.exports = (_env, argv) => ({
 
   plugins: [
     new HtmlWebpackPlugin({ inject: true, template: path.join(APP_PATH, 'index.html') }),
-  ]
+  ],
+
+  devtool: 'source-map',
 });

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const APP_PATH = path.resolve(__dirname, 'src');
 
-module.exports = (env, argv) => ({
+module.exports = (_env, argv) => ({
   entry: APP_PATH,
 
   output: {


### PR DESCRIPTION
At least the development build should have proper source maps. I actually think there is an argument to be made to also include them in the production build. Non-inline sourse maps cost basically nothing and they can greatly aid debugging production systems. Opinions?