### PR TITLE
Create Extension If Not Exists

### DIFF
--- a/backend/server/src/db/migrations/2-id-generation.sql
+++ b/backend/server/src/db/migrations/2-id-generation.sql
@@ -17,7 +17,7 @@
 -- -- [...]
 -- ```
 
-create extension pgcrypto;
+create extension if not exists pgcrypto;
 
 -- Create a table to hold encryption keys for the `xtea` function,
 -- one per relation where we want to "randomize" the IDs, to avoid


### PR DESCRIPTION
Creating/loading PostgreSQL extensions requires pretty high privileges
which is why it may make sense to create the extension at the same time
when the database is created. But that will currently let the migration
fail.

This patch fixes the issue by creating the extension on-the-fly only if
it does not already exist.