### PR TITLE
Use random-looking keys for realms

### DIFF
--- a/backend/server/src/db/migrations/2-id-generation.sql
+++ b/backend/server/src/db/migrations/2-id-generation.sql
@@ -30,7 +30,9 @@ create table __xtea_keys (
 create function prepare_randomized_ids(entity text) returns void
 language plpgsql
 as $$ begin
-    execute 'create sequence ' || quote_ident('__' || entity || '_ids') || ';';
+    execute 'create sequence '
+        || quote_ident('__' || entity || '_ids')
+        || ' minvalue -9223372036854775808 cycle;';
     insert into __xtea_keys (entity) values (entity);
 end; $$;
 

--- a/backend/server/src/db/migrations/3-realms.sql
+++ b/backend/server/src/db/migrations/3-realms.sql
@@ -1,10 +1,20 @@
 -- Creates the realms table and inserts the always-present root realm.
 
+select prepare_randomized_ids('realm');
+
 create table realms (
-    id bigint generated always as identity (start with 0 minvalue 0) primary key,
+    id bigint primary key default randomized_id('realm'),
     parent bigint not null references realms on delete restrict,
     name text not null,
     path_segment text not null
 );
 
+-- Insert the root realm. Since that realm has to have the ID=0, we have to
+-- set the sequence to a specific value. We can just apply inverse xtea to 0
+-- to get the value we have to set the sequence to.
+select setval(
+    '__realm_ids',
+    xtea(0, (select key from __xtea_keys where entity = 'realm'), false),
+    false
+);
 insert into realms (name, parent, path_segment) values ('root', 0, '');


### PR DESCRIPTION
While we don't know for sure that we need it (there are probably no "unlisted" realms?), it doesn't hurt and we use these random looking IDs for all other things already. This is slightly more complicated because we still want to maintain that the root realm has ID 0. 