### PR TITLE
404 for Unknown Domain

### DIFF
--- a/.deployment/templates/nginx.conf
+++ b/.deployment/templates/nginx.conf
@@ -77,6 +77,7 @@ http {
    # Allow for long domain names.
    server_names_hash_bucket_size 128;
 
+   # Always redirect to HTTPS
    server {
       listen 80;
       listen [::]:80;
@@ -86,6 +87,18 @@ http {
       }
    }
 
+   # Return an error page for unknown domains
+   server {
+      listen              443 ssl http2 default_server;
+      listen         [::]:443 ssl http2 default_server;
+
+      ssl_certificate_key /etc/nginx/ssl/tobira.opencast.org.key;
+      ssl_certificate     /etc/nginx/ssl/tobira.opencast.org.crt;
+
+      return 404;
+   }
+
+   # Serve the branch master as tobira.opencast.org
    server {
       listen              443 ssl http2;
       listen         [::]:443 ssl http2;


### PR DESCRIPTION
This patch makes the deployment return an HTTP 404 error code for
unknown domains instead of serving the `master` branch.