### PR TITLE
Enable incremental type-checking for `tsc`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 /src/query-types
+/tsconfig.tsbuildinfo

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "jsx": "react",
     "noEmit": true,
+    "incremental": true,
 
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The ability to use `--incremental` with `--noEmit` was added in TS4.
This notably improves the runtime of `tsc` invocations after the first
invocation. On my PC, each `npx tsc` took roughly 3.2s before this
change. After this change, the first run also takes 3.2s, but subsequent
runs (without changing anything) only take 1.2s!