### PR TITLE
Change OC host from `tobira.ethz.ch` to `oc.tobira.ethz.ch`

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -14,7 +14,7 @@ unix_socket_permissions = 0o777
 file = "/var/log/tobira/{{ id }}.log"
 
 [sync]
-host = "tobira.ethz.ch"
+host = "oc.tobira.ethz.ch"
 user = "admin"
 password = "{{ opencast_admin_password }}"
 


### PR DESCRIPTION
We changed our Opencast installation there, now serving it on the sub
domain. So we need to change it here, too. I already changed the config
of the two active deployments on the server manually.