### PR TITLE
Use realm API instead of dummy data

### DIFF
--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -22,8 +22,14 @@ impl Query {
 
     /// Returns the realm with the specific ID or `None` if the ID does not
     /// refer to a realm.
-    async fn realm(id: Id, context: &Context) -> Option<&Realm> {
+    async fn realm_by_id(id: Id, context: &Context) -> Option<&Realm> {
         context.realm_tree.get_node(&id)
+    }
+
+    /// Returns the realm with the specific path or `None` if the path does not
+    /// refer to a realm.
+    async fn realm_by_path(path: String, context: &Context) -> Option<&Realm> {
+        context.realm_tree.from_path(&path)
     }
 
     /// Returns the root realm.

--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -28,6 +28,13 @@ impl Query {
 
     /// Returns the realm with the specific path or `None` if the path does not
     /// refer to a realm.
+    ///
+    /// Every realm has its own "path segment", and the full path of a realm
+    /// is just the concatenation of all the path segments between the root realm
+    /// and the realm in question, delimited by `"/"`. The root realm is assumed
+    /// to have a path segment of `""`, and with the above rule so is its full
+    /// path. The path of every other realm will start with `"/"` delimiting the
+    /// root realm path segement from the second segment in the path.
     async fn realm_by_path(path: String, context: &Context) -> Option<&Realm> {
         context.realm_tree.from_path(&path)
     }

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -80,7 +80,7 @@ impl Tree {
     ) -> anyhow::Result<impl TryStream<Ok = Realm, Error = impl std::error::Error>> {
         let row_stream = db.get().await?
             .query_raw(
-                "select id, name, parent, path from realms",
+                "select id, name, parent, path_segment from realms",
                 std::iter::empty(),
             ).await?;
 

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -154,7 +154,7 @@ impl Tree {
     }
 
     pub(crate) fn root(&self) -> &Realm {
-        self.realms.get(&0).unwrap()
+        &self.realms[&0]
     }
 
     pub(crate) fn from_path(&self, path: &str) -> Option<&Realm> {

--- a/backend/api/src/realms.rs
+++ b/backend/api/src/realms.rs
@@ -68,8 +68,8 @@ impl Realm {
 }
 
 pub(crate) struct Tree {
-    pub(crate) realms: HashMap<u64, Realm>,
-    from_path: HashMap<String, u64>,
+    pub(crate) realms: HashMap<Key, Realm>,
+    from_path: HashMap<String, Key>,
 }
 
 impl Tree {
@@ -121,18 +121,18 @@ impl Tree {
         let from_path = index_by_path(&mut realms);
 
         fn index_by_path(
-            realms: &mut HashMap<u64, Realm>,
-        ) -> HashMap<String, u64> {
+            realms: &mut HashMap<Key, Realm>,
+        ) -> HashMap<String, Key> {
 
             let mut index = HashMap::new();
 
             fill_index_recursively(0, "", realms, &mut index);
 
             fn fill_index_recursively(
-                parent: u64,
+                parent: Key,
                 full_path: &str,
-                realms: &HashMap<u64, Realm>,
-                index: &mut HashMap<String, u64>,
+                realms: &HashMap<Key, Realm>,
+                index: &mut HashMap<String, Key>,
             ) {
                 index.insert(full_path.to_owned(), parent);
 

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -170,6 +170,7 @@ module.exports = {
     }],
     ignorePatterns: [
         "/build",
+        "/src/query-types",
         "!.*",
     ],
 };

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
             "named": "never",
             "asyncArrow": "always",
         }],
+        "no-shadow": "off",
         // `== null` is actually a useful check for `null` and `undefined` at the same time
         "no-eq-null": "off",
         "eqeqeq": ["error", "always", { null: "ignore" }],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { BrowserRouter as Router, Switch, Route, RouteComponentProps } from "react-router-dom";
 
+import { RelayEnvironmentProvider } from "react-relay/hooks";
+import { environment } from "./relay";
+
 import { GlobalStyle } from "./GlobalStyle";
 import { Root } from "./layout/Root";
 import { Realm } from "./page/Realm";
 import { NotFound } from "./page/NotFound";
 
-export const App: React.FC = () => <>
+export const App: React.FC = () => <RelayEnvironmentProvider {...{ environment }}>
     <GlobalStyle />
     <Router>
         <Root>
@@ -16,7 +19,7 @@ export const App: React.FC = () => <>
             </Switch>
         </Root>
     </Router>
-</>;
+</RelayEnvironmentProvider>;
 
 
 const RealmPage: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { BrowserRouter as Router, Switch, Route, RouteComponentProps } from "react-router-dom";
 
 import { RelayEnvironmentProvider } from "react-relay/hooks";
@@ -9,19 +9,23 @@ import { Root } from "./layout/Root";
 import { Realm } from "./page/Realm";
 import { NotFound } from "./page/NotFound";
 
-export const App: React.FC = () => <RelayEnvironmentProvider {...{ environment }}>
-    <GlobalStyle />
-    <Router>
-        <Root>
-            <Switch>
-                <Route exact path={["/", "/r/:path+"]} component={RealmPage} />
-                <Route exact path={["404", "*"]} component={NotFound} />
-            </Switch>
-        </Root>
-    </Router>
-</RelayEnvironmentProvider>;
+export const App: React.FC = () => (
+    <RelayEnvironmentProvider {...{ environment }}>
+        <GlobalStyle />
+        <Router>
+            <Root>
+                <Switch>
+                    <Route exact path={["/", "/r/:path+"]} component={RealmPage} />
+                    <Route exact path={["404", "*"]} component={NotFound} />
+                </Switch>
+            </Root>
+        </Router>
+    </RelayEnvironmentProvider>
+);
 
 
 const RealmPage: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
-    <Realm path={match.params.path?.split("/") ?? []} />
+    <Suspense fallback="Loading! (TODO)">
+        <Realm path={match.params.path ?? ""} />
+    </Suspense>
 );

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -13,7 +13,7 @@ export const Realm: React.FC<Props> = ({ path }) => {
     const ids = resolvePath(path);
     if (ids == null) {
         // TODO: that should obviously be handled in a better way
-        return <b>Realm path not found :(</b>;
+        return <b>{"Realm path not found :("}</b>;
     }
 
     const realmId = ids[ids.length - 1];

--- a/frontend/src/page/Realm.tsx
+++ b/frontend/src/page/Realm.tsx
@@ -36,13 +36,10 @@ export const Realm: React.FC<Props> = ({ path }) => {
     }
 
     // Prepare data for breadcrumbs
-    const breadcrumbs = [];
-    for (const { name, path } of realm.parents.slice(1)) {
-        breadcrumbs.push({
-            label: name,
-            href: `/r${path}`,
-        });
-    }
+    const breadcrumbs = realm.parents.slice(1).map(({ name, path }) => ({
+        label: name,
+        href: `/r${path}`,
+    }));
 
     return <>
         {!isRoot && <Breadcrumbs path={breadcrumbs} />}

--- a/frontend/src/relay.ts
+++ b/frontend/src/relay.ts
@@ -2,10 +2,11 @@ import { Environment, Store, RecordSource, Network } from "relay-runtime";
 
 export const environment = new Environment({
     store: new Store(new RecordSource()),
-    network: Network.create(({ text: query }, variables) =>
-        fetch("/graphql", {
+    network: Network.create(
+        ({ text: query }, variables) => fetch("/graphql", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ query, variables }),
-        }).then(response => response.json())),
+        }).then(response => response.json()),
+    ),
 });

--- a/frontend/src/relay.ts
+++ b/frontend/src/relay.ts
@@ -1,0 +1,11 @@
+import { Environment, Store, RecordSource, Network } from "relay-runtime";
+
+export const environment = new Environment({
+    store: new Store(new RecordSource()),
+    network: Network.create(({ text: query }, variables) =>
+        fetch("/graphql", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ query, variables }),
+        }).then(response => response.json())),
+});

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -11,7 +11,12 @@ type Query {
     Returns the realm with the specific ID or `None` if the ID does not
     refer to a realm.
   """
-  realm(id: ID!): Realm
+  realmById(id: ID!): Realm
+  """
+    Returns the realm with the specific path or `None` if the path does not
+    refer to a realm.
+  """
+  realmByPath(path: String!): Realm
   "Returns the root realm."
   rootRealm: Realm!
 }
@@ -20,6 +25,7 @@ type Realm {
   id: ID!
   name: String!
   parentId: ID!
+  path: String!
   parent: Realm!
   children: [Realm!]!
 }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -27,6 +27,7 @@ type Realm {
   parentId: ID!
   path: String!
   parent: Realm!
+  parents: [Realm!]!
   children: [Realm!]!
 }
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -15,6 +15,13 @@ type Query {
   """
     Returns the realm with the specific path or `None` if the path does not
     refer to a realm.
+
+    Every realm has its own "path segment", and the full path of a realm
+    is just the concatenation of all the path segments between the root realm
+    and the realm in question, delimited by `"/"`. The root realm is assumed
+    to have a path segment of `""`, and with the above rule so is its full
+    path. The path of every other realm will start with `"/"` delimiting the
+    root realm path segement from the second segment in the path.
   """
   realmByPath(path: String!): Realm
   "Returns the root realm."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -24,9 +24,9 @@ type Query {
 type Realm {
   id: ID!
   name: String!
-  parentId: ID!
+  parentId: ID
   path: String!
-  parent: Realm!
+  parent: Realm
   parents: [Realm!]!
   children: [Realm!]!
 }

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -5,18 +5,18 @@ declare
     root realms.id%type;
     y_root realms.id%type;
 begin
-    insert into realms (name, parent, path)
+    insert into realms (name, parent, path_segment)
     values (name, 0, replace(lower(name), ' ', '-'))
     returning id into root;
 
     for y in 2020 .. 2021 loop
-        insert into realms (name, parent, path)
+        insert into realms (name, parent, path_segment)
         values (y, root, y::text)
         returning id into y_root;
 
-        insert into realms (name, parent, path)
+        insert into realms (name, parent, path_segment)
         values ('Summer', y_root, 'summer');
-        insert into realms (name, parent, path)
+        insert into realms (name, parent, path_segment)
         values ('Winter', y_root, 'winter');
     end loop;
 end; $$;

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -5,19 +5,19 @@ declare
     root realms.id%type;
     y_root realms.id%type;
 begin
-    insert into realms (name, parent)
-    values (name, 0)
+    insert into realms (name, parent, path)
+    values (name, 0, replace(lower(name), ' ', '-'))
     returning id into root;
 
     for y in 2020 .. 2021 loop
-        insert into realms (name, parent)
-        values (y, root)
+        insert into realms (name, parent, path)
+        values (y, root, y::text)
         returning id into y_root;
 
-        insert into realms (name, parent)
-        values ('Summer', y_root);
-        insert into realms (name, parent)
-        values ('Winter', y_root);
+        insert into realms (name, parent, path)
+        values ('Summer', y_root, 'summer');
+        insert into realms (name, parent, path)
+        values ('Winter', y_root, 'winter');
     end loop;
 end; $$;
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -2,9 +2,9 @@ create table realms (
     id bigint generated always as identity (start with 0 minvalue 0) primary key,
     parent bigint not null references realms on delete restrict,
     name text not null,
-    path text not null
+    path_segment text not null
 );
 -- To truncate this and restart the primary key counter:
 --truncate realms restart identity;
 
-insert into realms (name, parent, path) values ('root', 0, '');
+insert into realms (name, parent, path_segment) values ('root', 0, '');

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,9 +1,10 @@
 create table realms (
     id bigint generated always as identity (start with 0 minvalue 0) primary key,
     parent bigint not null references realms on delete restrict,
-    name text not null
+    name text not null,
+    path text not null
 );
 -- To truncate this and restart the primary key counter:
 --truncate realms restart identity;
 
-insert into realms (name, parent) values ('root', 0);
+insert into realms (name, parent, path) values ('root', 0, '');


### PR DESCRIPTION
This PR:

* Adds a new API `realmByPath` to get a realm by its full path, which turns out to be what the frontend wants.
* Adds a new field `parents` to our `Realm` GraphQL-type to access a flat list of all of a realm's parents. This is useful to generate the breadcrumbs.
* Sets up a basic Relay environment
* As usual: Adapts the linter some more :wink: 
* Uses all that cool new stuff in the front end to replace the dummy data
* Stops exposing the root realm being its own parent; that's an implementation detail and makes things confusing.

---

Closes #82.