### PR TITLE
Add language selector in header

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -30,6 +30,12 @@ module.exports = {
         "no-magic-numbers": "off",
         "max-lines-per-function": "off",
         "default-case": "off",
+        "func-style": "off",
+        "space-before-function-paren": ["warn", {
+            "anonymous": "always",
+            "named": "never",
+            "asyncArrow": "always",
+        }],
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],
@@ -117,6 +123,7 @@ module.exports = {
             "@typescript-eslint/no-magic-numbers": "off",
             "@typescript-eslint/explicit-function-return-type": "off",
             "@typescript-eslint/promise-function-async": "off",
+            "implicit-arrow-linebreak": "off",
             // The rationale these two/three are based on is mostly out of date
             "@typescript-eslint/prefer-interface": "off",
             "@typescript-eslint/no-type-alias": "off",
@@ -145,6 +152,13 @@ module.exports = {
             "semi": "off",
             "no-unused-vars": "off",
             "no-extra-parens": "off",
+
+            // Change strange defaults.
+            "@typescript-eslint/space-before-function-paren": ["warn", {
+                "anonymous": "always",
+                "named": "never",
+                "asyncArrow": "always",
+            }],
         },
         settings: {
             react: {

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         "no-magic-numbers": "off",
         "max-lines-per-function": "off",
         "default-case": "off",
+        "no-console": "off",
         "func-style": "off",
         "space-before-function-paren": ["warn", {
             "anonymous": "always",
@@ -116,6 +117,7 @@ module.exports = {
             // Turn off some intrusive rules
             "react/prop-types": "off",
             "react/react-in-jsx-scope": "off",
+            "react/display-name": "off",
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-use-before-define": "off",
             "@typescript-eslint/typedef": "off",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
         "padded-blocks": "off",
         "quote-props": "off",
         "no-magic-numbers": "off",
+        "max-lines-per-function": "off",
+        "default-case": "off",
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],
@@ -113,6 +115,8 @@ module.exports = {
             "@typescript-eslint/typedef": "off",
             "@typescript-eslint/prefer-readonly-parameter-types": "off",
             "@typescript-eslint/no-magic-numbers": "off",
+            "@typescript-eslint/explicit-function-return-type": "off",
+            "@typescript-eslint/promise-function-async": "off",
             // The rationale these two/three are based on is mostly out of date
             "@typescript-eslint/prefer-interface": "off",
             "@typescript-eslint/no-type-alias": "off",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -933,6 +933,14 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-react-constant-elements": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.10.4.tgz",
+      "integrity": "sha512-cYmQBW1pXrqBte1raMkAulXmi7rjg3VI6ZLg9QIic8Hq7BtYXaWuZSxsr2siOMI6SWwpxjWfnwhTUrd7JlAV7g==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
@@ -1456,6 +1464,190 @@
         }
       }
     },
+    "@svgr/babel-plugin-add-jsx-attribute": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+      "integrity": "sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg=="
+    },
+    "@svgr/babel-plugin-remove-jsx-attribute": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+      "integrity": "sha512-yaS4o2PgUtwLFGTKbsiAy6D0o3ugcUhWK0Z45umJ66EPWunAz9fuFw2gJuje6wqQvQWOTJvIahUwndOXb7QCPg=="
+    },
+    "@svgr/babel-plugin-remove-jsx-empty-expression": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+      "integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA=="
+    },
+    "@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+      "integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ=="
+    },
+    "@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+      "integrity": "sha512-zSOZH8PdZOpuG1ZVx/cLVePB2ibo3WPpqo7gFIjLV9a0QsuQAzJiwwqmuEdTaW2pegyBE17Uu15mOgOcgabQZg=="
+    },
+    "@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+      "integrity": "sha512-cPzDbDA5oT/sPXDCUYoVXEmm3VIoAWAPT6mSPTJNbQaBNUuEKVKyGH93oDY4e42PYHRW67N5alJx/eEol20abw=="
+    },
+    "@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+      "integrity": "sha512-3eYP/SaopZ41GHwXma7Rmxcv9uRslRDTY1estspeB1w1ueZWd/tPlMfEOoccYpEMZU3jD4OU7YitnXcF5hLW2Q=="
+    },
+    "@svgr/babel-plugin-transform-svg-component": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.4.0.tgz",
+      "integrity": "sha512-zLl4Fl3NvKxxjWNkqEcpdSOpQ3LGVH2BNFQ6vjaK6sFo2IrSznrhURIPI0HAphKiiIwNYjAfE0TNoQDSZv0U9A=="
+    },
+    "@svgr/babel-preset": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.4.0.tgz",
+      "integrity": "sha512-Gyx7cCxua04DBtyILTYdQxeO/pwfTBev6+eXTbVbxe4HTGhOUW6yo7PSbG2p6eJMl44j6XSequ0ZDP7bl0nu9A==",
+      "requires": {
+        "@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+        "@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+        "@svgr/babel-plugin-transform-svg-component": "^5.4.0"
+      }
+    },
+    "@svgr/core": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.4.0.tgz",
+      "integrity": "sha512-hWGm1DCCvd4IEn7VgDUHYiC597lUYhFau2lwJBYpQWDirYLkX4OsXu9IslPgJ9UpP7wsw3n2Ffv9sW7SXJVfqQ==",
+      "requires": {
+        "@svgr/plugin-jsx": "^5.4.0",
+        "camelcase": "^6.0.0",
+        "cosmiconfig": "^6.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
+    },
+    "@svgr/hast-util-to-babel-ast": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.4.0.tgz",
+      "integrity": "sha512-+U0TZZpPsP2V1WvVhqAOSTk+N+CjYHdZx+x9UBa1eeeZDXwH8pt0CrQf2+SvRl/h2CAPRFkm+Ey96+jKP8Bsgg==",
+      "requires": {
+        "@babel/types": "^7.9.5"
+      }
+    },
+    "@svgr/plugin-jsx": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.4.0.tgz",
+      "integrity": "sha512-SGzO4JZQ2HvGRKDzRga9YFSqOqaNrgLlQVaGvpZ2Iht2gwRp/tq+18Pvv9kS9ZqOMYgyix2LLxZMY1LOe9NPqw==",
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@svgr/babel-preset": "^5.4.0",
+        "@svgr/hast-util-to-babel-ast": "^5.4.0",
+        "svg-parser": "^2.0.2"
+      }
+    },
+    "@svgr/plugin-svgo": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.4.0.tgz",
+      "integrity": "sha512-3Cgv3aYi1l6SHyzArV9C36yo4kgwVdF3zPQUC6/aCDUeXAofDYwE5kk3e3oT5ZO2a0N3lB+lLGvipBG6lnG8EA==",
+      "requires": {
+        "cosmiconfig": "^6.0.0",
+        "merge-deep": "^3.0.2",
+        "svgo": "^1.2.2"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        }
+      }
+    },
+    "@svgr/webpack": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.4.0.tgz",
+      "integrity": "sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==",
+      "requires": {
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-transform-react-constant-elements": "^7.9.0",
+        "@babel/preset-env": "^7.9.5",
+        "@babel/preset-react": "^7.9.4",
+        "@svgr/core": "^5.4.0",
+        "@svgr/plugin-jsx": "^5.4.0",
+        "@svgr/plugin-svgo": "^5.4.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -1501,6 +1693,11 @@
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/q": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
       "version": "16.9.48",
@@ -2727,6 +2924,38 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+      "requires": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "coa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+      "requires": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
+      }
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3152,10 +3381,60 @@
         "nth-check": "~1.0.1"
       }
     },
