### PR TITLE
Show title by default

### DIFF
--- a/backend/src/db/migrations/6-blocks.sql
+++ b/backend/src/db/migrations/6-blocks.sql
@@ -32,7 +32,7 @@ create table blocks (
     video_id bigint references events on delete set null,
 
     -- Blocks with a "natural title"
-    show_title boolean,
+    show_title boolean default true,
 
 
     -- Enforce several constraints

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -75,13 +75,16 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
             onClick={() => addBlock("Series", (_store, block) => {
                 block.setValue("NEW_TO_OLD", "order");
                 block.setValue("GRID", "layout");
+                block.setValue(true, "showTitle");
             })}
         >
             <FiGrid />
         </Button>
         <Button
             title={t("manage.realm.content.add-video")}
-            onClick={() => addBlock("Video")}
+            onClick={() => addBlock("Video", (_store, block) => {
+                block.setValue(true, "showTitle");
+            })}
         >
             <FiFilm />
         </Button>


### PR DESCRIPTION
Set `showTitle` to `true` by default for series and video blocks.

Note that this includes https://github.com/elan-ev/tobira/pull/377 for no particular reason other than my own convenience. :stuck_out_tongue_winking_eye: