### PR TITLE
Improve configuration system

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1281,6 +1281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tobira-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +125,21 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -403,6 +427,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1165,6 +1198,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1260,6 +1332,7 @@ dependencies = [
  "pretty_env_logger",
  "rust-embed",
  "serde",
+ "structopt",
  "tobira-api",
  "tobira-macros",
  "tokio",
@@ -1433,6 +1506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1548,12 @@ name = "uuid"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
 name = "tobira-macros"
 version = "0.1.0"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "tobira-api",
+ "tobira-macros",
  "tokio",
  "tokio-postgres",
  "toml",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["api", "server"]
+members = ["api", "macros", "server"]
 
 [profile.release]
 debug = 1

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,15 +35,12 @@ The backend loads configuration from `config.toml` in the current working direct
 [db]
 
 # Database user
-# Default: tobira
 user = "tobira"
 
 # Database password
-# Default: tobira
 password = "tobira"
 
 # Database host
-# Default: 127.0.0.1
 host = "127.0.0.1"
 
 # Database port

--- a/backend/config.toml
+++ b/backend/config.toml
@@ -1,0 +1,7 @@
+# Configuration for dev environments: unless you are a Tobira developer, you are
+# not intersted in this file.
+
+[db]
+user = "tobira"
+password = "tobira"
+host = "127.0.0.1"

--- a/backend/macros/Cargo.toml
+++ b/backend/macros/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro = true
 syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+heck = "0.3.1"

--- a/backend/macros/Cargo.toml
+++ b/backend/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tobira-macros"
+version = "0.1.0"
+authors = ["Lukas Kalbertodt <kalbertodt@elan-ev.de>"]
+edition = "2018"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+# TODO: remove `extra-traits`
+syn = { version = "1.0", features = ["extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/backend/macros/src/config.rs
+++ b/backend/macros/src/config.rs
@@ -341,10 +341,9 @@ fn collect_tokens<T>(
 }
 
 fn to_camel_case(ident: &Ident) -> Ident {
-    let s = ident.to_string();
-    let first = s.chars().next().unwrap();
-    let out = format!("{}{}", first.to_uppercase(), &s[first.len_utf8()..]);
-    Ident::new(&out, ident.span())
+    use heck::CamelCase;
+
+    Ident::new(&ident.to_string().to_camel_case(), ident.span())
 }
 
 // ==============================================================================================

--- a/backend/macros/src/config.rs
+++ b/backend/macros/src/config.rs
@@ -1,0 +1,343 @@
+//! A proc macro to easily and concisely define the configuration for Tobira.
+//!
+//! I thought a lot about configuration and as far as I see it, a proc macro is
+//! basically required to avoid duplicate code, docs or values.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    Error,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    spanned::Spanned,
+};
+use std::fmt::{self, Write};
+
+
+/// Entry point: parses the input and generates output.
+pub(crate) fn run(input: TokenStream) -> Result<TokenStream, Error> {
+    let input = syn::parse2::<Input>(input)?;
+
+    let toml = gen_toml(&input);
+
+    Ok(quote! {
+        const TOML: &str = #toml;
+    })
+}
+
+
+// ==============================================================================================
+// ===== Generating the output
+// ==============================================================================================
+
+/// Generates the TOML template file.
+fn gen_toml(input: &Input) -> String {
+    let mut out = String::new();
+
+    /// Writes all doc comments to the file.
+    fn write_doc(out: &mut String, doc: &[String]) {
+        for line in doc {
+            writeln!(out, "#{}", line).unwrap();
+        }
+    }
+
+    /// Adds zero, one or two line breaks to make sure that there are at least
+    /// two line breaks at the end of the string.
+    fn add_empty_line(out: &mut String) {
+        match () {
+            () if out.ends_with("\n\n") => {},
+            () if out.ends_with('\n') => out.push('\n'),
+            _ => out.push_str("\n\n"),
+        }
+    }
+
+    fn gen_recursive(out: &mut String, path: Vec<&syn::Ident>, fields: &[Node]) {
+        // If a new subsection starts, we always print the header, even if not
+        // strictly necessary.
+        if !path.is_empty() {
+            let joined_path = path.iter()
+                .map(|ident| ident.to_string())
+                .collect::<Vec<_>>()
+                .join(".");
+            writeln!(out, "[{}]", joined_path).unwrap();
+        }
+
+        // First just emit all leaf nodes/direct fields.
+        for node in fields {
+            if let Node::Leaf { doc, name, ty, default, example } = node {
+                write_doc(out, doc);
+
+                // Add note about default value or the value being required.
+                match default {
+                    Some(default) => {
+                        if !doc.is_empty() {
+                            writeln!(out, "#").unwrap();
+                        }
+                        writeln!(out, "# Default: {}", default).unwrap();
+                    }
+                    None if as_option(ty).is_some() => {}
+                    None => {
+                        if !doc.is_empty() {
+                            writeln!(out, "#").unwrap();
+                        }
+                        writeln!(out, "# Required: this value must be specified!").unwrap();
+                    }
+                }
+
+                // We check that already when parsing.
+                let example = example.as_ref()
+                    .or(default.as_ref())
+                    .expect("neither example nor default");
+
+                // Commented out example.
+                writeln!(out, "#{} = {}", name, example).unwrap();
+                add_empty_line(out);
+            }
+        }
+        add_empty_line(out);
+
+        // Recurse on all children.
+        for node in fields {
+            if let Node::Object { doc, name, children } = node {
+                write_doc(out, doc);
+                let mut child_path = path.clone();
+                child_path.push(name);
+                gen_recursive(out, child_path, children);
+            }
+        }
+    };
+
+    write_doc(&mut out, &input.doc);
+    add_empty_line(&mut out);
+    gen_recursive(&mut out, vec![], &input.fields);
+
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+
+    out
+}
+
+
+// ==============================================================================================
+// ===== Parsing the input
+// ==============================================================================================
+
+/// The parsed input to the `gen_config` macro.
+#[derive(Debug)]
+struct Input {
+    doc: Vec<String>,
+    fields: Vec<Node>,
+}
+
+/// One node in the tree of the configuration format. Can either be a leaf node
+/// (a string, int, float or bool value) or an internal node that contains
+/// children.
+#[derive(Debug)]
+enum Node {
+    Object {
+        doc: Vec<String>,
+        name: syn::Ident,
+        children: Vec<Node>,
+    },
+    Leaf {
+        doc: Vec<String>,
+        name: syn::Ident,
+        ty: syn::Type,
+        default: Option<Expr>,
+        example: Option<Expr>,
+    },
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let mut outer_attrs = input.call(syn::Attribute::parse_inner)?;
+        let doc = extract_doc(&mut outer_attrs)?;
+        let fields = input.call(<Punctuated<_, syn::Token![,]>>::parse_terminated)?;
+        assert_no_extra_attrs(&outer_attrs)?;
+
+        Ok(Self {
+            doc,
+            fields: fields.into_iter().collect(),
+        })
+    }
+}
+
+impl Parse for Node {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let mut attrs = input.call(syn::Attribute::parse_outer)?;
+        let doc = extract_doc(&mut attrs)?;
+
+        // All nodes start with an identifier and a colon.
+        let name = input.parse()?;
+        let _: syn::Token![:] = input.parse()?;
+
+        let out = if input.lookahead1().peek(syn::token::Brace) {
+            // --- A nested object ---
+
+            let inner;
+            syn::braced!(inner in input);
+            let fields = inner.call(<Punctuated<_, syn::Token![,]>>::parse_terminated)?;
+
+            Self::Object {
+                doc,
+                name,
+                children: fields.into_iter().collect(),
+            }
+        } else {
+            // --- A single value ---
+
+            // Type is mandatory.
+            let ty = input.parse()?;
+
+            // Optional default value.
+            let default = if input.lookahead1().peek(syn::Token![=]) {
+                let _: syn::Token![=] = input.parse()?;
+                Some(input.parse()?)
+            } else {
+                None
+            };
+
+            // Optional example value.
+            let example = attrs.iter()
+                .position(|attr| attr.path.is_ident("example"))
+                .map(|i| {
+                    let attr = attrs.remove(i);
+                    parse_attr_value::<Expr>(attr.tokens)
+                })
+                .transpose()?;
+
+            if example.is_none() && default.is_none() {
+                let msg = "either a default value or an example value has to be specified";
+                return Err(Error::new(name.span(), msg));
+            }
+
+            Self::Leaf { doc, name, ty, default, example }
+        };
+
+        assert_no_extra_attrs(&attrs)?;
+
+        Ok(out)
+    }
+}
+
+/// The kinds of expressions (just literals) we allow for default or example
+/// values.
+#[derive(Debug)]
+enum Expr {
+    Str(syn::LitStr),
+    Int(syn::LitInt),
+    Float(syn::LitFloat),
+    Bool(syn::LitBool),
+}
+
+impl Parse for Expr {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let lit = input.parse::<syn::Lit>()?;
+        let out = match lit {
+            syn::Lit::Str(l) => Self::Str(l),
+            syn::Lit::Int(l) => Self::Int(l),
+            syn::Lit::Float(l) => Self::Float(l),
+            syn::Lit::Bool(l) => Self::Bool(l),
+
+            _ => {
+                let msg = "only string, integer, float and bool literals are allowed here";
+                return Err(Error::new(lit.span(), msg));
+            }
+        };
+
+        Ok(out)
+    }
+}
+
+// This `Display` impl is for writing into a TOML file.
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            // TODO: not sure if `escape_debug` is really what we want here, but
+            // it's working for now.
+            Self::Str(lit) => write!(f, "\"{}\"", lit.value().escape_debug()),
+            Self::Int(lit) => lit.fmt(f),
+            Self::Float(lit) => lit.fmt(f),
+            Self::Bool(lit) => lit.value.fmt(f),
+        }
+    }
+}
+
+/// Makes sure that the given list is empty or returns an error otherwise.
+fn assert_no_extra_attrs(attrs: &[syn::Attribute]) -> Result<(), Error> {
+    if let Some(attr) = attrs.get(0) {
+        let msg = "unknown/unexpected/duplicate attribute in this position";
+        return Err(Error::new(attr.span(), msg));
+    }
+
+    Ok(())
+}
+
+/// Parses the tokenstream as a `T` preceeded by a `=`. This is useful for
+/// attributes of the form `#[foo = <T>]`.
+fn parse_attr_value<T: Parse>(tokens: TokenStream) -> Result<T, Error> {
+    use syn::parse::Parser;
+
+    fn parser<T: Parse>(input: ParseStream) -> Result<T, Error> {
+        let _: syn::Token![=] = input.parse()?;
+        input.parse()
+    }
+
+    parser.parse2(tokens)
+}
+
+/// Extract all doc attributes from the list and return them as simple strings.
+fn extract_doc(attrs: &mut Vec<syn::Attribute>) -> Result<Vec<String>, Error> {
+    let out = attrs.iter()
+        .filter(|attr| attr.path.is_ident("doc"))
+        .map(|attr| parse_attr_value::<syn::LitStr>(attr.tokens.clone()).map(|lit| lit.value()))
+        .collect::<Result<_, _>>()?;
+
+    // I know this is algorithmically not optimal, but `drain_filter` is still
+    // unstable and I can't be bothered to write the proper algorithm right now.
+    attrs.retain(|attr| !attr.path.is_ident("doc"));
+
+    Ok(out)
+}
+
+/// Checks if the given type is an `Option` and if so, return the inner type.
+///
+/// Note: this function clearly shows one of the major shortcomings of proc
+/// macros right now: we do not have access to the compiler's type tables and
+/// can only check if it "looks" like an `Option`. Of course, stuff can go
+/// wrong. But that's the best we can do and it's highly unlikely that someone
+/// shadows `Option`.
+fn as_option(ty: &syn::Type) -> Option<&syn::Type> {
+    let ty = match ty {
+        syn::Type::Path(path) => path,
+        _ => return None,
+    };
+
+    if ty.qself.is_some() || ty.path.leading_colon.is_some() {
+        return None;
+    }
+
+    let valid_paths = [
+        &["Option"] as &[_],
+        &["std", "option", "Option"],
+        &["core", "option", "Option"],
+    ];
+    if !valid_paths.iter().any(|vp| ty.path.segments.iter().map(|s| &s.ident).eq(*vp)) {
+        return None;
+    }
+
+    let args = match &ty.path.segments.last().unwrap().arguments {
+        syn::PathArguments::AngleBracketed(args) => args,
+        _ => return None,
+    };
+
+    if args.args.len() != 1 {
+        return None;
+    }
+
+    match &args.args[0] {
+        syn::GenericArgument::Type(t) => Some(t),
+        _ => None,
+    }
+}

--- a/backend/macros/src/lib.rs
+++ b/backend/macros/src/lib.rs
@@ -1,0 +1,14 @@
+use proc_macro::TokenStream as TokenStream1;
+
+
+mod config;
+
+
+/// Defines a configuration in a special syntax. TODO: explain what this
+/// generates.
+#[proc_macro]
+pub fn gen_config(input: TokenStream1) -> TokenStream1 {
+    config::run(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -24,6 +24,7 @@ pretty_env_logger = "0.4"
 rust-embed = "5.5"
 serde = { version = "1", features = ["derive"] }
 tobira-api = { path = "../api" }
+tobira-macros = { path = "../macros" }
 tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 tokio-postgres = "0.5"
 toml = "0.5"

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -23,6 +23,7 @@ mime_guess = "2"
 pretty_env_logger = "0.4"
 rust-embed = "5.5"
 serde = { version = "1", features = ["derive"] }
+structopt = "0.3"
 tobira-api = { path = "../api" }
 tobira-macros = { path = "../macros" }
 tokio = { version = "0.2", features = ["rt-threaded", "macros"] }

--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(
     about = "Video portal for Opencast.",
+    after_help = "When run without subcommand, the Tobira backend server is started.",
     setting(structopt::clap::AppSettings::VersionlessSubcommands),
 )]
 pub(crate) struct Args {

--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -14,4 +14,17 @@ pub(crate) struct Args {
     /// try opening `config.toml` or `/etc/tobira/config.toml`.
     #[structopt(short, long)]
     pub(crate) config: Option<PathBuf>,
+
+    #[structopt(subcommand)]
+    pub(crate) cmd: Option<Command>,
+}
+
+#[derive(Debug, StructOpt)]
+pub(crate) enum Command {
+    /// Outputs a template for the configuration file (which includes
+    /// descriptions or all options).
+    WriteConfig {
+        /// Target file. If not specified, the template is written to stdout.
+        target: Option<PathBuf>,
+    }
 }

--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -1,0 +1,17 @@
+//! This module defines the command line arguments Tobira accepts.
+
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    about = "Video portal for Opencast.",
+    setting(structopt::clap::AppSettings::VersionlessSubcommands),
+)]
+pub(crate) struct Args {
+    /// Path to the configuration file. If this is not specified, Tobira will
+    /// try opening `config.toml` or `/etc/tobira/config.toml`.
+    #[structopt(short, long)]
+    pub(crate) config: Option<PathBuf>,
+}

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -3,8 +3,9 @@ use log::{debug, info};
 use std::{
     convert::TryInto,
     fs,
+    io::{self, Write},
     net::IpAddr,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 
@@ -88,4 +89,20 @@ impl Config {
 
         Ok(())
     }
+}
+
+/// Writes the generated TOML config template file to the given destination or
+/// stdout.
+pub(crate) fn write_template(path: Option<&PathBuf>) -> Result<()> {
+    info!(
+        "Writing configuration template to '{}'",
+        path.map(|p| p.display().to_string()).unwrap_or("<stdout>".into()),
+    );
+
+    match path {
+        Some(path) => fs::write(path, TOML_TEMPLATE)?,
+        None => io::stdout().write_all(TOML_TEMPLATE.as_bytes())?,
+    }
+
+    Ok(())
 }

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -11,10 +11,12 @@ use std::{
 /// Configuration root.
 ///
 /// This is automatically deserialized from a TOML file.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(default)]
     pub http: Http,
+
     pub db: Db,
 }
 
