### PR TITLE
Add series relation

### DIFF
--- a/backend/server/src/db/migrations/4-series.sql
+++ b/backend/server/src/db/migrations/4-series.sql
@@ -1,0 +1,12 @@
+call prepare_randomized_ids('series');
+
+create table series (
+    id bigint primary key default randomized_id('series'),
+
+    -- Opencast internal data
+    opencast_id text not null,
+
+    -- Meta data
+    title text not null,
+    description text
+);

--- a/backend/server/src/db/mod.rs
+++ b/backend/server/src/db/mod.rs
@@ -257,4 +257,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     1: "xtea",
     2: "id-generation",
     3: "realms",
+    4: "series",
 ];


### PR DESCRIPTION
I just copied the (meta-)data fields from the admin UI for now. Feel free suggesting additional ones or removing some.

Some things to note:

* I opted to try out Postgres' `array` capabilities instead of a normalized schema with join tables for n:m fields like `contributors`
  * I never used those before, so I don't 100% know how they fare in terms of fast searchability and other criteria we might have in mind, but on the other hand having to join things is also not great for speed. :sweat_smile:
  * But of course this also has all the other caveats that come with non-normalized data, most notably probably the possibility for inconsistencies.
* `language` and `license` are just `text`, even though on the Opencast side these are (at least in the admin UI) constrained to a certain set of values. That set is configurable, though, AFAIK, and I don't think we want to track that configuration and `alter table` this relation constantly to fix the domain.