### PR TITLE
Properly handle panics in HTTP handlers

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1252,6 +1252,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "deadpool-postgres",
+ "futures",
  "hyper",
  "juniper_hyper",
  "log",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -16,6 +16,7 @@ default-run = "tobira"
 [dependencies]
 anyhow = "1"
 deadpool-postgres = { version = "0.5", default-features = false }
+futures = "0.3"
 hyper = "0.13"
 log = "0.4"
 mime_guess = "2"

--- a/backend/server/src/http.rs
+++ b/backend/server/src/http.rs
@@ -226,10 +226,22 @@ async fn serve_index() -> Response {
 
 /// Replies with a 404 Not Found.
 async fn reply_404(method: &Method, path: &str) -> Response {
-    // TODO: have a simple and user calming body.
-
     debug!("Responding with 404 to {:?} {}", method, path);
-    let mut response = Response::new(Body::empty());
-    *response.status_mut() = StatusCode::NOT_FOUND;
-    response
+
+    // We simply send the normal index and let the frontend router determinate
+    // this is a 404. That way, our 404 page looks like the main page and users
+    // are not confused. And it's easier to return to the normal page.
+    //
+    // TODO: I am somewhat uneasy about this code assuming the router of the
+    // frontend is the same as the backend router. Maybe we want to indicate to
+    // the frontend explicitly to show a 404 page? However, without redirecting
+    // to like `/404` because that's annoying for users.
+    let html = Assets::get(INDEX_FILE).unwrap();
+    let body = Body::from(html);
+
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .header("Content-Type", "text/html; charset=UTF-8")
+        .body(body)
+        .unwrap()
 }

--- a/backend/server/src/http.rs
+++ b/backend/server/src/http.rs
@@ -1,6 +1,6 @@
 //! The HTTP server, handler and routes.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use futures::FutureExt;
 use hyper::{
     Body, Method, Server, StatusCode,
@@ -29,7 +29,6 @@ pub async fn serve(
     api_root: api::RootNode,
     api_context: api::Context,
 ) -> Result<()> {
-    Assets::startup_check()?;
     let ctx = Arc::new(Context::new(api_root, api_context));
 
     // This sets up all the hyper server stuff. It's a bit of magic and touching
@@ -184,18 +183,6 @@ struct Assets;
 const INDEX_FILE: &str = "index.html";
 
 impl Assets {
-    fn startup_check() -> Result<()> {
-        if Self::get(INDEX_FILE).is_none() {
-            bail!("'index.html' is missing from the assets");
-        }
-
-        // TODO:
-        // - somehow check that we didn't embed stuff we don't want
-        // - check that all things we want are here?
-
-        Ok(())
-    }
-
     /// Responds with the asset identified by the given path. If there exists no
     /// asset with `path` or `path` is `INDEX_FILE`, `None` is returned.
     async fn serve(path: &str) -> Option<Response> {

--- a/backend/server/src/http.rs
+++ b/backend/server/src/http.rs
@@ -141,9 +141,9 @@ async fn handle(req: Request<Body>, ctx: Arc<Context>) -> Result<Response, hyper
     let response = match (method, path) {
         (&Method::GET, "/") => serve_index().await,
 
-        // The interactive GraphQL API explorer/IDE.
-        //
-        // TODO: do we want to remove this route in production?
+        // The interactive GraphQL API explorer/IDE. We actually keep this in
+        // production as it does not hurt and in particular: does not expose any
+        // information that isn't already exposed by the API itself.
         (&Method::GET, "/graphiql") => juniper_hyper::graphiql("/graphql", None).await?,
 
         // The actual GraphQL API.

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use log::{info, trace};
+use std::env;
 
 pub(crate) use tobira_api as api;
 mod config;
@@ -11,10 +12,20 @@ mod http;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // If `RUST_BACKTRACE` wasn't already set, we default to `1`. Backtraces are
+    // almost always useful for debugging. Generating a backtrace is somewhat
+    // costly, which is why it is disabled by default. However, we don't expect
+    // panics to occur regularly, so it shouldn't be a problem. Only
+    // consideration: maaaybe this is a way to DOS tobira? If someone finds a
+    // request that triggers a panic?
+    if env::var("RUST_BACKTRACE") == Err(env::VarError::NotPresent) {
+        env::set_var("RUST_BACKTRACE", "1");
+    }
+
     // If no logging level was specified, we default to "debug", but just for
     // our own code.
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "tobira=debug");
+    if env::var("RUST_LOG") == Err(env::VarError::NotPresent) {
+        env::set_var("RUST_LOG", "tobira=debug");
     }
     pretty_env_logger::init();
 

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -136,6 +136,7 @@ module.exports = {
             "react/jsx-curly-spacing": ["warn", { children: true }],
             "@typescript-eslint/no-extra-parens": ["warn", "all", { ignoreJSX: "all" }],
             "@typescript-eslint/no-unused-vars": ["warn", noUnusedVarsOptions],
+            "@typescript-eslint/comma-spacing": "warn",
             // This checks some more things than `no-unused-vars`,
             // but is less configurable.
             // Note that this is basically like setting `noUnusedLocals` and `noUnusedParameters`

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -2,3 +2,6 @@ language-name: Deutsch
 language: Sprache
 search: Suche
 home: Startseite
+page-not-found:
+  title: Seite nicht gefunden
+  body: Die angefragte Resource existiert nicht. Sorry! :-(

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -2,3 +2,6 @@ language-name: English
 language: Language
 search: Search
 home: Home
+page-not-found:
+  title: Page not found
+  body: The requested resource does not exist. Sorry! :-(

--- a/frontend/src/page/NotFound.tsx
+++ b/frontend/src/page/NotFound.tsx
@@ -1,7 +1,16 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 
-export const NotFound: React.FC = () => <>
-    <h1>404 Page not found</h1>
-    <p>No idea how you got here, but there is nothing here :(</p>
-</>;
+export const NotFound: React.FC = () => {
+    const { t } = useTranslation();
+
+    // TODO: we could add some hints what might went wrong or how to resolve the
+    // problem.
+    return (
+        <div css={{ margin: "0 auto", maxWidth: 600 }}>
+            <h1>{t("page-not-found.title")}</h1>
+            <p css={{ margin: "16px 0" }}>{t("page-not-found.body")}</p>
+        </div>
+    );
+};


### PR DESCRIPTION
Closes #68 
Closes #49

Still TODO before this PR is ready:

- [x] Discuss error handling in general: logging, monitoring, ... (next Thursday)
- [x] I still have to check what returning `Err` in various places does

With this PR, the following happens in case of error:

- Panic in HTTP handler functions: is caught and 500 is returned
- Panic in API handler: bubbles up through `juniper` and is handled like the panic in the previous point.
- Error in HTTP handler (`hyper::Error`): these errors only occur if hyper could not parse an HTTP request or sth like that. They are handled by hyper internally, presumably in the idiomatic way (what do you even respond to an invalid HTTP request?)
- Error in API handler (`juniper::FieldError`): is handled according to the GraphQL specs. There will be an `errors` field in the result and the corresponding value is `null`. See [here](https://graphql-rust.github.io/juniper/master/types/objects/error_handling.html).

It's still unclear what we will do if something like a DB error happens during an API request. Not sure if that should be a GraphQL `errors` entry or 500 or... something else.

This PR still uses the default panic handler, but sets `RUST_BACKTRACE=1` by default. This means the panic message and the backtrace is printed to `stderr` on a panic. This should be picked up by `journalctl`. If we want to write to a log file (a separate PR), then we might need to adjust the panic handler.

