### PR TITLE
Rename `VideoList` to `SeriesBlock` (and change a few more names)

### DIFF
--- a/backend/server/src/db/migrations/6-blocks.sql
+++ b/backend/server/src/db/migrations/6-blocks.sql
@@ -7,7 +7,7 @@
 
 select prepare_randomized_ids('block');
 
-create type block_type as enum ('text', 'videolist');
+create type block_type as enum ('text', 'series');
 create type video_list_layout as enum ('horizontal', 'vertical', 'grid');
 create type video_list_order as enum ('new_to_old', 'old_to_new');
 
@@ -22,8 +22,10 @@ create table blocks (
     -- Text blocks
     text_content text,
 
-    -- Video list blocks
-    videolist_series bigint references series on delete restrict,
+    -- Series blocks
+    series_id bigint references series on delete restrict,
+
+    -- All videolist-like blocks
     videolist_layout video_list_layout,
     videolist_order video_list_order
 );

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -13,11 +13,15 @@ type Event {
   series: Series
 }
 
-type Series {
+type Realm {
   id: ID!
-  title: String!
-  description: String
-  events: [Event!]!
+  name: String!
+  path: String!
+  parent: Realm
+  parents: [Realm!]!
+  children: [Realm!]!
+  "Returns the (content) blocks of this realm."
+  blocks: [Block!]!
 }
 
 "A `Block`: a UI element that belongs to a realm."
@@ -32,15 +36,8 @@ enum VideoListOrder {
   OLD_TO_NEW
 }
 
-"A block just showing the list of videos in an Opencast series"
-type VideoList implements Block {
-  series: Series!
-  layout: VideoListLayout!
-  order: VideoListOrder!
-}
-
 "A block just showing some text."
-type Text implements Block {
+type TextBlock implements Block {
   content: String!
 }
 
@@ -71,15 +68,18 @@ type Query {
   event(id: ID!): Event
 }
 
-type Realm {
+"A block just showing the list of videos in an Opencast series"
+type SeriesBlock implements Block {
+  series: Series!
+  layout: VideoListLayout!
+  order: VideoListOrder!
+}
+
+type Series {
   id: ID!
-  name: String!
-  path: String!
-  parent: Realm
-  parents: [Realm!]!
-  children: [Realm!]!
-  "Returns the (content) blocks of this realm."
-  blocks: [Block!]!
+  title: String!
+  description: String
+  events: [Event!]!
 }
 
 enum VideoListLayout {

--- a/frontend/src/ui/Blocks.tsx
+++ b/frontend/src/ui/Blocks.tsx
@@ -23,8 +23,8 @@ export const Blocks: React.FC<Props> = ({ realm }) => {
                     id
                     title
                     __typename
-                    ... on Text { content }
-                    ... on VideoList {
+                    ... on TextBlock { content }
+                    ... on SeriesBlock {
                         series {
                             title
                             events { id title thumbnail duration }
@@ -38,12 +38,12 @@ export const Blocks: React.FC<Props> = ({ realm }) => {
 
     return <>{
         blocks.map(block => match(block.__typename, {
-            "Text": () => <TextBlock
+            "TextBlock": () => <TextBlock
                 key={block.id}
                 title={block.title}
                 content={unwrap(block, "content")}
             />,
-            "VideoList": () => <VideoListBlock
+            "SeriesBlock": () => <SeriesBlock
                 key={block.id}
                 title={block.title}
                 series={unwrap(block, "series")}
@@ -68,12 +68,12 @@ const TextBlock: React.FC<TextProps> = ({ title, content }) => (
     </Block>
 );
 
-type VideoListProps = {
+type SeriesProps = {
     title: string | null;
     series: NonNullable<BlockData["series"]>;
 };
 
-const VideoListBlock: React.FC<VideoListProps> = ({ title, series }) => {
+const SeriesBlock: React.FC<SeriesProps> = ({ title, series }) => {
     const [THUMB_WIDTH, THUMB_HEIGHT] = [16, 9].map(x => x * 13);
 
     return (

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -25,11 +25,11 @@ begin
             0, 'text', 0,
             'Welcome to Tobira! This database contains dummy data intended for development. Have fun!'
         );
-    insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
-        values (0, 'videolist', 1, series_university_highlights, 'grid', 'new_to_old');
+    insert into blocks (realm_id, type, index, series_id, videolist_layout, videolist_order)
+        values (0, 'series', 1, series_university_highlights, 'grid', 'new_to_old');
 
-    insert into blocks (realm_id, type, index, videolist_series, videolist_layout, videolist_order)
-        values (events_realm_id, 'videolist', 1, series_christmas, 'grid', 'new_to_old');
+    insert into blocks (realm_id, type, index, series_id, videolist_layout, videolist_order)
+        values (events_realm_id, 'series', 1, series_christmas, 'grid', 'new_to_old');
 
 
     -- Add a bunch of events/videos


### PR DESCRIPTION
Fixes #166

With this, it's clear that the current content block is just about displaying series and nothing more fancy, like all newest videos below one realm or something like that.