### PR TITLE
Add `tobira db console` convenience command

### DIFF
--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -52,5 +52,7 @@ pub(crate) enum DbCommand {
     Migrate,
 
     /// Connects to the database and gives you an SQL prompt.
+    /// This just starts the `psql` client, so make sure that is installed
+    /// and accessible in your `PATH`.
     Console,
 }

--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -50,4 +50,7 @@ pub(crate) enum DbCommand {
     /// Runs the database migrations that also automatically run when starting
     /// the server.
     Migrate,
+
+    /// Connects to the database and gives you an SQL prompt.
+    Console,
 }

--- a/backend/server/src/db/cmd.rs
+++ b/backend/server/src/db/cmd.rs
@@ -117,4 +117,8 @@ fn console(config: &config::Db) -> Result<NeverReturns> {
     Err(error).context(message)
 }
 
+/// An empty `enum` for signaling the fact that a function (potentially) never returns.
+/// Note that you can't construct a value of this type, so a function returning it
+/// can never return. A function returning `Result<NeverReturns>` never returns
+/// when it succeeds, but it might still fail.
 enum NeverReturns {}


### PR DESCRIPTION
This gives you a `psql` prompt for the configured database.
It replaces the `tobira` process so that signals, streams, etc. are
handled correctly, and so that we don't have to care about errors.

Note that this is a Unix-only feature. Note also that this is like
calling `process::exit` in that it does not run any destructors.
The internal `execvp` call guarantees that all memory is freed
correctly at least, though.