+    "css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "requires": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
+    "csso": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
+      "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
+      "requires": {
+        "css-tree": "1.0.0-alpha.39"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.39",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+          "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+          "requires": {
+            "mdn-data": "2.0.6",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+          "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "csstype": {
       "version": "3.0.3",
@@ -4127,6 +4406,14 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4850,6 +5137,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4883,6 +5175,11 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "leven": {
       "version": "3.1.0",
@@ -4997,6 +5294,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -5004,6 +5306,26 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
+      }
+    },
+    "merge-deep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+      "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "merge2": {
@@ -5167,6 +5489,22 @@
           "requires": {
             "is-plain-object": "^2.0.4"
           }
+        }
+      }
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
     },
@@ -5425,7 +5763,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -5760,6 +6097,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6407,6 +6749,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "scheduler": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -6477,6 +6824,32 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "requires": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
       }
     },
     "shebang-command": {
@@ -6715,6 +7088,11 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -6839,6 +7217,58 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+    },
+    "svgo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^3.2.1",
+            "domutils": "^1.7.0",
+            "nth-check": "^1.0.2"
+          }
+        },
+        "css-what": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz",
+          "integrity": "sha512-wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g=="
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        }
       }
     },
     "table": {
@@ -7109,6 +7539,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4910,6 +4910,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ionicons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-5.2.1.tgz",
+      "integrity": "sha512-dtw4rR7Sr2ssGHRrkTMESQ/p4gwovmHgafKvZsEeMjb712xjBOD3YSycy5kofS5RusU/IFVog8693BZiJ0ELzA=="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "html-webpack-plugin": "^4.3.0",
     "i18next": "^19.7.0",
     "i18next-browser-languagedetector": "^6.0.1",
+    "ionicons": "^5.2.1",
     "raw-loader": "^4.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
+    "@svgr/webpack": "^5.4.0",
     "@types/react-router-dom": "^5.1.5",
     "babel-loader": "^8.1.0",
     "babel-plugin-relay": "^10.0.1",

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -4,6 +4,6 @@ declare module "*.yaml" {
 }
 
 declare module "*.svg" {
-    const content: any;
-    export default content;
+    const Component: React.FC<React.SVGProps<SVGSVGElement>>;
+    export default Component;
 }

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -4,6 +4,6 @@ declare module "*.yaml" {
 }
 
 declare module "*.svg" {
-  const content: any;
-  export default content;
+    const content: any;
+    export default content;
 }

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -2,3 +2,8 @@ declare module "*.yaml" {
     const value: any;
     export default value;
 }
+
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5,16 +5,17 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import enTranslations from "./locales/en.yaml";
 import deTranslations from "./locales/de.yaml";
 
-const resources = {
+export const languages = {
     en: { translation: enTranslations as ResourceLanguage },
     de: { translation: deTranslations as ResourceLanguage },
 };
 
+// TODO: wait for `init` to complete before rendering?
 void i18n
     .use(initReactI18next)
     .use(LanguageDetector)
     .init({
-        resources,
+        resources: languages,
         fallbackLng: "en",
         interpolation: {
             escapeValue: false,

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -1,2 +1,4 @@
+language-name: Deutsch
+language: Sprache
 search: Suche
 home: Startseite

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -1,1 +1,2 @@
+search: Suche
 home: Startseite

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -1,2 +1,4 @@
+language-name: English
+language: Language
 search: Search
 home: Home

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -1,1 +1,2 @@
+search: Search
 home: Home

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -101,20 +101,21 @@ const Menu: React.FC = () => {
 
     return (
         <div css={{ display: "flex", height: "100%", alignItems: "center", position: "relative" }}>
-            <LanguageIcon
-                onClick={() => toggleMenu("language")}
-                title={`${t("language")}: ${t("language-name")}`}
-                css={{
-                    fontSize: 38,
-                    margin: "0 8px",
-                    padding: 6,
-                    borderRadius: 4,
-                    cursor: "pointer",
-                    "&:hover": {
-                        backgroundColor: "#ddd",
-                    },
-                }}
-            />
+            <div title={`${t("language")}: ${t("language-name")}`}>
+                <LanguageIcon
+                    onClick={() => toggleMenu("language")}
+                    css={{
+                        fontSize: 38,
+                        margin: "0 8px",
+                        padding: 6,
+                        borderRadius: 4,
+                        cursor: "pointer",
+                        "&:hover": {
+                            backgroundColor: "#ddd",
+                        },
+                    }}
+                />
+            </div>
             <div>
                 Menu
                 <FontAwesomeIcon css={{ marginLeft: 4 }} icon={faCaretDown} size="lg" />

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 
 const HEIGHT = 60;
@@ -14,7 +15,6 @@ export const Header: React.FC = () => (
         justifyContent: "space-between",
         backgroundColor: "white",
         borderBottom: "1px solid #bbb",
-        padding: "0 8px",
     }}>
         <Logo />
         <Search />
@@ -24,12 +24,12 @@ export const Header: React.FC = () => (
 
 const Logo: React.FC = () => (
     <Link to="/" css={{ height: "100%", flex: "0 0 auto" }}>
-        <picture css={{
-            height: "100%",
-            "& > *": { height: "100%", padding: "4px 0" },
-        }}>
+        <picture css={{ height: "100%" }}>
             <source media="(min-width: 450px)" srcSet="/assets/static/logo-large.svg" />
-            <img src="/assets/static/logo-small.svg" />
+            <img
+                css={{ height: "100%", padding: "4px 8px" }}
+                src="/assets/static/logo-small.svg"
+            />
         </picture>
     </Link>
 );

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown, faCheck } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import LanguageIcon from "ionicons/dist/svg/language.svg";
 
 import { languages } from "../i18n";
-import { assertNever } from "../util/err";
+import { match } from "../util";
 
 
 const HEIGHT = 60;
@@ -63,42 +63,13 @@ const Search: React.FC = () => {
 };
 
 const Menu: React.FC = () => {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
 
     type MenuState = "closed" | "language";
     const [menuState, setMenuState] = useState<MenuState>("closed");
     const toggleMenu = (state: MenuState) => {
         setMenuState(menuState === state ? "closed" : state);
     };
-
-    const menuContent = (() => {
-        switch (menuState) {
-            case "closed": return null;
-            case "language": return (
-                <ul css={{
-                    width: "100%",
-                    listStyle: "none",
-                    margin: 0,
-                    padding: 0,
-                }}>
-                    {Object.keys(languages).map(lng => (
-                        <li
-                            onClick={() => i18n.changeLanguage(lng)}
-                            key={lng}
-                            css={{
-                                padding: "4px 8px 4px 16px",
-                                cursor: "pointer",
-                                "&:hover": {
-                                    backgroundColor: "#ddd",
-                                },
-                            }}
-                        >{t("language-name", { lng })}</li>
-                    ))}
-                </ul>
-            );
-            default: return assertNever(menuState);
-        }
-    })();
 
     return (
         <div css={{ display: "flex", height: "100%", alignItems: "center", position: "relative" }}>
@@ -132,7 +103,44 @@ const Menu: React.FC = () => {
                 borderRight: "none",
                 maxWidth: "100vw",
                 backgroundColor: "white",
-            }}>{menuContent}</div>
+            }}>
+                {match(menuState, {
+                    "closed": () => null,
+                    "language": () => <LanguageList />,
+                })}
+            </div>
         </div>
+    );
+};
+
+const LanguageList = () => {
+    const { t, i18n } = useTranslation();
+
+    return (
+        <ul css={{
+            width: "100%",
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+        }}>
+            {Object.keys(languages).map(lng => (
+                <li
+                    onClick={() => i18n.changeLanguage(lng)}
+                    key={lng}
+                    css={{
+                        padding: "4px 8px 4px 12px",
+                        cursor: "pointer",
+                        "&:hover": {
+                            backgroundColor: "#ddd",
+                        },
+                    }}
+                >
+                    <div className="fa-fw" css={{ display: "inline-block", marginRight: 8 }}>
+                        {lng === i18n.language && <FontAwesomeIcon icon={faCheck} fixedWidth />}
+                    </div>
+                    {t("language-name", { lng })}
+                </li>
+            ))}
+        </ul>
     );
 };

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -37,22 +37,26 @@ const Logo: React.FC = () => (
 
 const SEARCH_HEIGHT = 35;
 
-const Search: React.FC = () => (
-    <input
-        type="text"
-        placeholder="Search"
-        css={{
-            flex: "1 1 0px",
-            margin: "0 16px",
-            minWidth: 50,
-            maxWidth: 280,
-            height: SEARCH_HEIGHT,
-            borderRadius: SEARCH_HEIGHT / 2,
-            border: "1.5px solid #ccc",
-            padding: `0 ${SEARCH_HEIGHT / 2}px`,
-        }}
-    />
-);
+const Search: React.FC = () => {
+    const { t } = useTranslation();
+
+    return (
+        <input
+            type="text"
+            placeholder={t("search")}
+            css={{
+                flex: "1 1 0px",
+                margin: "0 8px",
+                minWidth: 50,
+                maxWidth: 280,
+                height: SEARCH_HEIGHT,
+                borderRadius: SEARCH_HEIGHT / 2,
+                border: "1.5px solid #ccc",
+                padding: `0 ${SEARCH_HEIGHT / 2}px`,
+            }}
+        />
+    );
+};
 
 const Menu: React.FC = () => (
     <div>

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -3,8 +3,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { languages } from "../i18n";
 import LanguageIcon from "ionicons/dist/svg/language.svg";
+
+import { languages } from "../i18n";
+import { assertNever } from "../util/err";
 
 
 const HEIGHT = 60;
@@ -94,8 +96,7 @@ const Menu: React.FC = () => {
                     ))}
                 </ul>
             );
-            // TODO: extract this helper function and give it a good name.
-            default: return ((x: never) => x)(menuState);
+            default: return assertNever(menuState);
         }
     })();
 

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { languages } from "../i18n";
+import LanguageIcon from "ionicons/dist/svg/language.svg";
 
 
 const HEIGHT = 60;
