### PR TITLE
Enable debug symbols for release builds

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,6 +3,8 @@ members = ["api", "server"]
 
 [profile.release]
 debug = 1
+codegen-units = 1
+lto = true
 
 [profile.release.package."*"]
 debug = false

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,2 +1,8 @@
 [workspace]
 members = ["api", "server"]
+
+[profile.release]
+debug = 1
+
+[profile.release.package."*"]
+debug = false


### PR DESCRIPTION
See commit messages.

Closes #91 

I took a quick look at why the file size is still 18MB and noticed a lot of possible improvements. But as this is not really all that important, I will comment my findings #59 and ignore that for now :D 

For reference, the resulting binary consist of:

- ≈ 3MB `.text` (assembly, actual code)
- ≈ 2.7MB `.rodata`
  - ≈ 2.2MB of that is embedded frontend files (the largest of which is `bundle.js.map`)
- ≈ 10.5MB debug info
  - Curiously it seems that a lot more is included than just "file/line" information (which `debug = 1` should do, in theory). 