### PR TITLE
Improve login proxy docker compose

### DIFF
--- a/scripts/auth/login-proxy-docker-compose.yml
+++ b/scripts/auth/login-proxy-docker-compose.yml
@@ -8,4 +8,4 @@ services:
     ports:
       - "3090:3090"
     volumes:
-      - ${PWD}/login-proxy-nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./login-proxy-nginx.conf:/etc/nginx/conf.d/default.conf

--- a/scripts/auth/login-proxy-docker-compose.yml
+++ b/scripts/auth/login-proxy-docker-compose.yml
@@ -9,4 +9,3 @@ services:
       - "3090:3090"
     volumes:
       - ${PWD}/login-proxy-nginx.conf:/etc/nginx/conf.d/default.conf
-


### PR DESCRIPTION
The login proxy nginx config is not in `$PWD`.
It is instead in the same directory as the compose file.
Conveniently this is exactly the directory that relative paths
in the file refer to.