### PR TITLE
Video block

### DIFF
--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -88,7 +88,6 @@ pub(crate) struct TextBlock {
     pub(crate) content: String,
 }
 
-#[graphql_interface]
 impl Block for TextBlock {
     fn shared(&self) -> &SharedData {
         &self.shared
@@ -122,7 +121,6 @@ pub(crate) struct SeriesBlock {
     pub(crate) order: VideoListOrder,
 }
 
-#[graphql_interface]
 impl Block for SeriesBlock {
     fn shared(&self) -> &SharedData {
         &self.shared

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -17,6 +17,7 @@ mod mutations;
 pub(crate) use mutations::{
     NewTextBlock,
     NewSeriesBlock,
+    NewVideoBlock,
     UpdateBlock,
     UpdateTextBlock,
     UpdateSeriesBlock,

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -230,18 +230,14 @@ impl BlockValue {
 
             BlockType::Series => SeriesBlock {
                 shared,
-                series: Id::series(
-                    get_type_dependent(&row, 5, "videolist", "series_id")?
-                ),
+                series: Id::series(get_type_dependent(&row, 5, "videolist", "series_id")?),
                 layout: get_type_dependent(&row, 6, "videolist", "videolist_layout")?,
                 order: get_type_dependent(&row, 7, "videolist", "videolist_order")?,
             }.into(),
 
             BlockType::Video => VideoBlock {
                 shared,
-                event: Id::event(
-                    get_type_dependent(&row, 8, "video", "video_id")?,
-                ),
+                event: Id::event(get_type_dependent(&row, 8, "video", "video_id")?),
             }.into(),
         };
 

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use mutations::{
     UpdateBlock,
     UpdateTextBlock,
     UpdateSeriesBlock,
+    UpdateVideoBlock,
     RemovedBlock,
 };
 

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -189,22 +189,19 @@ impl BlockValue {
         };
 
         let block = match ty {
-            BlockType::Text => {
-                TextBlock {
-                    shared,
-                    content: get_type_dependent(&row, 4, "text", "text_content")?,
-                }.into()
-            }
-            BlockType::Series => {
-                SeriesBlock {
-                    shared,
-                    series: Id::series(
-                        get_type_dependent(&row, 5, "videolist", "series_id")?
-                    ),
-                    layout: get_type_dependent(&row, 6, "videolist", "videolist_layout")?,
-                    order: get_type_dependent(&row, 7, "videolist", "videolist_order")?,
-                }.into()
-            }
+            BlockType::Text => TextBlock {
+                shared,
+                content: get_type_dependent(&row, 4, "text", "text_content")?,
+            }.into(),
+
+            BlockType::Series => SeriesBlock {
+                shared,
+                series: Id::series(
+                    get_type_dependent(&row, 5, "videolist", "series_id")?
+                ),
+                layout: get_type_dependent(&row, 6, "videolist", "videolist_layout")?,
+                order: get_type_dependent(&row, 7, "videolist", "videolist_order")?,
+            }.into(),
         };
 
         Ok(block)

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -51,6 +51,8 @@ pub(crate) enum BlockType {
     Text,
     #[postgres(name = "series")]
     Series,
+    #[postgres(name = "video")]
+    Video,
 }
 
 #[derive(Debug, Clone, Copy, FromSql, ToSql, GraphQLEnum)]
@@ -202,6 +204,8 @@ impl BlockValue {
                 layout: get_type_dependent(&row, 6, "videolist", "videolist_layout")?,
                 order: get_type_dependent(&row, 7, "videolist", "videolist_order")?,
             }.into(),
+
+            BlockType::Video => unimplemented!(),
         };
 
         Ok(block)

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -20,7 +20,7 @@ impl BlockValue {
 
         context.db
             .execute(
-                "insert into blocks (realm_id, index, type, title, text_content)
+                "insert into blocks (realm_id, index, type, title, text_content) \
                     values ($1, $2, 'text', $3, $4)",
                 &[&realm, &index, &block.title, &block.content],
             )
@@ -43,8 +43,8 @@ impl BlockValue {
 
         context.db
             .execute(
-                "insert into blocks
-                    (realm_id, index, type, title, series_id, videolist_order, videolist_layout)
+                "insert into blocks \
+                    (realm_id, index, type, title, series_id, videolist_order, videolist_layout) \
                     values ($1, $2, 'series', $3, $4, $5, $6)",
                 &[
                     &realm,
@@ -123,9 +123,9 @@ impl BlockValue {
 
         context.db
             .execute(
-                "update blocks
-                    set index = index + 1
-                    where realm_id = $1
+                "update blocks \
+                    set index = index + 1 \
+                    where realm_id = $1 \
                     and index >= $2",
                 &[&realm, &index],
             )
@@ -326,9 +326,9 @@ impl BlockValue {
         // Fix indices after removed block
         db
             .execute(
-                "update blocks
-                    set index = index - 1
-                    where realm_id = $1
+                "update blocks \
+                    set index = index - 1 \
+                    where realm_id = $1 \
                     and index > $2",
                 &[&realm.key, &index],
             )

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -188,7 +188,11 @@ impl BlockValue {
         Ok(realm)
     }
 
-    pub(crate) async fn update(id: Id, set: UpdateBlock, context: &Context) -> ApiResult<BlockValue> {
+    pub(crate) async fn update(
+        id: Id,
+        set: UpdateBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
                 &format!(
@@ -210,7 +214,11 @@ impl BlockValue {
         Ok(Self::from_row(updated_block)?)
     }
 
-    pub(crate) async fn update_text(id: Id, set: UpdateTextBlock, context: &Context) -> ApiResult<BlockValue> {
+    pub(crate) async fn update_text(
+        id: Id,
+        set: UpdateTextBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
                 &format!(
@@ -235,7 +243,11 @@ impl BlockValue {
         Ok(Self::from_row(updated_block)?)
     }
 
-    pub(crate) async fn update_series(id: Id, set: UpdateSeriesBlock, context: &Context) -> ApiResult<BlockValue> {
+    pub(crate) async fn update_series(
+        id: Id,
+        set: UpdateSeriesBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
                 &format!(

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -101,7 +101,7 @@ impl BlockValue {
     async fn prepare_realm_for_block(
         realm: Id,
         index: i32,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<(Key, i16)> {
         let realm = realm.key_for(Id::REALM_KIND)
             .ok_or_else(|| invalid_input!("`realm` does not refer to a realm"))?;
@@ -138,7 +138,7 @@ impl BlockValue {
         realm: Id,
         index_a: i32,
         index_b: i32,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<Realm> {
 
         if index_a == index_b {
@@ -212,7 +212,7 @@ impl BlockValue {
     pub(crate) async fn update(
         id: Id,
         set: UpdateBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
@@ -238,7 +238,7 @@ impl BlockValue {
     pub(crate) async fn update_text(
         id: Id,
         set: UpdateTextBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
@@ -267,7 +267,7 @@ impl BlockValue {
     pub(crate) async fn update_series(
         id: Id,
         set: UpdateSeriesBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(
@@ -303,7 +303,7 @@ impl BlockValue {
     pub(crate) async fn update_video(
         id: Id,
         set: UpdateVideoBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         let updated_block = context.db(context.require_moderator()?)
             .query_one(

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -41,20 +41,15 @@ impl BlockValue {
 
         let (realm, index) = Self::prepare_realm_for_block(realm, index, context).await?;
 
+        let series = block.series.key_for(Id::SERIES_KIND)
+            .ok_or_else(|| invalid_input!("`block.series` does not refer to a series"))?;
+
         context.db
             .execute(
                 "insert into blocks \
                     (realm_id, index, type, title, series_id, videolist_order, videolist_layout) \
                     values ($1, $2, 'series', $3, $4, $5, $6)",
-                &[
-                    &realm,
-                    &index,
-                    &block.title,
-                    &block.series.key_for(Id::SERIES_KIND)
-                        .ok_or_else(|| invalid_input!("`block.series` does not refer to a series"))?,
-                    &block.order,
-                    &block.layout,
-                ],
+                &[&realm, &index, &block.title, &series, &block.order, &block.layout],
             )
             .await?;
 
@@ -73,17 +68,14 @@ impl BlockValue {
 
         let (realm, index) = Self::prepare_realm_for_block(realm, index, context).await?;
 
+        let event = block.event.key_for(Id::EVENT_KIND)
+            .ok_or_else(|| invalid_input!("`block.event` does not refer to an event"))?;
+
         context.db
             .execute(
                 "insert into blocks (realm_id, index, type, title, video_id) \
                     values ($1, $2, 'video', $3, $4)",
-                &[
-                    &realm,
-                    &index,
-                    &block.title,
-                    &block.event.key_for(Id::EVENT_KIND)
-                        .ok_or_else(|| invalid_input!("`block.event` does not refer to an event"))?,
-                ],
+                &[&realm, &index, &block.title, &event],
             )
             .await?;
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -102,7 +102,7 @@ impl Event {
 }
 
 impl Event {
-    pub(crate) async fn load(context: &Context) -> ApiResult<Vec<Self>> {
+    pub(crate) async fn load_all(context: &Context) -> ApiResult<Vec<Self>> {
         context.db(context.require_moderator()?)
             .query_mapped(
                 &format!(

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -42,7 +42,7 @@ impl Series {
 }
 
 impl Series {
-    pub(crate) async fn load(context: &Context) -> ApiResult<Vec<Self>> {
+    pub(crate) async fn load_all(context: &Context) -> ApiResult<Vec<Self>> {
         context.db(context.require_moderator()?)
             .query_mapped(
                 &format!(

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -1,10 +1,10 @@
-use futures::TryStreamExt;
 use juniper::graphql_object;
 use tokio_postgres::Row;
 
 use crate::{
     api::{Context, err::ApiResult, Id, model::event::{Event, EventSortOrder}, Node, NodeValue},
-    db::{types::Key, util::dbargs},
+    db::{types::Key},
+    prelude::*,
 };
 
 
@@ -43,21 +43,18 @@ impl Series {
 
 impl Series {
     pub(crate) async fn load(context: &Context) -> ApiResult<Vec<Self>> {
-        let series = context.db(context.require_moderator()?)
-            .query_raw(
+        context.db(context.require_moderator()?)
+            .query_mapped(
                 &format!(
                     "select {} from series \
                         order by title",
                     Self::COL_NAMES,
                 ),
                 dbargs![],
+                Self::from_row,
             )
             .await?
-            .map_ok(Self::from_row)
-            .try_collect()
-            .await?;
-
-        Ok(series)
+            .pipe(Ok)
     }
 
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> ApiResult<Option<Self>> {

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -14,6 +14,7 @@ use super::{
             UpdateBlock,
             UpdateTextBlock,
             UpdateSeriesBlock,
+            UpdateVideoBlock,
             RemovedBlock,
         },
     },
@@ -132,6 +133,15 @@ impl Mutation {
         context: &Context
     ) -> ApiResult<BlockValue> {
         BlockValue::update_series(id, set, context).await
+    }
+
+    /// Update a video block's data
+    async fn update_video_block(
+        id: Id,
+        set: UpdateVideoBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
+        BlockValue::update_video(id, set, context).await
     }
 
     /// Remove a block from a realm.

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -64,7 +64,12 @@ impl Mutation {
     /// Or, if you prefer to think about it this way:
     /// It will be inserted before the block that currently sits
     /// at that index.
-    async fn add_text_block(realm: Id, index: i32, block: NewTextBlock, context: &Context) -> ApiResult<Realm> {
+    async fn add_text_block(
+        realm: Id,
+        index: i32,
+        block: NewTextBlock,
+        context: &Context
+    ) -> ApiResult<Realm> {
         BlockValue::add_text(realm, index, block, context).await
     }
 
@@ -75,7 +80,12 @@ impl Mutation {
     /// Or, if you prefer to think about it this way:
     /// It will be inserted before the block that currently sits
     /// at that index.
-    async fn add_series_block(realm: Id, index: i32, block: NewSeriesBlock, context: &Context) -> ApiResult<Realm> {
+    async fn add_series_block(
+        realm: Id,
+        index: i32,
+        block: NewSeriesBlock,
+        context: &Context
+    ) -> ApiResult<Realm> {
         BlockValue::add_series(realm, index, block, context).await
     }
 
@@ -95,12 +105,20 @@ impl Mutation {
     }
 
     /// Update a text block's data
-    async fn update_text_block(id: Id, set: UpdateTextBlock, context: &Context) -> ApiResult<BlockValue> {
+    async fn update_text_block(
+        id: Id,
+        set: UpdateTextBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
         BlockValue::update_text(id, set, context).await
     }
 
     /// Update a series block's data
-    async fn update_series_block(id: Id, set: UpdateSeriesBlock, context: &Context) -> ApiResult<BlockValue> {
+    async fn update_series_block(
+        id: Id,
+        set: UpdateSeriesBlock,
+        context: &Context
+    ) -> ApiResult<BlockValue> {
         BlockValue::update_series(id, set, context).await
     }
 

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -70,7 +70,7 @@ impl Mutation {
         realm: Id,
         index: i32,
         block: NewTextBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<Realm> {
         BlockValue::add_text(realm, index, block, context).await
     }
@@ -86,7 +86,7 @@ impl Mutation {
         realm: Id,
         index: i32,
         block: NewSeriesBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<Realm> {
         BlockValue::add_series(realm, index, block, context).await
     }
@@ -98,7 +98,12 @@ impl Mutation {
     /// Or, if you prefer to think about it this way:
     /// It will be inserted before the block that currently sits
     /// at that index.
-    async fn add_video_block(realm: Id, index: i32, block: NewVideoBlock, context: &Context) -> ApiResult<Realm> {
+    async fn add_video_block(
+        realm: Id,
+        index: i32,
+        block: NewVideoBlock,
+        context: &Context,
+    ) -> ApiResult<Realm> {
         BlockValue::add_video(realm, index, block, context).await
     }
 
@@ -107,7 +112,7 @@ impl Mutation {
         realm: Id,
         index_a: i32,
         index_b: i32,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<Realm> {
         BlockValue::swap_by_index(realm, index_a, index_b, context).await
     }
@@ -121,7 +126,7 @@ impl Mutation {
     async fn update_text_block(
         id: Id,
         set: UpdateTextBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         BlockValue::update_text(id, set, context).await
     }
@@ -130,7 +135,7 @@ impl Mutation {
     async fn update_series_block(
         id: Id,
         set: UpdateSeriesBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         BlockValue::update_series(id, set, context).await
     }
@@ -139,7 +144,7 @@ impl Mutation {
     async fn update_video_block(
         id: Id,
         set: UpdateVideoBlock,
-        context: &Context
+        context: &Context,
     ) -> ApiResult<BlockValue> {
         BlockValue::update_video(id, set, context).await
     }

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -59,7 +59,7 @@ impl Mutation {
         Realm::remove(id, context).await
     }
 
-    /// Adds a text block to a realm
+    /// Adds a text block to a realm.
     ///
     /// The new block will be inserted at the given index,
     /// i.e. it will be at that position after the insert.
@@ -75,7 +75,7 @@ impl Mutation {
         BlockValue::add_text(realm, index, block, context).await
     }
 
-    /// Adds a series block to a realm
+    /// Adds a series block to a realm.
     ///
     /// The new block will be inserted at the given index,
     /// i.e. it will be at that position after the insert.
@@ -91,7 +91,7 @@ impl Mutation {
         BlockValue::add_series(realm, index, block, context).await
     }
 
-    /// Adds a video block to a realm
+    /// Adds a video block to a realm.
     ///
     /// The new block will be inserted at the given index,
     /// i.e. it will be at that position after the insert.
@@ -117,12 +117,12 @@ impl Mutation {
         BlockValue::swap_by_index(realm, index_a, index_b, context).await
     }
 
-    /// Update a block's data
+    /// Update a block's data.
     async fn update_block(id: Id, set: UpdateBlock, context: &Context) -> ApiResult<BlockValue> {
         BlockValue::update(id, set, context).await
     }
 
-    /// Update a text block's data
+    /// Update a text block's data.
     async fn update_text_block(
         id: Id,
         set: UpdateTextBlock,
@@ -131,7 +131,7 @@ impl Mutation {
         BlockValue::update_text(id, set, context).await
     }
 
-    /// Update a series block's data
+    /// Update a series block's data.
     async fn update_series_block(
         id: Id,
         set: UpdateSeriesBlock,
@@ -140,7 +140,7 @@ impl Mutation {
         BlockValue::update_series(id, set, context).await
     }
 
-    /// Update a video block's data
+    /// Update a video block's data.
     async fn update_video_block(
         id: Id,
         set: UpdateVideoBlock,

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -10,6 +10,7 @@ use super::{
             BlockValue,
             NewTextBlock,
             NewSeriesBlock,
+            NewVideoBlock,
             UpdateBlock,
             UpdateTextBlock,
             UpdateSeriesBlock,
@@ -87,6 +88,17 @@ impl Mutation {
         context: &Context
     ) -> ApiResult<Realm> {
         BlockValue::add_series(realm, index, block, context).await
+    }
+
+    /// Adds a video block to a realm
+    ///
+    /// The new block will be inserted at the given index,
+    /// i.e. it will be at that position after the insert.
+    /// Or, if you prefer to think about it this way:
+    /// It will be inserted before the block that currently sits
+    /// at that index.
+    async fn add_video_block(realm: Id, index: i32, block: NewVideoBlock, context: &Context) -> ApiResult<Realm> {
+        BlockValue::add_video(realm, index, block, context).await
     }
 
     /// Swap two blocks.

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -47,6 +47,11 @@ impl Query {
         Event::load_by_id(id, context).await
     }
 
+    /// Returns a list of all events the current user has read access to
+    async fn events(context: &Context) -> ApiResult<Vec<Event>> {
+        Event::load(context).await
+    }
+
     /// Returns a list of all series
     async fn series(context: &Context) -> ApiResult<Vec<Series>> {
         Series::load(context).await

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -49,12 +49,12 @@ impl Query {
 
     /// Returns a list of all events the current user has read access to
     async fn events(context: &Context) -> ApiResult<Vec<Event>> {
-        Event::load(context).await
+        Event::load_all(context).await
     }
 
     /// Returns a list of all series
     async fn series(context: &Context) -> ApiResult<Vec<Series>> {
-        Series::load(context).await
+        Series::load_all(context).await
     }
 
     /// Returns the current user.

--- a/backend/src/db/migrations/1-xtea.sql
+++ b/backend/src/db/migrations/1-xtea.sql
@@ -1,7 +1,7 @@
 -- Create a "pseudo-encryption" function to generate random-looking IDs
 -- from standard sequential ones. This is done using a simple Feistel cipher.
 -- Being a block cipher, this constitutes a permutation of its input
--- (here `bigint`, i.e. $[-2^63, 2^63) \cap \mathbb{N}$).
+-- (here `bigint`, i.e. $[-2^63, 2^63) \cap \mathbb{Z}$).
 -- If we feed it sequential numbers, we get random looking numbers back,
 -- but we are still guaranteed to never get the same number twice.
 

--- a/backend/src/db/migrations/6-blocks.sql
+++ b/backend/src/db/migrations/6-blocks.sql
@@ -29,6 +29,7 @@ create table blocks (
     videolist_layout video_list_layout,
     videolist_order video_list_order,
 
+    -- Video blocks
     video_id bigint references events on delete restrict
 );
 

--- a/backend/src/db/migrations/6-blocks.sql
+++ b/backend/src/db/migrations/6-blocks.sql
@@ -7,7 +7,7 @@
 
 select prepare_randomized_ids('block');
 
-create type block_type as enum ('text', 'series');
+create type block_type as enum ('text', 'series', 'video');
 create type video_list_layout as enum ('horizontal', 'vertical', 'grid');
 create type video_list_order as enum ('new_to_old', 'old_to_new');
 
@@ -27,7 +27,9 @@ create table blocks (
 
     -- All videolist-like blocks
     videolist_layout video_list_layout,
-    videolist_order video_list_order
+    videolist_order video_list_order,
+
+    video_id bigint references events on delete restrict
 );
 
 -- Blocks are almost always looked up by realm ID.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -261,6 +261,12 @@ manage:
           dummy: Serie auswählen
           invalid: Bitte eine Serie auswählen
 
+      event:
+        event:
+          heading: Video
+          dummy: Video auswählen
+          invalid: Bitte ein Video auswählen
+
       save: Änderungen speichern
       cancel: Änderungen verwerfen
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -252,6 +252,12 @@ manage:
           dummy: Select a series
           invalid: Please select a series
 
+      event:
+        event:
+          heading: Event
+          dummy: Select an event
+          invalid: Please select an event
+
       save: Save changes
       cancel: Discard changes
 

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -87,7 +87,19 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
         >
             <FiGrid />
         </Button>
-        <Button title={t("manage.realm.content.add-video")}>
+        <Button
+            title={t("manage.realm.content.add-video")}
+            onClick={() => addBlock("Video", (store, block) => {
+                // See above for an explanation
+                const eventId = "clNOEVENT";
+                let dummyEvent = store.get(eventId);
+                if (!dummyEvent) {
+                    dummyEvent = store.create(eventId, "Event");
+                    dummyEvent.setValue(eventId, "id");
+                }
+                block.setLinkedRecord(dummyEvent, "event");
+            })}
+        >
             <FiFilm />
         </Button>
     </ButtonGroup>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -76,10 +76,7 @@ export const EditSeriesBlock = React.forwardRef<EditModeRef, EditSeriesBlockProp
                     : bug("not a series block");
 
                 save({
-                    variables: {
-                        id,
-                        set,
-                    },
+                    variables: { id, set },
                     onCompleted,
                     onError,
                 });
@@ -90,11 +87,7 @@ export const EditSeriesBlock = React.forwardRef<EditModeRef, EditSeriesBlockProp
                     : bug("not a series block");
 
                 create({
-                    variables: {
-                        realm,
-                        index,
-                        block,
-                    },
+                    variables: { realm, index, block },
                     onCompleted,
                     onError,
                 });

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -36,8 +36,6 @@ type EditSeriesBlockProps = {
 
 export const EditSeriesBlock = React.forwardRef<EditModeRef, EditSeriesBlockProps>(
     ({ block: blockRef }, ref) => {
-        const { t } = useTranslation();
-
 
         const { series: allSeries } = useFragment(graphql`
             fragment SeriesEditModeSeriesData on Query {
@@ -52,10 +50,6 @@ export const EditSeriesBlock = React.forwardRef<EditModeRef, EditSeriesBlockProp
                 series { id }
             }
         `, blockRef);
-
-
-        const form = useFormContext<EditModeFormData>();
-        const { formState: { errors } } = form;
 
 
         const [save] = useMutation<SeriesEditSaveMutation>(graphql`
@@ -107,6 +101,11 @@ export const EditSeriesBlock = React.forwardRef<EditModeRef, EditSeriesBlockProp
             },
         }));
 
+
+        const { t } = useTranslation();
+
+        const form = useFormContext<EditModeFormData>();
+        const { formState: { errors } } = form;
 
         return <div css={{ "& > h3": {
             marginTop: 8,

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -1,0 +1,120 @@
+import React, { useContext, useImperativeHandle } from "react";
+import { graphql, useFragment, useMutation } from "react-relay";
+import { useTranslation } from "react-i18next";
+import { useFormContext } from "react-hook-form";
+
+import { bug } from "../../../../../../util/err";
+import { Card } from "../../../../../../ui/Card";
+import { Select } from "../../../../../../ui/Input";
+import { ContentManageQueryContext } from "../..";
+import type { EditModeRef, EditModeFormData } from ".";
+import type { VideoEditModeBlockData$key } from "./__generated__/VideoEditModeBlockData.graphql";
+import type { VideoEditModeEventData$key } from "./__generated__/VideoEditModeEventData.graphql";
+import type { VideoEditSaveMutation } from "./__generated__/VideoEditSaveMutation.graphql";
+import type { VideoEditCreateMutation } from "./__generated__/VideoEditCreateMutation.graphql";
+
+
+export type VideoFormData = {
+    event: string;
+};
+
+type EditVideoBlockProps = {
+    block: VideoEditModeBlockData$key;
+};
+
+export const EditVideoBlock = React.forwardRef<EditModeRef, EditVideoBlockProps>(
+    ({ block: blockRef }, ref) => {
+
+        const { events } = useFragment(graphql`
+            fragment VideoEditModeEventData on Query {
+                events { id title }
+            }
+        `, useContext(ContentManageQueryContext) as VideoEditModeEventData$key);
+
+        const { event: { id: event } } = useFragment(graphql`
+            fragment VideoEditModeBlockData on VideoBlock {
+                event { id }
+            }
+        `, blockRef);
+
+
+        const [save] = useMutation<VideoEditSaveMutation>(graphql`
+            mutation VideoEditSaveMutation($id: ID!, $set: UpdateVideoBlock!) {
+                updateVideoBlock(id: $id, set: $set) {
+                    ... BlocksBlockData
+                    ... VideoBlockData
+                }
+            }
+        `);
+
+        const [create] = useMutation<VideoEditCreateMutation>(graphql`
+            mutation VideoEditCreateMutation($realm: ID!, $index: Int!, $block: NewVideoBlock!) {
+                addVideoBlock(realm: $realm, index: $index, block: $block) {
+                    ... ContentManageRealmData
+                }
+            }
+        `);
+
+        useImperativeHandle(ref, () => ({
+            save: (id, data, onCompleted, onError) => {
+                const { type: _type, ...set } = data.type === "VideoBlock"
+                    ? data
+                    : bug("not a video block");
+
+                save({
+                    variables: {
+                        id,
+                        set,
+                    },
+                    onCompleted,
+                    onError,
+                });
+            },
+            create: (realm, index, data, onCompleted, onError) => {
+                const { type: _type, ...block } = data.type === "VideoBlock"
+                    ? data
+                    : bug("not a video block");
+
+                create({
+                    variables: {
+                        realm,
+                        index,
+                        block,
+                    },
+                    onCompleted,
+                    onError,
+                });
+            },
+        }));
+
+
+        const { t } = useTranslation();
+
+        const form = useFormContext<EditModeFormData>();
+        const { formState: { errors } } = form;
+
+        return <div css={{ "& > h3": {
+            marginTop: 8,
+            marginBottom: 4,
+        } }}>
+            <h3>{t("manage.realm.content.event.event.heading")}</h3>
+            {"event" in errors && <div css={{ margin: "8px 0" }}>
+                <Card kind="error">{t("manage.realm.content.event.event.invalid")}</Card>
+            </div>}
+            <Select
+                css={{ maxWidth: "100%" }}
+                error={"event" in errors}
+                defaultValue={event}
+                {...form.register("event", { pattern: /^ev/ })}
+            >
+                {/* See the series block code for an explanation of this option */}
+                <option value="clNOEVENT" hidden>
+                    {t("manage.realm.content.event.event.dummy")}
+                </option>
+                {events.map(({ id, title }) => (
+                    <option key={id} value={id}>{title}</option>
+                ))}
+            </Select>
+        </div>;
+    },
+);

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -62,10 +62,7 @@ export const EditVideoBlock = React.forwardRef<EditModeRef, EditVideoBlockProps>
                     : bug("not a video block");
 
                 save({
-                    variables: {
-                        id,
-                        set,
-                    },
+                    variables: { id, set },
                     onCompleted,
                     onError,
                 });
@@ -76,11 +73,7 @@ export const EditVideoBlock = React.forwardRef<EditModeRef, EditVideoBlockProps>
                     : bug("not a video block");
 
                 create({
-                    variables: {
-                        realm,
-                        index,
-                        block,
-                    },
+                    variables: { realm, index, block },
                     onCompleted,
                     onError,
                 });

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -14,6 +14,7 @@ import { ButtonGroup } from "..";
 import { ConfirmationModal, ConfirmationModalHandle } from "../../../../../../ui/Modal";
 import { EditTextBlock, TextFormData } from "./Text";
 import { EditSeriesBlock, SeriesFormData } from "./Series";
+import { EditVideoBlock, VideoFormData } from "./Video";
 
 
 type EditModeProps = {
@@ -29,6 +30,8 @@ type BlockFormData = (
     { type: "TextBlock" } & TextFormData
 ) | (
     { type: "SeriesBlock" } & SeriesFormData
+) | (
+    { type: "VideoBlock" } & VideoFormData
 );
 
 export type EditModeFormData = {
@@ -74,6 +77,7 @@ export const EditMode: React.FC<EditModeProps> = ({
                 __typename
                 ... on TextBlock { ... TextEditModeBlockData }
                 ... on SeriesBlock { ... SeriesEditModeBlockData }
+                ... on VideoBlock { ... VideoEditModeBlockData }
             }
         }
     `, realmRef);
@@ -83,7 +87,7 @@ export const EditMode: React.FC<EditModeProps> = ({
 
     const form = useForm<EditModeFormData>({
         defaultValues: {
-            type: type as "TextBlock" | "SeriesBlock",
+            type: type as "TextBlock" | "SeriesBlock" | "VideoBlock",
         },
     });
     const editModeRef = useRef<EditModeRef>(null);
@@ -131,6 +135,7 @@ export const EditMode: React.FC<EditModeProps> = ({
             {match(block.__typename, {
                 "TextBlock": () => <EditTextBlock ref={editModeRef} block={block} />,
                 "SeriesBlock": () => <EditSeriesBlock ref={editModeRef} block={block} />,
+                "VideoBlock": () => <EditVideoBlock ref={editModeRef} block={block} />,
             })}
         </form>
     </FormProvider>;

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -58,6 +58,7 @@ const query = graphql`
             ... ContentManageRealmData
         }
         ... SeriesEditModeSeriesData
+        ... VideoEditModeEventData
     }
 `;
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -65,6 +65,16 @@ type Mutation {
     at that index.
   """
   addSeriesBlock(realm: ID!, index: Int!, block: NewSeriesBlock!): Realm!
+  """
+    Adds a video block to a realm
+
+    The new block will be inserted at the given index,
+    i.e. it will be at that position after the insert.
+    Or, if you prefer to think about it this way:
+    It will be inserted before the block that currently sits
+    at that index.
+  """
+  addVideoBlock(realm: ID!, index: Int!, block: NewVideoBlock!): Realm!
   "Swap two blocks."
   swapBlocksByIndex(realm: ID!, indexA: Int!, indexB: Int!): Realm!
   "Update a block's data"
@@ -164,6 +174,11 @@ type SeriesBlock implements Block {
   id: ID!
   index: Int!
   title: String
+}
+
+input NewVideoBlock {
+  title: String
+  event: ID!
 }
 
 input UpdateSeriesBlock {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -46,7 +46,7 @@ type Mutation {
   "Remove a realm from the tree."
   removeRealm(id: ID!): RemovedRealm!
   """
-    Adds a text block to a realm
+    Adds a text block to a realm.
 
     The new block will be inserted at the given index,
     i.e. it will be at that position after the insert.
@@ -56,7 +56,7 @@ type Mutation {
   """
   addTextBlock(realm: ID!, index: Int!, block: NewTextBlock!): Realm!
   """
-    Adds a series block to a realm
+    Adds a series block to a realm.
 
     The new block will be inserted at the given index,
     i.e. it will be at that position after the insert.
@@ -66,7 +66,7 @@ type Mutation {
   """
   addSeriesBlock(realm: ID!, index: Int!, block: NewSeriesBlock!): Realm!
   """
-    Adds a video block to a realm
+    Adds a video block to a realm.
 
     The new block will be inserted at the given index,
     i.e. it will be at that position after the insert.
@@ -77,13 +77,13 @@ type Mutation {
   addVideoBlock(realm: ID!, index: Int!, block: NewVideoBlock!): Realm!
   "Swap two blocks."
   swapBlocksByIndex(realm: ID!, indexA: Int!, indexB: Int!): Realm!
-  "Update a block's data"
+  "Update a block's data."
   updateBlock(id: ID!, set: UpdateBlock!): Block!
-  "Update a text block's data"
+  "Update a text block's data."
   updateTextBlock(id: ID!, set: UpdateTextBlock!): Block!
-  "Update a series block's data"
+  "Update a series block's data."
   updateSeriesBlock(id: ID!, set: UpdateSeriesBlock!): Block!
-  "Update a video block's data"
+  "Update a video block's data."
   updateVideoBlock(id: ID!, set: UpdateVideoBlock!): Block!
   "Remove a block from a realm."
   removeBlock(id: ID!): RemovedBlock!

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -140,6 +140,8 @@ type Query {
   realmByPath(path: String!): Realm
   "Returns an event by its ID."
   event(id: ID!): Event
+  "Returns a list of all events the current user has read access to"
+  events: [Event!]!
   "Returns a list of all series"
   series: [Series!]!
   "Returns the current user."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -83,6 +83,8 @@ type Mutation {
   updateTextBlock(id: ID!, set: UpdateTextBlock!): Block!
   "Update a series block's data"
   updateSeriesBlock(id: ID!, set: UpdateSeriesBlock!): Block!
+  "Update a video block's data"
+  updateVideoBlock(id: ID!, set: UpdateVideoBlock!): Block!
   "Remove a block from a realm."
   removeBlock(id: ID!): RemovedBlock!
 }
@@ -214,6 +216,11 @@ input UpdateRealm {
   parent: ID
   name: String
   pathSegment: String
+}
+
+input UpdateVideoBlock {
+  title: String
+  event: ID
 }
 
 enum EventSortColumn {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -116,11 +116,6 @@ type RemovedBlock {
   realm: Realm!
 }
 
-input ChildIndex {
-  id: ID!
-  index: Int!
-}
-
 type Query {
   "Returns the root realm."
   rootRealm: Realm!
@@ -156,6 +151,11 @@ enum RealmOrder {
   BY_INDEX
   ALPHABETIC_ASC
   ALPHABETIC_DESC
+}
+
+input ChildIndex {
+  id: ID!
+  index: Int!
 }
 
 type RemovedRealm {
@@ -221,6 +221,14 @@ enum EventSortColumn {
   DURATION
   CREATED
   UPDATED
+}
+
+"A block for presenting a single Opencast event"
+type VideoBlock implements Block {
+  event: Event!
+  id: ID!
+  index: Int!
+  title: String
 }
 
 input NewSeriesBlock {

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -1,9 +1,40 @@
-import { BlockContainer } from ".";
-import { Player, PlayerProps } from "../player";
+import { graphql, useFragment } from "react-relay";
+
+import { Track, Player } from "../player";
+import { VideoBlockData$key } from "./__generated__/VideoBlockData.graphql";
+import { Title, BlockContainer } from ".";
 
 
-export const VideoBlock: React.FC<PlayerProps> = props => (
-    <BlockContainer>
-        <Player {...props} />
-    </BlockContainer>
-);
+type Props = {
+    title?: string;
+    fragRef: VideoBlockData$key;
+};
+
+export const VideoBlock: React.FC<Props> = ({ title, fragRef }) => {
+    const { event } = useFragment(graphql`
+        fragment VideoBlockData on VideoBlock {
+            event {
+                title
+                duration
+                tracks {
+                    uri
+                    flavor
+                    mimetype
+                    resolution
+                }
+            }
+        }
+    `, fragRef);
+
+    return <BlockContainer>
+        {/* TODO The title display logic will change soon */}
+        <Title title={title ?? event.title} />
+        <Player
+            {...event}
+            // TODO In the future, duration won't be nullable anymore
+            duration={event.duration ?? 0}
+            // Relay returns `readonly` objects ...
+            tracks={event.tracks as Track[]}
+        />
+    </BlockContainer>;
+};

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -16,12 +16,7 @@ export const VideoBlock: React.FC<Props> = ({ title, fragRef }) => {
             event {
                 title
                 duration
-                tracks {
-                    uri
-                    flavor
-                    mimetype
-                    resolution
-                }
+                tracks { uri flavor mimetype resolution }
             }
         }
     `, fragRef);

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -7,6 +7,7 @@ import { BlocksBlockData$key } from "./__generated__/BlocksBlockData.graphql";
 import { match } from "../../util";
 import { TextBlockByQuery } from "./Text";
 import { SeriesBlockFromBlock } from "./Series";
+import { VideoBlock } from "./Video";
 
 
 type BlocksProps = {
@@ -56,6 +57,7 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             __typename
             ... on TextBlock { ... TextBlockData }
             ... on SeriesBlock { ... SeriesBlockData }
+            ... on VideoBlock { ... VideoBlockData }
         }
     `, blockRef);
     const { title, __typename } = block;
@@ -69,6 +71,10 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             "SeriesBlock": () => <SeriesBlockFromBlock
                 title={title ?? undefined}
                 realmPath={path}
+                fragRef={block}
+            />,
+            "VideoBlock": () => <VideoBlock
+                title={title ?? ""}
                 fragRef={block}
             />,
         })}


### PR DESCRIPTION
First draft of the video block. Contains the necessary API additions and UI for rendering video blocks in normal and edit mode.

Review can happen on a per commit basis, but looking at everything at once should be fine as well; there shouldn't be anything surprising in here. 🤷‍♀️

This will close #167.

Note that a few refactorings regarding the handling of block titles are still to come. If this PR is reviewed/merged by the time I'm done with them, I will just make a followup PR. Otherwise, I might just add these changes here. 🤷‍♀️ These will then also likely address the concerns raised in #327.