@@ -58,9 +60,77 @@ const Search: React.FC = () => {
     );
 };
 
-const Menu: React.FC = () => (
-    <div>
-        Not logged in
-        <FontAwesomeIcon css={{ marginLeft: 4 }} icon={faCaretDown} />
-    </div>
-);
+const Menu: React.FC = () => {
+    const { t, i18n } = useTranslation();
+
+    type MenuState = "closed" | "language";
+    const [menuState, setMenuState] = useState<MenuState>("closed");
+    const toggleMenu = (state: MenuState) => {
+        setMenuState(menuState === state ? "closed" : state);
+    };
+
+    const menuContent = (() => {
+        switch (menuState) {
+            case "closed": return null;
+            case "language": return (
+                <ul css={{
+                    width: "100%",
+                    listStyle: "none",
+                    margin: 0,
+                    padding: 0,
+                }}>
+                    {Object.keys(languages).map(lng => (
+                        <li
+                            onClick={() => i18n.changeLanguage(lng)}
+                            key={lng}
+                            css={{
+                                padding: "4px 8px 4px 16px",
+                                cursor: "pointer",
+                                "&:hover": {
+                                    backgroundColor: "#ddd",
+                                },
+                            }}
+                        >{t("language-name", { lng })}</li>
+                    ))}
+                </ul>
+            );
+            // TODO: extract this helper function and give it a good name.
+            default: return ((x: never) => x)(menuState);
+        }
+    })();
+
+    return (
+        <div css={{ display: "flex", height: "100%", alignItems: "center", position: "relative" }}>
+            <LanguageIcon
+                onClick={() => toggleMenu("language")}
+                title={`${t("language")}: ${t("language-name")}`}
+                css={{
+                    fontSize: 38,
+                    margin: "0 8px",
+                    padding: 6,
+                    borderRadius: 4,
+                    cursor: "pointer",
+                    "&:hover": {
+                        backgroundColor: "#ddd",
+                    },
+                }}
+            />
+            <div>
+                Menu
+                <FontAwesomeIcon css={{ marginLeft: 4 }} icon={faCaretDown} size="lg" />
+            </div>
+            <div css={{
+                position: "absolute",
+                ...menuState === "closed" && { display: "none" },
+                top: "100%",
+                right: 0,
+                width: 180,
+                border: "1px solid #bbb",
+                borderTop: "1px dashed #bbb",
+                borderRight: "none",
+                maxWidth: "100vw",
+                backgroundColor: "white",
+            }}>{menuContent}</div>
+        </div>
+    );
+};

