### PR TITLE
Add basic studio & editor integration

### DIFF
--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -32,6 +32,11 @@ impl User {
         self.can_use_studio(&context.config.auth)
     }
 
+    /// `True` if the user has the permission to use Opencast Studio.
+    fn can_use_editor(&self, context: &Context) -> bool {
+        self.can_use_editor(&context.config.auth)
+    }
+
     /// Returns all events that somehow "belong" to the user, i.e. that appear
     /// on the "my videos" page.
     ///

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -27,6 +27,11 @@ impl User {
         self.can_upload(&context.config.auth)
     }
 
+    /// `True` if the user has the permission to use Opencast Studio.
+    fn can_use_studio(&self, context: &Context) -> bool {
+        self.can_use_studio(&context.config.auth)
+    }
+
     /// Returns all events that somehow "belong" to the user, i.e. that appear
     /// on the "my videos" page.
     ///

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -79,6 +79,11 @@ pub(crate) struct AuthConfig {
     #[config(default = "ROLE_TOBIRA_STUDIO")]
     pub(crate) studio_role: String,
 
+    /// If a user has this role, they are allowed to use the Opencast editor to
+    /// edit videos they have write access to.
+    #[config(default = "ROLE_TOBIRA_EDITOR")]
+    pub(crate) editor_role: String,
+
     /// Duration of a Tobira-managed login session.
     /// Note: This is only relevant if `auth.mode` is `login-proxy`.
     #[config(default = "30d", deserialize_with = crate::config::deserialize_duration)]
@@ -272,6 +277,10 @@ pub(crate) trait HasRoles {
         AuthToken::some_if(self.can_use_studio(auth_config))
     }
 
+    fn required_editor_permission(&self, auth_config: &AuthConfig) -> Option<AuthToken> {
+        AuthToken::some_if(self.can_use_editor(auth_config))
+    }
+
     fn is_moderator(&self, auth_config: &AuthConfig) -> bool {
         self.is_admin() || self.roles().contains(&auth_config.moderator_role)
     }
@@ -282,6 +291,10 @@ pub(crate) trait HasRoles {
 
     fn can_use_studio(&self, auth_config: &AuthConfig) -> bool {
         self.is_moderator(auth_config) || self.roles().contains(&auth_config.studio_role)
+    }
+
+    fn can_use_editor(&self, auth_config: &AuthConfig) -> bool {
+        self.is_moderator(auth_config) || self.roles().contains(&auth_config.editor_role)
     }
 
     /// Returns `true` if the user is a global Opencast administrator and can do

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -74,6 +74,11 @@ pub(crate) struct AuthConfig {
     #[config(default = "ROLE_TOBIRA_UPLOAD")]
     pub(crate) upload_role: String,
 
+    /// If a user has this role, they are allowed to use Opencast Studio to
+    /// record and upload videos.
+    #[config(default = "ROLE_TOBIRA_STUDIO")]
+    pub(crate) studio_role: String,
+
     /// Duration of a Tobira-managed login session.
     /// Note: This is only relevant if `auth.mode` is `login-proxy`.
     #[config(default = "30d", deserialize_with = crate::config::deserialize_duration)]
@@ -263,12 +268,20 @@ pub(crate) trait HasRoles {
         AuthToken::some_if(self.can_upload(auth_config))
     }
 
+    fn required_studio_permission(&self, auth_config: &AuthConfig) -> Option<AuthToken> {
+        AuthToken::some_if(self.can_use_studio(auth_config))
+    }
+
     fn is_moderator(&self, auth_config: &AuthConfig) -> bool {
         self.is_admin() || self.roles().contains(&auth_config.moderator_role)
     }
 
     fn can_upload(&self, auth_config: &AuthConfig) -> bool {
         self.is_moderator(auth_config) || self.roles().contains(&auth_config.upload_role)
+    }
+
+    fn can_use_studio(&self, auth_config: &AuthConfig) -> bool {
+        self.is_moderator(auth_config) || self.roles().contains(&auth_config.studio_role)
     }
 
     /// Returns `true` if the user is a global Opencast administrator and can do

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -117,6 +117,12 @@
 # Default value: "ROLE_TOBIRA_UPLOAD"
 #upload_role = "ROLE_TOBIRA_UPLOAD"
 
+# If a user has this role, they are allowed to use Opencast Studio to
+# record and upload videos.
+#
+# Default value: "ROLE_TOBIRA_STUDIO"
+#studio_role = "ROLE_TOBIRA_STUDIO"
+
 # Duration of a Tobira-managed login session.
 # Note: This is only relevant if `auth.mode` is `login-proxy`.
 #

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -123,6 +123,12 @@
 # Default value: "ROLE_TOBIRA_STUDIO"
 #studio_role = "ROLE_TOBIRA_STUDIO"
 
+# If a user has this role, they are allowed to use the Opencast editor to
+# edit videos they have write access to.
+#
+# Default value: "ROLE_TOBIRA_EDITOR"
+#editor_role = "ROLE_TOBIRA_EDITOR"
+
 # Duration of a Tobira-managed login session.
 # Note: This is only relevant if `auth.mode` is `login-proxy`.
 #

--- a/frontend/src/User.tsx
+++ b/frontend/src/User.tsx
@@ -13,6 +13,7 @@ export type User = {
     username: string;
     displayName: string;
     canUpload: boolean;
+    canUseStudio: boolean;
 };
 
 const UserContext = React.createContext<UserState>("unknown");
@@ -63,6 +64,7 @@ const fragment = graphql`
             username
             displayName
             canUpload
+            canUseStudio
         }
     }
 `;

--- a/frontend/src/User.tsx
+++ b/frontend/src/User.tsx
@@ -14,6 +14,7 @@ export type User = {
     displayName: string;
     canUpload: boolean;
     canUseStudio: boolean;
+    canUseEditor: boolean;
 };
 
 const UserContext = React.createContext<UserState>("unknown");
@@ -65,6 +66,7 @@ const fragment = graphql`
             displayName
             canUpload
             canUseStudio
+            canUseEditor
         }
     }
 `;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -146,12 +146,12 @@ manage:
 
   dashboard:
     title: Dashboard
-    upload-tile: Videos von Ihrem Computer können Sie auf <1>dieser Seite</1> hochladen.
+    upload-tile: Hier können Sie einfach Videos von Ihrem Computer hochladen.
     studio-tile-title: Video aufnehmen
     studio-tile-body: >
-      Sie können sehr einfach ein neues Video erstellen, indem Sie Ihr Mikrofon, Ihren Bildschirm
-      und/oder Ihre Webcam auf <1>dieser Seite</1> aufzeichnen. (Funktioniert noch nicht!)
-    my-videos-tile: "Sie können Ihre Videos auf <1>der Seite „Meine\u00a0Videos“</1> sehen und bearbeiten."
+      Hier können Sie sehr einfach ein neues Video erstellen, indem Sie Ihr Mikrofon, Ihren Bildschirm
+      und/oder Ihre Webcam aufzeichnen. (Funktioniert noch nicht!)
+    my-videos-tile: Hier finden Sie alle Ihre Videos und können diese z.B. bearbeiten.
     manage-pages-tile-title: Seiten verwalten?
     manage-pages-tile-body: >
       Um Seiten zu bearbeiten, umzubenennen und zu löschen, navigieren Sie zu der gewünschten

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -171,6 +171,7 @@ manage:
     page-showing-video-ids: '{{start}}–{{end}} von {{total}}'
     no-videos-found: Keine Videos gefunden.
     share-direct-link: Via Direktlink teilen
+    open-in-editor: Im Videoeditor öffnen
     manage-video: Video verwalten
 
   are-you-sure: Sind Sie sich sicher?

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -150,7 +150,7 @@ manage:
     studio-tile-title: Video aufnehmen
     studio-tile-body: >
       Hier können Sie sehr einfach ein neues Video erstellen, indem Sie Ihr Mikrofon, Ihren Bildschirm
-      und/oder Ihre Webcam aufzeichnen. (Funktioniert noch nicht!)
+      und/oder Ihre Webcam aufzeichnen.
     my-videos-tile: Hier finden Sie alle Ihre Videos und können diese z.B. bearbeiten.
     manage-pages-tile-title: Seiten verwalten?
     manage-pages-tile-body: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -145,7 +145,7 @@ manage:
     studio-tile-title: Record video
     studio-tile-body: >
       Here you can easily create a new video by recording your microphone, screen and/or
-      webcam. (does not work yet!)
+      webcam.
     my-videos-tile: Here you can view and edit all your videos.
     manage-pages-tile-title: Manage pages?
     manage-pages-tile-body: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -141,12 +141,12 @@ manage:
 
   dashboard:
     title: Management Dashboard
-    upload-tile: You can upload a new video on <1>this page</1>.
+    upload-tile: Here you can upload a new video from your computer.
     studio-tile-title: Record video
     studio-tile-body: >
-      You can create a new video by recording your microphone, screen and/or
-      webcam easily by using <1>this tool</1>. (does not work yet!)
-    my-videos-tile: "View and edit your videos on <1>the “My\u00a0Videos” page</1>."
+      Here you can easily create a new video by recording your microphone, screen and/or
+      webcam. (does not work yet!)
+    my-videos-tile: Here you can view and edit all your videos.
     manage-pages-tile-title: Manage pages?
     manage-pages-tile-body: >
       To rename, modify, and delete pages, navigate to the page in question. If you

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -165,6 +165,7 @@ manage:
     page-showing-video-ids: '{{start}}–{{end}} of {{total}}'
     no-videos-found: No videos found.
     share-direct-link: Share via direct link
+    open-in-editor: Open in video editor
     manage-video: Manage video
 
   are-you-sure: Are you sure?

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -56,7 +56,7 @@ type LinkProps = {
 } & Omit<React.ComponentPropsWithoutRef<"a">, "href">;
 
 const Link = ({ to, children, htmlLink = false, ...props }: LinkProps): JSX.Element => (
-    htmlLink
+    htmlLink || to.startsWith("http://") || to.startsWith("https://")
         ? <a href={to} {...props}>{children}</a>
         : <RautaLink to={to} {...props}>{children}</RautaLink>
 );

--- a/frontend/src/routes/manage/Video/Single.tsx
+++ b/frontend/src/routes/manage/Video/Single.tsx
@@ -20,6 +20,9 @@ import { useTitle } from "../../../util";
 import { NotFound } from "../../NotFound";
 import { b64regex } from "../../Video";
 import { PATH as MANAGE_VIDEOS_PATH } from ".";
+import { useUser } from "../../../User";
+import { LinkButton } from "../../../ui/Button";
+import CONFIG from "../../../config";
 
 
 export const ManageSingleVideoRoute = makeRoute(url => {
@@ -95,6 +98,12 @@ const ManageSingleVideo: React.FC<Props> = ({ event }) => {
     const title = t("manage.my-videos.video-details", { title: event.title });
     useTitle(title);
 
+    const user = useUser();
+    if (user === "none" || user === "unknown") {
+        return <NotAuthorized />;
+    }
+    const editorUrl = `${CONFIG.ocUrl}/editor-ui/index.html?mediaPackageId=${event.opencastId}`;
+
     return <>
         <h1 css={{
             whiteSpace: "nowrap",
@@ -114,6 +123,11 @@ const ManageSingleVideo: React.FC<Props> = ({ event }) => {
         }}>
             <ThumbnailDateInfo event={event} />
             <div css={{ margin: "8px 2px", flex: "1 0 auto" }}>
+                {user.canUseEditor && event.canWrite && (
+                    <LinkButton to={editorUrl} css={{ marginBottom: 16 }}>
+                        {t("manage.my-videos.open-in-editor")}
+                    </LinkButton>
+                )}
                 <DirectLink event={event} />
                 <MetadataSection event={event} />
             </div>

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -14,6 +14,7 @@ import { Link } from "../../router";
 import { LinkList, LinkWithIcon } from "../../ui";
 import { NotAuthorized } from "../../ui/error";
 import { useUser } from "../../User";
+import CONFIG from "../../config";
 
 
 const PATH = "/~manage";
@@ -37,10 +38,7 @@ export const ManageRoute = makeRoute(url => {
 
 
 const query = graphql`
-    query manageDashboardQuery {
-        ...UserData
-        currentUser { canUpload }
-    }
+    query manageDashboardQuery { ...UserData }
 `;
 
 const Manage: React.FC = () => {
@@ -49,6 +47,8 @@ const Manage: React.FC = () => {
     if (user === "none" || user === "unknown") {
         return <NotAuthorized />;
     }
+    const returnTarget = encodeURIComponent(document.location.href);
+    const studioUrl = `${CONFIG.ocUrl}/studio?return.target=${returnTarget}`;
 
     return <>
         <h1>{t("manage.dashboard.title")}</h1>
@@ -57,7 +57,7 @@ const Manage: React.FC = () => {
             width: 950,
             maxWidth: "100%",
             margin: "32px 0",
-            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
+            gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
             gap: 24,
         }}>
             {user.canUpload && <GridTile link="/~upload">
@@ -65,12 +65,11 @@ const Manage: React.FC = () => {
                 <h2>{t("upload.title")}</h2>
                 {t("manage.dashboard.upload-tile")}
             </GridTile>}
-            {/* TODO: Studio integration */}
-            <GridTile link="#">
+            {user.canUseStudio && <GridTile link={studioUrl}>
                 <FiVideo />
                 <h2>{t("manage.dashboard.studio-tile-title")}</h2>
                 {t("manage.dashboard.studio-tile-body")}
-            </GridTile>
+            </GridTile>}
             <GridTile link="/~manage/videos">
                 <FiFilm />
                 <h2>{t("manage.my-videos.title")}</h2>

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { FiFilm, FiUpload, FiVideo } from "react-icons/fi";
 import { HiTemplate } from "react-icons/hi";
 import { graphql } from "react-relay";
@@ -59,54 +59,67 @@ const Manage: React.FC = () => {
             margin: "32px 0",
             gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
             gap: 24,
-            "& > div": {
-                borderRadius: 4,
-                border: "1px solid var(--grey92)",
-                backgroundColor: "var(--grey97)",
-                padding: "8px 16px 16px 16px",
-                fontSize: 14,
-                position: "relative",
-                "& > svg:first-of-type": {
-                    position: "absolute",
-                    top: 8,
-                    right: 8,
-                    color: "var(--accent-color)",
-                    fontSize: 22,
-                },
-                "& > h2": {
-                    fontSize: 18,
-                    marginBottom: 16,
-                },
-            },
         }}>
-            {user.canUpload && <div>
+            {user.canUpload && <GridTile link="/~upload">
                 <FiUpload />
                 <h2>{t("upload.title")}</h2>
-                <Trans i18nKey="manage.dashboard.upload-tile">
-                    Foo <Link to="/~upload">the uploader</Link>
-                </Trans>
-            </div>}
+                {t("manage.dashboard.upload-tile")}
+            </GridTile>}
             {/* TODO: Studio integration */}
-            <div>
+            <GridTile link="#">
                 <FiVideo />
                 <h2>{t("manage.dashboard.studio-tile-title")}</h2>
-                <Trans i18nKey="manage.dashboard.studio-tile-body">
-                    Foo <Link to="/~studio">OC Studio</Link>
-                </Trans>
-            </div>
-            <div>
+                {t("manage.dashboard.studio-tile-body")}
+            </GridTile>
+            <GridTile link="/~manage/videos">
                 <FiFilm />
                 <h2>{t("manage.my-videos.title")}</h2>
-                <Trans i18nKey="manage.dashboard.my-videos-tile">
-                    Foo <Link to="/~manage/videos">my videos</Link>
-                </Trans>
-            </div>
-            <div>
+                {t("manage.dashboard.my-videos-tile")}
+            </GridTile>
+            <GridTile>
                 <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
                 {t("manage.dashboard.manage-pages-tile-body")}
-            </div>
+            </GridTile>
         </div>
     </>;
+};
+
+type GridTileProps = {
+    link?: string;
+};
+
+const GridTile: React.FC<GridTileProps> = ({ link, children }) => {
+    const style = {
+        borderRadius: 4,
+        border: "1px solid var(--grey92)",
+        backgroundColor: "var(--grey97)",
+        padding: "8px 16px 16px 16px",
+        fontSize: 14,
+        color: "black",
+        "&:hover": !link
+            ? {}
+            : {
+                color: "black",
+                borderColor: "var(--grey80)",
+                boxShadow: "1px 1px 5px var(--grey92)",
+            },
+        position: "relative",
+        "& > svg:first-of-type": {
+            position: "absolute",
+            top: 8,
+            right: 8,
+            color: "var(--accent-color)",
+            fontSize: 22,
+        },
+        "& > h2": {
+            fontSize: 18,
+            marginBottom: 16,
+        },
+    } as const;
+
+    return link
+        ? <Link to={link} css={style}>{children}</Link>
+        : <div css={style}>{children}</div>;
 };
 
 type ManageNavProps = {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -274,6 +274,8 @@ type User {
   canUpload: Boolean!
   "`True` if the user has the permission to use Opencast Studio."
   canUseStudio: Boolean!
+  "`True` if the user has the permission to use Opencast Studio."
+  canUseEditor: Boolean!
   """
     Returns all events that somehow "belong" to the user, i.e. that appear
     on the "my videos" page.

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -272,6 +272,8 @@ type User {
   displayName: String!
   "`True` if the user has the permission to upload videos."
   canUpload: Boolean!
+  "`True` if the user has the permission to use Opencast Studio."
+  canUseStudio: Boolean!
   """
     Returns all events that somehow "belong" to the user, i.e. that appear
     on the "my videos" page.


### PR DESCRIPTION
This is just "basic" integration, because the Tobira user is not automatically logged into Opencast. Thus, they are greeted by Opencast's login page. Depending on the setup, this can vary from "slightly annoying" to "very limiting" (e.g. when not all Tobira users can log into Opencast).

Solving this well requires a bit of work on Opencast side: we want to create a login session via a JWT that is sent from Tobira. 

Closes #289