### PR TITLE
Switch to thin LTO for release builds

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,7 +4,7 @@ members = ["api", "macros", "server", "util"]
 [profile.release]
 debug = 1
 codegen-units = 1
-lto = true
+lto = "thin"
 
 [profile.release.package."*"]
 debug = false


### PR DESCRIPTION
The file size increases only by a small amount (26M -> 27M) but the build is considerably faster.

CC #59 