### PR TITLE
More initial design

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -37,7 +37,10 @@ module.exports = {
             "named": "never",
             "asyncArrow": "always",
         }],
+        "no-inline-comments": "off",
+        "prefer-destructuring": "off",
         "no-shadow": "off",
+        "newline-per-chained-call": "off",
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import { environment } from "./relay";
 
 import { GlobalStyle } from "./GlobalStyle";
 import { Root } from "./layout/Root";
-import { Realm } from "./page/Realm";
+import { RealmPage } from "./page/Realm";
+import { HomePage } from "./page/Home";
 import { NotFound } from "./page/NotFound";
 
 export const App: React.FC = () => (
@@ -15,7 +16,8 @@ export const App: React.FC = () => (
         <Router>
             <Root>
                 <Switch>
-                    <Route exact path={["/", "/r/:path+"]} component={RealmPage} />
+                    <Route exact path="/" component={HomeRoute} />
+                    <Route exact path="/r/:path+" component={RealmRoute} />
                     <Route exact path={["404", "*"]} component={NotFound} />
                 </Switch>
             </Root>
@@ -23,9 +25,14 @@ export const App: React.FC = () => (
     </RelayEnvironmentProvider>
 );
 
-
-const RealmPage: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
+const HomeRoute: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
     <Suspense fallback="Loading! (TODO)">
-        <Realm path={match.params.path ?? ""} />
+        <HomePage />
+    </Suspense>
+);
+
+const RealmRoute: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
+    <Suspense fallback="Loading! (TODO)">
+        <RealmPage path={match.params.path ?? ""} />
     </Suspense>
 );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ export const App: React.FC = () => (
     </RelayEnvironmentProvider>
 );
 
-const HomeRoute: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
+const HomeRoute: React.FC = () => (
     <Suspense fallback="Loading! (TODO)">
         <HomePage />
     </Suspense>

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -54,9 +54,18 @@ const GLOBAL_STYLE = css({
         fontFamily: "'Open Sans', sans-serif",
         fontWeight: 400,
 
+        // 16px is a good default body text size according to the internet (TM).
+        fontSize: 16,
+
         // From a set of popular phones, the iPhone 5 has the smallest viewport
         // width: 320px. It does make sense to set a minimum width early on in
         // order to know where we can stop caring.
         minWidth: 320,
+    },
+    h1: {
+        fontSize: 32,
+    },
+    h2: {
+        fontSize: 24,
     },
 });

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -2,6 +2,7 @@ language-name: Deutsch
 language: Sprache
 search: Suche
 home: Startseite
