### PR TITLE
Add video list rendering (grid layout) with dummy data

### DIFF
--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -11,6 +11,7 @@ pub(crate) struct Event {
     video: String,
     thumbnail: String,
     description: Option<String>,
+    duration: u32,
     series: Option<Key>,
 }
 
@@ -32,6 +33,10 @@ impl Event {
         &self.thumbnail
     }
 
+    fn duration(&self) -> f64 {
+        self.duration.into()
+    }
+
     fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
@@ -51,7 +56,7 @@ impl Event {
             context.db.get()
                 .await?
                 .query_opt(
-                    "select id, title, video, thumbnail, description, series
+                    "select id, title, video, thumbnail, duration, description, series
                         from events
                         where id = $1",
                     &[&(key as i64)],
@@ -69,7 +74,7 @@ impl Event {
         let result = context.db.get()
             .await?
             .query_raw(
-                "select id, title, video, thumbnail, description, series
+                "select id, title, video, thumbnail, duration, description, series
                     from events
                     where series = $1",
                 &[series_key as i64],
@@ -88,8 +93,9 @@ impl Event {
             title: row.get(1),
             video: row.get(2),
             thumbnail: row.get(3),
-            description: row.get(4),
-            series: row.get::<_, Option<i64>>(5).map(|series| series as u64),
+            duration: row.get::<_, i32>(4) as u32,
+            description: row.get(5),
+            series: row.get::<_, Option<i64>>(6).map(|series| series as u64),
         }
     }
 }

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -9,6 +9,7 @@ pub(crate) struct Event {
     key: Key,
     title: String,
     video: String,
+    thumbnail: String,
     description: Option<String>,
     series: Option<Key>,
 }
@@ -25,6 +26,10 @@ impl Event {
 
     fn video(&self) -> &str {
         &self.video
+    }
+
+    fn thumbnail(&self) -> &str {
+        &self.thumbnail
     }
 
     fn description(&self) -> Option<&str> {
@@ -46,7 +51,7 @@ impl Event {
             context.db.get()
                 .await?
                 .query_opt(
-                    "select id, title, video, description, series
+                    "select id, title, video, thumbnail, description, series
                         from events
                         where id = $1",
                     &[&(key as i64)],
@@ -64,7 +69,7 @@ impl Event {
         let result = context.db.get()
             .await?
             .query_raw(
-                "select id, title, video, description, series
+                "select id, title, video, thumbnail, description, series
                     from events
                     where series = $1",
                 &[series_key as i64],
@@ -82,8 +87,9 @@ impl Event {
             key: row.get_key(0),
             title: row.get(1),
             video: row.get(2),
-            description: row.get(3),
-            series: row.get::<_, Option<i64>>(4).map(|series| series as u64),
+            thumbnail: row.get(3),
+            description: row.get(4),
+            series: row.get::<_, Option<i64>>(5).map(|series| series as u64),
         }
     }
 }

--- a/backend/server/src/db/migrations/5-events.sql
+++ b/backend/server/src/db/migrations/5-events.sql
@@ -9,6 +9,7 @@ create table events (
     -- Meta data
     title text not null,
     description text,
+    duration int not null, -- in seconds
     series bigint references series,
 
     -- Media

--- a/backend/server/src/db/migrations/5-events.sql
+++ b/backend/server/src/db/migrations/5-events.sql
@@ -12,5 +12,6 @@ create table events (
     series bigint references series,
 
     -- Media
+    thumbnail text not null,
     video text not null
 );

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         "no-console": "off",
         "func-style": "off",
         "max-lines": "off",
+        "no-else-return": "off",
         "no-underscore-dangle": "off",
         "space-before-function-paren": ["warn", {
             "anonymous": "always",
@@ -107,7 +108,6 @@ module.exports = {
         "no-extra-parens": ["warn", "all", { enforceForArrowConditionals: false }],
         "max-statements-per-line": "warn",
         "curly": "warn",
-        "no-else-return": "warn",
         // Unused things should also only warn
         "no-unused-vars": ["warn", noUnusedVarsOptions],
     },
@@ -148,6 +148,7 @@ module.exports = {
 
             // Make style issues warnings
             "react/jsx-curly-spacing": ["warn", { children: true }],
+            "@typescript-eslint/quotes": "warn",
             "@typescript-eslint/no-extra-parens": [
                 "warn",
                 "all",

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -7,6 +7,7 @@ type Event {
   id: ID!
   title: String!
   video: String!
+  thumbnail: String!
   description: String
   series: Series
 }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -8,6 +8,7 @@ type Event {
   title: String!
   video: String!
   thumbnail: String!
+  duration: Float!
   description: String
   series: Series
 }

--- a/frontend/src/ui/Blocks.tsx
+++ b/frontend/src/ui/Blocks.tsx
@@ -57,12 +57,77 @@ const TextBlock: React.FC<TextProps> = ({ title, content }) => (
     </Block>
 );
 
-const VideoListBlock: React.FC<{ title: string | null }> = ({ title }) => (
-    <Block>
-        <Title title={title} />
-        <i>not yet implemented ☹️</i>
-    </Block>
-);
+const VideoListBlock: React.FC<{ title: string | null }> = ({ title }) => {
+    const [THUMB_WIDTH, THUMB_HEIGHT] = [16, 9].map(x => x * 13);
+
+    return (
+        <Block>
+            <Title title={title} />
+            <div css={{
+                display: "flex",
+                flexWrap: "wrap",
+            }}>
+                {DUMMY_VIDEOS.map(v => {
+                    const url = `/v/${v.id}`;
+
+                    return (
+                        <div
+                            key={v.id}
+                            css={{
+                                margin: "12px 8px",
+                                width: THUMB_WIDTH,
+                                "& a": { color: "black", textDecoration: "none" },
+                            }}
+                        >
+                            <a href={url} css={{ position: "relative", display: "block" }}>
+                                <img
+                                    src={v.thumbnail}
+                                    width={THUMB_WIDTH}
+                                    height={THUMB_HEIGHT}
+                                    css={{ display: "block" }}
+                                />
+                                <div css={{
+                                    position: "absolute",
+                                    right: 6,
+                                    bottom: 6,
+                                    backgroundColor: "hsla(0, 0%, 0%, 0.75)",
+                                    border: "1px solid black",
+                                    borderRadius: 4,
+                                    padding: "0 4px",
+                                    color: "white",
+                                }}>
+                                    {formatLength(v.length)}
+                                </div>
+                            </a>
+
+                            <h3 css={{
+                                fontSize: 16,
+                            }}>
+                                <a href={url}>{v.title}</a>
+                            </h3>
+                        </div>
+                    );
+                })}
+            </div>
+        </Block>
+    );
+};
+
+const formatLength = (totalSeconds: number) => {
+    const seconds = totalSeconds % 60;
+    const minutes = Math.floor(totalSeconds / 60) % 60;
+    const hours = Math.floor(totalSeconds / (60 * 60));
+
+    const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+
+    if (hours > 0) {
+        return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+    } else if (minutes > 0) {
+        return `${minutes}:${pad(seconds)}`;
+    } else {
+        return `0:${pad(seconds)}`;
+    }
+};
 
 const Title: React.FC<{ title: string | null }> = ({ title }) => (
     title === null ? null : <h2>{title}</h2>
@@ -90,3 +155,48 @@ function unwrap<K extends keyof BlockData>(block: BlockData, field: K): NonNulla
 
     return v;
 }
+
+const DUMMY_VIDEOS = [
+    {
+        id: 0,
+        title: "Programmieren in Rust: Einführung",
+        length: 5123,
+        thumbnail: "https://i.imgur.com/QtsTbCi.jpg",
+    },
+    {
+        id: 1,
+        title: "Programmieren in Rust: Module",
+        length: 5018,
+        thumbnail: "https://i.imgur.com/aoRSWgJ.jpg",
+    },
+    {
+        id: 2,
+        title: "The Physics behind a flying Bumblebee",
+        length: 47,
+        thumbnail: "https://i.imgur.com/TuS6Qxg.jpg",
+    },
+    {
+        id: 3,
+        title: "Programmieren in Rust: Performance & Effizienz",
+        length: 5329,
+        thumbnail: "https://i.imgur.com/4y40tkN.jpg",
+    },
+    {
+        id: 4,
+        title: "Spring (Open Blender Movie)",
+        length: 464,
+        thumbnail: "https://i.imgur.com/JhUYB7C.jpg",
+    },
+    {
+        id: 5,
+        title: "Cosmos Laundromat (Open Blender Movie)",
+        length: 730,
+        thumbnail: "https://i.imgur.com/qGOL4Jy.jpg",
+    },
+    {
+        id: 6,
+        title: "Programmieren in Rust: Stack & Heap",
+        length: 5399,
+        thumbnail: "https://i.imgur.com/XBDOO2R.jpg",
+    },
+];

--- a/frontend/src/ui/Blocks.tsx
+++ b/frontend/src/ui/Blocks.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { graphql, useFragment } from "react-relay/hooks";
 import {
     Blocks_blocks as QueryResult,
@@ -94,7 +95,7 @@ const VideoListBlock: React.FC<VideoListProps> = ({ title, series }) => {
                                 "& a": { color: "black", textDecoration: "none" },
                             }}
                         >
-                            <a href={url} css={{ position: "relative", display: "block" }}>
+                            <Link to={url} css={{ position: "relative", display: "block" }}>
                                 <img
                                     src={event.thumbnail}
                                     width={THUMB_WIDTH}
@@ -113,12 +114,12 @@ const VideoListBlock: React.FC<VideoListProps> = ({ title, series }) => {
                                 }}>
                                     {formatLength(event.duration)}
                                 </div>
-                            </a>
+                            </Link>
 
                             <h3 css={{
                                 fontSize: 16,
                             }}>
-                                <a href={url}>{event.title}</a>
+                                <Link to={url}>{event.title}</Link>
                             </h3>
                         </div>
                     );
@@ -137,10 +138,8 @@ const formatLength = (totalSeconds: number) => {
 
     if (hours > 0) {
         return `${hours}:${pad(minutes)}:${pad(seconds)}`;
-    } else if (minutes > 0) {
-        return `${minutes}:${pad(seconds)}`;
     } else {
-        return `0:${pad(seconds)}`;
+        return `${minutes}:${pad(seconds)}`;
     }
 };
 

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -41,3 +41,8 @@ export function match<T extends string | number, Out>(
         ? arms[value]!()
         : (arms[value] as (() => Out) | undefined ?? fallback)();
 }
+
+// Retrieves the key of an ID by stripping the "kind" prefix.
+export function keyOfId(id: string): string {
+    return id.substring(2);
+}

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -4,6 +4,7 @@ as $$
 declare
     series_university_highlights series.id%type;
     series_christmas series.id%type;
+    events_realm_id realms.id%type;
 begin
     -- Add a few series
     insert into series (opencast_id, title)
@@ -15,9 +16,9 @@ begin
 
     -- Add lots of realms
     perform create_departments();
-    perform create_top_level_realm('Events');
-    perform create_top_level_realm('Campus');
-    perform create_top_level_realm('Conferences');
+    events_realm_id := create_top_level_realm('Events', 'This university has very nice events. So very nice.');
+    perform create_top_level_realm('Campus', 'Videos about life on the campus, the library, and more.');
+    perform create_top_level_realm('Conferences', 'Videos from conferences our university hosts. Like Gamescom, ComicCon, BlizzCon, recon, and RustFest.eu.');
 
     insert into blocks (realm_id, type, index, text_content)
         values (
@@ -25,8 +26,13 @@ begin
             'Welcome to Tobira! This database contains dummy data intended for development. Have fun!'
         );
     insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
-        values (0, 'videolist', 1, series_university_highlights, 'horizontal', 'new_to_old');
+        values (0, 'videolist', 1, series_university_highlights, 'grid', 'new_to_old');
 
+    insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
+        values (events_realm_id, 'videolist', 1, series_christmas, 'grid', 'new_to_old');
+
+
+    -- Add a bunch of events/videos
     insert into events (opencast_id, title, video, thumbnail, duration, description, series)
         values (
             'bbb',
@@ -37,22 +43,96 @@ begin
             'Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation.',
             series_university_highlights
         );
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'cosmos-laundromat',
+            'Cosmos Laundromat',
+            'https://upload.wikimedia.org/wikipedia/commons/3/36/Cosmos_Laundromat_-_First_Cycle_-_Official_Blender_Foundation_release.webm',
+            'https://i.postimg.cc/HLQPr3mX/cosmos-laundromat.jpg',
+            730,
+            'Cosmos Laundromat: First Cycle is an animated absurdist sci-fi fantasy short film directed by Mathieu Auvray, written by Esther Wouda, and produced by Ton Roosendaal. It is the Blender Institutes 5th "open movie" project, and was made utilizing the Blender software.',
+            series_university_highlights
+        );
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'spring',
+            'Spring',
+            'https://upload.wikimedia.org/wikipedia/commons/a/a5/Spring_-_Blender_Open_Movie.webm',
+            'https://i.postimg.cc/Wzf5BHmL/spring.jpg',
+            464,
+            'Spring is a 2019 animated fantasy short film directed and written by Andreas Goralczyk and produced by Ton Roosendaal and Francesco Siddi. It is the Blender Institutes 12th "open movie", and was made utilizing the open-source software, Blender.',
+            series_university_highlights
+        );
+
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'bee',
+            'Guest Lecture: Group Intelligence of Bumblebees',
+            'https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4',
+            'https://i.postimg.cc/y83GHsrf/bumblebee.jpg',
+            552,
+            'Bumblebees are remarkable creatures. While a single one cannot achieve a lot on its own, in a group, they can even solve quantum gravity. Also, the video is actually Big Buck Bunny again.',
+            series_christmas
+        );
+
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'pir-introduction',
+            'Programmieren in Rust: Einführung',
+            'https://video4.virtuos.uos.de/static/mh_default_org/engage-player/2a7b1a55-5b47-4e13-bd11-45d5b6e3c2a2/20954d15-d0a5-4ce0-90ab-fc94620a4ccf/presentation_e048dadf_4cfc_4e30_be13_eb872574a7cb.mp4',
+            'https://i.postimg.cc/tg0MRwK9/pir-einf-hrung.jpg',
+            5159,
+            'Programmieren in Rust ist eine deutsche Vorlesung über die Programmiersprache Rust.',
+            series_university_highlights
+        );
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'pir-modules',
+            'Programmieren in Rust: Module',
+            'https://video4.virtuos.uos.de/static/mh_default_org/engage-player/bac86875-bbeb-42dc-9970-55af51c9f017/241ad38e-cc98-4326-a398-8c862d07ef9d/presentation_fc713d94_30ed_4056_a8a5_81ca90e8dcca.mp4',
+            'https://i.postimg.cc/cCJD5SnB/pir-modules.jpg',
+            4605,
+            'Programmieren in Rust ist eine deutsche Vorlesung über die Programmiersprache Rust.',
+            series_university_highlights
+        );
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'pir-stack-heap',
+            'Programmieren in Rust: Stack & Heap',
+            'https://video4.virtuos.uos.de/static/mh_default_org/engage-player/31d04ddc-80a3-4344-a2c4-b4a0316f2e3a/a389856e-cb85-445a-a696-4e520446b6fe/presentation_6969f780_37f0_49a8_9228_f30ef81cc4ee.mp4',
+            'https://i.postimg.cc/k4s1c4B5/pir-heap-stack.jpg',
+            4425,
+            'Programmieren in Rust ist eine deutsche Vorlesung über die Programmiersprache Rust.',
+            series_university_highlights
+        );
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
+        values (
+            'pir-performance',
+            'Programmieren in Rust: Performance & Effizienz',
+            'https://video4.virtuos.uos.de/static/mh_default_org/engage-player/84b2b573-e900-4692-bdab-7cea4fd8c332/376cb1f5-0535-4eef-bac4-ea3ee3fed6a8/presentation_c51b67c6_c5b1_498b_abbc_9171524008fd.mp4',
+            'https://i.postimg.cc/Y9MDYg2V/pir-performance.jpg',
+            5191,
+            'Programmieren in Rust ist eine deutsche Vorlesung über die Programmiersprache Rust.',
+            series_university_highlights
+        );
 end; $$;
 
 
 -- Creates a dummy realm with parent = root
-create function create_top_level_realm(name text) returns void
+create function create_top_level_realm(name text, description text) returns bigint
 language plpgsql
 as $$
 declare
-    root realms.id%type;
+    realm_id realms.id%type;
 begin
     insert into realms (name, parent, path_segment)
         values (name, 0, replace(lower(name), ' ', '-'))
-        returning id into root;
+        returning id into realm_id;
 
-    insert into blocks (realm_id, type, index, title, text_content)
-        values (root, 'text', '0', 'Description', 'Some other top level realm...');
+    insert into blocks (realm_id, type, index, text_content)
+        values (realm_id, 'text', '0', description);
+
+    return realm_id;
 end; $$;
 
 
@@ -120,3 +200,4 @@ select main();
 drop function main;
 drop function department;
 drop function create_departments;
+drop function create_top_level_realm;

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -27,11 +27,12 @@ begin
     insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
         values (0, 'videolist', 1, series_university_highlights, 'horizontal', 'new_to_old');
 
-    insert into events (opencast_id, title, video, description, series)
+    insert into events (opencast_id, title, video, thumbnail, description, series)
         values (
             'bbb',
             'Big Buck Bunny',
             'https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4',
+            'https://i.postimg.cc/nV2D2mTx/bbb.jpg',
             'Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation.',
             series_university_highlights
         );

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -27,12 +27,13 @@ begin
     insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
         values (0, 'videolist', 1, series_university_highlights, 'horizontal', 'new_to_old');
 
-    insert into events (opencast_id, title, video, thumbnail, description, series)
+    insert into events (opencast_id, title, video, thumbnail, duration, description, series)
         values (
             'bbb',
             'Big Buck Bunny',
             'https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4',
             'https://i.postimg.cc/nV2D2mTx/bbb.jpg',
+            596,
             'Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation.',
             series_university_highlights
         );


### PR DESCRIPTION
Only dummy data currently, but at least something one can use.

![Screenshot from 2021-01-28 18-22-59](https://user-images.githubusercontent.com/7419664/106175043-ee3e1700-6195-11eb-86e9-a59d7f8371c1.png)

Currently, it's not particularly optimized for small screens, but it also doesn't break.

Closes #84 