### PR TITLE
Add `auth.logout_link` configuration to make logout button a simple link

### DIFF
--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -49,6 +49,10 @@ pub(crate) struct AuthConfig {
     /// (not via `<a>`, but through JavaScript) links to Tobira's own login page.
     pub(crate) login_link: Option<String>,
 
+    /// Link of the logout button. If not set, clicking the logout button will
+    /// send a `DELETE` request to `/~session`.
+    pub(crate) logout_link: Option<String>,
+
     /// The header containing a unique and stable username of the current user.
     /// TODO: describe properties, requirements and usages of username.
     #[config(default = "x-tobira-username")]

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -84,6 +84,7 @@ impl Assets {
         variables.insert("global-style".into(), config.theme.to_css());
         variables.insert("auth".into(), json!({
             "loginLink": config.auth.login_link,
+            "logoutLink": config.auth.logout_link,
             "userIdLabel": config.auth.login_page.user_id_label,
             "passwordLabel": config.auth.login_page.password_label,
             "loginPageNote": config.auth.login_page.note,

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -51,7 +51,7 @@ In either case, you need a reverse proxy in front of Tobira.
 In this documentation, we will use nginx.
 We assume basic understanding of how to set up a reverse proxy in front of a backend application.
 
-The following subsection describe the general approach when using/not using Tobira's login page/session management.
+The following subsection describes the general approach when using/not using Tobira's login page/session management.
 For a more concrete look at how a setup might look like, check out these specific cases:
 
 - [Tobira's login page and session management](./all-tobira.md)
@@ -95,6 +95,7 @@ Skipping authentication for these paths is recommended for performance reasons.
 
 To create new sessions, you have to intercept login attempts (see "Login page" sections), read the login data, and authenticate the user and send an appropriate response to the login-page (likely containing a `Set-Cookie` header).
 To destroy sessions, you have to intercept logout attempts (`DELETE /~session`) and delete the session as appropriate.
+Alternatively, you can set `auth.logout_link` in the config to make the logout button a simple `<a>` link to that URL.
 
 
 ### Using Tobira's login page

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -106,6 +106,10 @@
 # (not via `<a>`, but through JavaScript) links to Tobira's own login page.
 #login_link =
 
+# Link of the logout button. If not set, clicking the logout button will
+# send a `DELETE` request to `/~session`.
+#logout_link =
+
 # The header containing a unique and stable username of the current user.
 # TODO: describe properties, requirements and usages of username.
 #

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -37,6 +37,7 @@ type FooterLink = "about" | "graphiql" | {
 
 type AuthConfig = {
     loginLink: string | null;
+    logoutLink: string | null;
     userIdLabel: TranslatedString | null;
     passwordLabel: TranslatedString | null;
     loginPageNote: TranslatedString | null;

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -367,15 +367,15 @@ const Logout: React.FC = () => {
     type State = "idle" | "pending" | "error";
     const [state, setState] = useState<State>("idle");
 
-    return (
-        <MenuItem
-            icon={match(state, {
-                "idle": () => <FiLogOut />,
-                "pending": () => <Spinner />,
-                "error": () => <FiAlertTriangle />,
-            })}
-            borderTop
-            onClick={() => {
+    const actionProps = CONFIG.auth.logoutLink !== null
+        // Just a normal link to the specified URL
+        ? {
+            htmlLink: true,
+            linkTo: CONFIG.auth.logoutLink,
+        }
+        // Our own internal link
+        : {
+            onClick: () => {
                 // We don't do anything if a request is already pending.
                 if (state === "pending") {
                     return;
@@ -398,8 +398,19 @@ const Logout: React.FC = () => {
                         console.error("Error during logout: ", error);
                         setState("error");
                     });
-            }}
+            },
+        };
+
+    return (
+        <MenuItem
+            icon={match(state, {
+                "idle": () => <FiLogOut />,
+                "pending": () => <Spinner />,
+                "error": () => <FiAlertTriangle />,
+            })}
+            borderTop
             css={{ color: "var(--danger-color)" }}
+            {...actionProps}
         >{t("user.logout")}</MenuItem>
     );
 };


### PR DESCRIPTION
Before, our logout button just sent `DELETE /~session` and our
assumption was, that the reverse proxy could just intercept that and
do whatever is necessary. However, in some systems like Shibboleth,
users actually need to visit another domain. The reverse proxy can't do
that because the relevant cookies for that other domain are not
included in the request.

So a configurable logout link is an easy and straight forward solution.

Closes #379 