### PR TITLE
Add `Id` type for opaque, globally-unique GraphQL node IDs

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "log",
  "paste",
  "static_assertions",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -787,6 +787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7ae1a2180ed02ddfdb5ab70c70d596a26dd642e097bb6fe78b1bde8588ed97"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1274,8 @@ dependencies = [
  "futures",
  "juniper",
  "log",
+ "paste",
+ "static_assertions",
 ]
 
 [[package]]

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -16,6 +16,8 @@ anyhow = "1"
 deadpool-postgres = { version = "0.5", default-features = false }
 futures = "0.3.1"
 log = "0.4"
+paste = "1"
+static_assertions = "1"
 
 # These currently use a specific commit from the git repository. The lastest
 # released version is still completely sync and based on old dependencies. To

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.1"
 log = "0.4"
 paste = "1"
 static_assertions = "1"
+tokio-postgres = "0.5"
 
 # These currently use a specific commit from the git repository. The lastest
 # released version is still completely sync and based on old dependencies. To

--- a/backend/api/src/id.rs
+++ b/backend/api/src/id.rs
@@ -1,0 +1,230 @@
+use std::convert::TryInto;
+
+
+/// An opaque, globally-unique identifier for all "nodes" that the GraphQL API
+/// might return.
+///
+/// While the ID should be treated as completely opaque by the frontend, of
+/// course there is some system in it that the backend can use. This is to make
+/// sure we can easily convert the ID to a database primary key.
+///
+/// Each key is encoded as 12 byte ASCII string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Id {
+    /// The kind of node. Each different "thing" in our API has a different
+    /// static prefix. For example, realms have the prefix `b"re"`. All IDs
+    /// referring to a realm starts with `re`.
+    kind: [u8; 2],
+
+    /// This uniquely refers to one object from the class of objects defined by
+    /// `kind`. This is typically exactly the primary bigint database key. This
+    /// data is encoded with base85 (well, our own flavor of it) to compactly
+    /// represent it in a JSON string.
+    key: Key,
+}
+
+/// The type of key we are using.
+pub type Key = u64;
+
+
+impl Id {
+    /// Creates a new ID. The `kind` must only consist of alphanumeric ASCII
+    /// characters.
+    pub fn new(kind: &'static [u8; 2], key: Key) -> Self {
+        assert!(kind.iter().all(|b| b.is_ascii_alphanumeric()));
+
+        Self {
+            kind: *kind,
+            key,
+        }
+    }
+
+    /// Returns the key of this id if the kind is equal to `expected_kind`. If
+    /// the kinds don't match, `None` is returned. This is not just a simple
+    /// getter as that would make it very easy to accidentally not check the
+    /// kind of an id.
+    pub(crate) fn key_for(&self, expected_kind: [u8; 2]) -> Option<Key> {
+        if self.kind == expected_kind {
+            Some(self.key)
+        } else {
+            None
+        }
+    }
+}
+
+#[juniper::graphql_scalar(
+    name = "ID",
+    description = "An opaque, globally-unique identifier",
+)]
+impl<S> GraphQLScalar for Id
+where
+    S: juniper::ScalarValue
+{
+    fn resolve(&self) -> juniper::Value {
+        let mut out = [0; 12];
+        out[0] = self.kind[0];
+        out[1] = self.kind[1];
+
+        out[2..7].copy_from_slice(&encode_base85((self.key >> 32) as u32));
+        out[7..12].copy_from_slice(&encode_base85(self.key as u32));
+
+        let s = std::str::from_utf8(&out)
+            .expect("bug: base85 did produce non ASCII character")
+            .to_owned();
+        juniper::Value::scalar(s)
+    }
+
+    fn from_input_value(value: &juniper::InputValue) -> Option<Self> {
+        let s = value.as_string_value()?;
+        if s.len() != 12 {
+            return None;
+        }
+
+        let s = s.as_bytes();
+        let kind = [s[0], s[1]];
+        let hi = decode_base85(s[2..7].try_into().unwrap())?;
+        let lo = decode_base85(s[7..12].try_into().unwrap())?;
+        let key = ((hi as u64) << 32) | lo as u64;
+
+        Some(Self { kind, key })
+    }
+
+    fn from_str<'a>(value: juniper::ScalarToken<'a>) -> juniper::ParseScalarResult<'a, S> {
+        <String as juniper::ParseScalarValue<S>>::from_str(value)
+    }
+}
+
+
+// ============================================================================
+// ===== Our base 85 encoding
+// ============================================================================
+
+/// Base 85 has no single formal definition and there are a few different
+/// implementations out there. They differ in how they do padding, how they
+/// chunk and in the alphabet. We use the alphabet suggested in RFC 1924 [1] as
+/// it can be represented in JSON without escaping. Note however that we don't
+/// use the same chunking as the mentioned RFC.
+///
+/// [1]: https://tools.ietf.org/html/rfc1924
+const BASE85_DIGITS: &[u8; 85] = b"\
+    0123456789\
+    ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+    abcdefghijklmnopqrstuvwxyz\
+    !#$%&()*+-;<=>?@^_`{|}~\
+";
+
+/// Encodes 4 bytes (one chunk) as base85, resulting in 5 ASCII bytes.
+fn encode_base85(v: u32) -> [u8; 5] {
+    // "Ascii 85" uses big endian encoding, but there is no official spec anyway
+    // and we do not need to stick to any rules. Our IDs do not interact with
+    // anything and are not supposed to be understood. We just need to be
+    // internally consistent. So we use little endian byte order. Let's be real,
+    // Tobira will only ever run on little endian machines. We still enforce a
+    // specific byte order here to be consistent across CPUs.
+    let mut v = v.to_le();
+
+    // Repeatedly divide by 85.
+    let mut out = [0u8; 5];
+    for i in (0..out.len()).rev() {
+        out[i] = BASE85_DIGITS[(v % 85) as usize];
+        v = v / 85;
+    }
+
+    out
+}
+
+/// Base 85 decodes one chunk of 5 ASCII bytes into the represented 4 bytes of
+/// data. Returns `None` if the the input contains invalid digits or encodes a
+/// number larger than `u32::MAX`.
+///
+/// This should return `Result` with useful error information once juniper can
+/// actually use that error information.
+fn decode_base85(s: [u8; 5]) -> Option<u32> {
+    /// The reverse lookup table to `BASE85_DIGITS`. If you index by an ASCII value, you
+    /// either get the corresponding digit value OR `0xFF`, signalling that the
+    /// character is not a valid base85 character.
+    const DECODE_TABLE: [u8; 256] = create_decode_table();
+
+    const fn create_decode_table() -> [u8; 256] {
+        let mut out = [0xFF; 256];
+
+        // If you wonder why we are using `while` instead of a more idiomatic loop:
+        // const fns are still somewhat limited and do not allow `for`.
+        let mut i = 0;
+        while i < BASE85_DIGITS.len() {
+            out[BASE85_DIGITS[i] as usize] = i as u8;
+            i += 1;
+        }
+
+        out
+    }
+
+    fn lookup(ascii: u8) -> Option<u64> {
+        let raw = DECODE_TABLE[ascii as usize];
+        if raw == 0xFF {
+            return None;
+        }
+
+        Some(raw as u64)
+    }
+
+    let v = lookup(s[4])?
+        + lookup(s[3])? * 85u64.pow(1)
+        + lookup(s[2])? * 85u64.pow(2)
+        + lookup(s[1])? * 85u64.pow(3)
+        + lookup(s[0])? * 85u64.pow(4);
+
+    let v: u32 = v.try_into().ok()?;
+
+    // See `encode_base85` regarding endianess.
+    Some(u32::from_le(v))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_base85, encode_base85, BASE85_DIGITS};
+
+    #[test]
+    fn simple() {
+        #[track_caller]
+        fn check(v: u32, s: [u8; 5]) {
+            assert_eq!(encode_base85(v), s);
+            assert_eq!(decode_base85(s), Some(v));
+        }
+
+        check(0, *b"00000");
+        check(83, *b"0000}");
+        check(84, *b"0000~");
+        check(85, *b"00010");
+        check(86, *b"00011");
+        check(u32::MAX - 1, *b"|NsB~");
+        check(u32::MAX, *b"|NsC0");
+    }
+
+    #[test]
+    fn invalid_decode() {
+        // Invalid characters
+        assert_eq!(decode_base85(*br"00\00"), None);
+        assert_eq!(decode_base85(*b"aa\0aa"), None);
+
+        // Encoded value > u32::MAX
+        assert_eq!(decode_base85(*b"|NsC1"), None);
+        assert_eq!(decode_base85(*b"~~~~~"), None);
+    }
+
+    #[test]
+    fn always_ascii() {
+        // We don't want to test all 4 billion possible u32 values, but by
+        // checking all two bytes patterns (and testing them in different shift
+        // positions), we should have good coverage. We just want to make sure
+        // we don't emit strange or non-ASCII characters.
+        for n in 0..=u16::MAX {
+            for &shift in &[0, 8, 16] {
+                let encoded = encode_base85((n as u32) << shift);
+                assert!(encoded.iter().all(|b| BASE85_DIGITS.contains(b)));
+                assert!(encoded.is_ascii());
+            }
+        }
+    }
+}

