### PR TITLE
Configurable session duration

### DIFF
--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -36,17 +36,7 @@ pub(crate) async fn handle_login(req: Request<Body>, ctx: &Context) -> Result<Re
             Response::builder()
                 .status(StatusCode::NO_CONTENT)
                 .header("set-cookie", session_id.set_cookie(
-                    // The `cookie` crate unfortunately uses `time::Duration`
-                    // which can represent negative durations for the price
-                    // of being able to represent very long durations.
-                    // Thus, conversions from `std::time::Duration` can fail.
-                    // This should not happen with the way we parse
-                    // the `session_duration` config value, though.
-                    ctx.config.auth.session_duration.try_into().unwrap_or_else(
-                        |error| match error {
-                            time::error::ConversionRange => panic!("session duration too large"),
-                        }
-                    )
+                    ctx.config.auth.session_duration
                 ).to_string())
                 .body(Body::empty())
                 .unwrap()

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -216,7 +216,7 @@ impl UserData {
         // Check if such a session exists in the DB.
         let sql = "update user_sessions \
             set last_used = now() \
-            where id = $1\
+            where id = $1 \
             returning username, display_name, roles";
         let row = match db.query_opt(sql, &[&session_id]).await? {
             None => return Ok(None),

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -126,7 +126,8 @@ impl User {
         match auth_config.mode {
             AuthMode::None => Ok(Self::None),
             AuthMode::FullAuthProxy => Ok(UserData::from_auth_headers(headers, auth_config).into()),
-            AuthMode::LoginProxy => UserData::from_session(headers, db, auth_config.session_duration).await
+            AuthMode::LoginProxy => UserData::from_session(headers, db, auth_config.session_duration)
+                .await
                 .map(Into::into),
         }
     }

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -126,7 +126,8 @@ impl User {
         match auth_config.mode {
             AuthMode::None => Ok(Self::None),
             AuthMode::FullAuthProxy => Ok(UserData::from_auth_headers(headers, auth_config).into()),
-            AuthMode::LoginProxy => UserData::from_session(headers, db).await.map(Into::into),
+            AuthMode::LoginProxy => UserData::from_session(headers, db, auth_config.session_duration).await
+                .map(Into::into),
         }
     }
 
@@ -206,7 +207,11 @@ impl UserData {
 
     /// Tries to load user data from a DB session referred to in a session
     /// cookie. Should only be called if the auth mode is `LoginProxy`.
-    async fn from_session(headers: &HeaderMap, db: &Client) -> Result<Option<Self>, PgError> {
+    async fn from_session(
+        headers: &HeaderMap,
+        db: &Client,
+        session_duration: Duration,
+    ) -> Result<Option<Self>, PgError> {
         // Try to get a session ID from the cookie.
         let session_id = match SessionId::from_headers(headers) {
             None => return Ok(None),
@@ -217,8 +222,9 @@ impl UserData {
         let sql = "update user_sessions \
             set last_used = now() \
             where id = $1 \
+            and extract(epoch from now() - created) < $2
             returning username, display_name, roles";
-        let row = match db.query_opt(sql, &[&session_id]).await? {
+        let row = match db.query_opt(sql, &[&session_id, &session_duration.as_secs_f64()]).await? {
             None => return Ok(None),
             Some(row) => row,
         };

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -68,42 +68,13 @@ pub(crate) struct AuthConfig {
     pub(crate) moderator_role: String,
 
     /// Duration of a Tobira-managed login session.
-    /// You can specify durations in different units of time
-    /// or the string `"browser-session"` in which case the session
-    /// is only lasts until the user closes their client.
-    /// (Although note that most browsers can restore a previously closed session,
-    /// so in reality they might last longer than that.)
-    ///
     /// Note: This is only relevant if `auth.mode` is `login-proxy`.
-    /// Example: 30d
-    #[config(default = "browser-session")]
-    pub(crate) session_duration: SessionDuration,
+    #[config(default = "30d", deserialize_with = crate::config::deserialize_duration)]
+    pub(crate) session_duration: Duration,
 
     /// Configuration related to the built-in login page.
     #[config(nested)]
     pub(crate) login_page: LoginPageConfig,
-}
-
-/// Duration of a Tobira-managed user session
-#[derive(Debug, serde::Deserialize)]
-#[serde(untagged)]
-pub(crate) enum SessionDuration {
-    #[serde(deserialize_with = "deserialize_browser_session_duration")]
-    BrowserSession,
-    #[serde(deserialize_with = "crate::config::deserialize_duration")]
-    Duration(Duration),
-}
-
-fn deserialize_browser_session_duration<'de, D>(deserializer: D) -> Result<(), D::Error>
-where D: serde::Deserializer<'de> {
-    use serde::{Deserialize, de::Error};
-
-    let s = String::deserialize(deserializer)?;
-    if s == "browser-session" {
-        Ok(())
-    } else {
-        Err(D::Error::invalid_value(serde::de::Unexpected::Str(&s), &"browser-session"))
-    }
 }
 
 /// Authentification and authorization

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -220,11 +220,9 @@ impl UserData {
         };
 
         // Check if such a session exists in the DB.
-        let sql = "update user_sessions \
-            set last_used = now() \
+        let sql = "select username, display_name, roles from user_sessions \
             where id = $1 \
-            and extract(epoch from now() - created) < $2
-            returning username, display_name, roles";
+            and extract(epoch from now() - created) < $2";
         let row = match db.query_opt(sql, &[&session_id, &session_duration.as_secs_f64()]).await? {
             None => return Ok(None),
             Some(row) => row,

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -106,6 +106,7 @@ impl SessionId {
             .max_age(time::Duration::zero())
             .secure(true)
             .http_only(true)
+            .same_site(cookie::SameSite::Lax)
             .finish()
     }
 

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -72,7 +72,7 @@ impl SessionId {
     /// ID in the client's cookie jar.
     pub(crate) fn set_cookie(&self, max_age: Duration) -> Cookie {
         // TODO: other cookie stuff!
-        let mut cookie = Cookie::build(SESSION_COOKIE, base64encode(self.0.expose_secret()))
+        Cookie::build(SESSION_COOKIE, base64encode(self.0.expose_secret()))
 
             // Only send via HTTPS as it contains sensitive information.
             .secure(true)
@@ -87,12 +87,10 @@ impl SessionId {
             // anything, so something like "link to `/realm/delete`" is not a
             // thing for Tobira.
             .same_site(cookie::SameSite::Lax)
-            .finish();
 
-        // Expire the cookie at the appropriate time
-        cookie.set_max_age(max_age);
-
-        cookie
+            // Expire the cookie at the appropriate time
+            .max_age(max_age)
+            .finish()
     }
 
     /// Returns a cookie for a `set-cookie` header that removes the session ID

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -93,7 +93,7 @@ impl SessionId {
     /// from the client's cookie jar.
     pub(crate) fn unset_cookie() -> Cookie<'static> {
         Cookie::build(SESSION_COOKIE, "")
-            .expires(time::OffsetDateTime::unix_epoch())
+            .max_age(time::Duration::zero())
             .secure(true)
             .http_only(true)
             .finish()

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -71,7 +71,6 @@ impl SessionId {
     /// Returns a cookie for a `set-cookie` header in order to store the session
     /// ID in the client's cookie jar.
     pub(crate) fn set_cookie(&self, max_age: Duration) -> Cookie {
-        // TODO: other cookie stuff!
         Cookie::build(SESSION_COOKIE, base64encode(self.0.expose_secret()))
 
             // Only send via HTTPS as it contains sensitive information.

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -70,7 +70,7 @@ impl SessionId {
 
     /// Returns a cookie for a `set-cookie` header in order to store the session
     /// ID in the client's cookie jar.
-    pub(crate) fn set_cookie(&self, max_age: Option<Duration>) -> Cookie {
+    pub(crate) fn set_cookie(&self, max_age: Duration) -> Cookie {
         // TODO: other cookie stuff!
         let mut cookie = Cookie::build(SESSION_COOKIE, base64encode(self.0.expose_secret()))
 

--- a/backend/src/db/migrations/8-user-sessions.sql
+++ b/backend/src/db/migrations/8-user-sessions.sql
@@ -7,6 +7,9 @@ create table user_sessions (
     display_name text not null,
     roles text[] not null,
 
+    -- When the session was created. Always in UTC!
+    created timestamp not null default now(),
+
     -- When the session was last used. Always in UTC!
     last_used timestamp not null default now()
 );

--- a/backend/src/db/migrations/8-user-sessions.sql
+++ b/backend/src/db/migrations/8-user-sessions.sql
@@ -8,8 +8,5 @@ create table user_sessions (
     roles text[] not null,
 
     -- When the session was created. Always in UTC!
-    created timestamp not null default now(),
-
-    -- When the session was last used. Always in UTC!
-    last_used timestamp not null default now()
+    created timestamp not null default now()
 );

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -112,17 +112,10 @@
 #moderator_role = "ROLE_TOBIRA_MODERATOR"
 
 # Duration of a Tobira-managed login session.
-# You can specify durations in different units of time
-# or the string `"browser-session"` in which case the session
-# is only lasts until the user closes their client.
-# (Although note that most browsers can restore a previously closed session,
-# so in reality they might last longer than that.)
-#
 # Note: This is only relevant if `auth.mode` is `login-proxy`.
-# Example: 30d
 #
-# Default value: "browser-session"
-#session_duration = "browser-session"
+# Default value: "30d"
+#session_duration = "30d"
 
 # Configuration related to the built-in login page.
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -111,6 +111,19 @@
 # Default value: "ROLE_TOBIRA_MODERATOR"
 #moderator_role = "ROLE_TOBIRA_MODERATOR"
 
+# Duration of a Tobira-managed login session.
+# You can specify durations in different units of time
+# or the string `"browser-session"` in which case the session
+# is only lasts until the user closes their client.
+# (Although note that most browsers can restore a previously closed session,
+# so in reality they might last longer than that.)
+#
+# Note: This is only relevant if `auth.mode` is `login-proxy`.
+# Example: 30d
+#
+# Default value: "browser-session"
+#session_duration = "browser-session"
+
 # Configuration related to the built-in login page.
 
 [auth.login_page]


### PR DESCRIPTION
This PR implements two things which combined should lead to correct session expiration based on a configurable duration in both the front- and backend:

* It sets a `Max-Age` header for the session cookies
* It adds a `created` column to the user session database table and checks whether this is not older than the configured session duration when trying to extract a user from a session ID

Note that this does **not** do any cleanup, yet. See also #296.

This should close #295.