### PR TITLE
Remove the `--quiet` flag from `floof`-s call to `relay-compiler`

### DIFF
--- a/floof.yaml
+++ b/floof.yaml
@@ -35,7 +35,7 @@ frontend:
         - webpack.config.js
         - src/
       run:
-        - npx relay-compiler --quiet
+        - npx relay-compiler
         - concurrently:
           - npx tsc --skipLibCheck
           - npx eslint .


### PR DESCRIPTION
Unfortunately it doesn't only suppress the noisy output,
but also any potential error messages.