@@ -29,16 +31,10 @@ impl Config {
         if let Some(path) = default_locations.iter().map(Path::new).find(|p| p.exists()) {
             Self::load_from(path)
         } else {
-            if cfg!(debug_assertions) {
-                Ok(Self::default())
-            } else {
-                bail!(
-                    "no configuration file found (note: this is a production build and \
-                        thus, a configuration file is required). Hint: we checked the \
-                        following paths: {}",
-                    default_locations.join(", "),
-                );
-            }
+            bail!(
+                "no configuration file found. Hint: we checked the following paths: {}",
+                default_locations.join(", "),
+            );
         }
     }
 
@@ -61,34 +57,6 @@ impl Config {
     /// conflicting values.
     fn validate(&self) -> Result<()> {
         debug!("Validating configuration...");
-
-        macro_rules! assert_is_specified {
-            ($($section:ident . $field:ident),* $(,)?) => {
-                $(
-                    if self.$section.$field.is_none() {
-                        bail!(
-                            "configuration file does not contain value for '{0}.{1}', \
-                                but it is required (note: this is a production build; \
-                                '{0}.{1}' has a default value, but only in non-production builds)",
-                            stringify!($section),
-                            stringify!($field),
-                        );
-                    }
-                )*
-            };
-        }
-
-        // Some fields have a default value for development builds. But in the
-        // binaries we deploy, we "disable" those defaults to make sure all
-        // important values are manually configured. We return an error here, if
-        // any of the following fields is not specified.
-        if !cfg!(debug_assertions) {
-            assert_is_specified!(
-                db.user,
-                db.password,
-                db.host,
-            );
-        }
 
         Ok(())
     }
@@ -115,42 +83,25 @@ impl Default for Http {
     }
 }
 
