### PR TITLE
Properly handle HTTP HEAD requests and remove `GET /graphql` route

### DIFF
--- a/backend/server/src/http/mod.rs
+++ b/backend/server/src/http/mod.rs
@@ -187,7 +187,11 @@ async fn handle(req: Request<Body>, ctx: Arc<Context>) -> Result<Response> {
         // From this point on, we only support GET and HEAD requests. All others
         // will result in 404.
         _ if method != Method::GET && method != Method::HEAD => {
-            reply_404(&ctx.assets, &method, path).await
+            Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .header("Content-Type", "text/plain; charset=UTF-8")
+                .body(Body::from("405 Method not allowed"))
+                .unwrap()
         }
 
         // Standard routes

--- a/backend/server/src/http/mod.rs
+++ b/backend/server/src/http/mod.rs
@@ -186,7 +186,7 @@ async fn handle(req: Request<Body>, ctx: Arc<Context>) -> Result<Response> {
         (&Method::GET, "/graphiql") => juniper_hyper::graphiql("/graphql", None).await?,
 
         // The actual GraphQL API.
-        (&Method::GET, "/graphql") | (&Method::POST, "/graphql") => {
+        (&Method::POST, "/graphql") => {
             juniper_hyper::graphql(ctx.api_root.clone(), ctx.api_context.clone(), req).await?
         }
 


### PR DESCRIPTION
Fixes #114

The body is automatically removed by `hyper` if the method is HEAD. This PR also removes the `GET /graphql` route (see commit message).