### PR TITLE
Fix direct link in search result

### DIFF
--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -127,7 +127,7 @@ const SearchEvent: React.FC<SearchEventProps> = ({
     const { t } = useTranslation();
 
     return (
-        <Item key={id} link={`/!${id.slice(2)}`}>
+        <Item key={id} link={`/!v/${id.slice(2)}`}>
             <Thumbnail
                 event={{
                     title,


### PR DESCRIPTION
The search result direct links are invalid because they are missing the `!v` path.

https://github.com/elan-ev/tobira/pull/410