### PR TITLE
Remove further `container_name` instructions

### DIFF
--- a/scripts/auth-proxy/docker-compose.yml
+++ b/scripts/auth-proxy/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   nginx:
-    container_name: tobira-login-proxy-dummy
     image: nginx
     network_mode: "host"
     ports:

--- a/scripts/dev-db/docker-compose.yml
+++ b/scripts/dev-db/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   database:
-    container_name: tobira-dev-postgres
     image: docker.io/library/postgres:10
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Note @LukasKalbertodt that this might disrupt your dev DB **once**, but it's really only once, because the container will now be named differently.