### PR TITLE
Support Unix Domain Sockets

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "base64",
  "byteorder",
  "chrono",
- "hex",
+ "hex 0.3.2",
  "libc",
  "linked-hash-map",
  "md5 0.6.1",
@@ -432,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +507,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f192a5a791c0781b93e69f60a652eb6ae9331f77b9efe90c9827a75df5141a9b"
+dependencies = [
+ "futures-util",
+ "hex 0.4.2",
+ "hyper",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -1283,6 +1302,7 @@ dependencies = [
  "futures",
  "hostname",
  "hyper",
+ "hyperlocal",
  "juniper_hyper",
  "log",
  "mime_guess",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -20,6 +20,7 @@ deadpool-postgres = { version = "0.5", default-features = false }
 futures = "0.3.1"
 hostname = "0.3"
 hyper = "0.13"
+hyperlocal = "0.7"
 log = { version = "0.4", features = ["serde", "std"] }
 mime_guess = "2"
 once_cell = "1.5"

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -42,11 +42,16 @@ tobira_macros::gen_config! {
         database: String = "tobira",
     },
     http: {
-        /// The port the HTTP server should listen on.
+        /// The TCP port the HTTP server should listen on.
         port: u16 = 3080,
 
         /// The bind address to listen on.
         address: IpAddr = "127.0.0.1",
+
+        /// Unix domain socket to listen on. Specifying this will overwrite 
+        /// the TCP configuration.
+        #[example = "/tmp/tobira.socket"]
+        unix_socket: Option<PathBuf>,
     },
     log: {
         /// Determines how many messages are logged. Log messages below


### PR DESCRIPTION
This patch adds support for serving Tobira via Unix domain sockets which
allows for specifying access based on Unix access rights and lowers the
possibility of TCP port conflicts.

The feature can be activated by configuring `unix_socket` which will
then also deactivate the TCP socket.