### PR TITLE
Adopt `*:all` presets in ESLint

### DIFF
--- a/frontend/.babelrc.js
+++ b/frontend/.babelrc.js
@@ -1,4 +1,6 @@
-const package = require("./package.json");
+"use strict";
+
+const manifest = require("./package.json");
 
 module.exports = {
     plugins: [
@@ -6,9 +8,10 @@ module.exports = {
     ],
     presets: [
         ["@babel/preset-env", {
-            // Uncomment to see which transformations will be run during the build
-            //debug: true,
-            targets: package.browserslist,
+            // Set to `true` to show which transforms will be run
+            // during the build
+            debug: false,
+            targets: manifest.browserslist,
         }],
         "@babel/preset-typescript",
         "@babel/preset-react",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,15 +1,91 @@
+"use strict";
+
+const magicNumberOptions = { ignore: [0, 1, 2] };
+const noUnusedVarsOptions = {
+    args: "all",
+    argsIgnorePattern: "^_",
+    caughtErrors: "all",
+    caughtErrorsIgnorePattern: "^_",
+};
+
+// eslint quote-props: "warn", "consistent-as-needed"
 module.exports = {
     parserOptions: {
         ecmaVersion: 11,
     },
     extends: [
-        "eslint:recommended",
+        "eslint:all",
     ],
     rules: {
-        "indent": "error",
-        "quotes": ["error", "double", { avoidEscape: true }],
-        "semi": "error",
-        "comma-dangle": ["error", "always-multiline"],
+        // Turn off or reconfigure some rather opinionated and intrusive rules
+        "max-statements": "off",
+        "no-warning-comments": "off",
+        "no-ternary": "off",
+        "id-length": "off",
+        "sort-keys": "off",
+        "sort-vars": "off",
+        "sort-imports": "off",
+        "prefer-named-capture-group": "off",
+        "padded-blocks": "off",
+        "quote-props": ["off"],
+        // `== null` is actually a useful check for `null` and `undefined` at the same time
+        "no-eq-null": "off",
+        "eqeqeq": ["error", "always", { null: "ignore" }],
+        // Everything this protects against is already covered by
+        // - `no-shadow-restricted-names`
+        // - `strict`
+        "no-undefined": "off",
+        "no-void": ["error", { allowAsStatement: true }],
+
+        // Style lints should only `"warn"`
+        "one-var": ["warn", "never"],
+        "spaced-comment": "warn",
+        "multiline-comment-style": ["warn", "separate-lines"],
+        "capitalized-comments": ["warn", "always", {
+            ignoreInlineComments: true,
+            ignoreConsecutiveComments: true,
+        }],
+        "comma-dangle": ["warn", "always-multiline"],
+        "array-bracket-newline": ["warn", "consistent"],
+        "array-bracket-spacing": "warn",
+        "object-curly-spacing": ["warn", "always"],
+        "computed-property-spacing": "warn",
+        "space-in-parens": "warn",
+        "comma-spacing": "warn",
+        "comma-style": "warn",
+        "operator-linebreak": "warn",
+        "space-infix-ops": "warn",
+        "keyword-spacing": "warn",
+        "space-unary-ops": "warn",
+        "func-call-spacing": "warn",
+        "function-call-argument-newline": ["warn", "consistent"],
+        "function-paren-newline": ["warn", "consistent"],
+        "object-property-newline": ["warn", {
+            allowAllPropertiesOnSameLine: true,
+        }],
+        "array-element-newline": ["warn", "consistent"],
+        "key-spacing": "warn",
+        "brace-style": "warn",
+        "rest-spread-spacing": ["warn", "always"],
+        "indent": "warn",
+        "semi": "warn",
+        "no-extra-semi": "warn",
+        "semi-spacing": "warn",
+        "quotes": ["warn", "double", { avoidEscape: true }],
+        "block-spacing": "warn",
+        "lines-between-class-members": "warn",
+        "padding-line-between-statements": "warn",
+        "arrow-body-style": "warn",
+        "multiline-ternary": ["warn", "always-multiline"],
+        "max-len": ["warn", { code: 100 }],
+        "no-magic-numbers": ["warn", magicNumberOptions],
+        "implicit-arrow-linebreak": "warn",
+        "arrow-parens": ["warn", "as-needed"],
+        "dot-location": ["warn", "property"],
+        "dot-notation": "warn",
+        "no-tabs": "warn",
+        // Unused things should also only warn
+        "no-unused-vars": ["warn", noUnusedVarsOptions],
     },
     overrides: [{
         files: ["./*"],
@@ -24,14 +100,48 @@ module.exports = {
             project: "./tsconfig.json",
         },
         extends: [
-            "plugin:@typescript-eslint/recommended",
-            "plugin:@typescript-eslint/recommended-requiring-type-checking",
+            "plugin:@typescript-eslint/all",
             "plugin:react/recommended",
         ],
+        // TODO We probably need to disable more ESLint rules here, right?
         rules: {
+            // Turn off some intrusive rules
             "react/prop-types": "off",
             "react/react-in-jsx-scope": "off",
             "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-use-before-define": "off",
+            "@typescript-eslint/typedef": "off",
+            "@typescript-eslint/prefer-readonly-parameter-types": "off",
+            // The rationale these two/three are based on is mostly out of date
+            "@typescript-eslint/prefer-interface": "off",
+            "@typescript-eslint/no-type-alias": "off",
+            "@typescript-eslint/consistent-type-definitions": "off",
+
+            // Make style issues warnings
+            "react/jsx-curly-spacing": ["warn", { children: true }],
+            "@typescript-eslint/no-extra-parens": ["warn", "all", { ignoreJSX: "all" }],
+            "@typescript-eslint/no-magic-numbers": ["warn", magicNumberOptions],
+            "@typescript-eslint/no-unused-vars": ["warn", noUnusedVarsOptions],
+            // This checks some more things than `no-unused-vars`,
+            // but is less configurable.
+            // Note that this is basically like setting `noUnusedLocals` and `noUnusedParameters`
+            // in `tsconfig.json`.
+            "@typescript-eslint/no-unused-vars-experimental": "warn",
+            "@typescript-eslint/semi": "warn",
+            "@typescript-eslint/indent": "warn",
+            "@typescript-eslint/naming-convention": ["warn", {
+                selector: "variable",
+                types: ["function"],
+                format: ["PascalCase", "camelCase"],
+            }],
+            "@typescript-eslint/member-delimiter-style": "warn",
+
+            // Turn off base rules overridden by `@typescript-eslint` rules
+            "indent": "off",
+            "semi": "off",
+            "no-unused-vars": "off",
+            "no-extra-parens": "off",
+            "no-magic-numbers": "off",
         },
         settings: {
             react: {

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const path = require("path");
 
 module.exports = {

--- a/frontend/relay.config.js
+++ b/frontend/relay.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const path = require("path");
 const { APP_PATH, OUT_PATH } = require("./constants");
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,20 +6,19 @@ import { Root } from "./layout/Root";
 import { Realm } from "./page/Realm";
 import { NotFound } from "./page/NotFound";
 
-export const App: React.FC = () => {
-    return <>
-        <GlobalStyle />
-        <Router>
-            <Root>
-                <Switch>
-                    <Route exact path={["/", "/r/:path+"]} component={RealmPage} />
-                    <Route exact path={["404", "*"]} component={NotFound} />
-                </Switch>
-            </Root>
-        </Router>
-    </>;
-};
+export const App: React.FC = () => <>
+    <GlobalStyle />
+    <Router>
+        <Root>
+            <Switch>
+                <Route exact path={["/", "/r/:path+"]} component={RealmPage} />
+                <Route exact path={["404", "*"]} component={NotFound} />
+            </Switch>
+        </Root>
+    </Router>
+</>;
+
 
 const RealmPage: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
-    <Realm path={match.params.path?.split("/") || []} />
+    <Realm path={match.params.path?.split("/") ?? []} />
 );

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -6,29 +6,28 @@ import { Link } from "react-router-dom";
 
 const HEIGHT = 60;
 
-export const Header: React.FC = () => {
-    return (
-        <div css={{
-            height: HEIGHT,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            backgroundColor: "white",
-            borderBottom: "1px solid #bbb",
-            padding: "0 8px",
-        }}>
-            <Logo />
-            <Search />
-            <Menu />
-        </div>
-    );
-};
+export const Header: React.FC = () => (
+    <div css={{
+        height: HEIGHT,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        backgroundColor: "white",
+        borderBottom: "1px solid #bbb",
+        padding: "0 8px",
+    }}>
+        <Logo />
+        <Search />
+        <Menu />
+    </div>
+);
 
 const Logo: React.FC = () => (
     <Link to="/" css={{ height: "100%", flex: "0 0 auto" }}>
-        <picture
-            css={{ height: "100%", "& > *": { height: "100%", padding: "4px 0" } }}
-        >
+        <picture css={{
+            height: "100%",
+            "& > *": { height: "100%", padding: "4px 0" },
+        }}>
             <source media="(min-width: 450px)" srcSet="/assets/static/logo-large.svg" />
             <img src="/assets/static/logo-small.svg" />
         </picture>

--- a/frontend/src/layout/Root.tsx
+++ b/frontend/src/layout/Root.tsx
@@ -3,11 +3,9 @@ import React from "react";
 import { Header } from "./Header";
 
 
-export const Root: React.FC = ({ children }) => {
-    return (
-        <div>
-            <Header />
-            <main css={{ padding: 16 }}>{children}</main>
-        </div>
-    );
-};
+export const Root: React.FC = ({ children }) => (
+    <div>
+        <Header />
+        <main css={{ padding: 16 }}>{children}</main>
+    </div>
+);

--- a/frontend/src/page/NotFound.tsx
+++ b/frontend/src/page/NotFound.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
 
-export const NotFound: React.FC = () => {
-    return <>
-        <h1>404 Page not found</h1>
-        <p>No idea how you got here, but there is nothing here :(</p>
-    </>;
-};
+export const NotFound: React.FC = () => <>
+    <h1>404 Page not found</h1>
+    <p>No idea how you got here, but there is nothing here :(</p>
+</>;

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -5,14 +5,14 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 
 
 type Props = {
-    path: string[],
+    path: string[];
 };
 
 export const Realm: React.FC<Props> = ({ path }) => {
     const isRoot = path.length === 0;
     const ids = resolvePath(path);
     if (ids == null) {
-        // TODO: that should obviously handled in a better way
+        // TODO: that should obviously be handled in a better way
         return <b>Realm path not found :(</b>;
     }
 
@@ -23,7 +23,7 @@ export const Realm: React.FC<Props> = ({ path }) => {
     const breadcrumbs = [];
     let tmpPath = "/r";
     for (const id of ids.slice(1)) {
-        tmpPath += "/" + REALMS[id].path;
+        tmpPath += `/${REALMS[id].path}`;
         breadcrumbs.push({
             label: REALMS[id].name,
             href: tmpPath,
@@ -36,7 +36,7 @@ export const Realm: React.FC<Props> = ({ path }) => {
         <ul>
             {REALMS[realmId].children.map(id => (
                 <li key={id}>
-                    <Link to={"/r/" + path.concat(REALMS[id].path).join("/") }>
+                    <Link to={`/r/${path.concat(REALMS[id].path).join("/")}`}>
                         {REALMS[id].name}
                     </Link>
                 </li>
@@ -61,7 +61,7 @@ const resolvePath = (path: string[]): number[] | null => {
     for (const segment of path) {
         const lastId = ids[ids.length - 1];
         const next = REALMS[lastId].children.find(child => REALMS[child].path === segment);
-        if (!next) {
+        if (next === undefined) {
             return null;
         }
         ids.push(next);
@@ -71,10 +71,10 @@ const resolvePath = (path: string[]): number[] | null => {
 };
 
 type Realm = {
-    path: string,
-    name: string,
-    parent: number,
-    children: number[],
+    path: string;
+    name: string;
+    parent: number;
+    children: number[];
 };
 
 // Dummy data
@@ -91,6 +91,7 @@ const REALMS: Record<number, Realm> = {
 
     8: { path: "algebra", name: "Linear Algebra I", parent: 4, children: [] },
     9: { path: "analysis", name: "Analysis", parent: 4, children: [] },
+    // eslint-disable-next-line max-len
     10: { path: "single-variable-calculus", name: "Single Variable Calculus", parent: 4, children: [] },
     11: { path: "probability", name: "Probability", parent: 4, children: [] },
 };

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -6,13 +6,13 @@ import { useTranslation } from "react-i18next";
 
 
 type Props = {
-    path: Segment[],
+    path: Segment[];
 };
 
 type Segment = {
-    label: string,
-    href: string,
-}
+    label: string;
+    href: string;
+};
 
 export const Breadcrumbs: React.FC<Props> = ({ path }) => {
     const { t } = useTranslation();
@@ -20,7 +20,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path }) => {
     return (
         <nav aria-label="breadcrumbs" css={{ marginBottom: 16 }}>
             <ol css={{ listStyle: "none", padding: 0, margin: 0 }}>
-                <Segment target="/" first active={path.length == 0}>
+                <Segment target="/" first active={path.length === 0}>
                     <FontAwesomeIcon title={t("home")} icon={faHome} />
                 </Segment>
                 {path.map((segment, i) => (
@@ -34,9 +34,9 @@ export const Breadcrumbs: React.FC<Props> = ({ path }) => {
 };
 
 type SegmentProps = {
-    target: string,
-    active: boolean,
-    first?: boolean,
+    target: string;
+    active: boolean;
+    first?: boolean;
 };
 
 const Segment: React.FC<SegmentProps> = ({ target, active, first = false, children }) => (

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const path = require("path");
@@ -18,11 +20,11 @@ module.exports = (_env, argv) => ({
 
     module: {
         rules: [{
-            test: /\.(ts|js)x?$/,
+            test: /\.(ts|js)x?$/u,
             loader: "babel-loader",
-            ... argv.mode === "development" && { exclude: /node_modules/ },
+            ... argv.mode === "development" && { exclude: /node_modules/u },
         }, {
-            test: /\.yaml$/,
+            test: /\.yaml$/u,
             use: "yaml-loader",
             type: "json",
         }],


### PR DESCRIPTION
This also makes the first necessary exceptions and modifications to
these presets where they disagree with the way we want to use the
linter and the way we want to style our code, and it changes the code
where it disagrees with rules we actually want.

---

Okay, so I was a bit optimistic in #37, when I said that I would go through all the linter rules available to us. I started doing so and actually found some deviations from `eslint:recommended` that I personally would add, so I think there **is** value in personalizing these `:recommended` presets. However, I also realize now that going through a couple hundred rules alone and all at once is impractical.

I see two alternatives now: Either we stick to the `*:recommended` presets and adapt them as we go; as in: When we see someone do something we don't like in a code review, we comment on it as usual, and if it's something we can agree on and think a linter should catch, we look for a corresponding rule and configure it. Of course we could also remove rules if we find things we want to do, but `*:recommended` prevents us. These rule changes would then show up in a PR and we could discuss it there.

The other possibility, which is basically what this PR does, is to configure the linter maximally<sup id="a1">[1](#f1)</sup> strict and then basically only do the latter part of the process described above. This is, of course, slightly more annoying in the beginning, but would, over the long run, guarantee a more strict linter setup and thus hopefully more robust, consistent, readable, and all-in-all just better code. :D

I already started this process with the code we already have as a guideline, but the list of rule changes in here are by no means complete; we will probably still tweak this a lot during the first couple of PRs.

What do you think, @lkiesow, @LukasKalbertodt?

I should also say that browsing for ESLint related stuff I found a lot of other cool plugins and rulesets we could try with this approach. And I would like to do that in the future when time allows it. So technically #30 is not really completed with this, but I from a practical standpoint, this should probably close #30 for now, since there is **always** more one could do when it comes to this stuff, and I guess I have done enough yak shaving for one day. :sweat_smile: 

---

<b id="f1">[1](#a1)</b>: That's not quite true. While the `*:all` presets contain all the rules of the given plugin with the `"error"` option, some of the rules might have additional options that would make them even stricter. So even if we go with the latter approach, we might still want to look for these when we find something during code review where we think that a linter should (have) cought that.