### PR TITLE
Change some minor linting and best-practices issues

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -7,6 +7,8 @@ const noUnusedVarsOptions = {
     caughtErrors: "all",
     caughtErrorsIgnorePattern: "^_",
 };
+const indentation = 4;
+const indentOptions = [indentation, { SwitchCase: 1 }];
 
 // eslint quote-props: "warn", "consistent-as-needed"
 module.exports = {
@@ -27,7 +29,7 @@ module.exports = {
         "sort-imports": "off",
         "prefer-named-capture-group": "off",
         "padded-blocks": "off",
-        "quote-props": ["off"],
+        "quote-props": "off",
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],
@@ -66,8 +68,8 @@ module.exports = {
         "array-element-newline": ["warn", "consistent"],
         "key-spacing": "warn",
         "brace-style": "warn",
-        "rest-spread-spacing": ["warn", "always"],
-        "indent": "warn",
+        "rest-spread-spacing": "warn",
+        "indent": ["warn", ...indentOptions],
         "semi": "warn",
         "no-extra-semi": "warn",
         "semi-spacing": "warn",
@@ -84,6 +86,7 @@ module.exports = {
         "dot-location": ["warn", "property"],
         "dot-notation": "warn",
         "no-tabs": "warn",
+        "no-extra-parens": "warn",
         // Unused things should also only warn
         "no-unused-vars": ["warn", noUnusedVarsOptions],
     },
@@ -128,7 +131,7 @@ module.exports = {
             // in `tsconfig.json`.
             "@typescript-eslint/no-unused-vars-experimental": "warn",
             "@typescript-eslint/semi": "warn",
-            "@typescript-eslint/indent": "warn",
+            "@typescript-eslint/indent": ["warn", ...indentOptions],
             "@typescript-eslint/naming-convention": ["warn", {
                 selector: "variable",
                 types: ["function"],

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -8,7 +8,6 @@ const noUnusedVarsOptions = {
     caughtErrorsIgnorePattern: "^_",
 };
 const indentation = 4;
-const indentOptions = [indentation, { SwitchCase: 1 }];
 
 // eslint quote-props: "warn", "consistent-as-needed"
 module.exports = {
@@ -69,7 +68,7 @@ module.exports = {
         "key-spacing": "warn",
         "brace-style": "warn",
         "rest-spread-spacing": "warn",
-        "indent": ["warn", ...indentOptions],
+        "indent": ["warn", indentation, { SwitchCase: 1 }],
         "semi": "warn",
         "no-extra-semi": "warn",
         "semi-spacing": "warn",
@@ -131,7 +130,7 @@ module.exports = {
             // in `tsconfig.json`.
             "@typescript-eslint/no-unused-vars-experimental": "warn",
             "@typescript-eslint/semi": "warn",
-            "@typescript-eslint/indent": ["warn", ...indentOptions],
+            "@typescript-eslint/indent": "warn",
             "@typescript-eslint/naming-convention": ["warn", {
                 selector: "variable",
                 types: ["function"],

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,13 +1,11 @@
 "use strict";
 
-const magicNumberOptions = { ignore: [0, 1, 2] };
 const noUnusedVarsOptions = {
     args: "all",
     argsIgnorePattern: "^_",
     caughtErrors: "all",
     caughtErrorsIgnorePattern: "^_",
 };
-const indentation = 4;
 
 // eslint quote-props: "warn", "consistent-as-needed"
 module.exports = {
@@ -29,6 +27,7 @@ module.exports = {
         "prefer-named-capture-group": "off",
         "padded-blocks": "off",
         "quote-props": "off",
+        "no-magic-numbers": "off",
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],
@@ -68,7 +67,7 @@ module.exports = {
         "key-spacing": "warn",
         "brace-style": "warn",
         "rest-spread-spacing": "warn",
-        "indent": ["warn", indentation, { SwitchCase: 1 }],
+        "indent": ["warn", 4, { SwitchCase: 1 }],
         "semi": "warn",
         "no-extra-semi": "warn",
         "semi-spacing": "warn",
@@ -79,7 +78,6 @@ module.exports = {
         "arrow-body-style": "warn",
         "multiline-ternary": ["warn", "always-multiline"],
         "max-len": ["warn", { code: 100 }],
-        "no-magic-numbers": ["warn", magicNumberOptions],
         "implicit-arrow-linebreak": "warn",
         "arrow-parens": ["warn", "as-needed"],
         "dot-location": ["warn", "property"],
@@ -114,6 +112,7 @@ module.exports = {
             "@typescript-eslint/no-use-before-define": "off",
             "@typescript-eslint/typedef": "off",
             "@typescript-eslint/prefer-readonly-parameter-types": "off",
+            "@typescript-eslint/no-magic-numbers": "off",
             // The rationale these two/three are based on is mostly out of date
             "@typescript-eslint/prefer-interface": "off",
             "@typescript-eslint/no-type-alias": "off",
@@ -122,7 +121,6 @@ module.exports = {
             // Make style issues warnings
             "react/jsx-curly-spacing": ["warn", { children: true }],
             "@typescript-eslint/no-extra-parens": ["warn", "all", { ignoreJSX: "all" }],
-            "@typescript-eslint/no-magic-numbers": ["warn", magicNumberOptions],
             "@typescript-eslint/no-unused-vars": ["warn", noUnusedVarsOptions],
             // This checks some more things than `no-unused-vars`,
             // but is less configurable.
@@ -143,7 +141,6 @@ module.exports = {
             "semi": "off",
             "no-unused-vars": "off",
             "no-extra-parens": "off",
-            "no-magic-numbers": "off",
         },
         settings: {
             react: {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -20,12 +20,17 @@ module.exports = (_env, argv) => ({
 
     module: {
         rules: [{
-            test: /\.(ts|js)x?$/u,
+            test: /\.[jt]sx?$/u,
             loader: "babel-loader",
-            ... argv.mode === "development" && { exclude: /node_modules/u },
+            include: [
+                APP_PATH,
+                ...argv.mode === "development"
+                    ? []
+                    : [path.join(__dirname, "node_modules")],
+            ],
         }, {
             test: /\.yaml$/u,
-            use: "yaml-loader",
+            loader: "yaml-loader",
             type: "json",
         }],
     },


### PR DESCRIPTION
- Adopt TS indentation style for `switch`-statements globally,
- revert to ESLint's default `rest-spread-spacing` options
  - and adapt the existing code accordingly,
- make `extra-parens` a warning since it's a stylistic issue,
- disable `no-mixed-operators`,
- simplify the regex used to match the files for `babel-loader`
- use `include` over `exclude` as per Webpack recommendations,
- use absolute paths over regexes in `include` as per the same,
- and use `use` vs. `loader` consistently.