### PR TITLE
Add `serve` subcommand to replace subcommand-less invocation

### DIFF
--- a/.deployment/templates/tobira.service
+++ b/.deployment/templates/tobira.service
@@ -7,7 +7,7 @@ After=network.target
 
 [Service]
 WorkingDirectory=/opt/tobira/{{ id }}/
-ExecStart=/opt/tobira/{{ id }}/tobira
+ExecStart=/opt/tobira/{{ id }}/tobira serve
 Restart=always
 User=tobira
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Use cargo to build and run the Rust based backend.
 cd backend/
 # build only
 cargo build
-# build and run
-cargo run
+# build and start backend server
+cargo run -- serve
 ```
 
 ## Auto-Rebuilds

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,8 +21,8 @@ This needs the frontend to be built.
 ```sh
 # build only
 cargo build
-# build and run
-cargo run
+# build and start backend server
+cargo run -- serve
 ```
 
 Configuration

--- a/backend/server/src/args.rs
+++ b/backend/server/src/args.rs
@@ -7,7 +7,6 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(
     about = "Video portal for Opencast.",
-    after_help = "When run without subcommand, the Tobira backend server is started.",
     setting(structopt::clap::AppSettings::VersionlessSubcommands),
 )]
 pub(crate) struct Args {
@@ -17,11 +16,14 @@ pub(crate) struct Args {
     pub(crate) config: Option<PathBuf>,
 
     #[structopt(subcommand)]
-    pub(crate) cmd: Option<Command>,
+    pub(crate) cmd: Command,
 }
 
 #[derive(Debug, StructOpt)]
 pub(crate) enum Command {
+    /// Starts the backend HTTP server.
+    Serve,
+
     /// Outputs a template for the configuration file (which includes
     /// descriptions or all options).
     WriteConfig {

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -35,17 +35,17 @@ async fn main() -> Result<()> {
 
     // Dispatch subcommand.
     match &args.cmd {
-        None => {
+        Command::Serve => {
             let config = load_config_and_init_logger(&args)?;
             start_server(&config).compat().await?;
         }
-        Some(Command::WriteConfig { target }) => {
+        Command::WriteConfig { target } => {
             if args.config.is_some() {
                 bail!("`-c/--config` parameter is not valid for this subcommand");
             }
             config::write_template(target.as_ref())?
         }
-        Some(Command::Db { cmd }) => {
+        Command::Db { cmd } => {
             let config = load_config_and_init_logger(&args)?;
             db::cmd::run(cmd, &config.db).compat().await?;
         }

--- a/floof.yaml
+++ b/floof.yaml
@@ -21,7 +21,7 @@ backend:
           - macros/
         run:
           - reload:
-          - cargo run
+          - cargo run -- serve
 
 frontend:
   - set-workdir: frontend


### PR DESCRIPTION
Just starting the binary without arguments now results in the help text
and does not start the backend HTTP server anymore. This is done with
`./tobira serve`. This is to make starting the server more deliberate.
We have quite a few subcommands now, so having a subcommand for the
server makes for a clearer CLI.

Of course, happy bikeshedding about `serve`. Alternatives would be `run`, `start`, `server`, ...