### PR TITLE
Update Default Database Password

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,8 +39,8 @@ The backend loads configuration from `config.toml` in the current working direct
 user = "tobira"
 
 # Database password
-# Default: tobira-dev-db-pw
-password = "tobira-dev-db-pw"
+# Default: tobira
+password = "tobira"
 
 # Database host
 # Default: 127.0.0.1

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -127,7 +127,7 @@ pub struct Db {
 
 impl Db {
     const DEFAULT_USER: &'static str = "tobira";
-    const DEFAULT_PASSWORD: &'static str = "tobira-dev-db-pw";
+    const DEFAULT_PASSWORD: &'static str = "tobira";
     const DEFAULT_HOST: &'static str = "localhost";
     const DEFAULT_PORT: u16 = 5432;
     const DEFAULT_DATABASE: &'static str = "tobira";

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - tobira-dev-postgres:/var/lib/postgresql/data
     environment:
-      - POSTGRES_PASSWORD=tobira-dev-db-pw
+      - POSTGRES_PASSWORD=tobira
       - POSTGRES_USER=tobira
       - POSTGRES_DB=tobira
 


### PR DESCRIPTION
This patch changes the default database password from `tobira-dev-db-pw`
to just `tobira` since the former is somewhat annoying to type and
remember. I'm apparently getting old ;-)

This is based on pull request #70 .