### PR TITLE
Routing improvements

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -33,7 +33,7 @@ pub(crate) struct Cursor(String);
 
 impl Cursor {
     pub(crate) fn new(data: impl Serialize) -> Self {
-        let mut b64writer = base64::write::EncoderStringWriter::new(base64::URL_SAFE);
+        let mut b64writer = base64::write::EncoderStringWriter::new(base64::URL_SAFE_NO_PAD);
         bincode::DefaultOptions::new().serialize_into(&mut b64writer, &data)
             .unwrap_or_else(|e| unreachable!("bincode serialize failed without size limit: {}", e));
         Self(b64writer.into_inner())
@@ -44,7 +44,7 @@ impl Cursor {
         for<'de> T: Deserialize<'de>,
     {
         let mut bytes = self.0.as_bytes();
-        let b64reader = base64::read::DecoderReader::new(&mut bytes, base64::URL_SAFE);
+        let b64reader = base64::read::DecoderReader::new(&mut bytes, base64::URL_SAFE_NO_PAD);
         bincode::DefaultOptions::new()
             .deserialize_from(b64reader)
             .map_err(|e| err::invalid_input!("given cursor is invalid: {}", e))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import createEmotionCache from "@emotion/cache";
 import { environment } from "./relay";
 import { GlobalStyle } from "./GlobalStyle";
 import { ActiveRoute, Router } from "./router";
-import { MatchedRouteErased } from "./rauta";
+import { MatchedRoute } from "./rauta";
 import { MenuProvider } from "./layout/MenuState";
 import { InitialLoading } from "./layout/Root";
 import { GraphQLErrorBoundary } from "./relay/boundary";
@@ -14,7 +14,7 @@ import { GraphQLErrorBoundary } from "./relay/boundary";
 
 
 type Props = {
-    initialRoute: MatchedRouteErased;
+    initialRoute: MatchedRoute;
 };
 
 export const App: React.FC<Props> = ({ initialRoute }) => (

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -169,7 +169,7 @@ manage:
       Error: invalid path to page. Was the page deleted or its path changed?
     heading: Settings of page “{{realm}}”
     heading-root: Homepage settings
-    descendants-count: This page has {{count}} many direct and indirect sub-pages.
+    descendants-count: This page has {{count}} direct and indirect sub-pages.
     view-page: Go to page
 
     name-must-not-be-empty: Name must not be empty.

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -11,6 +11,7 @@ import { match } from "../util";
 /** The breakpoint, in pixels, where mobile/desktop navigations are swapped. */
 export const BREAKPOINT = 880;
 
+export type NavItems = [] | JSX.Element | [JSX.Element, JSX.Element];
 
 type Props = {
     fragRef: NavigationData$key;

--- a/frontend/src/relay/index.ts
+++ b/frontend/src/relay/index.ts
@@ -1,4 +1,4 @@
-import { loadQuery as relayLoadQuery } from "react-relay";
+import { loadQuery as relayLoadQuery, LoadQueryOptions } from "react-relay";
 import type { PreloadableConcreteRequest, PreloadedQuery } from "react-relay";
 import { Environment, Store, RecordSource, Network } from "relay-runtime";
 import type {
@@ -51,8 +51,9 @@ export const environment = new Environment({
 export function loadQuery<TQuery extends OperationType>(
     preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,
     variables: VariablesOf<TQuery>,
+    options?: LoadQueryOptions,
 ): PreloadedQuery<TQuery> {
-    return relayLoadQuery(environment, preloadableRequest, variables);
+    return relayLoadQuery(environment, preloadableRequest, variables, options);
 }
 
 

--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -11,12 +11,16 @@ import { ABOUT_PATH } from "./paths";
 import { makeRoute } from "../rauta";
 
 
-export const AboutRoute = makeRoute<PreloadedQuery<AboutQuery>>({
-    path: ABOUT_PATH,
-    queryParams: [],
-    prepare: () => loadQuery(query, {}),
-    render: queryRef => <About queryRef={queryRef} />,
-    dispose: prepared => prepared.dispose(),
+export const AboutRoute = makeRoute(url => {
+    if (url.pathname !== ABOUT_PATH) {
+        return null;
+    }
+
+    const queryRef = loadQuery<AboutQuery>(query, {});
+    return {
+        render: () => <About queryRef={queryRef} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 const query = graphql`

--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { graphql, usePreloadedQuery } from "react-relay";
-import type { PreloadedQuery } from "react-relay";
+import { graphql } from "react-relay";
 
 import { Nav } from "../layout/Navigation";
-import { Root } from "../layout/Root";
+import { RootLoader } from "../layout/Root";
 import { loadQuery } from "../relay";
 import { AboutQuery } from "./__generated__/AboutQuery.graphql";
 import { ABOUT_PATH } from "./paths";
@@ -18,7 +17,11 @@ export const AboutRoute = makeRoute(url => {
 
     const queryRef = loadQuery<AboutQuery>(query, {});
     return {
-        render: () => <About queryRef={queryRef} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => <Nav fragRef={data.realm} />}
+            render={() => <About />}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });
@@ -32,25 +35,18 @@ const query = graphql`
     }
 `;
 
-type Props = {
-    queryRef: PreloadedQuery<AboutQuery>;
-};
-
-const About: React.FC<Props> = ({ queryRef }) => {
+const About: React.FC = () => {
     const { t } = useTranslation();
-    const result = usePreloadedQuery(query, queryRef);
 
     return (
-        <Root nav={<Nav fragRef={result.realm} />} userQuery={result}>
-            <div css={{ margin: "0 auto", maxWidth: 600 }}>
-                <h1>{t("about-tobira.title")}</h1>
-                <p css={{ margin: "16px 0" }}>
-                    <Trans i18nKey="about-tobira.body">
-                        Description.
-                        <a href="https://github.com/elan-ev/tobira">GitHub repo</a>
-                    </Trans>
-                </p>
-            </div>
-        </Root>
+        <div css={{ margin: "0 auto", maxWidth: 600 }}>
+            <h1>{t("about-tobira.title")}</h1>
+            <p css={{ margin: "16px 0" }}>
+                <Trans i18nKey="about-tobira.body">
+                    Description.
+                    <a href="https://github.com/elan-ev/tobira">GitHub repo</a>
+                </Trans>
+            </p>
+        </div>
     );
 };

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -22,12 +22,16 @@ import { LOGIN_PATH } from "./paths";
 import { makeRoute } from "../rauta";
 
 
-export const LoginRoute = makeRoute<PreloadedQuery<LoginQuery>>({
-    path: LOGIN_PATH,
-    queryParams: [],
-    prepare: () => loadQuery(query, {}),
-    render: queryRef => <Login queryRef={queryRef} />,
-    dispose: prepared => prepared.dispose(),
+export const LoginRoute = makeRoute(url => {
+    if (url.pathname !== LOGIN_PATH) {
+        return null;
+    }
+
+    const queryRef = loadQuery<LoginQuery>(query, {});
+    return {
+        render: () => <Login queryRef={queryRef} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 const query = graphql`

--- a/frontend/src/routes/NotFound.tsx
+++ b/frontend/src/routes/NotFound.tsx
@@ -5,13 +5,13 @@ import { Root } from "../layout/Root";
 import { Link } from "../router";
 import { match } from "../util";
 import { CenteredContent } from "../ui";
-import { makeFallbackRoute } from "../rauta";
 
 
-export const NotFoundRoute = makeFallbackRoute({
-    prepare: () => {},
-    render: () => <NotFound kind="page" />,
-});
+export const NotFoundRoute = {
+    prepare: () => ({
+        render: () => <NotFound kind="page" />,
+    }),
+};
 
 type Props = {
     kind: "page" | "video";

--- a/frontend/src/routes/NotFound.tsx
+++ b/frontend/src/routes/NotFound.tsx
@@ -9,7 +9,7 @@ import { CenteredContent } from "../ui";
 
 export const NotFoundRoute = {
     prepare: () => ({
-        render: () => <NotFound kind="page" />,
+        render: () => <Root nav={[]}><NotFound kind="page" /></Root>,
     }),
 };
 
@@ -20,27 +20,25 @@ type Props = {
 export const NotFound: React.FC<Props> = ({ kind }) => {
     const { t } = useTranslation();
 
-    return (
-        <Root nav={[]}>
-            <FiFrown css={{ margin: "0 auto", display: "block", fontSize: 90 }} />
-            <h1 css={{ textAlign: "center", margin: "32px 0 48px 0 !important" }}>
+    return <>
+        <FiFrown css={{ margin: "0 auto", display: "block", fontSize: 90 }} />
+        <h1 css={{ textAlign: "center", margin: "32px 0 48px 0 !important" }}>
+            {match(kind, {
+                "page": () => t("not-found.page-not-found"),
+                "video": () => t("not-found.video-not-found"),
+            })}
+        </h1>
+        <CenteredContent>
+            <p css={{ margin: "16px 0" }}>
                 {match(kind, {
-                    "page": () => t("not-found.page-not-found"),
-                    "video": () => t("not-found.video-not-found"),
+                    "page": () => t("not-found.page-explanation"),
+                    "video": () => t("not-found.video-explanation"),
                 })}
-            </h1>
-            <CenteredContent>
-                <p css={{ margin: "16px 0" }}>
-                    {match(kind, {
-                        "page": () => t("not-found.page-explanation"),
-                        "video": () => t("not-found.video-explanation"),
-                    })}
-                    {t("not-found.url-typo")}
-                </p>
-                <Trans i18nKey="not-found.actions">
-                    foo<Link to="/">bar</Link>
-                </Trans>
-            </CenteredContent>
-        </Root>
-    );
+                {t("not-found.url-typo")}
+            </p>
+            <Trans i18nKey="not-found.actions">
+                foo<Link to="/">bar</Link>
+            </Trans>
+        </CenteredContent>
+    </>;
 };

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -8,15 +8,13 @@ import { FiLayout, FiPlus, FiTool } from "react-icons/fi";
 import { environment as relayEnv } from "../relay";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { Blocks } from "../ui/Blocks";
-import { Root } from "../layout/Root";
+import { RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
-import { Nav, NavItems } from "../layout/Navigation";
+import { Nav } from "../layout/Navigation";
 import { LinkList, LinkWithIcon } from "../ui";
 import CONFIG from "../config";
 import { useTitle, useTranslatedConfig } from "../util";
 import { makeRoute } from "../rauta";
-import { UserData$key } from "../__generated__/UserData.graphql";
-import { QueryLoader } from "../util/QueryLoader";
 
 /** A valid realm path segment */
 export const PATH_SEGMENT_REGEX = "[\\p{Alphabetic}\\d][\\p{Alphabetic}\\d\\-]+";
@@ -34,16 +32,28 @@ export const RealmRoute = makeRoute(url => {
     const queryRef = loadQuery<RealmQuery>(relayEnv, query, { path });
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => (
-            !result.realm
-                ? <NotFound kind="page" />
-                : <RealmPage {...{ userQuery: result, path, realm: result.realm }} />
-        )} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => {
+                if (!data.realm) {
+                    return [];
+                }
+
+                const mainNav = <Nav key="nav" fragRef={data.realm} />;
+                return data.realm.canCurrentUserEdit
+                    ? [mainNav, <RealmEditLinks key="edit-buttons" path={path} />]
+                    : mainNav;
+            }}
+            render={data => (
+                data.realm
+                    ? <RealmPage {...{ path, realm: data.realm }} />
+                    : <NotFound kind="page" />
+            )}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });
 
-// TODO Build this query from fragments!
 const query = graphql`
     query RealmQuery($path: String!) {
         ... UserData
@@ -61,12 +71,10 @@ const query = graphql`
 `;
 
 type Props = {
-    userQuery: UserData$key;
     realm: NonNullable<RealmQueryResponse["realm"]>;
-    path: string;
 };
 
-const RealmPage: React.FC<Props> = ({ userQuery, realm, path }) => {
+const RealmPage: React.FC<Props> = ({ realm }) => {
     const siteTitle = useTranslatedConfig(CONFIG.siteTitle);
     const breadcrumbs = realm.ancestors
         .concat(realm)
@@ -77,19 +85,13 @@ const RealmPage: React.FC<Props> = ({ userQuery, realm, path }) => {
 
     const isRoot = realm.parent === null;
     const title = isRoot ? siteTitle : realm.name;
-    const mainNav = <Nav key="nav" fragRef={realm} />;
-    const nav: NavItems = realm.canCurrentUserEdit
-        ? [mainNav, <RealmEditLinks key="edit-buttons" path={path} />]
-        : mainNav;
     useTitle(title, isRoot);
 
-    return (
-        <Root nav={nav} userQuery={userQuery}>
-            {!isRoot && <Breadcrumbs path={breadcrumbs} />}
-            {title && <h1>{title}</h1>}
-            <Blocks realm={realm} />
-        </Root>
-    );
+    return <>
+        {!isRoot && <Breadcrumbs path={breadcrumbs} />}
+        {title && <h1>{title}</h1>}
+        <Blocks realm={realm} />
+    </>;
 };
 
 export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { Blocks } from "../ui/Blocks";
 import { Root } from "../layout/Root";
 import { NotFound } from "./NotFound";
-import { Nav } from "../layout/Navigation";
+import { Nav, NavItems } from "../layout/Navigation";
 import { LinkList, LinkWithIcon } from "../ui";
 import CONFIG from "../config";
 import { useTitle, useTranslatedConfig } from "../util";
@@ -78,9 +78,9 @@ const RealmPage: React.FC<Props> = ({ userQuery, realm, path }) => {
     const isRoot = realm.parent === null;
     const title = isRoot ? siteTitle : realm.name;
     const mainNav = <Nav key="nav" fragRef={realm} />;
-    const nav = realm.canCurrentUserEdit
+    const nav: NavItems = realm.canCurrentUserEdit
         ? [mainNav, <RealmEditLinks key="edit-buttons" path={path} />]
-        : [mainNav];
+        : mainNav;
     useTitle(title, isRoot);
 
     return (

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -27,12 +27,16 @@ import { Card } from "../ui/Card";
 import { InputContainer, TitleLabel } from "../ui/metadata";
 
 
-export const UploadRoute = makeRoute<PreloadedQuery<UploadQuery>>({
-    path: UPLOAD_PATH,
-    queryParams: [],
-    prepare: () => loadQuery(query, {}),
-    render: queryRef => <Upload queryRef={queryRef} />,
-    dispose: prepared => prepared.dispose(),
+export const UploadRoute = makeRoute(url => {
+    if (url.pathname !== UPLOAD_PATH) {
+        return null;
+    }
+
+    const queryRef = loadQuery<UploadQuery>(query, {});
+    return {
+        render: () => <Upload queryRef={queryRef} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 const query = graphql`

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { graphql, usePreloadedQuery, useRelayEnvironment } from "react-relay";
-import type { PreloadedQuery } from "react-relay";
+import { graphql, useRelayEnvironment } from "react-relay";
 import { keyframes } from "@emotion/react";
 import { useForm } from "react-hook-form";
 import { Environment, fetchQuery } from "relay-runtime";
 import { FiCheckCircle, FiUpload } from "react-icons/fi";
 import { useBeforeunload } from "react-beforeunload";
 
-import { Root } from "../layout/Root";
+import { RootLoader } from "../layout/Root";
 import { loadQuery } from "../relay";
 import { UploadQuery } from "./__generated__/UploadQuery.graphql";
 import { UPLOAD_PATH } from "./paths";
@@ -34,7 +33,11 @@ export const UploadRoute = makeRoute(url => {
 
     const queryRef = loadQuery<UploadQuery>(query, {});
     return {
-        render: () => <Upload queryRef={queryRef} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={() => []}
+            render={() => <Upload />}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });
@@ -51,28 +54,20 @@ type Metadata = {
     description: string;
 };
 
-type Props = {
-    queryRef: PreloadedQuery<UploadQuery>;
-};
-
-const Upload: React.FC<Props> = ({ queryRef }) => {
+const Upload: React.FC = () => {
     const { t } = useTranslation();
-    const result = usePreloadedQuery(query, queryRef);
-
 
     return (
-        <Root nav={[]} userQuery={result}>
-            <div css={{
-                margin: "0 auto",
-                height: "100%",
-                display: "flex",
-                flexDirection: "column",
-            }}>
-                <h1>{t("upload.title")}</h1>
-                <div css={{ fontSize: 14, marginBottom: 16 }}>{t("upload.public-note")}</div>
-                <UploadMain />
-            </div>
-        </Root>
+        <div css={{
+            margin: "0 auto",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+        }}>
+            <h1>{t("upload.title")}</h1>
+            <div css={{ fontSize: 14, marginBottom: 16 }}>{t("upload.public-note")}</div>
+            <UploadMain />
+        </div>
     );
 };
 

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
 
-import { Root } from "../../../layout/Root";
+import { RootLoader } from "../../../layout/Root";
 import type {
     AddChildQuery,
     AddChildQueryResponse,
@@ -21,7 +21,6 @@ import { AddChildMutationResponse } from "./__generated__/AddChildMutation.graph
 import { Spinner } from "../../../ui/Spinner";
 import { Nav } from "../../../layout/Navigation";
 import { makeRoute } from "../../../rauta";
-import { QueryLoader } from "../../../util/QueryLoader";
 import { Card } from "../../../ui/Card";
 
 
@@ -40,21 +39,20 @@ export const AddChildRoute = makeRoute(url => {
     const queryRef = loadQuery<AddChildQuery>(query, { parent });
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => {
-            const { parent } = result;
-            const nav = !parent ? [] : <Nav fragRef={parent} />;
-
-            let inner;
-            if (!parent) {
-                inner = <PathInvalid />;
-            } else if (!parent.canCurrentUserEdit) {
-                inner = <NotAuthorized />;
-            } else {
-                inner = <AddChild parent={parent} />;
-            }
-
-            return <Root nav={nav} userQuery={result}>{inner}</Root>;
-        }} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => data.parent ? <Nav fragRef={data.parent} /> : []}
+            render={data => {
+                const parent = data.parent;
+                if (!parent) {
+                    return <PathInvalid />;
+                } else if (!parent.canCurrentUserEdit) {
+                    return <NotAuthorized />;
+                } else {
+                    return <AddChild parent={parent} />;
+                }
+            }}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import type { PreloadedQuery } from "react-relay";
 
 import { Root } from "../../../layout/Root";
 import type {
@@ -28,26 +27,36 @@ import { Card } from "../../../ui/Card";
 
 export const PATH = "/~manage/realm/add-child";
 
-export const AddChildRoute = makeRoute<PreloadedQuery<AddChildQuery>, ["parent"]>({
-    path: PATH,
-    queryParams: ["parent"],
-    prepare: ({ queryParams: { parent } }) => loadQuery(query, { parent }),
-    render: queryRef => <QueryLoader {...{ query, queryRef }} render={result => {
-        const { parent } = result;
-        const nav = !parent ? [] : <Nav fragRef={parent} />;
+export const AddChildRoute = makeRoute(url => {
+    if (url.pathname !== PATH) {
+        return null;
+    }
 
-        let inner;
-        if (!parent) {
-            inner = <PathInvalid />;
-        } else if (!parent.canCurrentUserEdit) {
-            inner = <NotAuthorized />;
-        } else {
-            inner = <AddChild parent={parent} />;
-        }
+    const parent = url.searchParams.get("parent");
+    if (parent === null) {
+        return null;
+    }
 
-        return <Root nav={nav} userQuery={result}>{inner}</Root>;
-    }} />,
-    dispose: queryRef => queryRef.dispose(),
+    const queryRef = loadQuery<AddChildQuery>(query, { parent });
+
+    return {
+        render: () => <QueryLoader {...{ query, queryRef }} render={result => {
+            const { parent } = result;
+            const nav = !parent ? [] : <Nav fragRef={parent} />;
+
+            let inner;
+            if (!parent) {
+                inner = <PathInvalid />;
+            } else if (!parent.canCurrentUserEdit) {
+                inner = <NotAuthorized />;
+            } else {
+                inner = <AddChild parent={parent} />;
+            }
+
+            return <Root nav={nav} userQuery={result}>{inner}</Root>;
+        }} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -3,7 +3,7 @@ import { Trans } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 import { useBeforeunload } from "react-beforeunload";
 
-import { Root } from "../../../../layout/Root";
+import { RootLoader } from "../../../../layout/Root";
 import type {
     ContentManageQuery,
     ContentManageQueryResponse,
@@ -16,7 +16,6 @@ import { RealmSettingsContainer } from "../util";
 import { Nav } from "../../../../layout/Navigation";
 import { makeRoute } from "../../../../rauta";
 import { Link } from "../../../../router";
-import { QueryLoader } from "../../../../util/QueryLoader";
 import { Spinner } from "../../../../ui/Spinner";
 import { AddButtons } from "./AddButtons";
 import { EditBlock } from "./Block";
@@ -37,23 +36,19 @@ export const ManageRealmContentRoute = makeRoute(url => {
     const queryRef = loadQuery<ContentManageQuery>(query, { path });
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => {
-            const { realm } = result;
-            const nav = realm ? <Nav fragRef={realm} /> : [];
-
-            let children = null;
-            if (!realm) {
-                children = <PathInvalid />;
-            } else if (!realm.canCurrentUserEdit) {
-                children = <NotAuthorized />;
-            } else {
-                children = <ManageContent data={result} />;
-            }
-
-            return <Root nav={nav} userQuery={result}>
-                {children}
-            </Root>;
-        }} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+            render={data => {
+                if (!data.realm) {
+                    return <PathInvalid />;
+                } else if (!data.realm.canCurrentUserEdit) {
+                    return <NotAuthorized />;
+                } else {
+                    return <ManageContent data={data} />;
+                }
+            }}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import type { PreloadedQuery } from "react-relay";
 
 import { Root } from "../../../layout/Root";
 import type {
@@ -27,21 +26,31 @@ import { QueryLoader } from "../../../util/QueryLoader";
 
 export const PATH = "/~manage/realm";
 
-export const ManageRealmRoute = makeRoute<PreloadedQuery<RealmManageQuery>, ["path"]>({
-    path: PATH,
-    queryParams: ["path"],
-    prepare: ({ queryParams: { path } }) => loadQuery(query, { path }),
-    render: queryRef => <QueryLoader {...{ query, queryRef }} render={result => {
-        const { realm } = result;
-        const nav = !realm ? [] : <Nav fragRef={realm} />;
+export const ManageRealmRoute = makeRoute(url => {
+    if (url.pathname !== PATH) {
+        return null;
+    }
 
-        return (
-            <Root nav={nav} userQuery={result}>
-                {!realm ? <PathInvalid /> : <SettingsPage realm={realm} />}
-            </Root>
-        );
-    }} />,
-    dispose: queryRef => queryRef.dispose(),
+    const path = url.searchParams.get("path");
+    if (path === null) {
+        return null;
+    }
+
+    const queryRef = loadQuery<RealmManageQuery>(query, { path });
+
+    return {
+        render: () => <QueryLoader {...{ query, queryRef }} render={result => {
+            const { realm } = result;
+            const nav = !realm ? [] : <Nav fragRef={realm} />;
+
+            return (
+                <Root nav={nav} userQuery={result}>
+                    {!realm ? <PathInvalid /> : <SettingsPage realm={realm} />}
+                </Root>
+            );
+        }} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
 
-import { Root } from "../../../layout/Root";
+import { RootLoader } from "../../../layout/Root";
 import type {
     RealmManageQuery,
     RealmManageQueryResponse,
@@ -19,7 +19,6 @@ import { CenteredContent } from "../../../ui";
 import { NotAuthorized } from "../../../ui/error";
 import { RealmSettingsContainer } from "./util";
 import { makeRoute } from "../../../rauta";
-import { QueryLoader } from "../../../util/QueryLoader";
 
 
 // Route definition
@@ -39,16 +38,11 @@ export const ManageRealmRoute = makeRoute(url => {
     const queryRef = loadQuery<RealmManageQuery>(query, { path });
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => {
-            const { realm } = result;
-            const nav = !realm ? [] : <Nav fragRef={realm} />;
-
-            return (
-                <Root nav={nav} userQuery={result}>
-                    {!realm ? <PathInvalid /> : <SettingsPage realm={realm} />}
-                </Root>
-            );
-        }} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+            render={data => data.realm ? <SettingsPage realm={data.realm} /> : <PathInvalid />}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });

--- a/frontend/src/routes/manage/Video/Single.tsx
+++ b/frontend/src/routes/manage/Video/Single.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { FiArrowLeft } from "react-icons/fi";
 import { graphql } from "react-relay";
 
-import { Root } from "../../../layout/Root";
+import { RootLoader } from "../../../layout/Root";
 import {
     SingleVideoManageQuery,
     SingleVideoManageQueryResponse,
@@ -17,7 +17,6 @@ import { CopyableInput, Input, TextArea } from "../../../ui/Input";
 import { InputContainer, TitleLabel } from "../../../ui/metadata";
 import { Thumbnail } from "../../../ui/Video";
 import { useTitle } from "../../../util";
-import { QueryLoader } from "../../../util/QueryLoader";
 import { NotFound } from "../../NotFound";
 import { b64regex } from "../../Video";
 import { PATH as MANAGE_VIDEOS_PATH } from ".";
@@ -34,18 +33,16 @@ export const ManageSingleVideoRoute = makeRoute(url => {
     const queryRef = loadQuery<SingleVideoManageQuery>(query, { id: `ev${videoId}` });
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => (
-            result.event === null
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={() => <BackLink />}
+            render={data => data.event === null
                 ? <NotFound kind="video" />
-                : (
-                    <Root nav={<BackLink />} userQuery={result}>
-                        {result.event.canWrite
-                            ? <ManageSingleVideo event={result.event}/>
-                            : <NotAuthorized />
-                        }
-                    </Root>
-                )
-        )} />,
+                : data.event.canWrite
+                    ? <ManageSingleVideo event={data.event}/>
+                    : <NotAuthorized />
+            }
+        />,
         dispose: () => queryRef.dispose(),
     };
 });
@@ -53,6 +50,9 @@ export const ManageSingleVideoRoute = makeRoute(url => {
 const BackLink: React.FC = () => {
     const { t } = useTranslation();
 
+    // TODO: if `history.length > 0`, go back in the history instead of having a
+    // link. Going back should preserve the pagination and stuff on the
+    // previous page.
     const items = [
         <LinkWithIcon key={MANAGE_VIDEOS_PATH} to={MANAGE_VIDEOS_PATH} iconPos="left">
             <FiArrowLeft />

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -27,24 +27,20 @@ import LastPage from "../../../icons/last-page.svg";
 import { Card } from "../../../ui/Card";
 
 
-const PATH = "/~manage/videos";
+export const PATH = "/~manage/videos";
 
-type Prepared = {
-    queryRef: PreloadedQuery<VideoManageQuery>;
-    sortOrder: EventSortOrder;
-};
+export const ManageVideosRoute = makeRoute(url => {
+    if (url.pathname !== PATH) {
+        return null;
+    }
 
-export const ManageVideosRoute = makeRoute<Prepared>({
-    path: PATH,
-    queryParams: [],
-    prepare: ({ url }) => {
-        const sortOrder = queryParamsToOrder(url.searchParams);
-        return {
-            queryRef: loadQuery(query, { order: sortOrder, first: LIMIT }),
-            sortOrder,
-        };
-    },
-    render: prepared => <Page {...prepared} />,
+    const sortOrder = queryParamsToOrder(url.searchParams);
+    const queryRef = loadQuery<VideoManageQuery>(query, { order: sortOrder, first: LIMIT });
+
+    return {
+        render: () => <Page {...{ sortOrder, queryRef }} />,
+        dispose: () => queryRef.dispose(),
+    };
 });
 
 const query = graphql`
@@ -73,8 +69,13 @@ const query = graphql`
     }
 `;
 
+type PageProps = {
+    queryRef: PreloadedQuery<VideoManageQuery>;
+    sortOrder: EventSortOrder;
+};
+
 /** Main component, mainly loading relay data */
-const Page: React.FC<Prepared> = ({ queryRef: initialQueryRef, sortOrder }) => {
+const Page: React.FC<PageProps> = ({ queryRef: initialQueryRef, sortOrder }) => {
     const [queryRef, loadQuery] = useQueryLoader(query, initialQueryRef);
     if (!queryRef) {
         // `useQueryLoader` is incorrectly typed, I believe. If

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,27 +1,23 @@
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiChevronDown, FiChevronLeft, FiChevronRight, FiChevronUp } from "react-icons/fi";
-import { graphql, PreloadedQuery, useQueryLoader } from "react-relay";
+import { graphql, VariablesOf } from "react-relay";
 
 import { ManageNav } from "..";
 import { Root } from "../../../layout/Root";
 import {
     EventSortColumn,
-    EventSortOrder,
     SortDirection,
     VideoManageQuery,
     VideoManageQueryResponse,
-    VideoManageQueryVariables,
 } from "./__generated__/VideoManageQuery.graphql";
 import { makeRoute } from "../../../rauta";
 import { loadQuery } from "../../../relay";
 import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
-import { Spinner } from "../../../ui/Spinner";
 import { Thumbnail } from "../../../ui/Video";
 import { QueryLoader } from "../../../util/QueryLoader";
 import { keyOfId, match, useTitle } from "../../../util";
-import { unreachable } from "../../../util/err";
 import FirstPage from "../../../icons/first-page.svg";
 import LastPage from "../../../icons/last-page.svg";
 import { Card } from "../../../ui/Card";
@@ -34,11 +30,21 @@ export const ManageVideosRoute = makeRoute(url => {
         return null;
     }
 
-    const sortOrder = queryParamsToOrder(url.searchParams);
-    const queryRef = loadQuery<VideoManageQuery>(query, { order: sortOrder, first: LIMIT });
+    const vars = queryParamsToVars(url.searchParams);
+    const queryRef = loadQuery<VideoManageQuery>(query, vars);
 
     return {
-        render: () => <Page {...{ sortOrder, queryRef }} />,
+        render: () => <QueryLoader {...{ query, queryRef }} render={result => (
+            <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
+                {!result.currentUser
+                    ? <NotAuthorized />
+                    : <ManageVideos
+                        vars={vars}
+                        connection={result.currentUser.myVideos}
+                    />
+                }
+            </Root>
+        )} />,
         dispose: () => queryRef.dispose(),
     };
 });
@@ -69,79 +75,30 @@ const query = graphql`
     }
 `;
 
-type PageProps = {
-    queryRef: PreloadedQuery<VideoManageQuery>;
-    sortOrder: EventSortOrder;
-};
-
-/** Main component, mainly loading relay data */
-const Page: React.FC<PageProps> = ({ queryRef: initialQueryRef, sortOrder }) => {
-    const [queryRef, loadQuery] = useQueryLoader(query, initialQueryRef);
-    if (!queryRef) {
-        // `useQueryLoader` is incorrectly typed, I believe. If
-        // `initialQueryRef` is given, it never returns null.
-        return unreachable();
-    }
-
-    return <QueryLoader {...{ query, queryRef }} render={result => (
-        <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
-            {!result.currentUser
-                ? <NotAuthorized />
-                : <ManageVideos
-                    urlSortOrder={sortOrder}
-                    reloadQuery={vars => loadQuery(vars, { fetchPolicy: "network-only" })}
-                    connection={result.currentUser.myVideos}
-                />
-            }
-        </Root>
-    )} />;
-};
-
-
 type EventConnection = NonNullable<VideoManageQueryResponse["currentUser"]>["myVideos"];
 type Events = EventConnection["items"];
 
 type Props = {
     connection: EventConnection;
-    urlSortOrder: EventSortOrder;
-    reloadQuery: (vars: VideoManageQueryVariables) => void;
+    vars: VariablesOf<VideoManageQuery>;
 };
 
 const LIMIT = 15;
 
 /** Main part of this page */
-const ManageVideos: React.FC<Props> = ({ urlSortOrder, connection, reloadQuery }) => {
+const ManageVideos: React.FC<Props> = ({ connection, vars }) => {
     const { t } = useTranslation();
-
-    const [sortOrder, setSortOrder] = useState(urlSortOrder);
-    const [isPending, startTransition] = useTransition();
-    const loadFirst = (after: string | null) => {
-        startTransition(() => reloadQuery({ order: sortOrder, after, first: LIMIT }));
-    };
-    const loadLast = (before: string | null) => {
-        startTransition(() => reloadQuery({ order: sortOrder, before, last: LIMIT }));
-    };
-    const reloadWithOrder = (order: EventSortOrder) => {
-        startTransition(() => {
-            // We go to page one again when changing sort order.
-            reloadQuery({ order, first: LIMIT });
-            setSortOrder(order);
-        });
-    };
 
     let inner;
     if (connection.items.length === 0 && connection.totalCount === 0) {
         inner = <Card kind="info">{t("manage.my-videos.no-videos-found")}</Card>;
     } else {
         inner = <>
-            <PageNavigation {...{ loadFirst, loadLast, connection }} />
+            <PageNavigation {...{ vars, connection }} />
             <div css={{ flex: "1 0 0" }}>
-                <EventTable
-                    events={connection.items}
-                    {...{ reloadWithOrder, isPending, sortOrder }}
-                />
+                <EventTable events={connection.items} vars={vars} />
             </div>
-            <PageNavigation {...{ loadFirst, loadLast, connection }} />
+            <PageNavigation {...{ vars, connection }} />
         </>;
     }
 
@@ -165,17 +122,10 @@ const THUMBNAIL_WIDTH = 16 * 8;
 
 type EventTableProps = {
     events: Events;
-    reloadWithOrder: (order: EventSortOrder) => void;
-    isPending: boolean;
-    sortOrder: EventSortOrder;
+    vars: VariablesOf<VideoManageQuery>;
 };
 
-const EventTable: React.FC<EventTableProps> = ({
-    events,
-    reloadWithOrder,
-    isPending,
-    sortOrder,
-}) => {
+const EventTable: React.FC<EventTableProps> = ({ events, vars }) => {
     const { t } = useTranslation();
 
     // We need to know whether the table header is in its "sticky" position to apply a box
@@ -197,40 +147,11 @@ const EventTable: React.FC<EventTableProps> = ({
         return () => {};
     });
 
-    const onColHeaderClick = (sortKey: EventSortColumn) => {
-        const newOrder: EventSortOrder = {
-            column: sortKey,
-            direction: sortOrder.column === sortKey
-                ? (sortOrder.direction === "ASCENDING" ? "DESCENDING" : "ASCENDING")
-                : "ASCENDING",
-        };
-
-        setSortQueryParams(newOrder);
-        reloadWithOrder(newOrder);
-    };
-
     return <div css={{ position: "relative" }}>
-        {isPending && (
-            <div css={{
-                position: "absolute",
-                zIndex: 100,
-                fontSize: 48,
-                left: 0,
-                right: 0,
-                top: 64,
-                textAlign: "center",
-            }}><Spinner/></div>
-        )}
         <table css={{
             width: "100%",
             borderSpacing: 0,
             tableLayout: "fixed",
-
-            ...isPending && {
-                pointerEvents: "none",
-                "& > thead > tr, & > tbody": { opacity: 0.3 },
-            },
-
             "& > thead": {
                 position: "sticky",
                 top: 0,
@@ -274,14 +195,12 @@ const EventTable: React.FC<EventTableProps> = ({
                     <ColumnHeader
                         label={t("manage.my-videos.columns.title")}
                         sortKey="TITLE"
-                        onClick={onColHeaderClick}
-                        {...{ sortOrder }}
+                        {...{ vars }}
                     />
                     <ColumnHeader
                         label={t("manage.my-videos.columns.created")}
                         sortKey="CREATED"
-                        onClick={onColHeaderClick}
-                        {...{ sortOrder }}
+                        {...{ vars }}
                     />
                 </tr>
             </thead>
@@ -295,14 +214,20 @@ const EventTable: React.FC<EventTableProps> = ({
 type ColumnHeaderProps = {
     label: string;
     sortKey: EventSortColumn;
-    sortOrder: EventSortOrder;
-    onClick: (sortKey: EventSortColumn) => void;
+    vars: VariablesOf<VideoManageQuery>;
 };
 
-const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, sortOrder, onClick }) => (
+const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => (
     <th>
-        <div
-            onClick={() => onClick(sortKey)}
+        <Link
+            to={varsToLink({
+                order: {
+                    column: sortKey,
+                    direction: vars.order.column === sortKey && vars.order.direction === "ASCENDING"
+                        ? "DESCENDING"
+                        : "ASCENDING",
+                },
+            })}
             css={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -318,11 +243,11 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, sortOrder, 
             }}
         >
             {label}
-            {sortOrder.column === sortKey && match(sortOrder.direction, {
+            {vars.order.column === sortKey && match(vars.order.direction, {
                 "ASCENDING": () => <FiChevronUp />,
                 "DESCENDING": () => <FiChevronDown />,
             }, () => null)}
-        </div>
+        </Link>
     </th>
 );
 
@@ -386,11 +311,10 @@ const Description: React.FC<{ text: string | null }> = ({ text }) => {
 
 type PageNavigationProps = {
     connection: EventConnection;
-    loadFirst: (after: string | null) => void;
-    loadLast: (before: string | null) => void;
+    vars: VariablesOf<VideoManageQuery>;
 };
 
-const PageNavigation: React.FC<PageNavigationProps> = ({ connection, loadFirst, loadLast }) => {
+const PageNavigation: React.FC<PageNavigationProps> = ({ connection, vars }) => {
     const { t } = useTranslation();
     const pageInfo = connection.pageInfo;
 
@@ -409,36 +333,35 @@ const PageNavigation: React.FC<PageNavigationProps> = ({ connection, loadFirst, 
                 })}
             </div>
             <div>
-                <PageButton
-                    onClick={() => loadFirst(null)}
+                <PageLink
+                    vars={{ order: vars.order, first: LIMIT }}
+                    disabled={!pageInfo.hasPreviousPage && connection.items.length === LIMIT}
+                ><FirstPage /></PageLink>
+                <PageLink
+                    vars={{ order: vars.order, before: pageInfo.startCursor, last: LIMIT }}
                     disabled={!pageInfo.hasPreviousPage}
-                ><FirstPage /></PageButton>
-                <PageButton
-                    onClick={() => loadLast(pageInfo.startCursor)}
-                    disabled={!pageInfo.hasPreviousPage}
-                ><FiChevronLeft /></PageButton>
-                <PageButton
-                    onClick={() => loadFirst(pageInfo.endCursor)}
+                ><FiChevronLeft /></PageLink>
+                <PageLink
+                    vars={{ order: vars.order, after: pageInfo.endCursor, first: LIMIT }}
                     disabled={!pageInfo.hasNextPage}
-                ><FiChevronRight /></PageButton>
-                <PageButton
-                    onClick={() => loadLast(null)}
+                ><FiChevronRight /></PageLink>
+                <PageLink
+                    vars={{ order: vars.order, last: LIMIT }}
                     disabled={!pageInfo.hasNextPage}
-                ><LastPage /></PageButton>
+                ><LastPage /></PageLink>
             </div>
         </div>
     );
 };
 
-type PageButtonProps = {
-    onClick: () => void;
+type PageLinkProps = {
+    vars: VariablesOf<VideoManageQuery>;
     disabled: boolean;
 };
 
-const PageButton: React.FC<PageButtonProps> = ({ children, onClick, disabled }) => (
-    <button
-        onClick={disabled ? () => {} : onClick}
-        disabled={disabled}
+const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled }) => (
+    <Link
+        to={varsToLink(vars)}
         css={{
             background: "none",
             border: "none",
@@ -449,6 +372,7 @@ const PageButton: React.FC<PageButtonProps> = ({ children, onClick, disabled }) 
             ...disabled
                 ? {
                     color: "var(--grey80)",
+                    pointerEvents: "none",
                 }
                 : {
                     color: "var(--grey40)",
@@ -458,10 +382,15 @@ const PageButton: React.FC<PageButtonProps> = ({ children, onClick, disabled }) 
                     },
                 },
         }}
-    >{children}</button>
+    >{children}</Link>
 );
 
-const queryParamsToOrder = (queryParams: URLSearchParams): EventSortOrder => {
+const DEFAULT_SORT_COLUMN: EventSortColumn = "CREATED";
+const DEFAULT_SORT_DIRECTION: SortDirection = "DESCENDING";
+
+/** Reads URL query parameters and converts them into query variables */
+const queryParamsToVars = (queryParams: URLSearchParams): VariablesOf<VideoManageQuery> => {
+    // Sort order
     const sortBy = queryParams.get("sortBy");
     const column = sortBy !== null && match<string, EventSortColumn>(sortBy, {
         "title": () => "TITLE",
@@ -476,17 +405,55 @@ const queryParamsToOrder = (queryParams: URLSearchParams): EventSortOrder => {
         "asc": () => "ASCENDING",
     });
 
-    return column === false || direction === false
-        ? { column: "CREATED", direction: "DESCENDING" }
+    const order = !column || !direction
+        ? { column: DEFAULT_SORT_COLUMN, direction: DEFAULT_SORT_DIRECTION }
         : { column, direction };
+
+    // Pagination
+    if (queryParams.has("lastPage")) {
+        return { order, last: LIMIT };
+    }
+    if (queryParams.has("before")) {
+        return { order, before: queryParams.get("before"), last: LIMIT };
+    }
+    if (queryParams.has("after")) {
+        return { order, after: queryParams.get("after"), first: LIMIT };
+    }
+
+    return { order, first: LIMIT };
 };
 
-const setSortQueryParams = (order: EventSortOrder) => {
+/** Converts query variables to URL query parameters */
+const varsToQueryParams = (vars: VariablesOf<VideoManageQuery>): URLSearchParams => {
+    const searchParams = new URLSearchParams();
+
+    // Sort order
+    const isDefaultOrder = vars.order.column === DEFAULT_SORT_COLUMN
+        && vars.order.direction === DEFAULT_SORT_DIRECTION;
+    if (!isDefaultOrder) {
+        searchParams.set("sortBy", vars.order.column.toLowerCase());
+        searchParams.set("sortOrder", match(vars.order.direction, {
+            "ASCENDING": () => "asc",
+            "DESCENDING": () => "desc",
+        }, () => ""));
+    }
+
+    // Pagination
+    if (vars.last !== undefined) {
+        if (!vars.before) {
+            searchParams.set("lastPage", "");
+        } else {
+            searchParams.set("before", vars.before);
+        }
+    } else if (vars.after) {
+        searchParams.set("after", vars.after);
+    }
+
+    return searchParams;
+};
+
+const varsToLink = (vars: VariablesOf<VideoManageQuery>): string => {
     const url = new URL(document.location.href);
-    url.searchParams.set("sortBy", order.column.toLowerCase());
-    url.searchParams.set("sortOrder", match(order.direction, {
-        "ASCENDING": () => "asc",
-        "DESCENDING": () => "desc",
-    }, () => ""));
-    history.pushState(null, "", url);
+    url.search = varsToQueryParams(vars).toString();
+    return url.href;
 };

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -4,7 +4,7 @@ import { FiChevronDown, FiChevronLeft, FiChevronRight, FiChevronUp } from "react
 import { graphql, VariablesOf } from "react-relay";
 
 import { ManageNav } from "..";
-import { Root } from "../../../layout/Root";
+import { RootLoader } from "../../../layout/Root";
 import {
     EventSortColumn,
     SortDirection,
@@ -16,7 +16,6 @@ import { loadQuery } from "../../../relay";
 import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Thumbnail } from "../../../ui/Video";
-import { QueryLoader } from "../../../util/QueryLoader";
 import { keyOfId, match, useTitle } from "../../../util";
 import FirstPage from "../../../icons/first-page.svg";
 import LastPage from "../../../icons/last-page.svg";
@@ -34,17 +33,14 @@ export const ManageVideosRoute = makeRoute(url => {
     const queryRef = loadQuery<VideoManageQuery>(query, vars);
 
     return {
-        render: () => <QueryLoader {...{ query, queryRef }} render={result => (
-            <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
-                {!result.currentUser
-                    ? <NotAuthorized />
-                    : <ManageVideos
-                        vars={vars}
-                        connection={result.currentUser.myVideos}
-                    />
-                }
-            </Root>
-        )} />,
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={() => <ManageNav key={1} active={PATH} />}
+            render={data => !data.currentUser
+                ? <NotAuthorized />
+                : <ManageVideos vars={vars} connection={data.currentUser.myVideos} />
+            }
+        />,
         dispose: () => queryRef.dispose(),
     };
 });

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -4,7 +4,7 @@ import { FiFilm, FiUpload, FiVideo } from "react-icons/fi";
 import { HiTemplate } from "react-icons/hi";
 import { graphql } from "react-relay";
 
-import { Root } from "../../layout/Root";
+import { RootLoader } from "../../layout/Root";
 import {
     manageDashboardQuery as ManageDashboardQuery,
 } from "./__generated__/manageDashboardQuery.graphql";
@@ -14,7 +14,6 @@ import { Link } from "../../router";
 import { LinkList, LinkWithIcon } from "../../ui";
 import { NotAuthorized } from "../../ui/error";
 import { useUser } from "../../User";
-import { QueryLoader } from "../../util/QueryLoader";
 
 
 const PATH = "/~manage";
@@ -26,13 +25,12 @@ export const ManageRoute = makeRoute(url => {
 
     const queryRef = loadQuery<ManageDashboardQuery>(query, {});
     return {
-        render: () => (
-            <QueryLoader {...{ query, queryRef }} render={result => (
-                <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
-                    <Manage />
-                </Root>
-            )} />
-        ),
+
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={() => <ManageNav key={1} active={PATH} />}
+            render={() => <Manage />}
+        />,
         dispose: () => queryRef.dispose(),
     };
 });

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { FiFilm, FiUpload, FiVideo } from "react-icons/fi";
 import { HiTemplate } from "react-icons/hi";
-import { graphql, PreloadedQuery } from "react-relay";
+import { graphql } from "react-relay";
 
 import { Root } from "../../layout/Root";
 import {
@@ -19,16 +19,24 @@ import { QueryLoader } from "../../util/QueryLoader";
 
 const PATH = "/~manage";
 
-export const ManageRoute = makeRoute<PreloadedQuery<ManageDashboardQuery>>({
-    path: PATH,
-    queryParams: [],
-    prepare: () => loadQuery(query, {}),
-    render: queryRef => <QueryLoader {...{ query, queryRef }} render={result => (
-        <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
-            <Manage />
-        </Root>
-    )} />,
+export const ManageRoute = makeRoute(url => {
+    if (url.pathname !== PATH) {
+        return null;
+    }
+
+    const queryRef = loadQuery<ManageDashboardQuery>(query, {});
+    return {
+        render: () => (
+            <QueryLoader {...{ query, queryRef }} render={result => (
+                <Root nav={<ManageNav key={1} active={PATH} />} userQuery={result}>
+                    <Manage />
+                </Root>
+            )} />
+        ),
+        dispose: () => queryRef.dispose(),
+    };
 });
+
 
 const query = graphql`
     query manageDashboardQuery {


### PR DESCRIPTION
The main reason why I did all of this is to implement the frontend search well. We had the problem that most routes were rendering `<Root>` at a different position in the component tree. This meant that the header was completely unmounted and remounted on each route change, making the search field lose input focus. But I also wanted to implement some of these improvements anyway, as I hope they do in fact improve code of the individual routes.

This PR does two main things:

- Change `rauta` to define each route with a simple function basically. That function gets an URL, has to decide whether it matches and then prepares the route and returns `render` and `dispose` functions. See the first commit for more info.

- Add `<RootLoader>` helper to consistently render `<Root>` and load the query.