### PR TITLE
Conditionally Install Ansible in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
 
     - name: install ansible postgres extensions
       run: ansible-galaxy collection install community.general
+      if: ${{ github.event_name == 'push' && github.repository_owner == 'elan-ev' }}
 
     - name: deploy tobira branch
       working-directory: .deployment


### PR DESCRIPTION
This patch skips the installation of the PostgreSQL Ansible plugins if
we don't actually deploy anyway.