### PR TITLE
Partially revert "dynamically load player JS code" to fix bug

### DIFF
--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -17,19 +17,7 @@ const ASSETS: Setup = assets! {
         hash,
         append: b"//# sourceMappingURL=/~assets/{{: path:main.bundle.js.map :}}"
     },
-    "paella.bundle.js": {
-        template,
-        hash,
-        append: b"//# sourceMappingURL=/~assets/{{: path:paella.bundle.js.map :}}"
-    },
-    "plyr.bundle.js": {
-        template,
-        hash,
-        append: b"//# sourceMappingURL=/~assets/{{: path:plyr.bundle.js.map :}}"
-    },
     "main.bundle.js.map": { hash },
-    "paella.bundle.js.map": { hash },
-    "plyr.bundle.js.map": { hash },
 
     // Static files for the plyr media player.
     "blank.mp4": { hash },

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 
 import { MAIN_PADDING } from "../../layout/Root";
 import { Spinner } from "../Spinner";
+import PaellaPlayer from "./Paella";
+import PlyrPlayer from "./Plyr";
 
 
 export type PlayerProps = {
@@ -54,8 +56,8 @@ export const Player: React.FC<PlayerProps> = props => {
     );
 };
 
-const LoadPaellaPlayer = React.lazy(() => import(/* webpackChunkName: "paella" */ "./Paella"));
-const LoadPlyrPlayer = React.lazy(() => import(/* webpackChunkName: "plyr" */ "./Plyr"));
+const LoadPaellaPlayer = PaellaPlayer;
+const LoadPlyrPlayer = PlyrPlayer;
 
 const PlayerFallback: React.FC<{ image: string | null }> = ({ image }) => {
     const { t } = useTranslation();


### PR DESCRIPTION
This was done in a47f1abbb1084f8d3aacef6d719ec4e269896185 but caused
super breaking bugs in release mode where the asset files have a hash
embedded in it. I have plans to properly fix that, but those won't
land until the Opencast summit. So to make the test deploy work during
that time, I just not load the extra files dynamically for now.