+navigation: Navigation
 page-not-found:
   title: Seite nicht gefunden
   body: Die angefragte Resource existiert nicht. Sorry! :-(

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -2,6 +2,7 @@ language-name: English
 language: Language
 search: Search
 home: Home
+navigation: Navigation
 page-not-found:
   title: Page not found
   body: The requested resource does not exist. Sorry! :-(

--- a/frontend/src/layout/NavMain.tsx
+++ b/frontend/src/layout/NavMain.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSitemap } from "@fortawesome/free-solid-svg-icons";
+import { useTranslation } from "react-i18next";
+
+
+type Props = {
+    title?: string;
+    breadcrumbs?: React.ReactNode;
+    navItems: NavItem[];
+};
+
+type NavItem = {
+    label: string;
+    link: string;
+};
+
+// At this screen width, the layout changes from a sidebar for navigation (for
+// larger screens) and the navigation inlined (for smaller screens).
+const BREAKPOINT = 720;
+
+// A layout for the `<main>` part of pages that require a navigation (mainly
+// realms). The navigation is either shown on the left as a sidebar (for large
+// screens) or inline below the page title (for small screens).
+export const NavMain: React.FC<Props> = ({ title, breadcrumbs, navItems, children }) => (
+    <div css={{
+        // This funky expressions just means: above a screen width of 1100px,
+        // the extra space will be 10% margin left and right. This is the middle
+        // ground between filling the full screen and having a fixed max width.
+        margin: "0 calc(max(0px, 100% - 1100px) * 0.1)",
+
+        [`@media (min-width: ${BREAKPOINT}px)`]: {
+            display: "grid",
+            columnGap: 32,
+            grid: `
+                "nav  breadcrumbs" auto
+                "nav  title"       auto
+                "nav  main"        1fr
+                / fit-content(27%) 1fr
+            `,
+        },
+    }}>
+        <div css={{ gridArea: "breadcrumbs" }}>{breadcrumbs}</div>
+        <h1 css={{ gridArea: "title", margin: "12px 0" }}>{title}</h1>
+        <Nav items={navItems} />
+        <div css={{ gridArea: "main" }}>{children}</div>
+    </div>
+);
+
+type NavProps = {
+    items: NavItem[];
+};
+
+// The navigation part of the layout.
+const Nav: React.FC<NavProps> = ({ items }) => {
+    const [navExpanded, setNavExpanded] = useState(false);
+    const { t } = useTranslation();
+
+    return (
+        <nav css={{
+            gridArea: "nav",
+
+            // This is necessary for the `fit-content` column width to correctly
+            // apply.
+            overflow: "hidden",
+
+            [`@media not all and (min-width: ${BREAKPOINT}px)`]: {
+                margin: 16,
+                border: "1px solid #888",
+            },
+        }}>
+            <div
+                onClick={() => setNavExpanded(prev => !prev)}
+                css={{
+                    padding: "6px 12px",
+                    fontSize: 18,
+
+                    // This is required to make the parent `div` (a grid item)
+                    // span up to 300px wide. This is basically the only way to
+                    // get this grid item span a percentage with a maximum
+                    // width.
+                    minWidth: 300,
+
+                    [`@media not all and (min-width: ${BREAKPOINT}px)`]: {
+                        cursor: "pointer",
+                        "&:hover": {
+                            backgroundColor: "#eee",
+                        },
+                    },
+                }}
+            >
+                {/* TODO: this icon is not optimal */}
+                <FontAwesomeIcon icon={faSitemap} css={{ marginRight: 8 }} />
+                <b>{t("navigation")}</b>
+            </div>
+            <ul css={{
+                listStyle: "none",
+                margin: 0,
+                padding: 0,
+                borderTop: "2px solid #888",
+
+                [`@media not all and (min-width: ${BREAKPOINT}px)`]: {
+                    borderTop: navExpanded ? "1px solid #888" : "none",
+                    height: navExpanded ? "auto" : 0,
+                    overflow: "hidden",
+                },
+            }}>
+                {items.map((item, i) => (
+                    <li
+                        key={i}
+                        css={{ borderBottom: "1px solid #ccc" }}
+                    >
+                        <Link
+                            to={item.link}
+                            css={{
+                                padding: "6px 12px",
+                                textDecoration: "none",
+                                display: "block",
+                                transition: "background-color 0.1s",
+                                "&:hover": {
+                                    transitionDuration: "0.05s",
+                                    backgroundColor: "#eee",
+                                    textDecoration: "underline",
+                                },
+                            }}
+                        >{item.label}</Link>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+};

--- a/frontend/src/layout/NavMain.tsx
+++ b/frontend/src/layout/NavMain.tsx
@@ -11,6 +11,7 @@ type Props = {
 } & NavProps;
 
 type NavItem = {
+    id: string;
     label: string;
     link: string;
 
@@ -116,7 +117,7 @@ const Nav: React.FC<NavProps> = ({ items, leafNode }) => {
                     overflow: "hidden",
                 },
             }}>
-                {items.map((item, i) => {
+                {items.map(item => {
                     const baseStyle = { padding: "6px 12px", display: "block" };
                     const inner = item.active
                         ? <b css={{ ...baseStyle, backgroundColor: "#ddd" }}>
@@ -137,7 +138,7 @@ const Nav: React.FC<NavProps> = ({ items, leafNode }) => {
                         >{item.label}</Link>;
 
                     return (
-                        <li key={i} css={{ borderBottom: "1px solid #ccc" }}>
+                        <li key={item.id} css={{ borderBottom: "1px solid #ccc" }}>
                             {inner}
                         </li>
                     );

--- a/frontend/src/layout/NavMain.tsx
+++ b/frontend/src/layout/NavMain.tsx
@@ -8,14 +8,7 @@ import { useTranslation } from "react-i18next";
 type Props = {
     title?: string;
     breadcrumbs?: React.ReactNode;
-    navItems: NavItem[];
-
-    // Is this node a leaf node (i.e. does not have any children)? If so, the
-    // navigation items are expected to be the siblings of the current node
-    // instead of the children. Futhermore, the navigation is only shown for
-    // wide screens.
-    leafNode: boolean;
-};
+} & NavProps;
 
 type NavItem = {
     label: string;
@@ -33,7 +26,7 @@ const BREAKPOINT = 720;
 // A layout for the `<main>` part of pages that require a navigation (mainly
 // realms). The navigation is either shown on the left as a sidebar (for large
 // screens) or inline below the page title (for small screens).
-export const NavMain: React.FC<Props> = ({ title, breadcrumbs, navItems, leafNode, children }) => (
+export const NavMain: React.FC<Props> = ({ title, breadcrumbs, children, ...navProps }) => (
     <div css={{
         // This funky expressions just means: above a screen width of 1100px,
         // the extra space will be 10% margin left and right. This is the middle
@@ -53,13 +46,18 @@ export const NavMain: React.FC<Props> = ({ title, breadcrumbs, navItems, leafNod
     }}>
         <div css={{ gridArea: "breadcrumbs" }}>{breadcrumbs}</div>
         <h1 css={{ gridArea: "title", margin: "12px 0" }}>{title}</h1>
-        <Nav items={navItems} leafNode={leafNode} />
+        <Nav {...navProps} />
         <div css={{ gridArea: "main" }}>{children}</div>
     </div>
 );
 
 type NavProps = {
     items: NavItem[];
+
+    // Is this node a leaf node (i.e. does not have any children)? If so, the
+    // navigation items are expected to be the siblings of the current node
+    // instead of the children. Futhermore, the navigation is only shown for
+    // wide screens.
     leafNode: boolean;
 };
 

--- a/frontend/src/page/Home.tsx
+++ b/frontend/src/page/Home.tsx
@@ -18,9 +18,11 @@ export const HomePage: React.FC = () => {
 
     return (
         <MainLayout
+            leafNode={false}
             navItems={realm.children.map(({ path, name }) => ({
                 label: name,
                 link: `/r${path}`,
+                active: false,
             }))}
         >
             <p>Welcome to Tobira :3</p>

--- a/frontend/src/page/Home.tsx
+++ b/frontend/src/page/Home.tsx
@@ -19,7 +19,7 @@ export const HomePage: React.FC = () => {
     return (
         <MainLayout
             leafNode={false}
-            navItems={realm.children.map(({ path, name }) => ({
+            items={realm.children.map(({ path, name }) => ({
                 label: name,
                 link: `/r${path}`,
                 active: false,

--- a/frontend/src/page/Home.tsx
+++ b/frontend/src/page/Home.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { graphql, useLazyLoadQuery } from "react-relay/hooks";
+import { HomeQuery } from "../query-types/HomeQuery.graphql";
+
+import { NavMain as MainLayout } from "../layout/NavMain";
+
+
+export const HomePage: React.FC = () => {
+    const { realm } = useLazyLoadQuery<HomeQuery>(graphql`
+        query HomeQuery {
+            realm: rootRealm {
+                name
+                path
+                children { name path }
+            }
+        }
+    `, {});
+
+    return (
+        <MainLayout
+            navItems={realm.children.map(({ path, name }) => ({
+                label: name,
+                link: `/r${path}`,
+            }))}
+        >
+            <p>Welcome to Tobira :3</p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+                ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                aliquip ex ea commodo consequat. Duis aute irure dolor in
+                reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+                culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+        </MainLayout>
+    );
+};

--- a/frontend/src/page/Home.tsx
+++ b/frontend/src/page/Home.tsx
@@ -11,7 +11,7 @@ export const HomePage: React.FC = () => {
             realm: rootRealm {
                 name
                 path
-                children { name path }
+                children { id name path }
             }
         }
     `, {});
@@ -19,7 +19,8 @@ export const HomePage: React.FC = () => {
     return (
         <MainLayout
             leafNode={false}
-            items={realm.children.map(({ path, name }) => ({
+            items={realm.children.map(({ id, path, name }) => ({
+                id,
                 label: name,
                 link: `/r${path}`,
                 active: false,

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -51,7 +51,7 @@ export const RealmPage: React.FC<Props> = ({ path }) => {
         .concat(realm)
         .map(({ name, path }) => ({
             label: name,
-            href: `/r${path}`,
+            link: `/r${path}`,
         }));
 
     const navItems = realm.children.length > 0

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -11,7 +11,7 @@ type Props = {
     path: string;
 };
 
-export const Realm: React.FC<Props> = ({ path }) => {
+export const RealmPage: React.FC<Props> = ({ path }) => {
     const isRoot = path === "";
 
     // TODO Build this query from fragments!
@@ -47,8 +47,8 @@ export const Realm: React.FC<Props> = ({ path }) => {
 
     return (
         <MainLayout
-            title={isRoot ? undefined : realm.name}
-            breadcrumbs={isRoot ? undefined : <Breadcrumbs path={breadcrumbs} />}
+            title={realm.name}
+            breadcrumbs={<Breadcrumbs path={breadcrumbs} />}
             navItems={realm.children.map(({ path, name }) => ({
                 label: name,
                 link: `/r${path}`,

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -70,7 +70,7 @@ export const RealmPage: React.FC<Props> = ({ path }) => {
         <MainLayout
             title={realm.name}
             breadcrumbs={<Breadcrumbs path={breadcrumbs} />}
-            navItems={navItems}
+            items={navItems}
             leafNode={realm.children.length === 0}
         >
             <p>

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 import { graphql, useLazyLoadQuery } from "react-relay/hooks";
 import { RealmQuery } from "../query-types/RealmQuery.graphql";
 
 import { Breadcrumbs } from "../ui/Breadcrumbs";
+import { NavMain as MainLayout } from "../layout/NavMain";
 
 
 type Props = {
@@ -19,6 +19,7 @@ export const Realm: React.FC<Props> = ({ path }) => {
         query RealmQuery($path: String!) {
             realm: realmByPath(path: $path) {
                 name
+                path
                 parents { name path }
                 children { id name path }
             }
@@ -36,31 +37,32 @@ export const Realm: React.FC<Props> = ({ path }) => {
     }
 
     // Prepare data for breadcrumbs
-    const breadcrumbs = realm.parents.slice(1).map(({ name, path }) => ({
-        label: name,
-        href: `/r${path}`,
-    }));
+    const breadcrumbs = realm.parents
+        .slice(1)
+        .concat(realm)
+        .map(({ name, path }) => ({
+            label: name,
+            href: `/r${path}`,
+        }));
 
-    return <>
-        {!isRoot && <Breadcrumbs path={breadcrumbs} />}
-        <h1>{realm.name}</h1>
-        <ul>
-            {realm.children.map(({ id, path, name }) => (
-                <li key={id}>
-                    <Link to={`/r${path}`}>
-                        {name}
-                    </Link>
-                </li>
-            ))}
-        </ul>
-        <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
-        </p>
-    </>;
+    return (
+        <MainLayout
+            title={isRoot ? undefined : realm.name}
+            breadcrumbs={isRoot ? undefined : <Breadcrumbs path={breadcrumbs} />}
+            navItems={realm.children.map(({ path, name }) => ({
+                label: name,
+                link: `/r${path}`,
+            }))}
+        >
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+                ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                aliquip ex ea commodo consequat. Duis aute irure dolor in
+                reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+                culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+        </MainLayout>
+    );
 };

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -55,12 +55,14 @@ export const RealmPage: React.FC<Props> = ({ path }) => {
         }));
 
     const navItems = realm.children.length > 0
-        ? realm.children.map(({ path, name }) => ({
+        ? realm.children.map(({ id, path, name }) => ({
+            id,
             label: name,
             link: `/r${path}`,
             active: false,
         }))
         : realm.parent.children.map(({ id, name, path }) => ({
+            id,
             label: name,
             link: `/r${path}`,
             active: id === realm.id,

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -18,7 +18,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path }) => {
     const { t } = useTranslation();
 
     return (
-        <nav aria-label="breadcrumbs" css={{ marginBottom: 16 }}>
+        <nav aria-label="breadcrumbs">
             <ol css={{ listStyle: "none", padding: 0, margin: 0 }}>
                 <Segment target="/" first active={path.length === 0}>
                     <FontAwesomeIcon title={t("home")} icon={faHome} />

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 type Segment = {
     label: string;
-    href: string;
+    link: string;
 };
 
 export const Breadcrumbs: React.FC<Props> = ({ path }) => {
@@ -24,7 +24,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path }) => {
                     <FontAwesomeIcon title={t("home")} icon={faHome} />
                 </Segment>
                 {path.map((segment, i) => (
-                    <Segment key={i} target={segment.href} active={i === path.length - 1}>
+                    <Segment key={i} target={segment.link} active={i === path.length - 1}>
                         {segment.label}
                     </Segment>
                 ))}


### PR DESCRIPTION
This adds a responsive sidebar for navigation. This sidebar is shown inline (in a collapsed state) on small screens. The navigation of children is pretty important and thus, we don't want to hide the children too much on mobile. I think in this solution it's fairly prominent (even if collapsed by default). Better than hiding them in a hamburger menu or a thumbs menu. 
PR also contains some minor improvements.