--- a/backend/api/src/id.rs
+++ b/backend/api/src/id.rs
@@ -10,7 +10,7 @@ use std::convert::TryInto;
 ///
 /// Each key is encoded as 12 byte ASCII string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Id {
+pub(crate) struct Id {
     /// The kind of node. Each different "thing" in our API has a different
     /// static prefix. For example, realms have the prefix `b"re"`. All IDs
     /// referring to a realm starts with `re`.
@@ -24,13 +24,13 @@ pub struct Id {
 }
 
 /// The type of key we are using.
-pub type Key = u64;
+pub(crate) type Key = u64;
 
 
 impl Id {
     /// Creates a new ID. The `kind` must only consist of alphanumeric ASCII
     /// characters.
-    pub fn new(kind: &'static [u8; 2], key: Key) -> Self {
+    pub(crate) fn new(kind: &'static [u8; 2], key: Key) -> Self {
         assert!(kind.iter().all(|b| b.is_ascii_alphanumeric()));
 
         Self {

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -14,6 +14,7 @@ pub mod subscription;
 
 mod realms;
 mod id;
+mod util;
 
 pub(crate) use id::{Id, Key};
 

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -13,6 +13,9 @@ pub mod query;
 pub mod subscription;
 
 pub mod realms;
+mod id;
+
+pub use id::Id;
 
 
 /// Creates and returns the API root node.

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -12,10 +12,10 @@ pub mod mutation;
 pub mod query;
 pub mod subscription;
 
-pub mod realms;
+mod realms;
 mod id;
 
-pub use id::{Id, Key};
+pub(crate) use id::{Id, Key};
 
 
 /// Creates and returns the API root node.

--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -15,7 +15,7 @@ pub mod subscription;
 pub mod realms;
 mod id;
 
-pub use id::Id;
+pub use id::{Id, Key};
 
 
 /// Creates and returns the API root node.

--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -2,7 +2,7 @@ use juniper::graphql_object;
 
 use crate::{
     Context, Id,
-    realms::{self, Realm}
+    realms::Realm,
 };
 
 
@@ -15,16 +15,19 @@ impl Query {
         "0.0"
     }
 
+    /// Returns a flat list of all realms.
     async fn realms(context: &Context) -> Vec<&Realm> {
         context.realm_tree.realms.values().collect()
     }
 
-    #[graphql(
-        arguments(
-            id(default = Id::new(realms::KIND_PREFIX, 0))
-        )
-    )]
+    /// Returns the realm with the specific ID or `None` if the ID does not
+    /// refer to a realm.
     async fn realm(id: Id, context: &Context) -> Option<&Realm> {
         context.realm_tree.get_node(&id)
+    }
+
+    /// Returns the root realm.
+    async fn root_realm(context: &Context) -> &Realm {
+        context.realm_tree.root()
     }
 }

--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -1,6 +1,10 @@
 use juniper::graphql_object;
 
-use super::{Context, realms::{self, Realm}};
+use crate::{
+    Context, Id,
+    realms::{self, Realm}
+};
+
 
 /// The root query object.
 pub struct Query;
@@ -17,10 +21,10 @@ impl Query {
 
     #[graphql(
         arguments(
-            id(default = 0)
+            id(default = Id::new(realms::KIND_PREFIX, 0))
         )
     )]
-    async fn realm(id: realms::Id, context: &Context) -> Option<&Realm> {
+    async fn realm(id: Id, context: &Context) -> Option<&Realm> {
         context.realm_tree.get_node(&id)
     }
 }

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -6,8 +6,6 @@ use std::collections::HashMap;
 use crate::{Context, Id, Key};
 
 
-pub(crate) const KIND_PREFIX: &[u8; 2] = b"re";
-
 pub(crate) struct Realm {
     key: Key,
     name: String,
@@ -17,7 +15,7 @@ pub(crate) struct Realm {
 #[graphql_object(Context = Context)]
 impl Realm {
     fn id(&self) -> Id {
-        Id::new(KIND_PREFIX, self.key)
+        Id::realm(self.key)
     }
 
     fn name(&self) -> &str {
@@ -25,7 +23,7 @@ impl Realm {
     }
 
     fn parent_id(&self) -> Id {
-        Id::new(KIND_PREFIX, self.parent_key)
+        Id::realm(self.parent_key)
     }
 
     fn parent(&self, context: &Context) -> &Realm {
@@ -87,7 +85,7 @@ impl Tree {
     }
 
     pub(crate) fn get_node(&self, id: &Id) -> Option<&Realm> {
-        self.realms.get(&id.key_for(*KIND_PREFIX)?)
+        self.realms.get(&id.key_for(Id::REALM_KIND)?)
     }
 
     pub(crate) fn root(&self) -> &Realm {

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 use crate::{Context, Id, Key};
 
 
-pub const KIND_PREFIX: &[u8; 2] = b"re";
+pub(crate) const KIND_PREFIX: &[u8; 2] = b"re";
 
-pub(super) struct Realm {
+pub(crate) struct Realm {
     key: Key,
     name: String,
     parent_key: Key,
@@ -43,13 +43,13 @@ impl Realm {
     }
 }
 
-pub(super) struct Tree {
-    pub(super) realms: HashMap<u64, Realm>,
+pub(crate) struct Tree {
+    pub(crate) realms: HashMap<u64, Realm>,
     children: HashMap<u64, Vec<u64>>,
 }
 
 impl Tree {
-    pub(super) async fn raw_from_db(
+    pub(crate) async fn raw_from_db(
         db: &Pool,
     ) -> anyhow::Result<impl TryStream<Ok = Realm, Error = impl std::error::Error>> {
         let row_stream = db.get().await?
@@ -65,7 +65,7 @@ impl Tree {
         }))
     }
 
-    pub(super) async fn from_db(db: &Pool) -> anyhow::Result<Self> {
+    pub(crate) async fn from_db(db: &Pool) -> anyhow::Result<Self> {
         // We store the nodes of the realm tree in a hash map
         // accessible by the database ID
         let realms = Self::raw_from_db(db).await?
@@ -86,11 +86,11 @@ impl Tree {
         Ok(Tree { realms, children })
     }
 
-    pub(super) fn get_node(&self, id: &Id) -> Option<&Realm> {
+    pub(crate) fn get_node(&self, id: &Id) -> Option<&Realm> {
         self.realms.get(&id.key_for(*KIND_PREFIX)?)
     }
 
-    pub(super) fn root(&self) -> &Realm {
+    pub(crate) fn root(&self) -> &Realm {
         self.realms.get(&0).expect("bug: no root realm")
     }
 }

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -3,7 +3,10 @@ use futures::{stream::TryStreamExt, TryStream};
 use juniper::graphql_object;
 use std::collections::HashMap;
 
-use crate::{Context, Id, Key};
+use crate::{
+    Context, Id, Key,
+    util::RowExt,
+};
 
 
 pub(crate) struct Realm {
@@ -57,9 +60,9 @@ impl Tree {
             ).await?;
 
         Ok(row_stream.map_ok(|row| Realm {
-            key: row.get::<_, i64>(0) as u64,
+            key: row.get_key(0),
             name: row.get(1),
-            parent_key: row.get::<_, i64>(2) as u64,
+            parent_key: row.get_key(2),
         }))
     }
 

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -89,4 +89,8 @@ impl Tree {
     pub(super) fn get_node(&self, id: &Id) -> Option<&Realm> {
         self.realms.get(&id.key_for(*KIND_PREFIX)?)
     }
+
+    pub(super) fn root(&self) -> &Realm {
+        self.realms.get(&0).expect("bug: no root realm")
+    }
 }

--- a/backend/api/src/util.rs
+++ b/backend/api/src/util.rs
@@ -1,0 +1,24 @@
+use tokio_postgres::Row;
+
+use crate::Key;
+
+
+/// Extension trait to add some useful methods to the `Row` type.
+pub(crate) trait RowExt {
+    /// Retrieves a `bigint` value at the given index as `u64` from the row.
+    fn get_key(&self, index: usize) -> Key;
+}
+
+impl RowExt for Row {
+    fn get_key(&self, index: usize) -> Key {
+        // This is fine for two reasons:
+        // - Our keys are auto-incremented and once the signed int max value is
+        //   reached, inserting more rows results in errors. So we only stored
+        //   positive integers. Positive integers have the same bit pattern in
+        //   `u64` and `i64`.
+        // - Even if negative values would be inside the database, as none of
+        //   those negative values is special cased, we can easily cast. The
+        //   cast is just a reinterpret cast and cannot fail.
+        self.get::<_, i64>(index) as u64
+    }
+}

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -5,8 +5,15 @@
 
 type Query {
   apiVersion: String!
+  "Returns a flat list of all realms."
   realms: [Realm!]!
-  realm(id: ID = "re0000000000"): Realm
+  """
+    Returns the realm with the specific ID or `None` if the ID does not
+    refer to a realm.
+  """
+  realm(id: ID!): Realm
+  "Returns the root realm."
+  rootRealm: Realm!
 }
 
 type Realm {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -6,13 +6,13 @@
 type Query {
   apiVersion: String!
   realms: [Realm!]!
-  realm(id: Int = 0): Realm
+  realm(id: ID = "re0000000000"): Realm
 }
 
 type Realm {
-  id: Int!
+  id: ID!
   name: String!
-  parentId: Int!
+  parentId: ID!
   parent: Realm!
   children: [Realm!]!
 }

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,6 +1,6 @@
 create table realms (
-    id int generated always as identity (start with 0 minvalue 0) primary key,
-    parent int not null references realms on delete restrict,
+    id bigint generated always as identity (start with 0 minvalue 0) primary key,
+    parent bigint not null references realms on delete restrict,
     name text not null
 );
 -- To truncate this and restart the primary key counter:


### PR DESCRIPTION
Relay requires globally unique IDs and a way to refetch any data via those IDs (usually a `node` endpoint). This PR implements the first part of that requirement. 