### PR TITLE
Use `.deployment/templates/config.toml` from branch/PR, not `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,4 @@ jobs:
           backend/logo-large.svg
           backend/logo-small.svg
           deploy-id
+          .deployment/templates/config.toml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           const artifacts = await github.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{github.event.workflow_run.id }},
+              run_id: ${{ github.event.workflow_run.id }},
           });
           const deployFiles = artifacts.data.artifacts
               .filter(a => a.name == "test-deployment-files")[0];
@@ -55,6 +55,7 @@ jobs:
     # explicitly remove the file we expect to get overwriten.
     - name: extract artifacts
       run: |
+        rm .deployment/templates/config.toml || true
         rm scripts/fixtures.sql || true
         rm backend/logo-large.svg || true
         rm backend/logo-small.svg || true


### PR DESCRIPTION
Another CI/deploy PR :( I hope I'm done with those soon.

This was already a "problem" in #205 which was never deployed because of that. Everything worked after merging it into `master`, but it would be nice to deploy such PRs already.