### PR TITLE
Enable PR deployments from forks

### DIFF
--- a/.deployment/deploy-id.sh
+++ b/.deployment/deploy-id.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Reads the GITHUB_REF env variable and prints an ID that can be used as
+# subdomain and identifier.
+
+if [[ $GITHUB_REF == refs/pull/* ]]; then
+    tmp="${GITHUB_REF#refs/pull/}"
+    echo "pr${tmp%/merge}"
+else
+    branch="${GITHUB_REF#refs/heads/}"
+    branch_short="${branch:0:40}"
+
+    # We need to set `LC_ALL` here as `a-z` depends on the locale and might
+    # match characters outside of the `a-z` range.
+    sanitized=$(echo $branch_short | LC_ALL=C sed -e 's/[^a-zA-Z0-9\-]/-/g')
+
+    # If limiting the length or sanitizing the name changed anything, we also
+    # print a checksum to make sure the name stays unique.
+    if [[ "$sanitized" != "$branch" ]]; then
+        hash=$(echo $branch | md5sum | awk '{ print $1 }')
+        echo "$sanitized-${hash:0:8}"
+    else
+        echo "$sanitized"
+    fi
+fi

--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -4,11 +4,8 @@
 - hosts: all
 
   vars:
-    # default branch
-    # will usually be overwritten by --extra-vars='branch=<branch>'
-    branch: master
-    b64_branch: "{{ branch  | b64encode | replace('=', '') }}"
-    id: "{{ branch | regex_replace('[^a-zA-Z0-9]', '') }}-{{ b64_branch }}"
+    # will usually be overwritten by --extra-vars='deployid=<id>'
+    id: "{{ deployid }}"
 
   tasks:
 

--- a/.deployment/remove-deployment.yml
+++ b/.deployment/remove-deployment.yml
@@ -4,11 +4,8 @@
 - hosts: all
 
   vars:
-    # default branch
-    # will usually be opverwritten by --extra-vars='branch=<breanch>'
-    branch: master
-    b64_branch: "{{ branch  | b64encode | replace('=', '') }}"
-    id: "{{ branch | regex_replace('[^a-zA-Z0-9]', '') }}-{{ b64_branch }}"
+    # will usually be overwritten by --extra-vars='deployid=<id>'
+    id: "{{ deployid }}"
 
   tasks:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build, test and deploy
+name: Build & test
 
 on: [pull_request, push]
 
@@ -69,37 +69,18 @@ jobs:
       working-directory: backend
       run: cargo run --bin export-schema | diff -u --color=always - ../frontend/src/schema.graphql
 
-    # Deployment
-    - name: Build server binary for CI
+    # Prepare binary for deployment
+    - name: Build server binary for test deployment
       working-directory: backend/server
       run: cargo build --features=embed-in-debug
-    - name: Prepare binary and demo data for deployment
-      run: |
-        cp -v backend/target/debug/tobira .deployment/files/
-        cp -v scripts/fixtures.sql .deployment/files/
-        cp -v backend/logo-large.svg .deployment/files/
-        cp -v backend/logo-small.svg .deployment/files/
 
-    - name: prepare deploy key
-      env:
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-      run: |
-        install -dm 700 ~/.ssh/
-        echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
-        chmod 600 ~/.ssh/id_ed25519
-        ssh-keyscan tobira.opencast.org >> ~/.ssh/known_hosts
-      if: ${{ github.event_name == 'push' }}
-
-    - name: install ansible postgres extensions
-      run: ansible-galaxy collection install community.postgresql
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'elan-ev' }}
-
-    - name: deploy tobira branch
-      working-directory: .deployment
-      run: >
-        ansible-playbook
-        --private-key=~/.ssh/id_ed25519
-        --extra-vars="branch='${GITHUB_REF#refs/heads/}'"
-        -u github
-        deploy.yml
-      if: ${{ github.event_name == 'push' && github.repository_owner == 'elan-ev' }}
+    # Archive files to be used in the `deploy` workflow
+    - name: Archive deployment files as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-deployment-files
+        path: |
+          backend/target/debug/tobira
+          scripts/fixtures.sql
+          backend/logo-large.svg
+          backend/logo-small.svg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
       working-directory: backend/server
       run: cargo build --features=embed-in-debug
 
+    # Prepare the ID (used in the subdomain) for deployment. This has to be done
+    # here because in the `deploy` workflow, we don't have access to the correct
+    # `GITHUB_REF` anymore.
+    - name: Write deploy ID to file
+      run: ./.deployment/deploy-id.sh > deploy-id
+
     # Archive files to be used in the `deploy` workflow
     - name: Archive deployment files as artifact
       uses: actions/upload-artifact@v2
@@ -84,3 +90,4 @@ jobs:
           scripts/fixtures.sql
           backend/logo-large.svg
           backend/logo-small.svg
+          deploy-id

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build & test"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    if: >
+      ${{ github.event.workflow_run.conclusion == 'success' && (
+        github.actor == 'LukasKalbertodt' ||
+        github.actor == 'JulianKniephoff' ||
+        github.actor == 'lkiesow'
+      ) }}
+    steps:
+    - uses: actions/checkout@v2
+
+    # Unfortunately we cannot use `actions/download-artifact` here since that
+    # only allows to download artifacts from the same run.
+    - name: Download artifacts from build workflow
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          const artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          const deployFiles = artifacts.data.artifacts
+              .filter(a => a.name == "test-deployment-files")[0];
+          const download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+              archive_format: 'zip',
+          });
+
+          const fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+    - run: unzip -u artifacts.zip
+
+    - name: Prepare files for deployment
+      run: |
+        cp -v backend/target/debug/tobira .deployment/files/
+        cp -v scripts/fixtures.sql .deployment/files/
+        cp -v backend/logo-large.svg .deployment/files/
+        cp -v backend/logo-small.svg .deployment/files/
+
+    - name: prepare deploy key
+      env:
+        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      run: |
+        install -dm 700 ~/.ssh/
+        echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan tobira.opencast.org >> ~/.ssh/known_hosts
+
+    - name: install ansible postgres extensions
+      run: ansible-galaxy collection install community.postgresql
+
+    - name: deploy tobira branch
+      working-directory: .deployment
+      run: >
+        ansible-playbook
+        --private-key=~/.ssh/id_ed25519
+        --extra-vars="branch='${GITHUB_REF#refs/heads/}'"
+        -u github
+        deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,6 @@ jobs:
       run: >
         ansible-playbook
         --private-key=~/.ssh/id_ed25519
-        --extra-vars="branch='${GITHUB_REF#refs/heads/}'"
+        --extra-vars="deployid='$(cat deploy-id)'"
         -u github
         deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,13 @@ jobs:
 
           const fs = require('fs');
           fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
+
+          // The artifact is not needed anymore
+          github.actions.deleteArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: deployFiles.id,
+          })
     - run: unzip -u artifacts.zip
 
     - name: Prepare files for deployment


### PR DESCRIPTION
This makes it so that PRs from @JulianKniephoff @lkiesow or myself are automatically test deployed. Unfortunately, the relevant CI script does NOT run for this PR, but only after merging. I know, it's weird but there are reasons. See the commit message for more information:
> Our goal is to test deploy pull request so that one can easily test the
> changes without checking them out locally. The problem is that we need
> secrets for the deployment (i.e. to access the server). Just running
> the script with secrets for random PRs is a security problem as CI
> essentially executes arbitrary attackers code.
> 
> The solution, which I luckily found in a blog post, is to use the
> `workflow_run` trigger to start one workflow after another one has
> finished. The first workflow builds and tests the actual project code
> and has no access to secrets. Some of those results (e.g. the resulting
> binary) are then archived as artifacts.
> 
> The next workflow can then download those artifacts and do the
> deployment. That second, `workflow_run`, workflow does have access to
> the secrets.
> 
> However, we still essentially take one executable that is fully
> controlled by the PR author and execute it on our servers. Here is
> where the last point of defense comes in: we only deploy if
> `github.actor` is one of three blessed people. But: this check is
> defined in the `deploy.yml` file, so what if an attacker just edits
> that to remove the chat? Well, `workflow_run` triggered workflows run
> in the context of the main repo and always use the version on the
> default branch. So changes in `deploy.yml` are not actually used until
> the PR is merged (and well, this shouldn't happen if the change is
> malicious).
> 
> Somewhat annoyingly, this means that to test my script, we actually
> need to merge my PR now. No way to test it before.
> 
> And finally: at some point we might want to also test deploy PRs from
> other people by first doing a code review and then commenting `/deploy`
> on the PR or something like that.

Some links for reference:
- `workflow_run` docs: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
- The blog post that taught me about `workflow_run` in the first place: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- A blog post about deploying on a special comment: https://sanderknape.com/2020/05/deploy-pull-requests-github-actions-deployments/
- Documentation about `github.actor`: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context