### PR TITLE
Use released version of `juniper` and `juniper_hyper`

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -678,8 +678,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "juniper"
-version = "0.15.5"
-source = "git+https://github.com/LukasKalbertodt/juniper?branch=tokio1#5665857ef344795d145c00755acd5c6adc1b3800"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637ffa8a8d8a05aed3331449e311f145864adcd82442d82e54d0522decb7cecf"
 dependencies = [
  "async-trait",
  "bson",
@@ -699,8 +700,9 @@ dependencies = [
 
 [[package]]
 name = "juniper_codegen"
-version = "0.15.5"
-source = "git+https://github.com/LukasKalbertodt/juniper?branch=tokio1#5665857ef344795d145c00755acd5c6adc1b3800"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a040e09482a45e77dd2dafa0d9d2651d17faf0ac674da0c93eabc3075ee24997"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -710,8 +712,9 @@ dependencies = [
 
 [[package]]
 name = "juniper_hyper"
-version = "0.7.0"
-source = "git+https://github.com/LukasKalbertodt/juniper?branch=tokio1#5665857ef344795d145c00755acd5c6adc1b3800"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a502579036a091b0b55defae02c48d35edaabdbce68954cd9c735610652af00e"
 dependencies = [
  "futures",
  "hyper",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -15,7 +15,7 @@ description = "GraphQL API of the Tobira video portal for Opencast"
 anyhow = "1"
 deadpool-postgres = { version = "0.9", default-features = false }
 futures = "0.3.1"
-juniper = { git = "https://github.com/LukasKalbertodt/juniper", branch = "tokio1" }
+juniper = "0.15.7"
 log = "0.4"
 paste = "1"
 postgres-types = { version = "0.2", features = ["derive"] }

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -27,7 +27,7 @@ hostname = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "http2"] }
 hyperlocal = "0.8"
 hyper-tls = "0.5"
-juniper_hyper = { git = "https://github.com/LukasKalbertodt/juniper", branch = "tokio1" }
+juniper_hyper = "0.8.0"
 log = { version = "0.4", features = ["serde", "std"] }
 mime_guess = "2"
 once_cell = "1.5"


### PR DESCRIPTION
They finally merged the PR and released everything to crates.io :tada: 