### PR TITLE
Don't Deploy Forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,4 @@ jobs:
         --extra-vars="branch='${GITHUB_REF#refs/heads/}'"
         -u github
         deploy.yml
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'elan-ev' }}

--- a/.github/workflows/remove-deployment.yml
+++ b/.github/workflows/remove-deployment.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   main:
+    if: github.repository_owner == 'elan-ev'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This patch makes the deployment run only on the main Tobira repository,
not on any fork. Running the deployment on forks would fail anyway since
they don't have the repository secret configured. This would cause the
whole CI workflow to fail.