### PR TITLE
Better info message for path-segments with reserved characters

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -287,8 +287,8 @@ manage:
       Der Seitename wird im Navigationsmenü und als Überschrift auf der Seite selber angezeigt.
       Seitennamen können jederzeit geändert werden.
     path-segment-info: >
-      Pfadsegmente dürfen keine Kontroll- oder Leerzeichen enthalten.
-      Sie sollten außerdem möglichst kurz sein und keine Information aus vorangehenden
+      Pfadsegmente dürfen keine Leerzeichen enthalten und nicht mit <1>-+~@_!$&;:.,=*'</1>
+      beginnen. Sie sollten außerdem möglichst kurz sein und keine Information aus vorangehenden
       Pfadsegmenten wiederholen. Eine spätere Änderung des Pfadsegments sollte vermieden werden.
 
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -278,10 +278,10 @@ manage:
       The page name is shown in the navigation menu and as heading on the page itself.
       You can change the page name at any time.
     path-segment-info: >
-      Path segments may not contain any control or white space characters.
-      Try keeping the segment rather short and don't repeat information already
-      contained in preceeding path segments. Changing the path segment later should
-      be avoided.
+      Path segments may not contain any white space characters and must not start
+      with <1>-+~@_!$&;:.,=*'</1>. Try keeping the segment rather short and
+      don't repeat information already contained in preceeding path segments.
+      Changing the path segment later should be avoided.
 
 
 # These errors map the `key` field of an API error response to a nice message.

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -146,8 +146,18 @@ const AddChild: React.FC<Props> = ({ parent }) => {
                     {boxError(errors.name?.message)}
                 </InputWithInfo>
 
-                <InputWithInfo info={t("manage.add-child.path-segment-info")}>
-                    {/* TODO: Add explanation on how to chose a good path segment */}
+                <InputWithInfo
+                    info={(
+                        <Trans i18nKey="manage.add-child.path-segment-info">
+                            foo
+                            <code css={{
+                                whiteSpace: "nowrap",
+                                borderRadius: 4,
+                                backgroundColor: "var(--grey80)",
+                            }}>chars</code>
+                        </Trans>
+                    )}
+                >
                     <label htmlFor="path-field">{t("manage.add-child.path-segment")}</label>
                     <PathSegmentInput
                         id="path-field"
@@ -173,7 +183,7 @@ const AddChild: React.FC<Props> = ({ parent }) => {
 };
 
 type InputWithInfoProps = {
-    info: string;
+    info: JSX.Element;
 };
 
 const InputWithInfo: React.FC<InputWithInfoProps> = ({ info, children }) => (


### PR DESCRIPTION
As discussed in #322 the error or info message for path segments with forbidden characters was not clear on what characters are actually not forbidden. This commit lists the reserved character so the user can adjust accordingly.