### PR TITLE
Use DB transaction for each API request and improve storage & loading of realms

### DIFF
--- a/backend/api/src/lib.rs
+++ b/backend/api/src/lib.rs
@@ -1,6 +1,5 @@
 //! Definition of the GraphQL API.
 
-use tobira_util::prelude::*;
 use crate::{
     mutation::Mutation,
     query::Query,
@@ -33,16 +32,11 @@ pub type RootNode = juniper::RootNode<'static, Query, Mutation, Subscription>;
 /// The context that is accessible to every resolver in our API.
 pub struct Context {
     db: tx::Transaction,
-    realm_tree: model::realm::Tree,
 }
 
 impl Context {
-    pub async fn new(db: Transaction) -> Result<Self> {
-        let realm_tree = model::realm::Tree::load(&**db).await?;
-        Ok(Self {
-            db,
-            realm_tree,
-        })
+    pub fn new(db: Transaction) -> Self {
+        Self { db }
     }
 }
 

--- a/backend/api/src/model/block.rs
+++ b/backend/api/src/model/block.rs
@@ -116,8 +116,7 @@ impl SeriesBlock {
 impl BlockValue {
     /// Fetches all blocks for the given realm from the database.
     pub(crate) async fn load_for_realm(realm_key: Key, context: &Context) -> FieldResult<Vec<Self>> {
-        context.db.get()
-            .await?
+        context.db
             .query_raw(
                 "select id, type, index, title, text_content, series_id,
                     videolist_layout, videolist_order

--- a/backend/api/src/model/event.rs
+++ b/backend/api/src/model/event.rs
@@ -72,8 +72,7 @@ impl Event {
 impl Event {
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> FieldResult<Option<Self>> {
         let result = if let Some(key) = id.key_for(Id::EVENT_KIND) {
-            context.db.get()
-                .await?
+            context.db
                 .query_opt(
                     &*format!("select {} from events where id = $1", Self::COL_NAMES),
                     &[&(key as i64)],
@@ -88,8 +87,7 @@ impl Event {
     }
 
     pub(crate) async fn load_for_series(series_key: Key, context: &Context) -> FieldResult<Vec<Self>> {
-        let result = context.db.get()
-            .await?
+        let result = context.db
             .query_raw(
                 &*format!("select {} from events where series = $1", Self::COL_NAMES),
                 &[series_key as i64],

--- a/backend/api/src/model/realm.rs
+++ b/backend/api/src/model/realm.rs
@@ -1,6 +1,6 @@
-use deadpool_postgres::Pool;
 use futures::stream::TryStreamExt;
 use juniper::{FieldResult, graphql_object};
+use tokio_postgres::GenericClient;
 use std::collections::HashMap;
 
 use tobira_util::{
@@ -74,13 +74,12 @@ pub(crate) struct Tree {
 }
 
 impl Tree {
-    pub(crate) async fn load(db: &Pool) -> Result<Self> {
+    pub(crate) async fn load(db: &impl GenericClient) -> Result<Self> {
         debug!("Loading realms from database");
 
         // We store the nodes of the realm tree in a hash map
         // accessible by the database ID
-        let mut realms = db.get()
-            .await?
+        let mut realms = db
             .query_raw(
                 "select id, name, parent, path_segment from realms",
                 NO_PARAMS,

--- a/backend/api/src/model/realm.rs
+++ b/backend/api/src/model/realm.rs
@@ -1,12 +1,6 @@
 use futures::stream::TryStreamExt;
 use juniper::{FieldResult, graphql_object};
-use tokio_postgres::GenericClient;
-use std::collections::HashMap;
 
-use tobira_util::{
-    prelude::*,
-    db::NO_PARAMS,
-};
 use crate::{
     Context, Id, Key,
     model::block::BlockValue,
@@ -16,10 +10,87 @@ use crate::{
 
 pub(crate) struct Realm {
     key: Key,
-    name: String,
     parent_key: Option<Key>,
-    path_segment: String,
-    child_keys: Vec<Key>,
+    name: String,
+
+    /// Full realm path. Empty string for root realm.
+    path: String,
+}
+
+impl Realm {
+    pub(crate) fn root() -> Self {
+        Self {
+            key: 0,
+            parent_key: None,
+            name: String::new(),
+            path: String::new(),
+        }
+    }
+
+    pub(crate) async fn load_by_id(id: Id, context: &Context) -> FieldResult<Option<Self>> {
+        if let Some(key) = id.key_for(Id::REALM_KIND) {
+            Self::load_by_key(key, context).await
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn load_by_key(key: Key, context: &Context) -> FieldResult<Option<Self>> {
+        if key == 0 {
+            return Ok(Some(Self::root()));
+        }
+
+        let result = context.db
+            .query_opt(
+                "select parent, name, full_realm_path(id)
+                    from realms
+                    where id = $1",
+                &[&(key as i64)],
+            )
+            .await?
+            .map(|row| Self {
+                key,
+                parent_key: Some(row.get_key(0)),
+                name: row.get(1),
+                path: row.get(2),
+            });
+
+        Ok(result)
+    }
+
+    pub(crate) async fn load_by_path(mut path: String, context: &Context) -> FieldResult<Option<Self>> {
+        // Normalize path: strip optional trailing slash.
+        if path.ends_with('/') {
+            path.pop();
+        }
+
+        // Check for root realm.
+        if path.is_empty() {
+            return Ok(Some(Self::root()));
+        }
+
+        // All non-root paths have to start with `/`.
+        if !path.starts_with('/') {
+            return Ok(None);
+        }
+
+        let result = context.db
+            .query_opt(
+                "select id, parent, name
+                    from realms
+                    where full_realm_path(id) = $1",
+                &[&path],
+            )
+            .await?
+            .map(|row| Self {
+                key: row.get_key(0),
+                parent_key: Some(row.get_key(1)),
+                name: row.get(2),
+                path,
+            });
+
+        Ok(result)
+    }
 }
 
 #[graphql_object(Context = Context)]
@@ -36,26 +107,68 @@ impl Realm {
         self.key == 0
     }
 
-    fn path(&self, context: &Context) -> String {
-        Tree::path(self, &context.realm_tree.realms)
+    /// Returns the full path of this realm. `""` for the root realm. For
+    /// non-root realms, the path always starts with `/` and never has a
+    /// trailing `/`.
+    fn path(&self) -> &str {
+        &self.path
     }
 
-    fn parent(&self, context: &Context) -> Option<&Realm> {
-        self.parent_key.map(|parent_key| &context.realm_tree.realms[&parent_key])
+    /// Returns the immediate parent of this realm.
+    async fn parent(&self, context: &Context) -> FieldResult<Option<Realm>> {
+        match self.parent_key {
+            Some(parent_key) => Realm::load_by_key(parent_key, context).await,
+            None => Ok(None)
+        }
     }
 
-    fn parents(&self, context: &Context) -> Vec<&Realm> {
-        let mut parents = Tree::walk_up(self, &context.realm_tree.realms)
-            .skip(1)
-            .collect::<Vec<_>>();
-        parents.reverse();
-        parents
+    /// Returns all ancestors between the root realm to this realm
+    /// (excluding both, the root realm and this realm).
+    async fn ancestors(&self, context: &Context) -> FieldResult<Vec<Realm>> {
+        let result = context.db
+            .query_raw(
+                "select id, parent, name, full_realm_path(id)
+                    from ancestors_of_realm($1)
+                    where height <> 0 and id <> 0",
+                &[&(self.key as i64)],
+            )
+            .await?
+            .map_ok(|row| {
+                Self {
+                    key: row.get_key(0),
+                    parent_key: Some(row.get_key(1)),
+                    name: row.get(2),
+                    path: row.get(3),
+                }
+            })
+            .try_collect()
+            .await?;
+
+        Ok(result)
     }
 
-    fn children(&self, context: &Context) -> Vec<&Realm> {
-        self.child_keys.iter()
-            .map(|child| &context.realm_tree.realms[&child])
-            .collect()
+    /// Returns all immediate children of this realm.
+    async fn children(&self, context: &Context) -> FieldResult<Vec<Self>> {
+        let result = context.db
+            .query_raw(
+                "select id, name, path_segment
+                    from realms
+                    where parent = $1",
+                &[&(self.key as i64)],
+            )
+            .await?
+            .map_ok(|row| {
+                Self {
+                    key: row.get_key(0),
+                    parent_key: Some(self.key),
+                    name: row.get(1),
+                    path: format!("{}/{}", self.path, row.get::<_, String>(2)),
+                }
+            })
+            .try_collect()
+            .await?;
+
+        Ok(result)
     }
 
     /// Returns the (content) blocks of this realm.
@@ -65,95 +178,5 @@ impl Realm {
         // will only show one realm at a time, so the query will also only
         // request the blocks of one realm.
         BlockValue::load_for_realm(self.key, context).await
-    }
-}
-
-pub(crate) struct Tree {
-    pub(crate) realms: HashMap<Key, Realm>,
-    from_path: HashMap<String, Key>,
-}
-
-impl Tree {
-    pub(crate) async fn load(db: &impl GenericClient) -> Result<Self> {
-        debug!("Loading realms from database");
-
-        // We store the nodes of the realm tree in a hash map
-        // accessible by the database ID
-        let mut realms = db
-            .query_raw(
-                "select id, name, parent, path_segment from realms",
-                NO_PARAMS,
-            )
-            .await?
-            .map_ok(|row| {
-                let key = row.get_key(0);
-                Realm {
-                    key,
-                    name: row.get(1),
-                    parent_key: if key == 0 { None } else { Some(row.get_key(2)) },
-                    path_segment: row.get(3),
-                    child_keys: vec![],
-                }
-            })
-            .map_ok(|realm| (realm.key, realm))
-            .try_collect::<HashMap<_, _>>()
-            .await?;
-
-        // With this, and the `parent` member of the `Realm`,
-        // we already have quick access to the data of a realm's parent.
-        // To also get to the children quickly we maintain a corresponding list
-        // for each realm
-        let keys = realms.values()
-            .filter_map(|realm| {
-                realm.parent_key.map(|parent_key| (realm.key, parent_key))
-            })
-            .collect::<Vec<_>>();
-        for (key, parent_key) in keys {
-            let parent = realms.get_mut(&parent_key)
-                .with_context(|| format!("invalid parent {} of {}", parent_key, key))?;
-            parent.child_keys.push(key);
-        }
-
-        // After this point, we should know the tree structure to be valid.
-        // That is, we can now safely panic if we can't find things in our maps/lists;
-        // that's totally a bug in this code, then, not an inconsistency in the db.
-
-        // We also need a map from the full path to the proper realm.
-        let from_path = realms.iter()
-            .map(|(key, realm)| (Tree::path(realm, &realms), *key))
-            .collect::<HashMap<_, _>>();
-
-        debug!("Loaded {} realms from the database", realms.len());
-
-        Ok(Tree { realms, from_path })
-    }
-
-    fn walk_up<'a>(realm: &'a Realm, realms: &'a HashMap<Key, Realm>) -> impl Iterator<Item = &'a Realm> {
-        std::iter::successors(
-            Some(realm),
-            move |child| child.parent_key.map(|parent_key| &realms[&parent_key])
-        )
-    }
-
-    fn path(realm: &Realm, realms: &HashMap<Key, Realm>) -> String {
-        let mut segments = Tree::walk_up(realm, realms)
-            .map(|realm| &*realm.path_segment)
-            .collect::<Vec<_>>();
-        segments.reverse();
-        segments.join("/")
-    }
-
-    pub(crate) fn get_node(&self, id: &Id) -> Option<&Realm> {
-        self.realms.get(&id.key_for(Id::REALM_KIND)?)
-    }
-
-    pub(crate) fn root(&self) -> &Realm {
-        &self.realms[&0]
-    }
-
-    pub(crate) fn from_path(&self, path: &str) -> Option<&Realm> {
-        // We accept path with and without a trailing slash.
-        let path = if path.ends_with('/') { &path[..path.len() - 1] } else { path };
-        self.from_path.get(path).map(|key| &self.realms[key])
     }
 }

--- a/backend/api/src/model/series.rs
+++ b/backend/api/src/model/series.rs
@@ -38,8 +38,7 @@ impl Series {
     }
 
     pub(crate) async fn load_by_key(key: Key, context: &Context) -> FieldResult<Option<Series>> {
-        let result = context.db.get()
-            .await?
+        let result = context.db
             .query_opt(
                 "select id, title, description
                     from series

--- a/backend/api/src/query.rs
+++ b/backend/api/src/query.rs
@@ -12,33 +12,25 @@ impl Query {
         "0.0"
     }
 
-    /// Returns a flat list of all realms.
-    fn realms(context: &Context) -> Vec<&Realm> {
-        context.realm_tree.realms.values().collect()
+    /// Returns the root realm.
+    fn root_realm() -> Realm {
+        Realm::root()
     }
 
     /// Returns the realm with the specific ID or `None` if the ID does not
     /// refer to a realm.
-    fn realm_by_id(id: Id, context: &Context) -> Option<&Realm> {
-        context.realm_tree.get_node(&id)
+    async fn realm_by_id(id: Id, context: &Context) -> FieldResult<Option<Realm>> {
+        Realm::load_by_id(id, context).await
     }
 
-    /// Returns the realm with the specific path or `None` if the path does not
+    /// Returns the realm with the given path or `None` if the path does not
     /// refer to a realm.
     ///
-    /// Every realm has its own "path segment", and the full path of a realm
-    /// is just the concatenation of all the path segments between the root realm
-    /// and the realm in question, delimited by `"/"`. The root realm is assumed
-    /// to have a path segment of `""`, and with the above rule so is its full
-    /// path. The path of every other realm will start with `"/"` delimiting the
-    /// root realm path segement from the second segment in the path.
-    fn realm_by_path(path: String, context: &Context) -> Option<&Realm> {
-        context.realm_tree.from_path(&path)
-    }
-
-    /// Returns the root realm.
-    fn root_realm(context: &Context) -> &Realm {
-        context.realm_tree.root()
+    /// Paths with and without trailing slash are accepted and treated equally.
+    /// The paths `""` and `"/"` refer to the root realm. All other paths have
+    /// to start with `"/"`.
+    async fn realm_by_path(path: String, context: &Context) -> FieldResult<Option<Realm>> {
+        Realm::load_by_path(path, context).await
     }
 
     /// Returns an event by its ID.

--- a/backend/api/src/tx.rs
+++ b/backend/api/src/tx.rs
@@ -1,0 +1,20 @@
+use std::{ops::Deref, sync::Arc};
+
+
+/// A database transaction that has been started for one API request.
+pub struct Transaction {
+    inner: Arc<deadpool_postgres::Transaction<'static>>,
+}
+
+impl Transaction {
+    pub fn new(inner: Arc<deadpool_postgres::Transaction<'static>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Deref for Transaction {
+    type Target = deadpool_postgres::Transaction<'static>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/backend/server/src/db/migrations/3-realms.sql
+++ b/backend/server/src/db/migrations/3-realms.sql
@@ -1,10 +1,11 @@
--- Creates the realms table and inserts the always-present root realm.
+-- Creates the realms table, inserts the always-present root realm and adds
+-- useful realm-related functions.
 
 select prepare_randomized_ids('realm');
 
 create table realms (
     id bigint primary key default randomized_id('realm'),
-    parent bigint not null references realms on delete restrict,
+    parent bigint references realms on delete restrict,
     name text not null,
     path_segment text not null
 
@@ -13,7 +14,8 @@ create table realms (
     -- particular, this implies path segments are at least two characters long.
     -- This check is disabled for the root realm as it has an empty path
     -- segment.
-    constraint valid_alphanum_path check (id = 0 or path_segment ~* '^[[:alnum:]][[:alnum:]\-]+$')
+    constraint valid_alphanum_path check (id = 0 or path_segment ~* '^[[:alnum:]][[:alnum:]\-]+$'),
+    constraint has_parent check (id = 0 or parent is not null)
 );
 
 -- Insert the root realm. Since that realm has to have the ID=0, we have to
@@ -24,4 +26,42 @@ select setval(
     xtea(0, (select key from __xtea_keys where entity = 'realm'), false),
     false
 );
-insert into realms (name, parent, path_segment) values ('root', 0, '');
+insert into realms (name, parent, path_segment) values ('', null, '');
+
+
+-- Returns all ancestors of the given realm, including the root realm and the
+-- given realm itself. Returns all columns plus a `height` column that counts
+-- up, starting from the given realm which has `height = 0`.
+create function ancestors_of_realm(realm_id bigint)
+    returns table (
+        id bigint,
+        parent bigint,
+        name text,
+        path_segment text,
+        height int
+    )
+    language 'sql'
+    stable
+as $$
+with recursive ancestors(id, parent, name, path_segment) as (
+    select *, 0 as height from realms
+    where id = realm_id
+  union
+    select r.id, r.parent, r.name, r.path_segment, a.height + 1 as height from ancestors a
+    join realms r on a.parent = r.id
+    where a.id <> 0
+)
+SELECT * FROM ancestors order by height desc
+$$;
+
+
+-- Returns the full realm path for the given realm. Returns an empty string for
+-- the root realm. For non-root realms, the string starts with `/`, e.g.
+-- `/foo/bar`.
+create function full_realm_path(realm_id bigint)
+    returns text
+    language 'sql'
+    stable
+as $$
+select string_agg(path_segment, '/') from (SELECT * FROM ancestors_of_realm(realm_id)) as t;
+$$;

--- a/backend/server/src/db/migrations/3-realms.sql
+++ b/backend/server/src/db/migrations/3-realms.sql
@@ -7,19 +7,22 @@ create table realms (
     id bigint primary key default randomized_id('realm'),
     parent bigint references realms on delete restrict,
     name text not null,
-    path text not null,
+    path_segment text not null,
+
+    -- This is calculated by DB triggers: operations never have to set this value.
+    full_path text not null,
 
     -- This makes sure that a realm path segment consists of an alphanumeric
     -- character followed by one or more alphanumeric characters or hyphens. In
     -- particular, this implies path segments are at least two characters long.
     -- This check is disabled for the root realm as it has an empty path
     -- segment.
-    constraint valid_alphanum_path check (id = 0 or path ~* '^(/[[:alnum:]][[:alnum:]\-]+)+$'),
+    constraint valid_alphanum_path check (id = 0 or path_segment ~* '^[[:alnum:]][[:alnum:]\-]+$'),
     constraint has_parent check (id = 0 or parent is not null)
 );
 
 -- Full path to realm lookups happen on nearly every page view
-create unique index idx_realm_path on realms (path);
+create unique index idx_realm_path on realms (full_path);
 
 -- Insert the root realm. Since that realm has to have the ID=0, we have to
 -- set the sequence to a specific value. We can just apply inverse xtea to 0
@@ -29,8 +32,98 @@ select setval(
     xtea(0, (select key from __xtea_keys where entity = 'realm'), false),
     false
 );
-insert into realms (name, parent, path) values ('', null, '');
+insert into realms (name, parent, path_segment, full_path) values ('', null, '', '');
 
+
+
+-- Triggers to update `full_path` ---------------------------------------------------------
+--
+-- The `full_path` column is completely managed by triggers to always have the
+-- correct values according to `path_segment` and `parent`. Doing this is a bit
+-- tricky.
+
+-- The `before insert` trigger is straight forward because we know that there
+-- don't exist any children yet that have to be updated. We make sure that
+-- insert operations do not try to specifcy the `full_path` already since that
+-- would be overwritten anyway.
+create function set_full_realm_path() returns trigger as $$
+begin
+    if NEW.full_path is not null then
+        raise exception 'do not set the full path of a realm directly (for realm %)', NEW.id;
+    end if;
+
+    NEW.full_path := (select full_path from realms where id = NEW.parent) || '/' || NEW.path_segment;
+    return NEW;
+end;
+$$ language plpgsql;
+
+-- However, handling updates gets interesting since we potentially have to
+-- update a large number of (indirect) children. To visit all descendents of a
+-- realm, we could have a recursive function, for example. But: changing those
+-- descendents via `update` would cause the another trigger to get triggered! I
+-- don't think one can avoid that. But we can just use this to our advantage
+-- since then we don't have to do recursion ourselves.
+--
+-- So the idea is to just set the `full_path` of all children to a dummy value,
+-- causing this trigger to get fired for all children, fixing the full path.
+-- However, since the "fixing" involves querying the full path of the parent,
+-- the update of the parent must be finished already before the child triggers
+-- can run. In order to achieve that, we install both, `before update` and
+-- `after update` triggers. Both call this function, which distinguishes the
+-- two cases with `TG_WHEN`.
+--
+-- One last problem is that, since we set the `full_path` to fire the trigger,
+-- we cannot raise an exception anymore when users incorrectly set the value.
+-- Well, we can, with a hack. We just set the full path to a very particular
+-- value to signal that the trigger, and not a user, set this.
+create function update_full_realm_path() returns trigger as $$
+begin
+    -- If only the name changed, we don't need to update anything.
+    if
+        NEW.path_segment = OLD.path_segment and
+        NEW.parent = OLD.parent and
+        NEW.full_path = OLD.full_path
+    then
+        return NEW;
+    end if;
+
+    if TG_WHEN = 'BEFORE' then
+        -- If there was an attempt to change the full path directly and it wasn't
+        -- us, we raise an exception.
+        if NEW.full_path <> OLD.full_path and NEW.full_path <> '__fixpath_oRiV4qGFmZ' then
+            raise exception 'do not change the full path directly (for realm %)', OLD.id;
+        end if;
+
+        -- If we are in the "before" handler, we set the correct full path.
+        NEW.full_path := (select full_path from realms where id = NEW.parent)
+            || '/' || NEW.path_segment;
+        return NEW;
+    else
+        -- In the "after" handler, we update all children to recursively fire
+        -- this trigger.
+        update realms set full_path = '__fixpath_oRiV4qGFmZ' where parent = NEW.id;
+        return null;
+    end if;
+end;
+$$ language plpgsql;
+
+create trigger set_full_path_on_insert
+    before insert on realms
+    for each row
+    execute procedure set_full_realm_path();
+
+create trigger fix_full_path_before_update
+    before update on realms
+    for each row
+    execute procedure update_full_realm_path();
+
+create trigger fix_full_path_after_update
+    after update on realms
+    for each row
+    execute procedure update_full_realm_path();
+
+
+-- Useful functions ---------------------------------------------------------------------
 
 -- Returns all ancestors of the given realm, including the root realm and the
 -- given realm itself. Returns all columns plus a `height` column that counts
@@ -40,17 +133,18 @@ create function ancestors_of_realm(realm_id bigint)
         id bigint,
         parent bigint,
         name text,
-        path text,
+        path_segment text,
+        full_path text,
         height int
     )
     language 'sql'
-    stable
 as $$
-with recursive ancestors(id, parent, name, path) as (
+with recursive ancestors(id, parent, name, path_segment, full_path) as (
     select *, 0 as height from realms
     where id = realm_id
   union
-    select r.id, r.parent, r.name, r.path, a.height + 1 as height from ancestors a
+    select r.id, r.parent, r.name, r.path_segment, r.full_path, a.height + 1 as height
+    from ancestors a
     join realms r on a.parent = r.id
     where a.id <> 0
 )

--- a/backend/server/src/http/mod.rs
+++ b/backend/server/src/http/mod.rs
@@ -287,8 +287,7 @@ async fn handle_api(req: Request<Body>, ctx: &Context) -> Response {
         Arc::new(static_tx)
     };
 
-    let api_context = api::Context::new(Transaction::new(tx.clone())).await
-        .expect("failed to load realm tree"); // TODO
+    let api_context = api::Context::new(Transaction::new(tx.clone()));
     let out = juniper_hyper::graphql(ctx.api_root.clone(), Arc::new(api_context), req).await;
 
     // Check whether we own the last remaining handle of this Arc.

--- a/backend/server/src/http/mod.rs
+++ b/backend/server/src/http/mod.rs
@@ -1,5 +1,7 @@
 //! The HTTP server, handler and routes.
 
+use api::Transaction;
+use deadpool_postgres::Pool;
 use futures::FutureExt;
 use hyper::{
     Body, Method, Server, StatusCode,
@@ -10,6 +12,7 @@ use std::{
     convert::Infallible,
     fs,
     future::Future,
+    mem,
     net::SocketAddr,
     os::unix::fs::PermissionsExt,
     panic::AssertUnwindSafe,
@@ -33,10 +36,10 @@ type Request<T = Body> = hyper::Request<T>;
 pub(crate) async fn serve(
     config: &Config,
     api_root: api::RootNode,
-    api_context: api::Context,
+    db: Pool,
 ) -> Result<()> {
     let assets = Assets::init(config).await.context("failed to initialize assets")?;
-    let ctx = Arc::new(Context::new(api_root, api_context, assets));
+    let ctx = Arc::new(Context::new(api_root, db, assets));
 
     // This sets up all the hyper server stuff. It's a bit of magic and touching
     // this code likely results in strange lifetime errors.
@@ -99,13 +102,6 @@ pub(crate) async fn serve(
 async fn handle_internal_errors(
     future: impl Future<Output = Response>,
 ) -> Result<Response, Infallible> {
-    fn internal_server_error() -> Response {
-        Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body("Internal server error".into())
-            .unwrap()
-    }
-
     // TODO: We want to log lots of information about the exact HTTP request in
     // the error case.
 
@@ -143,15 +139,15 @@ async fn handle_internal_errors(
 /// Context that the request handler has access to.
 struct Context {
     api_root: Arc<api::RootNode>,
-    api_context: Arc<api::Context>,
+    db_pool: Pool,
     assets: Assets,
 }
 
 impl Context {
-    fn new(api_root: api::RootNode, api_context: api::Context, assets: Assets) -> Self {
+    fn new(api_root: api::RootNode, db_pool: Pool, assets: Assets) -> Self {
         Self {
             api_root: Arc::new(api_root),
-            api_context: Arc::new(api_context),
+            db_pool,
             assets,
         }
     }
@@ -174,9 +170,7 @@ async fn handle(req: Request<Body>, ctx: Arc<Context>) -> Response {
     match path {
         // The GraphQL endpoint. This is the only path for which POST is
         // allowed.
-        "/graphql" if method == Method::POST => {
-            juniper_hyper::graphql(ctx.api_root.clone(), ctx.api_context.clone(), req).await
-        }
+        "/graphql" if method == Method::POST => handle_api(req, &ctx).await,
 
         // From this point on, we only support GET and HEAD requests. All others
         // will result in 404.
@@ -243,5 +237,101 @@ pub(crate) async fn reply_404(assets: &Assets, method: &Method, path: &str) -> R
         .status(StatusCode::NOT_FOUND)
         .header("Content-Type", "text/html; charset=UTF-8")
         .body(html)
+        .unwrap()
+}
+
+async fn handle_api(req: Request<Body>, ctx: &Context) -> Response {
+    // Get a connection for this request.
+    let mut connection = match ctx.db_pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to obtain DB connection for API request: {}", e);
+            return service_unavailable();
+        }
+    };
+
+    let tx = match connection.transaction().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            error!("Failed to start transaction for API request: {}", e);
+            return internal_server_error();
+        }
+    };
+
+    // Okay, lets take a deep breath.
+    //
+    // Unfortunately, `juniper` does not support contexts with a lifetime
+    // parameter. However, we'd like to have one SQL transaction per API
+    // request. The transaction type (`deadpool_postgres::Transaction`) borrows
+    // from the DB connection (`tokio_postgres::Client`) and thus has a
+    // lifetime parameter. This makes sense for the API of that library since
+    // it statically prevents a number of logic bugs. But it is inconvenient
+    // for us.
+    //
+    // Unfortunately, we think the best solution for us is to use `unsafe` here
+    // to just get rid of the lifetime parameter. We can pretend that the
+    // lifetime is `'static`. Of course, we then have to make sure that the
+    // transaction does not outlive the borrowed connection. We do that by
+    // putting the transaction into an `Arc`. That way we can check whether
+    // there still exists a reference after calling the API handlers. The
+    // transaction is not `Clone` and `Arc` only gives an immutable reference
+    // to the underlying value. So even a buggy handler could not move the
+    // transaction out of the `Arc`.
+    //
+    // Unfortunately, `connection` is not treated as borrowed after this unsafe
+    // block. So we must make sure not to access it at all until we get rid of
+    // the transaction (by committing it below).
+    type PgTx<'a> = deadpool_postgres::Transaction<'a>;
+    let tx = unsafe {
+        let static_tx = mem::transmute::<PgTx<'_>, PgTx<'static>>(tx);
+        Arc::new(static_tx)
+    };
+
+    let api_context = api::Context::new(Transaction::new(tx.clone())).await
+        .expect("failed to load realm tree"); // TODO
+    let out = juniper_hyper::graphql(ctx.api_root.clone(), Arc::new(api_context), req).await;
+
+    // Check whether we own the last remaining handle of this Arc.
+    match Arc::try_unwrap(tx) {
+        Err(_) => {
+            // There are still other handles, meaning that the API handler
+            // incorrect stored the transaction in some static variable. This
+            // is our fault and should NEVER happen. If it does happen, we
+            // would have UB after this function exits. We can't have that. And
+            // since panicking only brings down the current thread, we have to
+            // reach for more drastic measures.
+            error!("FATAL BUG: API handler kept reference to transaction. Ending process.");
+            std::process::abort();
+        }
+        Ok(tx) => {
+            match tx.commit().await {
+                // If the transaction succeeded we can return the generated response.
+                Ok(_) => out,
+
+                // Otherwise, we would like to retry a couple times, but for now
+                // we just immediately reply 5xx.
+                //
+                // TODO: write `graphql_hyper` logic ourselves to be able to put
+                // all of this code in a loop and retry a couple times.
+                Err(e) => {
+                    error!("Failed to commit transaction for API request: {}", e);
+                    service_unavailable()
+                }
+            }
+        }
+    }
+}
+
+fn service_unavailable() -> Response {
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .body("Server error: service unavailable. Potentially try again later.".into())
+        .unwrap()
+}
+
+fn internal_server_error() -> Response {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body("Internal server error".into())
         .unwrap()
 }

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -73,9 +73,7 @@ async fn start_server(config: &Config) -> Result<()> {
         .context("failed to check/run DB migrations")?;
 
     let root_node = api::root_node();
-    let context = api::Context::new(db).await?;
-
-    http::serve(&config, root_node, context).await
+    http::serve(&config, root_node, db).await
         .context("failed to start HTTP server")?;
 
     Ok(())

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -29,7 +29,7 @@ const query = graphql`
             id
             name
             path
-            parents { name path }
+            ancestors { name path }
             parent { id }
             ... Blocks_blocks
             ... NavigationData
@@ -48,8 +48,7 @@ const RealmPage: React.FC<Props> = ({ queryRef }) => {
         return <NotFound kind="page" />;
     }
 
-    const breadcrumbs = realm.parents
-        .slice(1)
+    const breadcrumbs = realm.ancestors
         .concat(realm)
         .map(({ name, path }) => ({
             label: name,

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -39,27 +39,22 @@ type TextBlock implements Block {
 
 type Query {
   apiVersion: String!
-  "Returns a flat list of all realms."
-  realms: [Realm!]!
+  "Returns the root realm."
+  rootRealm: Realm!
   """
     Returns the realm with the specific ID or `None` if the ID does not
     refer to a realm.
   """
   realmById(id: ID!): Realm
   """
-    Returns the realm with the specific path or `None` if the path does not
+    Returns the realm with the given path or `None` if the path does not
     refer to a realm.
 
-    Every realm has its own "path segment", and the full path of a realm
-    is just the concatenation of all the path segments between the root realm
-    and the realm in question, delimited by `"/"`. The root realm is assumed
-    to have a path segment of `""`, and with the above rule so is its full
-    path. The path of every other realm will start with `"/"` delimiting the
-    root realm path segement from the second segment in the path.
+    Paths with and without trailing slash are accepted and treated equally.
+    The paths `""` and `"/"` refer to the root realm. All other paths have
+    to start with `"/"`.
   """
   realmByPath(path: String!): Realm
-  "Returns the root realm."
-  rootRealm: Realm!
   "Returns an event by its ID."
   event(id: ID!): Event
 }
@@ -82,9 +77,20 @@ type Realm {
   id: ID!
   name: String!
   isRoot: Boolean!
+  """
+    Returns the full path of this realm. `""` for the root realm. For
+    non-root realms, the path always starts with `/` and never has a
+    trailing `/`.
+  """
   path: String!
+  "Returns the immediate parent of this realm."
   parent: Realm
-  parents: [Realm!]!
+  """
+    Returns all ancestors between the root realm to this realm
+    (excluding both, the root realm and this realm).
+  """
+  ancestors: [Realm!]!
+  "Returns all immediate children of this realm."
   children: [Realm!]!
   "Returns the (content) blocks of this realm."
   blocks: [Block!]!

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -197,8 +197,8 @@ as $$
 declare
     realm_id realms.id%type;
 begin
-    insert into realms (name, parent, path)
-        values (name, 0, '/' || replace(lower(name), ' ', '-'))
+    insert into realms (name, parent, path_segment)
+        values (name, 0, replace(lower(name), ' ', '-'))
         returning id into realm_id;
 
     insert into blocks (realm_id, type, index, text_content)
@@ -215,8 +215,8 @@ as $$
 declare
     root realms.id%type;
 begin
-    insert into realms (name, parent, path)
-        values ('Lectures', 0, '/lectures')
+    insert into realms (name, parent, path_segment)
+        values ('Lectures', 0, 'lectures')
         returning id into root;
 
     insert into blocks (realm_id, type, index, title, text_content)
@@ -239,8 +239,8 @@ declare
     root realms.id%type;
     y_root realms.id%type;
 begin
-    insert into realms (name, parent, path)
-        values (name, lectures_root, '/lectures/' || replace(lower(name), ' ', '-'))
+    insert into realms (name, parent, path_segment)
+        values (name, lectures_root, replace(lower(name), ' ', '-'))
         returning id into root;
 
     insert into blocks (realm_id, type, index, title, text_content)
@@ -253,14 +253,14 @@ begin
         ));
 
     for y in 2020 .. 2021 loop
-        insert into realms (name, parent, path)
-            values (y, root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text)
+        insert into realms (name, parent, path_segment)
+            values (y, root, y::text)
             returning id into y_root;
 
-        insert into realms (name, parent, path)
-            values ('Summer', y_root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text || '/summer');
-        insert into realms (name, parent, path)
-            values ('Winter', y_root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text || '/winter');
+        insert into realms (name, parent, path_segment)
+            values ('Summer', y_root, 'summer');
+        insert into realms (name, parent, path_segment)
+            values ('Winter', y_root, 'winter');
     end loop;
 end; $$;
 

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -197,8 +197,8 @@ as $$
 declare
     realm_id realms.id%type;
 begin
-    insert into realms (name, parent, path_segment)
-        values (name, 0, replace(lower(name), ' ', '-'))
+    insert into realms (name, parent, path)
+        values (name, 0, '/' || replace(lower(name), ' ', '-'))
         returning id into realm_id;
 
     insert into blocks (realm_id, type, index, text_content)
@@ -215,8 +215,8 @@ as $$
 declare
     root realms.id%type;
 begin
-    insert into realms (name, parent, path_segment)
-        values ('Lectures', 0, 'lectures')
+    insert into realms (name, parent, path)
+        values ('Lectures', 0, '/lectures')
         returning id into root;
 
     insert into blocks (realm_id, type, index, title, text_content)
@@ -239,8 +239,8 @@ declare
     root realms.id%type;
     y_root realms.id%type;
 begin
-    insert into realms (name, parent, path_segment)
-        values (name, lectures_root, replace(lower(name), ' ', '-'))
+    insert into realms (name, parent, path)
+        values (name, lectures_root, '/lectures/' || replace(lower(name), ' ', '-'))
         returning id into root;
 
     insert into blocks (realm_id, type, index, title, text_content)
@@ -253,14 +253,14 @@ begin
         ));
 
     for y in 2020 .. 2021 loop
-        insert into realms (name, parent, path_segment)
-            values (y, root, y::text)
+        insert into realms (name, parent, path)
+            values (y, root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text)
             returning id into y_root;
 
-        insert into realms (name, parent, path_segment)
-            values ('Summer', y_root, 'summer');
-        insert into realms (name, parent, path_segment)
-            values ('Winter', y_root, 'winter');
+        insert into realms (name, parent, path)
+            values ('Summer', y_root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text || '/summer');
+        insert into realms (name, parent, path)
+            values ('Winter', y_root, '/lectures/' || replace(lower(name), ' ', '-') || '/' || y::text || '/winter');
     end loop;
 end; $$;
 


### PR DESCRIPTION
Both of these things are in preparation to make the realm tree configurable in the frontend. These changes are a bit involved, so check the commit messages.

Closes #190 (the data structure we already used is fine by using another computed column `full_path` and recursive queries)
Closes #89 (we decided against caching in Rust, so the issue just tracked the removal of the cached realm tree)
