### PR TITLE
Treat event duration is non-null

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -26,7 +26,7 @@ pub(crate) struct Event {
 
     title: String,
     description: Option<String>,
-    duration: Option<i32>,
+    duration: i32,
     created: DateTime<Utc>,
     updated: DateTime<Utc>,
     creator: Option<String>,
@@ -68,8 +68,8 @@ impl Event {
         self.description.as_deref()
     }
     /// Duration in ms.
-    fn duration(&self) -> Option<f64> {
-        self.duration.map(Into::into)
+    fn duration(&self) -> i32 {
+        self.duration
     }
     fn thumbnail(&self) -> Option<&str> {
         self.thumbnail.as_deref()
@@ -455,10 +455,7 @@ impl EventCursor {
     fn new(event: &Event, order: &EventSortOrder) -> Self {
         let sort_filter = match order.column {
             EventSortColumn::Title => CursorSortFilter::Title(event.title.clone()),
-            EventSortColumn::Duration => CursorSortFilter::Duration(
-                // TODO: figure out nullable durations
-                event.duration.expect("null duration")
-            ),
+            EventSortColumn::Duration => CursorSortFilter::Duration(event.duration),
             EventSortColumn::Created => CursorSortFilter::Created(event.created),
             EventSortColumn::Updated => CursorSortFilter::Updated(event.updated),
         };

--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -10,7 +10,7 @@ pub(crate) struct SearchEvent {
     pub(crate) title: String,
     pub(crate) description: Option<String>,
     pub(crate) thumbnail: Option<String>,
-    pub(crate) duration: Option<i32>,
+    pub(crate) duration: i32,
     pub(crate) tracks: Vec<Track>,
 }
 
@@ -35,7 +35,7 @@ impl SearchEvent {
         self.thumbnail.as_deref()
     }
 
-    fn duration(&self) -> Option<i32> {
+    fn duration(&self) -> i32 {
         self.duration
     }
 

--- a/backend/src/db/migrations/5-events.sql
+++ b/backend/src/db/migrations/5-events.sql
@@ -36,7 +36,7 @@ create table events (
     -- Meta data
     title text not null,
     description text,
-    duration int, -- in ms
+    duration int not null, -- in ms
     created timestamp with time zone not null,
     updated timestamp with time zone not null,
     creator text,

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -27,7 +27,7 @@ pub(super) enum HarvestItem {
         #[serde(with = "chrono::serde::ts_milliseconds")]
         created: DateTime<Utc>,
         creator: Option<String>,
-        duration: Option<i32>,
+        duration: i32,
         tracks: Vec<Track>,
         thumbnail: Option<String>,
         acl: Acl,

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -89,7 +89,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                         <Thumbnail
                             event={{
                                 thumbnail: item.thumbnail ?? null,
-                                duration: item.duration ?? null,
+                                duration: item.duration ?? bug("SearchEvent without duration"),
                                 tracks: item.tracks ?? bug(""),
                             }}
                             css={{ width: "100%" }}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -122,7 +122,6 @@ const VideoPage: React.FC<Props> = ({ event, realm, realmPath, id }) => {
         : null;
 
     const { title, tracks, description } = event;
-    const duration = event.duration ?? 0; // <-- TODO
     useTitle(title);
 
     const breadcrumbs = (realm.isRoot ? realm.ancestors : realm.ancestors.concat(realm))
@@ -130,7 +129,7 @@ const VideoPage: React.FC<Props> = ({ event, realm, realmPath, id }) => {
 
     return <>
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
-        <Player tracks={tracks as Track[]} title={title} duration={duration} />
+        <Player tracks={tracks as Track[]} title={title} duration={event.duration} />
         <h1 css={{ marginTop: 24, fontSize: 24 }}>{title}</h1>
         {description !== null && <TextBlock content={description} />}
         <table css={{

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -9,7 +9,7 @@ type Event implements Node {
   title: String!
   description: String
   "Duration in ms."
-  duration: Float
+  duration: Int!
   thumbnail: String
   tracks: [Track!]!
   created: DateTimeUtc!
@@ -161,7 +161,7 @@ type SearchEvent implements Node {
   title: String!
   description: String
   thumbnail: String
-  duration: Int
+  duration: Int!
   tracks: [Track!]!
 }
 

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -33,8 +33,6 @@ export const VideoBlock: React.FC<Props> = ({ title, fragRef }) => {
         <Title title={title ?? event.title} />
         <Player
             {...event}
-            // TODO In the future, duration won't be nullable anymore
-            duration={event.duration ?? 0}
             // Relay returns `readonly` objects ...
             tracks={event.tracks as Track[]}
         />

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -6,7 +6,7 @@ type ThumbnailProps = JSX.IntrinsicElements["div"] & {
     /** The event of which a thumbnail should be shown */
     event: {
         thumbnail: string | null;
-        duration: number | null;
+        duration: number;
         tracks: readonly { resolution: readonly number[] | null }[];
     };
 
@@ -61,21 +61,17 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({
         }} {...rest}>
             {inner}
             {active && <ActiveIndicator />}
-            {event.duration != null && (
-                <div css={{
-                    position: "absolute",
-                    right: 6,
-                    bottom: 6,
-                    backgroundColor: "hsla(0, 0%, 0%, 0.75)",
-                    border: "1px solid black",
-                    borderRadius: 4,
-                    padding: "0 4px",
-                    color: "white",
-                    fontSize: 14,
-                }}>
-                    {formatDuration(event.duration)}
-                </div>
-            )}
+            <div css={{
+                position: "absolute",
+                right: 6,
+                bottom: 6,
+                backgroundColor: "hsla(0, 0%, 0%, 0.75)",
+                border: "1px solid black",
+                borderRadius: 4,
+                padding: "0 4px",
+                color: "white",
+                fontSize: 14,
+            }}>{formatDuration(event.duration)}</div>
         </div>
     );
 };


### PR DESCRIPTION
This has been changed in the Tobira API: it never returns `null` as duration anymore. This simplifies lots of code.

See: https://github.com/elan-ev/opencast-tobira/pull/66