### PR TITLE
Make the XTEA keys unique

### DIFF
--- a/backend/server/src/db/migrations/2-id-generation.sql
+++ b/backend/server/src/db/migrations/2-id-generation.sql
@@ -24,7 +24,7 @@ create extension pgcrypto;
 -- being able to cross-guess the sequence.
 create table __xtea_keys (
     entity text primary key,
-    key bytea not null unique check (octet_length(key) = 16) default gen_random_bytes(16)
+    key bytea unique not null unique check (octet_length(key) = 16) default gen_random_bytes(16)
 );
 
 create procedure prepare_randomized_ids(entity text)


### PR DESCRIPTION
If the random generator we use for the XTEA keys ever happens to output the same key twice on the same Tobira instance, people might be able to cross-guess between the id sequences. This patch makes the migration fail when this happens. That's unfortunate, but also very unlikely to ever happen, anyway, Plus, that's better than silently generating weak IDs in that case.

Note that this does not protect us from cross-guesses **between** Tobira instances!