### PR TITLE
Add isolated module checking to the TypeScript configuration

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
-    "strict": true
+    "strict": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
TypeScript has access to the entire module tree when transpiling.
Babel on the other hand transpiles one module at a time.
This can lead to problems, which this option can warn us about.