--- a/frontend/src/util/err.ts
+++ b/frontend/src/util/err.ts
@@ -1,0 +1,41 @@
+// Make sure that the parameter is `never`. This is particularly useful for
+// enum-like types where you want to make sure you handled all cases. For
+// example:
+//
+// ```
+// type Foo = "anna" | "bob";
+// const x = "anna" as Foo;
+//
+// switch x {
+//     case "anna": ...; break;
+//     case "bob": ...; break;
+//     default: assertNever(x);
+// }
+// ```
+//
+// If you add another variant to that type, the switch statement will fail to
+// compile. This is what we want in most cases! That way, we are notified of all
+// places which we might need to change after adding a new variant.
+export const assertNever = (_n: never): never =>
+    bug("`assertNever` call was reached, that's a soundness hole in the typesystem :(");
+
+// A custom error type that represents bugs: errors that are not expected and
+// that cannot be handled. They are caused by a bug in our code and not by the
+// "world" (e.g. any input). Use the helper functions below to throw this error.
+export class Bug extends Error {
+    public constructor(msg: string) {
+        super(`${msg} (this is a bug in Tobira)`);
+        this.name = "Bug";
+    }
+}
+
+// Throws a `Bug` error. Use this function to signal a bug in the code.
+export const bug = (msg: string): never => {
+    throw new Bug(msg);
+};
+
+// Like `bug`, but specifically for code paths that should be unreachable.
+export const unreachable = (msg?: string): never => {
+    const prefix = "reached unreachable code";
+    throw new Bug(msg === undefined ? prefix : `${prefix}: ${msg}`);
+};

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -1,0 +1,43 @@
+
+// A switch-like expression with exhaustiveness check (or fallback value). A bit
+// like Rust's `match`, but worse.
+//
+// If the `fallback` is not given, the given match arms need to be exhaustive.
+// This helps a lot with maintanence as adding a new variant to a union type
+// will throw compile errors in all places that likely need adjustment. You can
+// also pass a fallback (default) value as third parameter, disabling the
+// exhaustiveness check.
+//
+// ```
+// type Animal = "dog" | "cat" | "fox";
+//
+// const animal = "fox" as Animal;
+// const awesomeness = match(animal, {
+//     "dog": () => 7,
+//     "cat": () => 6,
+//     "fox": () => 100,
+// });
+// ```
+export function match<T extends string | number, Out>(
+    value: T,
+    arms: Record<T, () => Out>,
+): Out;
+export function match<T extends string | number, Out>(
+    value: T,
+    arms: Partial<Record<T, () => Out>>,
+    fallback: () => Out,
+): Out;
+export function match<T extends string | number, Out>(
+    value: T,
+    arms: Partial<Record<T, () => Out>>,
+    fallback?: () => Out,
+): Out {
+    return fallback === undefined
+        // Unfortunately, we haven't found a way to make the TS typesystem to
+        // understand that in the case of `fallback === undefined`, `arms` is
+        // not a partial map. But it is, as you can see from the two callable
+        // signatures above.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ? arms[value]!()
+        : (arms[value] as (() => Out) | undefined ?? fallback)();
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -32,6 +32,14 @@ module.exports = (_env, argv) => ({
             test: /\.yaml$/u,
             loader: "yaml-loader",
             type: "json",
+        }, {
+            test: /\.svg$/,
+            use: [{
+                loader: "@svgr/webpack",
+                options: {
+                    icon: true,
+                },
+            }],
         }],
     },
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (_env, argv) => ({
             loader: "yaml-loader",
             type: "json",
         }, {
-            test: /\.svg$/,
+            test: /\.svg$/u,
             use: [{
                 loader: "@svgr/webpack",
                 options: {


### PR DESCRIPTION
This also adds some basic code to add the "main menu" more easily later. 

Note that this is of course not necessarily the final design. But I still think these PRs are useful now: we have a more complete application to test stuff in and most of the code can be reused when changing the design.

There's still one **open question**: the icon is taken from a MIT licensed icon library. There is an npm package, but it doesn't contain types (and there is no `@types` lib). Sure, we could add some ourselves, but we want to load SVGs (our own icons) at some point anyway, so yeah. Anyway, the question is: how to give attribution as required by MIT? Right now there is a comment inside the SVG which seems to be removed by webpack. Is that a good solution? We could also add a `NOTICES` file. Opinions, @lkiesow @JulianKniephoff ?