### PR TITLE
Use `eslint --cache` in floof script

### DIFF
--- a/floof.yaml
+++ b/floof.yaml
@@ -39,7 +39,7 @@ frontend:
         - npx relay-compiler
         - concurrently:
           - npx tsc --skipLibCheck
-          - npx eslint .
+          - npx eslint . --cache
           - npx webpack --mode=development --display=errors-only
         - reload:
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@
 /build
 /src/query-types
 /tsconfig.tsbuildinfo
+/.eslintcache


### PR DESCRIPTION
This reduces the runtime from eslint from 4s to 2s for me. And as eslint is the bottleneck for the floof script, that's a nice win.