+
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields, default)]
+#[serde(deny_unknown_fields)]
 pub struct Db {
-    user: Option<String>,
-    password: Option<String>,
-    host: Option<String>,
-    pub port: u16,
-    pub database: String,
+    pub user: String,
+    pub password: String,
+    pub host: String,
+    port: Option<u16>,
+    database: Option<String>,
 }
 
 impl Db {
-    const DEFAULT_USER: &'static str = "tobira";
-    const DEFAULT_PASSWORD: &'static str = "tobira";
-    const DEFAULT_HOST: &'static str = "localhost";
     const DEFAULT_PORT: u16 = 5432;
     const DEFAULT_DATABASE: &'static str = "tobira";
 
-    pub fn user(&self) -> &str {
-        self.user.as_deref().unwrap_or(Self::DEFAULT_USER)
+    pub fn port(&self) -> u16 {
+        self.port.unwrap_or(Self::DEFAULT_PORT)
     }
-    pub fn password(&self) -> &str {
-        self.password.as_deref().unwrap_or(Self::DEFAULT_PASSWORD)
-    }
-    pub fn host(&self) -> &str {
-        self.host.as_deref().unwrap_or(Self::DEFAULT_HOST)
-    }
-}
-
-impl Default for Db {
-    fn default() -> Self {
-        Self {
-            user: None,
-            password: None,
-            host: None,
-            port: Self::DEFAULT_PORT,
-            database: Self::DEFAULT_DATABASE.into(),
-        }
+    pub fn database(&self) -> &str {
+        self.database.as_deref().unwrap_or(Self::DEFAULT_DATABASE)
     }
 }

--- a/backend/server/src/db.rs
+++ b/backend/server/src/db.rs
@@ -11,11 +11,11 @@ use crate::config;
 /// Creates a new database connection pool.
 pub async fn create_pool(config: &config::Db) -> Result<Pool> {
     let pool_config = PoolConfig {
-        user: Some(config.user().into()),
-        password: Some(config.password().into()),
-        host: Some(config.host().into()),
-        port: Some(config.port),
-        dbname: Some(config.database.clone()),
+        user: Some(config.user.clone()),
+        password: Some(config.password.clone()),
+        host: Some(config.host.clone()),
+        port: Some(config.port()),
+        dbname: Some(config.database().into()),
         .. PoolConfig::default()
     };
 
@@ -23,10 +23,10 @@ pub async fn create_pool(config: &config::Db) -> Result<Pool> {
 
     debug!(
         "Connecting to postgresql://{}:*****@{}:{}/{}",
-        config.user(),
-        config.host(),
-        config.port,
-        config.database,
+        config.user,
+        config.host,
+        config.port(),
+        config.database(),
     );
 
     let pool = pool_config.create_pool(NoTls)?;

--- a/backend/server/src/db.rs
+++ b/backend/server/src/db.rs
@@ -2,31 +2,29 @@
 
 use anyhow::{bail, Context, Result};
 use deadpool_postgres::{Config as PoolConfig, Pool};
-use log::{debug, info, trace};
+use log::{debug, info};
 use tokio_postgres::NoTls;
 
 use crate::config;
 
 
 /// Creates a new database connection pool.
-pub async fn create_pool(config: &config::Db) -> Result<Pool> {
+pub(crate) async fn create_pool(config: &config::Db) -> Result<Pool> {
     let pool_config = PoolConfig {
         user: Some(config.user.clone()),
         password: Some(config.password.clone()),
         host: Some(config.host.clone()),
-        port: Some(config.port()),
-        dbname: Some(config.database().into()),
+        port: Some(config.port),
+        dbname: Some(config.database.clone()),
         .. PoolConfig::default()
     };
-
-    trace!("Database configuration: {:#?}", pool_config);
 
     debug!(
         "Connecting to postgresql://{}:*****@{}:{}/{}",
         config.user,
         config.host,
-        config.port(),
-        config.database(),
+        config.port,
+        config.database,
     );
 
     let pool = pool_config.create_pool(NoTls)?;

--- a/backend/server/src/http.rs
+++ b/backend/server/src/http.rs
@@ -24,7 +24,7 @@ type Request<T = Body> = hyper::Request<T>;
 
 /// Starts the HTTP server. The future returned by this function must be awaited
 /// to actually run it.
-pub async fn serve(
+pub(crate) async fn serve(
     config: &config::Http,
     api_root: api::RootNode,
     api_context: api::Context,

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,6 +1,6 @@
 //! The Tobira backend server.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use log::{info, trace};
 use std::env;
 use structopt::StructOpt;
@@ -43,7 +43,12 @@ async fn main() -> Result<()> {
 
     match args.cmd {
         None => start_server(&args).await?,
-        Some(Command::WriteConfig { target }) => config::write_template(target.as_ref())?,
+        Some(Command::WriteConfig { target }) => {
+            if args.config.is_some() {
+                bail!("`-c/--config` parameter is not valid for this subcommand");
+            }
+            config::write_template(target.as_ref())?
+        },
     }
 
     Ok(())

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -5,7 +5,7 @@ use log::{info, trace};
 use std::env;
 use structopt::StructOpt;
 use crate::{
-    args::Args,
+    args::{Args, Command},
     config::Config,
 };
 
@@ -41,6 +41,15 @@ async fn main() -> Result<()> {
     let args = Args::from_args();
     trace!("Command line arguments: {:#?}", args);
 
+    match args.cmd {
+        None => start_server(&args).await?,
+        Some(Command::WriteConfig { target }) => config::write_template(target.as_ref())?,
+    }
+
+    Ok(())
+}
+
+async fn start_server(args: &Args) -> Result<()> {
     // Load configuration
     let config = match &args.config {
         Some(path) => Config::load_from(path),

--- a/floof.yaml
+++ b/floof.yaml
@@ -18,6 +18,7 @@ backend:
           - Cargo.lock
           - api/
           - server/
+          - macros/
         run:
           - reload:
           - cargo run


### PR DESCRIPTION
Closes #24 
CC #76

I finally got around to fixing this part of the code and I am pretty happy with it now. Most development time went into writing a macro which generates the required structs (and other items) from a very short (as in: non-boilerplate code) definition of the configuration. This also means we now have the configuration definition with its description and default values in a single place. And with this system, we could easily read some configuration values from environment variables later if we so wish. 

This macro part... you can of course review but I'm not sure how useful that time is spent. Your call. In any case, I plan on extracting that logic into a separate public crate at some point because it is widely useful IMO. 

The more "user facing" features of this PR are:

- Remove `cfg(debug)` conditionals to provide some default values only for debug mode and instead add a `backend/config.toml` file intended for development. 
- Add `/etc/tobira/config.toml` as default search path
- Add ability to specify path to configuration file via command line
- Add `tobira config` subcommand which outputs the TOML config template to a file or stdout. This is also generated from the in-Rust config definition. 

You are probably best off reviewing each commit individually.  

**Still do decide**:

- Should the subcommand really be called `tobira config` or rather something more explicit like `tobira write-config-template` or sth like that?
- Should the subcommand overwrite the given file or error if the given path already exists?