### PR TITLE
Unix Socket Permissions

### DIFF
--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -52,6 +52,9 @@ tobira_macros::gen_config! {
         /// the TCP configuration.
         #[example = "/tmp/tobira.socket"]
         unix_socket: Option<PathBuf>,
+
+        /// Unix domain socket file permissions.
+        unix_socket_permissions: u32 = 0o755,
     },
     log: {
         /// Determines how many messages are logged. Log messages below

--- a/backend/server/src/http.rs
+++ b/backend/server/src/http.rs
@@ -11,6 +11,7 @@ use std::{
     fs,
     future::Future,
     net::SocketAddr,
+    os::unix::fs::PermissionsExt,
     panic::AssertUnwindSafe,
     sync::Arc,
 };
@@ -73,6 +74,8 @@ pub(crate) async fn serve(
         }
         let server = Server::bind_unix(&unix_socket)?.serve(factory!());
         info!("Listening on unix://{}", unix_socket.display());
+        let permissions = fs::Permissions::from_mode(config.unix_socket_permissions);
+        fs::set_permissions(unix_socket, permissions)?;
         server.await?;
     } else {
         // Bind to TCP socket.


### PR DESCRIPTION
This patch allows users to specify the file permissions used for the
Unix domain socket which are hard to specify otherwise since the socket
is created anew every time Tobira is started.