### PR TITLE
Make frontend doc comments use tsdoc standard

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
             "named": "never",
             "asyncArrow": "always",
         }],
+        "lines-around-comment": ["warn", { "allowBlockStart": true }],
         "camelcase": ["warn", {
             allow: ["\\$key$"],
             ignoreImports: true,
@@ -191,6 +192,7 @@ module.exports = {
                 "named": "never",
                 "asyncArrow": "always",
             }],
+            "lines-around-comment": ["warn", { "allowBlockStart": true }],
         },
         settings: {
             react: {

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -7,11 +7,12 @@ export const GlobalStyle: React.FC = () => <>
     <Global styles={GLOBAL_STYLE} />
 </>;
 
-
-// The following is a minimal set of CSS reset rules in order to get rid of
-// browser dependent, inconsistent or unexpected behavior. Parts of this
-// are taken from here: https://github.com/hankchizljaw/modern-css-reset
-// Licensed as MIT, Andy Bell and other contributors
+/**
+ * The following is a minimal set of CSS reset rules in order to get rid of
+ * browser dependent, inconsistent or unexpected behavior. Parts of this
+ * are taken from here: https://github.com/hankchizljaw/modern-css-reset
+ * Licensed as MIT, Andy Bell and other contributors
+ */
 const CSS_RESETS = css({
     // Everything should have box-sizing border-box by default as it's more
     // intuitive and expected.
@@ -48,7 +49,7 @@ const CSS_RESETS = css({
     },
 });
 
-// This is just styling for Tobira that we want to apply globally.
+/** This is just styling for Tobira that we want to apply globally. */
 const GLOBAL_STYLE = css({
     body: {
         fontFamily: "'Open Sans', sans-serif",

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,10 +1,10 @@
 import { bug } from "./util/err";
 
 
-// The ID of the HTML element containing our configuration.
+/** The ID of the HTML element containing our configuration. */
 const ID = "tobira-frontend-config";
 
-// Loads the frontend config and returns it as object.
+/** Loads the frontend config and returns it as object. */
 const parseConfig: () => Config = () => {
     const tag = document.getElementById(ID);
     if (tag === null) {

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -65,7 +65,7 @@ const Search: React.FC = () => {
     );
 };
 
-// The icons on the right side of the header: changing language and main menu.
+/** The icons on the right side of the header: changing language and main menu. */
 const ActionIcons: React.FC = () => {
     const { t } = useTranslation();
 
@@ -134,9 +134,11 @@ type ActionIconProps = {
     isActive: boolean;
 };
 
-// A single icon/button on the right of the header. There is some trickery
-// involved to make this arrow/triangle indicator when a specific icon is
-// active.
+/**
+ * A single icon/button on the right of the header. There is some trickery
+ * involved to make this arrow/triangle indicator when a specific icon is
+ * active.
+ */
 const ActionIcon: React.FC<ActionIconProps> = ({ title, onClick, isActive, children }) => {
     const iconSize = 28;
     const arrowSize = 14;
@@ -187,7 +189,7 @@ const ActionIcon: React.FC<ActionIconProps> = ({ title, onClick, isActive, child
     );
 };
 
-// The main menu with several links and functions.
+/** The main menu with several links and functions. */
 const MainMenu: React.FC<{ closeMenu: () => void }> = ({ closeMenu }) => {
     const { t } = useTranslation();
     const iconStyle = {

--- a/frontend/src/layout/NavMain.tsx
+++ b/frontend/src/layout/NavMain.tsx
@@ -20,13 +20,17 @@ type NavItem = {
     active: boolean;
 };
 
-// At this screen width, the layout changes from a sidebar for navigation (for
-// larger screens) and the navigation inlined (for smaller screens).
+/**
+ * At this screen width, the layout changes from a sidebar for navigation (for
+ * larger screens) and the navigation inlined (for smaller screens).
+ */
 const BREAKPOINT = 720;
 
-// A layout for the `<main>` part of pages that require a navigation (mainly
-// realms). The navigation is either shown on the left as a sidebar (for large
-// screens) or inline below the page title (for small screens).
+/**
+ * A layout for the `<main>` part of pages that require a navigation (mainly
+ * realms). The navigation is either shown on the left as a sidebar (for large
+ * screens) or inline below the page title (for small screens).
+ */
 export const NavMain: React.FC<Props> = ({ title, breadcrumbs, children, ...navProps }) => (
     <div css={{
         // This funky expressions just means: above a screen width of 1100px,
@@ -65,7 +69,7 @@ type NavProps = {
     leafNode: boolean;
 };
 
-// The navigation part of the layout.
+/** The navigation part of the layout. */
 const Nav: React.FC<NavProps> = ({ items, leafNode }) => {
     const [navExpanded, setNavExpanded] = useState(false);
     const { t } = useTranslation();

--- a/frontend/src/relay/errors.ts
+++ b/frontend/src/relay/errors.ts
@@ -12,10 +12,12 @@ import type {
 // With our current usage of Relay, these will be most useful in error boundaries.
 
 
-// This error gets thrown if there was an error "below" the layer of GraphQL,
-// i.e. when we didn't even get a response from the API. This can happen
-// because there was a network level error, but specifically also happens
-// whenever we get a `4xx` or `5xx` response from the backend.
+/**
+ * This error gets thrown if there was an error "below" the layer of GraphQL,
+ * i.e. when we didn't even get a response from the API. This can happen
+ * because there was a network level error, but specifically also happens
+ * whenever we get a `4xx` or `5xx` response from the backend.
+ */
 export class ServerError extends Error {
     public response: Response;
 
@@ -26,20 +28,23 @@ export class ServerError extends Error {
     }
 }
 
-// This error is supposed to be thrown whenever the API response
-// contained an `errors` field. This is GraphQL's mechanism to report errors,
-// as opposed to the HTTP status code based reporting of typical REST APIs.
-// This way, GraphQL can even report partial errors (together with a partial response).
-// For us, this is kind of awkward to use, because the Relay hooks
-// never pass these errors to the calling component.
-// With this error, you can at least grab them in an error boundary, though,
-// and you can even get the partial data, if any, because we package it in here.
-// Note, however, that we currently recommend modeling error/partial data situations
-// explicitly instead of relying on this, because of how awkward it would be
-// to pass the partial data to your component from the error boundary.
-// (You would have to extract the Relay query from the rendering logic,
-// so that you can call the latter from both, the component that does the query,
-// and from the error boundary.)
+/**
+ * This error is supposed to be thrown whenever the API response contained an
+ * `errors` field. This is GraphQL's mechanism to report errors, as opposed to
+ * the HTTP status code based reporting of typical REST APIs. This way, GraphQL
+ * can even report partial errors (together with a partial response).
+ *
+ * For us, this is kind of awkward to use, because the Relay hooks never pass
+ * these errors to the calling component. With this error, you can at least
+ * grab them in an error boundary, though, and you can even get the partial
+ * data, if any, because we package it in here. Note, however, that we
+ * currently recommend modeling error/partial data situations explicitly
+ * instead of relying on this, because of how awkward it would be to pass the
+ * partial data to your component from the error boundary. (You would have to
+ * extract the Relay query from the rendering logic, so that you can call the
+ * latter from both, the component that does the query, and from the error
+ * boundary.)
+ */
 export class APIError extends Error {
     // Note: This is a kind of misleading name.
     // There could still be a `data` field on this.
@@ -52,7 +57,7 @@ export class APIError extends Error {
     }
 }
 
-// Checks whether the given GraphQL response contains any errors
+/** Checks whether the given GraphQL response contains any errors. */
 export const hasErrors = (
     response: GraphQLSingularResponse,
 ): response is GraphQLResponseWithoutData =>

--- a/frontend/src/ui/Blocks.tsx
+++ b/frontend/src/ui/Blocks.tsx
@@ -61,11 +61,13 @@ export const Block: React.FC = ({ children }) => (
     <div css={{ margin: "30px 0" }}>{children}</div>
 );
 
-// A helper function to getting block-type dependent fields as non-null values.
+/** A helper function to getting block-type dependent fields as non-null values. */
 function unwrap<K extends keyof BlockData>(block: BlockData, field: K): NonNullable<BlockData[K]> {
-    // This is a function because for some reason, inlining this check below
-    // confused the TS compiler. In that case it wouldn't understand that
-    // `return v` in the end is actually a non-null value.
+    /**
+     * This is a function because for some reason, inlining this check below
+     * confused the TS compiler. In that case it wouldn't understand that
+     * `return v` in the end is actually a non-null value.
+     */
     function isNotNullish<T>(value: T): value is NonNullable<T> {
         return value !== undefined && value !== null;
     }

--- a/frontend/src/ui/Player.tsx
+++ b/frontend/src/ui/Player.tsx
@@ -11,10 +11,12 @@ import { HEIGHT as HEADER_HEIGHT } from "../layout/Header";
 type PlayerProps = {
     mediaUrl: string;
 
-    // `true` if this player appears on some content block. `false` if the
-    // player is on the dedicated player page. A `false` just leads to the
-    // player taking up more screen space, growing larger than its parent
-    // container. Defaults to `false`.
+    /**
+     * `true` if this player appears on some content block. `false` if the
+     * player is on the dedicated player page. A `false` just leads to the
+     * player taking up more screen space, growing larger than its parent
+     * container. Defaults to `false`.
+     */
     embedded?: boolean;
 };
 

--- a/frontend/src/util/err.ts
+++ b/frontend/src/util/err.ts
@@ -1,27 +1,31 @@
-// Make sure that the parameter is `never`. This is particularly useful for
-// enum-like types where you want to make sure you handled all cases. For
-// example:
-//
-// ```
-// type Foo = "anna" | "bob";
-// const x = "anna" as Foo;
-//
-// switch x {
-//     case "anna": ...; break;
-//     case "bob": ...; break;
-//     default: assertNever(x);
-// }
-// ```
-//
-// If you add another variant to that type, the switch statement will fail to
-// compile. This is what we want in most cases! That way, we are notified of all
-// places which we might need to change after adding a new variant.
+/**
+ * Make sure that the parameter is `never`. This is particularly useful for
+ * enum-like types where you want to make sure you handled all cases. For
+ * example:
+ *
+ * ```
+ * type Foo = "anna" | "bob";
+ * const x = "anna" as Foo;
+ *
+ * switch x {
+ *     case "anna": ...; break;
+ *     case "bob": ...; break;
+ *     default: assertNever(x);
+ * }
+ * ```
+ *
+ * If you add another variant to that type, the switch statement will fail to
+ * compile. This is what we want in most cases! That way, we are notified of all
+ * places which we might need to change after adding a new variant.
+ */
 export const assertNever = (_n: never): never =>
     bug("`assertNever` call was reached, that's a soundness hole in the typesystem :(");
 
-// A custom error type that represents bugs: errors that are not expected and
-// that cannot be handled. They are caused by a bug in our code and not by the
-// "world" (e.g. any input). Use the helper functions below to throw this error.
+/**
+ * A custom error type that represents bugs: errors that are not expected and
+ * that cannot be handled. They are caused by a bug in our code and not by the
+ * "world" (e.g. any input). Use the helper functions below to throw this error.
+ */
 export class Bug extends Error {
     public constructor(msg: string) {
         super(`${msg} (this is a bug in Tobira)`);
@@ -29,12 +33,12 @@ export class Bug extends Error {
     }
 }
 
-// Throws a `Bug` error. Use this function to signal a bug in the code.
+/** Throws a `Bug` error. Use this function to signal a bug in the code. */
 export const bug = (msg: string): never => {
     throw new Bug(msg);
 };
 
-// Like `bug`, but specifically for code paths that should be unreachable.
+/** Like `bug`, but specifically for code paths that should be unreachable. */
 export const unreachable = (msg?: string): never => {
     const prefix = "reached unreachable code";
     throw new Bug(msg === undefined ? prefix : `${prefix}: ${msg}`);

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -1,23 +1,25 @@
 
-// A switch-like expression with exhaustiveness check (or fallback value). A bit
-// like Rust's `match`, but worse.
-//
-// If the `fallback` is not given, the given match arms need to be exhaustive.
-// This helps a lot with maintanence as adding a new variant to a union type
-// will throw compile errors in all places that likely need adjustment. You can
-// also pass a fallback (default) value as third parameter, disabling the
-// exhaustiveness check.
-//
-// ```
-// type Animal = "dog" | "cat" | "fox";
-//
-// const animal = "fox" as Animal;
-// const awesomeness = match(animal, {
-//     "dog": () => 7,
-//     "cat": () => 6,
-//     "fox": () => 100,
-// });
-// ```
+/**
+ * A switch-like expression with exhaustiveness check (or fallback value). A bit
+ * like Rust's `match`, but worse.
+ *
+ * If the `fallback` is not given, the given match arms need to be exhaustive.
+ * This helps a lot with maintanence as adding a new variant to a union type
+ * will throw compile errors in all places that likely need adjustment. You can
+ * also pass a fallback (default) value as third parameter, disabling the
+ * exhaustiveness check.
+ *
+ * ```
+ * type Animal = "dog" | "cat" | "fox";
+ *
+ * const animal = "fox" as Animal;
+ * const awesomeness = match(animal, {
+ *     "dog": () => 7,
+ *     "cat": () => 6,
+ *     "fox": () => 100,
+ * });
+ * ```
+ */
 export function match<T extends string | number, Out>(
     value: T,
     arms: Record<T, () => Out>,
@@ -42,7 +44,7 @@ export function match<T extends string | number, Out>(
         : (arms[value] as (() => Out) | undefined ?? fallback)();
 }
 
-// Retrieves the key of an ID by stripping the "kind" prefix.
+/** Retrieves the key of an ID by stripping the "kind" prefix. */
 export function keyOfId(id: string): string {
     return id.substring(2);
 }


### PR DESCRIPTION
It's a good idea to use a standard. I changed it now because my editor
learned how to show the definition of symbols, also showing tsdoc docs.
So this already helps me navigate the codebase.

This change does not yet use any special features of tsdoc (i.e. the `@` directives). 

Closes #155 