### PR TITLE
Change restart policy for development DB container

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: tobira-dev-postgres
     image: docker.io/library/postgres:10
-    restart: always
+    restart: unless-stopped
     ports:
       - 127.0.0.1:5432:5432
     volumes:


### PR DESCRIPTION
With `restart: always` the container is automatically started every time
you (re-)start the Docker daemon. Unless you do fancy stuff
with `systemd` socket activation or things like that,
this is basically every time you turn on your computer.
But even if you do that fancy stuff, or just manually start the daemon
every time, you still might do so because you want to use it
for other reasons; you might want to not run the Tobira development
database every time.

Now, I don't want to eliminate that possibility, but I think
there should be an opt-out. Luckily, there is another restart policy,
`unless-stopped`, that allows for exactly that!
If you explicitly stop the container for example using

    docker-compose stop

or by just `Ctrl-C`-ing out if you didn't detach (`-d`)
from `docker-compose` it is not restarted automatically.
If you don't, it behaves as it did before.