### PR TITLE
Improve logging format and colors

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -131,6 +131,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bunt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae469fdd2750327907287e2aa8487964f7015e968bbdf71d4309d6f4b6360e"
+dependencies = [
+ "bunt-macros",
+ "termcolor",
+]
+
+[[package]]
+name = "bunt-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e7b5e5ba5b913f8d68407ae2083d166ab0cd306521e9259d58a63f456f699b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1548,7 @@ name = "tobira"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bunt",
  "chrono",
  "deadpool-postgres",
  "futures",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -18,6 +18,7 @@ embed-in-debug = ["reinda/debug-is-prod"]
 
 [dependencies]
 anyhow = "1"
+bunt = "0.2.4"
 chrono = "0.4"
 deadpool-postgres = { version = "0.7", default-features = false }
 futures = "0.3.1"


### PR DESCRIPTION
Once again, but I think it's an improvement:
- The green INFO message before were misleading since green typically
  indicates something good. And in general, everything might have been
  too colorful.
- The [] in the previous output were a bit hard on the eyes. Spaces do
  the job just as well and look cleaner overall.

The intense black might break in some color schemes. But for now, I am the person who needs to parse these logs most often, so we can still fix that later if others complain.