### PR TITLE
Series API

### DIFF
--- a/backend/api/src/model/block.rs
+++ b/backend/api/src/model/block.rs
@@ -2,7 +2,7 @@
 
 use anyhow::anyhow;
 use futures::TryStreamExt;
-use juniper::{graphql_interface, FieldResult, GraphQLEnum, GraphQLObject};
+use juniper::{graphql_interface, graphql_object, FieldResult, GraphQLEnum, GraphQLObject};
 use postgres_types::FromSql;
 
 use tobira_util::prelude::*;
@@ -82,11 +82,7 @@ impl Block for Text {
     }
 }
 
-/// A block just showing the list of videos in an Opencast series
-#[derive(GraphQLObject)]
-#[graphql(impl = BlockValue)]
 pub(crate) struct VideoList {
-    #[graphql(skip)]
     pub(crate) shared: SharedData,
     pub(crate) series: Id,
     pub(crate) layout: VideoListLayout,
@@ -97,6 +93,22 @@ pub(crate) struct VideoList {
 impl Block for VideoList {
     fn shared(&self) -> &SharedData {
         &self.shared
+    }
+}
+
+/// A block just showing the list of videos in an Opencast series
+#[graphql_object(impl = BlockValue)]
+impl VideoList {
+    fn series(&self) -> Id {
+        self.series
+    }
+
+    fn layout(&self) -> VideoListLayout {
+        self.layout
+    }
+
+    fn order(&self) -> VideoListOrder {
+        self.order
     }
 }
 

--- a/backend/api/src/model/block.rs
+++ b/backend/api/src/model/block.rs
@@ -82,7 +82,7 @@ impl Block for Text {
     }
 }
 
-/// A block just showing some text.
+/// A block just showing the list of videos in an Opencast series
 #[derive(GraphQLObject)]
 #[graphql(impl = BlockValue)]
 pub(crate) struct VideoList {

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -30,7 +30,7 @@ impl Event {
 }
 
 impl Event {
-    pub async fn load_by_id(id: Id, context: &Context) -> FieldResult<Option<Self>> {
+    pub(crate) async fn load_by_id(id: Id, context: &Context) -> FieldResult<Option<Self>> {
         let result = if let Some(key) = id.key_for(Id::EVENT_KIND) {
             context.db.get()
                 .await?
@@ -41,7 +41,7 @@ impl Event {
                     &[&(key as i64) as _],
                 )
                 .await?
-                .map(|row| Event {
+                .map(|row| Self {
                     key: row.get_key(0),
                     title: row.get(1),
                     video: row.get(2),

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -65,8 +65,8 @@ impl Event {
             .await?
             .query_raw(
                 "select id, title, video, description, series
-                        from events
-                        where series = $1",
+                    from events
+                    where series = $1",
                 &[series_key as i64],
             )
             .await?

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -38,7 +38,7 @@ impl Event {
                     "select id, title, video, description
                         from events
                         where id = $1",
-                    &[&(key as i64) as _],
+                    &[&(key as i64)],
                 )
                 .await?
                 .map(|row| Self {

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -1,7 +1,8 @@
 use futures::stream::TryStreamExt;
+use tokio_postgres::Row;
 use juniper::{graphql_object, FieldResult};
 
-use crate::{Context, Id, id::Key, util::RowExt};
+use crate::{Context, Id, id::Key, model::series::Series, util::RowExt};
 
 
 pub(crate) struct Event {
@@ -9,9 +10,10 @@ pub(crate) struct Event {
     title: String,
     video: String,
     description: Option<String>,
+    series: Option<Key>,
 }
 
-#[graphql_object]
+#[graphql_object(Context = Context)]
 impl Event {
     fn id(&self) -> Id {
         Id::event(self.key)
@@ -29,7 +31,13 @@ impl Event {
         self.description.as_deref()
     }
 
-    // TODO Grant access to the event's series
+    async fn series(&self, context: &Context) -> FieldResult<Option<Series>> {
+        if let Some(series) = self.series {
+            Series::load_by_id(Id::series(series), context).await
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 impl Event {
@@ -38,18 +46,13 @@ impl Event {
             context.db.get()
                 .await?
                 .query_opt(
-                    "select id, title, video, description
+                    "select id, title, video, description, series
                         from events
                         where id = $1",
                     &[&(key as i64)],
                 )
                 .await?
-                .map(|row| Self {
-                    key: row.get_key(0),
-                    title: row.get(1),
-                    video: row.get(2),
-                    description: row.get(3),
-                })
+                .map(Self::from_row)
         } else {
             None
         };
@@ -61,21 +64,26 @@ impl Event {
         let result = context.db.get()
             .await?
             .query_raw(
-                "select id, title, video, description
+                "select id, title, video, description, series
                         from events
                         where series = $1",
                 &[series_key as i64],
             )
             .await?
-            .map_ok(|row| Self {
-                key: row.get_key(0),
-                title: row.get(1),
-                video: row.get(2),
-                description: row.get(3),
-            })
+            .map_ok(Self::from_row)
             .try_collect()
             .await?;
 
         Ok(result)
+    }
+
+    fn from_row(row: Row) -> Self {
+        Self {
+            key: row.get_key(0),
+            title: row.get(1),
+            video: row.get(2),
+            description: row.get(3),
+            series: row.get::<_, Option<i64>>(4).map(|series| series as u64),
+        }
     }
 }

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -1,3 +1,4 @@
+use futures::stream::TryStreamExt;
 use juniper::{graphql_object, FieldResult};
 
 use crate::{Context, Id, id::Key, util::RowExt};
@@ -27,6 +28,8 @@ impl Event {
     fn description(&self) -> Option<&str> {
         self.description.as_deref()
     }
+
+    // TODO Grant access to the event's series
 }
 
 impl Event {
@@ -50,6 +53,28 @@ impl Event {
         } else {
             None
         };
+
+        Ok(result)
+    }
+
+    pub(crate) async fn load_for_series(series_key: Key, context: &Context) -> FieldResult<Vec<Self>> {
+        let result = context.db.get()
+            .await?
+            .query_raw(
+                "select id, title, video, description
+                        from events
+                        where series = $1",
+                &[series_key as i64],
+            )
+            .await?
+            .map_ok(|row| Self {
+                key: row.get_key(0),
+                title: row.get(1),
+                video: row.get(2),
+                description: row.get(3),
+            })
+            .try_collect()
+            .await?;
 
         Ok(result)
     }

--- a/backend/api/src/model/mod.rs
+++ b/backend/api/src/model/mod.rs
@@ -3,4 +3,5 @@
 
 pub(crate) mod realm;
 pub(crate) mod event;
+pub(crate) mod series;
 pub(crate) mod block;

--- a/backend/api/src/model/realm.rs
+++ b/backend/api/src/model/realm.rs
@@ -79,8 +79,7 @@ impl Tree {
 
         // We store the nodes of the realm tree in a hash map
         // accessible by the database ID
-        let mut realms = db
-            .get()
+        let mut realms = db.get()
             .await?
             .query_raw(
                 "select id, name, parent, path_segment from realms",

--- a/backend/api/src/model/series.rs
+++ b/backend/api/src/model/series.rs
@@ -1,6 +1,6 @@
 use juniper::{graphql_object, FieldResult};
 
-use crate::{Context, id::Key, Id, util::RowExt};
+use crate::{Context, id::Key, Id, model::event::Event, util::RowExt};
 
 
 pub(crate) struct Series {
@@ -9,7 +9,7 @@ pub(crate) struct Series {
     description: Option<String>,
 }
 
-#[graphql_object]
+#[graphql_object(Context = Context)]
 impl Series {
     fn id(&self) -> Id {
         Id::series(self.key)
@@ -23,7 +23,9 @@ impl Series {
         self.description.as_deref()
     }
 
-    // TODO Return events
+    async fn events(&self, context: &Context) -> FieldResult<Vec<Event>> {
+        Event::load_for_series(self.key, context).await
+    }
 }
 
 impl Series {

--- a/backend/api/src/model/series.rs
+++ b/backend/api/src/model/series.rs
@@ -30,24 +30,28 @@ impl Series {
 
 impl Series {
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> FieldResult<Option<Self>> {
-        let result = if let Some(key) = id.key_for(Id::SERIES_KIND) {
-            context.db.get()
-                .await?
-                .query_opt(
-                    "select id, title, description
+        if let Some(key) = id.key_for(Id::SERIES_KIND) {
+            Self::load_by_key(key, context).await
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) async fn load_by_key(key: Key, context: &Context) -> FieldResult<Option<Series>> {
+        let result = context.db.get()
+            .await?
+            .query_opt(
+                "select id, title, description
                         from series
                         where id = $1",
-                    &[&(key as i64) as _],
-                )
-                .await?
-                .map(|row| Self {
-                    key: row.get_key(0),
-                    title: row.get(1),
-                    description: row.get(2),
-                })
-        } else {
-            None
-        };
+                &[&(key as i64) as _],
+            )
+            .await?
+            .map(|row| Self {
+                key: row.get_key(0),
+                title: row.get(1),
+                description: row.get(2),
+            });
 
         Ok(result)
     }

--- a/backend/api/src/model/series.rs
+++ b/backend/api/src/model/series.rs
@@ -1,0 +1,27 @@
+use juniper::graphql_object;
+
+use crate::{id::Key, Id};
+
+
+pub(crate) struct Series {
+    key: Key,
+    title: String,
+    description: Option<String>,
+}
+
+#[graphql_object]
+impl Series {
+    fn id(&self) -> Id {
+        Id::series(self.key)
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    // TODO Return events
+}

--- a/backend/api/src/model/series.rs
+++ b/backend/api/src/model/series.rs
@@ -42,9 +42,9 @@ impl Series {
             .await?
             .query_opt(
                 "select id, title, description
-                        from series
-                        where id = $1",
-                &[&(key as i64) as _],
+                    from series
+                    where id = $1",
+                &[&(key as i64)],
             )
             .await?
             .map(|row| Self {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -10,6 +10,12 @@ type Event {
   description: String
 }
 
+type Series {
+  id: ID!
+  title: String!
+  description: String
+}
+
 "A `Block`: a UI element that belongs to a realm."
 interface Block {
   id: ID!
@@ -24,7 +30,7 @@ enum VideoListOrder {
 
 "A block just showing the list of videos in an Opencast series"
 type VideoList implements Block {
-  series: ID!
+  series: Series!
   layout: VideoListLayout!
   order: VideoListOrder!
 }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -8,6 +8,7 @@ type Event {
   title: String!
   video: String!
   description: String
+  series: Series
 }
 
 type Series {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -14,6 +14,7 @@ type Series {
   id: ID!
   title: String!
   description: String
+  events: [Event!]!
 }
 
 "A `Block`: a UI element that belongs to a realm."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -22,7 +22,7 @@ enum VideoListOrder {
   OLD_TO_NEW
 }
 
-"A block just showing some text."
+"A block just showing the list of videos in an Opencast series"
 type VideoList implements Block {
   series: ID!
   layout: VideoListLayout!

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -26,6 +26,15 @@ begin
         );
     insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
         values (0, 'videolist', 1, series_university_highlights, 'horizontal', 'new_to_old');
+
+    insert into events (opencast_id, title, video, description, series)
+        values (
+            'bbb',
+            'Big Buck Bunny',
+            'https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4',
+            'Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation.',
+            series_university_highlights
+        );
 end; $$;
 
 
@@ -109,11 +118,3 @@ select main();
 drop function main;
 drop function department;
 drop function create_departments;
-
-insert into events (opencast_id, title, video, description)
-    values (
-        'bbb',
-        'Big Buck Bunny',
-        'https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4',
-        'Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation.'
-    );


### PR DESCRIPTION
A first draft of a series API.

Note that there is no top level API, yet, and maybe never will be. The only way to get to a series is currently through a video block associated to it.

If you use our fixtures, a (probably nonsensical) query like the following should return something more or less meaningful.

```graphql
query {
  rootRealm {
    blocks {
      ... on VideoList {
        series {
          title
          events {
            title
            series {
              title
            }
          }
        }
      }
    }
  }
}
```

Note also that this is still pretty naive; the database is hit once for every mention of `series` within your query. Same for `events` within a `series`.

---

Closes #86.

## TODO

* [x] Get a series' events
* [x] Get an event's series