### PR TITLE
Stop duplicating browserslist config

### DIFF
--- a/frontend/.babelrc.js
+++ b/frontend/.babelrc.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const manifest = require("./package.json");
-
 module.exports = {
     parserOpts: {
         strictMode: true,
@@ -15,7 +13,6 @@ module.exports = {
             // Set to `true` to show which transforms will be run
             // during the build
             debug: false,
-            targets: manifest.browserslist,
         }],
         [
             "@babel/preset-typescript",

--- a/frontend/.babelrc.js
+++ b/frontend/.babelrc.js
@@ -20,14 +20,14 @@ module.exports = {
         [
             "@babel/preset-typescript",
             {
-                "allowDeclareFields": true,
+                allowDeclareFields: true,
             },
         ],
         [
             "@babel/preset-react",
             {
-                "runtime": "automatic",
-                "importSource": "@emotion/react",
+                runtime: "automatic",
+                importSource: "@emotion/react",
             },
         ],
     ],


### PR DESCRIPTION
Removing this does not change the transformations used for me anymore. With that, we can close #33.

I opted to keep the Babel config file a script instead of migrating it to a JSON file as I alluded to in the issue because of the comments we have in there. :shrug: 