### PR TITLE
Client side API error handling

### DIFF
--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -11,7 +11,7 @@ pub struct Query;
 
 #[graphql_object(Context = Context)]
 impl Query {
-    fn apiVersion() -> &str {
+    fn api_version() -> &str {
         "0.0"
     }
 

--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -16,13 +16,13 @@ impl Query {
     }
 
     /// Returns a flat list of all realms.
-    async fn realms(context: &Context) -> Vec<&Realm> {
+    fn realms(context: &Context) -> Vec<&Realm> {
         context.realm_tree.realms.values().collect()
     }
 
     /// Returns the realm with the specific ID or `None` if the ID does not
     /// refer to a realm.
-    async fn realm_by_id(id: Id, context: &Context) -> Option<&Realm> {
+    fn realm_by_id(id: Id, context: &Context) -> Option<&Realm> {
         context.realm_tree.get_node(&id)
     }
 
@@ -35,12 +35,12 @@ impl Query {
     /// to have a path segment of `""`, and with the above rule so is its full
     /// path. The path of every other realm will start with `"/"` delimiting the
     /// root realm path segement from the second segment in the path.
-    async fn realm_by_path(path: String, context: &Context) -> Option<&Realm> {
+    fn realm_by_path(path: String, context: &Context) -> Option<&Realm> {
         context.realm_tree.from_path(&path)
     }
 
     /// Returns the root realm.
-    async fn root_realm(context: &Context) -> &Realm {
+    fn root_realm(context: &Context) -> &Realm {
         context.realm_tree.root()
     }
 }

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -97,6 +97,9 @@ module.exports = {
         "dot-notation": "warn",
         "no-tabs": "warn",
         "no-extra-parens": "warn",
+        "max-statements-per-line": "warn",
+        "curly": "warn",
+        "no-else-return": "warn",
         // Unused things should also only warn
         "no-unused-vars": ["warn", noUnusedVarsOptions],
     },
@@ -153,6 +156,9 @@ module.exports = {
                 format: ["PascalCase", "camelCase"],
             }],
             "@typescript-eslint/member-delimiter-style": "warn",
+            "@typescript-eslint/brace-style": "warn",
+            "@typescript-eslint/lines-between-class-members": "warn",
+            "@typescript-eslint/explicit-member-accessibility": "warn",
 
             // Turn off base rules overridden by `@typescript-eslint` rules
             "indent": "off",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,14 @@ import React, { Suspense } from "react";
 import { BrowserRouter as Router, Switch, Route, RouteComponentProps } from "react-router-dom";
 
 import { RelayEnvironmentProvider } from "react-relay/hooks";
-import { environment } from "./relay";
+import { environment, APIError } from "./relay";
 
 import { GlobalStyle } from "./GlobalStyle";
 import { Root } from "./layout/Root";
 import { RealmPage } from "./page/Realm";
 import { HomePage } from "./page/Home";
 import { NotFound } from "./page/NotFound";
+
 
 export const App: React.FC = () => (
     <RelayEnvironmentProvider {...{ environment }}>
@@ -26,13 +27,54 @@ export const App: React.FC = () => (
 );
 
 const HomeRoute: React.FC = () => (
-    <Suspense fallback="Loading! (TODO)">
+    <APIWrapper>
         <HomePage />
-    </Suspense>
+    </APIWrapper>
 );
 
 const RealmRoute: React.FC<RouteComponentProps<{ path?: string }>> = ({ match }) => (
-    <Suspense fallback="Loading! (TODO)">
+    <APIWrapper>
         <RealmPage path={match.params.path ?? ""} />
-    </Suspense>
+    </APIWrapper>
 );
+
+
+const APIWrapper: React.FC = ({ children }) => (
+    <APIErrorBoundary>
+        <Suspense fallback="Loading! (TODO)">
+            {children}
+        </Suspense>
+    </APIErrorBoundary>
+);
+
+// TODO This is of course rather bare bones;
+// it mainly serves to demonstrate what we have to do to **get to** the
+// errors we might get from Relay, not necessarily how to handle them.
+class APIErrorBoundary extends React.Component<unknown, boolean> {
+    public constructor(props: unknown) {
+        super(props);
+        this.state = false;
+    }
+
+    public static getDerivedStateFromError(error: unknown) {
+        if (error instanceof APIError) {
+            // >= 400 response from the API
+            return true;
+        } else if (error instanceof Error && error.name === "RelayNetwork") {
+            // **Probably** got no `data` in the API response.
+            // However, there is no way to distinguish this from potential further errors
+            // of the same "type", other than comparing messages (which contain data about
+            // the request). Let's hope the Relay folks change that when they introduce
+            // additional error scenarios in the future.
+            return true;
+        }
+        // Not our problem
+        return false;
+    }
+
+    public render() {
+        return this.state
+            ? "An error occured (TODO)"
+            : this.props.children;
+    }
+}

--- a/frontend/src/relay.ts
+++ b/frontend/src/relay.ts
@@ -3,10 +3,26 @@ import { Environment, Store, RecordSource, Network } from "relay-runtime";
 export const environment = new Environment({
     store: new Store(new RecordSource()),
     network: Network.create(
-        ({ text: query }, variables) => fetch("/graphql", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ query, variables }),
-        }).then(response => response.json()),
+        async ({ text: query }, variables) => {
+            const response = await fetch("/graphql", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ query, variables }),
+            });
+            if (!response.ok) {
+                throw new APIError(response);
+            }
+            return response.json();
+        },
     ),
 });
+
+export class APIError extends Error {
+    public response: Response;
+
+    public constructor(response: Response) {
+        super(response.statusText);
+        this.name = "APIError";
+        this.response = response;
+    }
+}


### PR DESCRIPTION
This represents a first stab at handling API errors in the frontend. Specifically it prevents it from crashing on >=400 responses from the backend. With this, it fixes #106.

It also handles the case of getting "pure `errors`" from the backend, i.e. no partial data. Partial data is not really supported by Relay's hook API, so we should probably avoid creating it in the backend. Instead, we should model errors as data explicitly.