### PR TITLE
Deal with not fully synchronized series

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -5,7 +5,7 @@ use crate::{
     api::{
         Id, Context,
         err::{self, ApiResult},
-        model::{event::Event, series::Series, realm::Realm},
+        model::{event::Event, series::{WaitingSeries, ReadySeries}, realm::Realm},
     },
     search::Event as SearchEvent,
     search::Realm as SearchRealm,
@@ -15,7 +15,7 @@ use crate::{
 /// A node with a globally unique ID. Mostly useful for relay.
 #[juniper::graphql_interface(
     Context = Context,
-    for = [Event, Realm, Series, SearchEvent, SearchRealm]
+    for = [Event, Realm, WaitingSeries, ReadySeries, SearchEvent, SearchRealm]
 )]
 pub(crate) trait Node {
     fn id(&self) -> Id;

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -1,6 +1,5 @@
 //! Blocks that make up the content of realm pages.
 
-use std::{fmt, error::Error};
 use juniper::{graphql_interface, graphql_object, GraphQLEnum};
 use postgres_types::{FromSql, ToSql};
 use tokio_postgres::Row;
@@ -278,46 +277,4 @@ fn get_type_dependent<'a, T: FromSql<'a>>(
         type_name,
         field_name,
     ))
-}
-
-#[derive(Debug)]
-pub(crate) struct BlockTypeError;
-
-impl fmt::Display for BlockTypeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "wrong block type")
-    }
-}
-
-impl Error for BlockTypeError {}
-
-// TODO? What about video?
-impl TryFrom<BlockValue> for TitleBlock {
-    type Error = BlockTypeError;
-    fn try_from(block: BlockValue) -> Result<Self, Self::Error> {
-        match block {
-            BlockValue::TitleBlock(b) => Ok(b),
-            _ => Err(BlockTypeError),
-        }
-    }
-}
-
-impl TryFrom<BlockValue> for TextBlock {
-    type Error = BlockTypeError;
-    fn try_from(block: BlockValue) -> Result<Self, Self::Error> {
-        match block {
-            BlockValue::TextBlock(b) => Ok(b),
-            _ => Err(BlockTypeError),
-        }
-    }
-}
-
-impl TryFrom<BlockValue> for SeriesBlock {
-    type Error = BlockTypeError;
-    fn try_from(block: BlockValue) -> Result<Self, Self::Error> {
-        match block {
-            BlockValue::SeriesBlock(b) => Ok(b),
-            _ => Err(BlockTypeError),
-        }
-    }
 }

--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -5,7 +5,12 @@ use postgres_types::{FromSql, ToSql};
 use tokio_postgres::Row;
 
 use crate::{
-    api::{Context, err::{ApiError, ApiResult, internal_server_err}, Id, model::{series::Series, event::Event}},
+    api::{
+        Context,
+        err::{ApiError, ApiResult, internal_server_err},
+        Id,
+        model::{event::Event, series::SeriesValue},
+    },
     db::types::Key,
     prelude::*,
 };
@@ -141,11 +146,11 @@ impl Block for SeriesBlock {
 /// A block just showing the list of videos in an Opencast series
 #[graphql_object(Context = Context, impl = BlockValue)]
 impl SeriesBlock {
-    async fn series(&self, context: &Context) -> ApiResult<Option<Series>> {
+    async fn series(&self, context: &Context) -> ApiResult<Option<SeriesValue>> {
         match self.series {
             None => Ok(None),
             // `unwrap` is okay here because of our foreign key constraint
-            Some(series_id) => Ok(Some(Series::load_by_id(series_id, context).await?.unwrap())),
+            Some(series_id) => Ok(Some(SeriesValue::load_by_id(series_id, context).await?.unwrap())),
         }
     }
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -10,7 +10,7 @@ use crate::{
     api::{
         Context, Cursor, Id, Node, NodeValue,
         err::{self, ApiResult, invalid_input},
-        model::{series::Series, realm::Realm},
+        model::{series::{SeriesValue, ReadySeries}, realm::Realm},
     },
     db::types::{EventTrack, Key},
     prelude::*,
@@ -95,9 +95,17 @@ impl Event {
         self.can_write
     }
 
-    async fn series(&self, context: &Context) -> ApiResult<Option<Series>> {
+    async fn series(&self, context: &Context) -> ApiResult<Option<ReadySeries>> {
         if let Some(series) = self.series {
-            Series::load_by_id(Id::series(series), context).await
+            let series = SeriesValue::load_by_id(Id::series(series), context)
+                .await?
+                .map(|series| match series {
+                    SeriesValue::ReadySeries(series) => series,
+                    // We currently assume (and guarantee) that a series that is referenced by an event
+                    // is completely synced before that event.
+                    SeriesValue::WaitingSeries(_) => unreachable!(),
+                });
+            Ok(series)
         } else {
             Ok(None)
         }

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -47,7 +47,6 @@ pub(crate) struct Track {
     resolution: Option<Vec<i32>>,
 }
 
-#[juniper::graphql_interface]
 impl Node for Event {
     fn id(&self) -> Id {
         Id::event(self.key)

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -130,7 +130,6 @@ impl Realm {
     }
 }
 
-#[juniper::graphql_interface]
 impl Node for Realm {
     fn id(&self) -> Id {
         Id::realm(self.key)

--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 
-#[juniper::graphql_interface]
 impl Node for search::Event {
     fn id(&self) -> Id {
         Id::search_event(self.id.0)

--- a/backend/src/api/model/search/realm.rs
+++ b/backend/src/api/model/search/realm.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 
-#[juniper::graphql_interface]
 impl Node for search::Realm {
     fn id(&self) -> Id {
         Id::search_realm(self.id.0)

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -94,7 +94,7 @@ impl Series {
         }
     }
 
-    pub(crate) async fn load_by_key(key: Key, context: &Context) -> ApiResult<Option<Series>> {
+    pub(crate) async fn load_by_key(key: Key, context: &Context) -> ApiResult<Option<Self>> {
         let result = context.db
             .query_opt(
                 &format!(
@@ -111,7 +111,7 @@ impl Series {
         Ok(result)
     }
 
-    pub(crate) async fn load_by_opencast_id(id: String, context: &Context) -> ApiResult<Option<Series>> {
+    pub(crate) async fn load_by_opencast_id(id: String, context: &Context) -> ApiResult<Option<Self>> {
         let query = format!("select {} from series where opencast_id = $1", Self::COL_NAMES);
         context.db
             .query_opt(&query, &[&id])

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -1,4 +1,4 @@
-use juniper::graphql_object;
+use juniper::{graphql_interface, graphql_object};
 use tokio_postgres::Row;
 
 use crate::{
@@ -11,48 +11,31 @@ use crate::{
             event::{Event, EventSortOrder}
         },
         Node,
-        NodeValue,
     },
-    db::{types::Key},
+    db::types::{SeriesState as State, Key},
     prelude::*,
 };
 
 
-pub(crate) struct Series {
-    pub(crate) key: Key,
-    opencast_id: String,
-    title: String,
-    description: Option<String>,
-}
-
-impl Node for Series {
-    fn id(&self) -> Id {
-        Id::series(self.key)
-    }
-}
-
-#[graphql_object(Context = Context, impl = NodeValue)]
-impl Series {
-    fn id(&self) -> Id {
-        Node::id(self)
-    }
-
-    fn title(&self) -> &str {
-        &self.title
-    }
-
-    fn description(&self) -> Option<&str> {
-        self.description.as_deref()
-    }
-
-    fn opencast_id(&self) -> &str {
-        &self.opencast_id
-    }
-
-    #[graphql(arguments(order(default = Default::default())))]
-    async fn events(&self, order: EventSortOrder, context: &Context) -> ApiResult<Vec<Event>> {
-        Event::load_for_series(self.key, order, context).await
-    }
+/// Represents an Opencast series.
+/// These can exist in different states during their lifecycle,
+/// represented by different implementations of this interface:
+///
+/// - `WaitingSeries`: The series was created "out of band" in regards
+///     to the usual path of communication between Opencast and Tobira
+///     (i.e. the harvesting protocol).
+///     Thus, it does not have all its (meta-)data, yet,
+///     and is *waiting* to be fully synced.
+///     This can currently only happen using the `mount`-API
+///     used by the Opencast Admin UI.
+/// - `ReadySeries`: The series is fully synced and up to date, as far
+///     as Tobira is concerned. All of its mandatory data fields are set,
+///     and the optional ones should reflect the state of the Opencast
+///     series as of the last harvest.
+#[graphql_interface(Context = Context, for = [WaitingSeries, ReadySeries])]
+pub(crate) trait Series {
+    fn id(&self) -> Id;
+    fn opencast_id(&self) -> &str;
 
     /// Returns a list of realms where this series is referenced (via some kind of block).
     async fn host_realms(&self, context: &Context) -> ApiResult<Vec<Realm>> {
@@ -64,13 +47,103 @@ impl Series {
                 on realms.id = blocks.realm_id and
                 type = 'series' and blocks.series_id = $1 \
         ");
-        context.db.query_mapped(&query, dbargs![&self.key], Realm::from_row)
+        context.db.query_mapped(
+            &query,
+            dbargs![&self.id().key_for(Id::SERIES_KIND)],
+            Realm::from_row,
+        )
             .await?
             .pipe(Ok)
     }
 }
 
-impl Series {
+pub(crate) struct SharedData {
+    pub(crate) key: Key,
+    opencast_id: String,
+}
+
+pub(crate) struct WaitingSeries {
+    pub(crate) shared: SharedData,
+}
+
+impl Series for WaitingSeries {
+    fn id(&self) -> Id {
+        Id::series(self.shared.key)
+    }
+
+    fn opencast_id(&self) -> &str {
+        &self.shared.opencast_id
+    }
+}
+
+/// See `Series`
+#[graphql_object(Context = Context, impl = SeriesValue)]
+impl WaitingSeries {
+    fn id(&self) -> Id {
+        Series::id(self)
+    }
+
+    fn opencast_id(&self) -> &str {
+        Series::opencast_id(self)
+    }
+
+    async fn host_realms(&self, context: &Context) -> ApiResult<Vec<Realm>> {
+        Series::host_realms(self, context).await
+    }
+}
+
+pub(crate) struct ReadySeries {
+    pub(crate) shared: SharedData,
+    title: String,
+    description: Option<String>,
+}
+
+impl Series for ReadySeries {
+    fn id(&self) -> Id {
+        Id::series(self.shared.key)
+    }
+
+    fn opencast_id(&self) -> &str {
+        &self.shared.opencast_id
+    }
+}
+
+/// See `Series`
+#[graphql_object(Context = Context, impl = SeriesValue)]
+impl ReadySeries {
+    fn id(&self) -> Id {
+        Series::id(self)
+    }
+
+    fn opencast_id(&self) -> &str {
+        Series::opencast_id(self)
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    #[graphql(arguments(order(default = Default::default())))]
+    async fn events(&self, order: EventSortOrder, context: &Context) -> ApiResult<Vec<Event>> {
+        Event::load_for_series(self.shared.key, order, context).await
+    }
+
+    async fn host_realms(&self, context: &Context) -> ApiResult<Vec<Realm>> {
+        Series::host_realms(self, context).await
+    }
+}
+
+impl<S: Series> Node for S {
+    fn id(&self) -> Id {
+        Series::id(self)
+    }
+}
+
+impl SeriesValue {
     pub(crate) async fn load_all(context: &Context) -> ApiResult<Vec<Self>> {
         context.db(context.require_moderator()?)
             .query_mapped(
@@ -142,11 +215,18 @@ impl Series {
     const COL_NAMES: &'static str = "id, opencast_id, state, title, description";
 
     fn from_row(row: Row) -> Self {
-        Self {
+        let shared = SharedData {
             key: row.get(0),
             opencast_id: row.get(1),
-            title: row.get(2),
-            description: row.get(3),
+        };
+        let state = row.get::<_, State>(2);
+        match state {
+            State::Waiting => WaitingSeries { shared }.into(),
+            State::Ready => ReadySeries {
+                shared,
+                title: row.get(3),
+                description: row.get(4),
+            }.into(),
         }
     }
 }

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -25,7 +25,6 @@ pub(crate) struct Series {
     description: Option<String>,
 }
 
-#[juniper::graphql_interface]
 impl Node for Series {
     fn id(&self) -> Id {
         Id::series(self.key)

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -193,9 +193,7 @@ impl Mutation {
             }
         }
 
-        let series = Series::load_by_opencast_id(oc_series_id, context)
-            .await?
-            .ok_or_else(|| invalid_input!("`ocSeriesId` does not refer to a valid Opencast series ID"))?;
+        let series = Series::load_or_create_by_opencast_id(oc_series_id, context).await?;
 
         let target_realm = {
             let mut target_realm = parent_realm;

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -5,8 +5,8 @@ use super::{
     err::{ApiResult, invalid_input},
     id::Id,
     model::{
+        series::{Series, SeriesValue},
         realm::{ChildIndex, NewRealm, Realm, RealmOrder, RemovedRealm, UpdateRealm, RealmSpecifier},
-        series::Series,
         block::{
             BlockValue,
             NewTitleBlock,
@@ -193,7 +193,7 @@ impl Mutation {
             }
         }
 
-        let series = Series::load_or_create_by_opencast_id(oc_series_id, context).await?;
+        let series = SeriesValue::load_or_create_by_opencast_id(oc_series_id, context).await?;
 
         let target_realm = {
             let mut target_realm = parent_realm;
@@ -211,7 +211,7 @@ impl Mutation {
             Id::realm(target_realm.key),
             0,
             NewSeriesBlock {
-                series: Id::series(series.key),
+                series: Series::id(&series),
                 show_title: false,
                 order: VideoListOrder::NewToOld,
             },

--- a/backend/src/db/migrations/04-series.sql
+++ b/backend/src/db/migrations/04-series.sql
@@ -1,15 +1,42 @@
 select prepare_randomized_ids('series');
 
+-- Series can exist in different states during their lifecycle:
+-- `'waiting'`: The series was created "out of band" in regards to the
+--     usual path of communication between Opencast and Tobira
+--     (i.e. the harvesting protocol).
+--     Thus, it does not have all its (meta-)data, yet,
+--     and is *waiting* to be fully synced.
+--     This can currently only happen using the `mount`-API
+--     used by the Opencast Admin UI.
+--     In this state, only the Opencast ID is valid.
+--     All other (nullable) fields should be `null`,
+--     and the updated timestamp should be `-infinity`, i.e. before
+--     all other timestamps.
+-- `'ready'`: The series is fully synced and up to date, as far as
+--     Tobira is concerned. All of its mandatory data fields are set,
+--     and the optional ones should reflect the state of the Opencast
+--     series as of the last harvest.
+create type series_state as enum ('waiting', 'ready');
+
 create table series (
     id bigint primary key default randomized_id('series'),
+
+    state series_state not null,
 
     -- Opencast internal data
     opencast_id text not null unique,
 
     -- Meta data
-    title text not null,
+    title text,
     description text,
-    updated timestamp with time zone not null
+    updated timestamp with time zone not null,
+
+    constraint ready_series_has_fields check (state <> 'ready' or (
+        title is not null
+    )),
+    constraint waiting_series_not_updated check (state <> 'waiting' or (
+        updated = '-infinity'
+    ))
 );
 
 create index idx_series_opencast_id on series (opencast_id);

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use bytes::BytesMut;
+use juniper::GraphQLEnum;
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +14,17 @@ pub struct EventTrack {
     pub flavor: String,
     pub mimetype: Option<String>,
     pub resolution: Option<[i32; 2]>,
+}
+
+/// Represents the `series_state` type defined in `04-series.sql`.
+#[derive(Debug, Clone, Copy, FromSql, ToSql, GraphQLEnum)]
+#[postgres(name = "series_state")]
+#[graphql(description = "Represents the different states a series can be in during its lifecycle")]
+pub enum SeriesState {
+    #[postgres(name = "ready")]
+    Ready,
+    #[postgres(name = "waiting")]
+    Waiting,
 }
 
 

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -7,7 +7,7 @@ use hyper::http::status::StatusCode;
 use tokio_postgres::types::ToSql;
 
 use crate::{
-    db::{types::{EventTrack, Key}, DbConnection},
+    db::{types::{EventTrack, SeriesState, Key}, DbConnection},
     prelude::*,
     search::{self, IndexItemKind}, config::Config,
 };
@@ -230,6 +230,7 @@ async fn store_in_db(
                 // We first simply upsert the series.
                 let new_id = upsert(db, "series", "opencast_id", &[
                     ("opencast_id", &opencast_id),
+                    ("state", &SeriesState::Ready),
                     ("title", &title),
                     ("description", &description),
                     ("updated", &updated),

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -112,6 +112,12 @@ series:
   no-events: Diese Serie enthält keine Videos oder Sie sind nicht berechtigt, diese zu sehen.
   videos:
     heading: Videos
+  not-ready:
+    title: Serie noch nicht synchronisiert
+    text: >
+      Diese Opencast-Serie wurde noch nicht vollständig mit Tobira synchronisiert.
+      Sie wird aber wahrscheinlich bald ankommen, also können Sie einfach später
+      noch einmal vorbeischauen.
 
 realm:
   page-settings: Seiteneinstellungen
@@ -299,6 +305,7 @@ manage:
           heading: Serie
           none: Keine Serie ausgewählt
           invalid: Bitte eine Serie auswählen
+          waiting: Nicht synchronisierte Serie
 
       event:
         event:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -108,6 +108,11 @@ series:
   no-events: This series does not contain any events, or you might not be authorized to see them.
   videos:
     heading: Videos
+  not-ready:
+    title: Series not synchronized, yet
+    text: >
+      This Opencast series has not been fully synchronized with Tobira, yet.
+      It will probably arrive soon, though, so you can just check back in at a later time.
 
 realm:
   page-settings: Page settings
@@ -288,6 +293,7 @@ manage:
           heading: Series
           none: No series selected
           invalid: Please select a series
+          waiting: Non-synchronized series
 
       event:
         event:

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -36,13 +36,19 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
 
     const { series: allSeries } = useFragment(graphql`
         fragment SeriesEditModeSeriesData on Query {
-            series { id title }
+            series {
+                id
+                __typename
+                ... on ReadySeries {
+                    title
+                }
+            }
         }
     `, useContext(ContentManageQueryContext) as SeriesEditModeSeriesData$key);
 
     const { series, showTitle, order } = useFragment(graphql`
         fragment SeriesEditModeBlockData on SeriesBlock {
-            series { id }
+            series { id __typename}
             showTitle
             order
         }
@@ -105,9 +111,12 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
             <option value="" hidden>
                 {t("manage.realm.content.series.series.none")}
             </option>
-            {allSeries.map(({ id, title }) => (
-                <option key={id} value={id}>{title}</option>
-            ))}
+            {series && series.__typename !== "ReadySeries" && <option value={series.id} hidden>
+                {t("manage.realm.content.series.series.waiting")}
+            </option>}
+            {allSeries
+                .filter(series => series.__typename === "ReadySeries")
+                .map(({ id, title }) => <option key={id} value={id}>{title}</option>)}
         </Select>
         <ShowTitle showTitle={showTitle} />
     </EditModeForm>;

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -18,7 +18,7 @@ type Event implements Node {
   creators: [String!]!
   "Whether the current user has write access to this event."
   canWrite: Boolean!
-  series: Series
+  series: ReadySeries
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!
 }
@@ -211,13 +211,34 @@ input UpdateSeriesBlock {
   order: VideoListOrder
 }
 
-type Series implements Node {
+"""
+  Represents an Opencast series.
+  These can exist in different states during their lifecycle,
+  represented by different implementations of this interface:
+
+  - `WaitingSeries`: The series was created "out of band" in regards
+      to the usual path of communication between Opencast and Tobira
+      (i.e. the harvesting protocol).
+      Thus, it does not have all its (meta-)data, yet,
+      and is *waiting* to be fully synced.
+      This can currently only happen using the `mount`-API
+      used by the Opencast Admin UI.
+  - `ReadySeries`: The series is fully synced and up to date, as far
+      as Tobira is concerned. All of its mandatory data fields are set,
+      and the optional ones should reflect the state of the Opencast
+      series as of the last harvest.
+"""
+interface Series {
   id: ID!
-  title: String!
-  description: String
   opencastId: String!
-  events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [Event!]!
   "Returns a list of realms where this series is referenced (via some kind of block)."
+  hostRealms: [Realm!]!
+}
+
+"See `Series`"
+type WaitingSeries implements Series {
+  id: ID!
+  opencastId: String!
   hostRealms: [Realm!]!
 }
 
@@ -248,6 +269,16 @@ input UpdateRealm {
 
 input UpdateTitleBlock {
   content: String
+}
+
+"See `Series`"
+type ReadySeries implements Series {
+  id: ID!
+  opencastId: String!
+  title: String!
+  description: String
+  events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [Event!]!
+  hostRealms: [Realm!]!
 }
 
 input UpdateVideoBlock {

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -97,17 +97,19 @@ export const SeriesBlock: React.FC<Props> = ({
 
     const { t } = useTranslation();
 
+    const blockTitle = title ?? (showTitle && series.title);
+
     return (
         <div css={{
             marginTop: 24,
             padding: 12,
-            paddingTop: 0,
+            ...blockTitle && { paddingTop: 0 },
             backgroundColor: "var(--grey95)",
             borderRadius: 10,
         }}>
             {/* This is a way to make this fancy title. It's not perfect, but it works fine. */}
-            {(title || showTitle) && <div css={{ maxHeight: 50 }}>
-                <h2 title={title ?? series.title} css={{
+            {blockTitle && <div css={{ maxHeight: 50 }}>
+                <h2 title={blockTitle} css={{
                     backgroundColor: "var(--accent-color)",
                     color: "white",
                     padding: "4px 12px",

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -90,10 +90,10 @@ export const SeriesBlock: React.FC<Props> = ({
 }) => {
     const sortedEvents = [...series.events];
 
-    match(order, {
-        NEW_TO_OLD: () => sortedEvents.sort(compareNewToOld),
-        OLD_TO_NEW: () => sortedEvents.sort(compareOldToNew),
-    }, unreachable);
+    sortedEvents.sort(match(order, {
+        NEW_TO_OLD: () => compareNewToOld,
+        OLD_TO_NEW: () => compareOldToNew,
+    }, unreachable));
 
     const { t } = useTranslation();
 

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -58,7 +58,7 @@ export const SeriesBlockFromBlock: React.FC<FromBlockProps> = ({ fragRef, ...res
         : <SeriesBlockFromSeries fragRef={series} {...rest} {...block} />;
 };
 
-type BlockOnlyProps = Omit<NonNullable<SeriesBlockData$data>, "series" | " $fragmentType">;
+type BlockOnlyProps = Omit<SeriesBlockData$data, "series" | " $fragmentType">;
 
 type FromSeriesProps = SharedProps & {
     fragRef: SeriesBlockSeriesData$key;

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -51,6 +51,88 @@ export function match<T extends string | number, Out>(
         : (arms[value] as (() => Out) | undefined ?? fallback)();
 }
 
+/**
+ * Similar to `match` above, but specifically for use with discriminated unions.
+ * Let's say you have something like
+ *
+ *     type T = { type: "number", value: number } | { type: "string", value: string };
+ *     const t: T = ...;
+ *
+ * Then you can say
+ *
+ *     discriminate(t, "type", {
+ *         number: ({ value }) => ..., // `value` is a `number` here!
+ *         string: ({ value }) => ..., // and a `string` here!
+ *     })
+ */
+export function discriminate<
+    Union extends Discriminated<Discriminator>,
+    Discriminator extends Discriminators<Union>,
+    Arms extends DiscriminateArms<Union, Discriminator>,
+>(
+    value: Union,
+    discriminator: Discriminator,
+    arms: Restrict<Arms, DiscriminateArms<Union, Discriminator>>,
+): DiscriminateResult<Union, Discriminator, Arms>;
+export function discriminate<
+    Union extends Discriminated<Discriminator>,
+    Discriminator extends Discriminators<Union>,
+    Arms extends Partial<DiscriminateArms<Union, Discriminator>>,
+    Fallback,
+>(
+    value: Union,
+    discriminator: Discriminator,
+    arms: Restrict<Arms, Partial<DiscriminateArms<Union, Discriminator>>>,
+    fallback: (value: Union) => Fallback,
+): DiscriminateResult<Union, Discriminator, Arms> | Fallback;
+export function discriminate<
+    Union extends Discriminated<Discriminator>,
+    Discriminator extends Discriminators<Union>,
+    Arms extends Partial<DiscriminateArms<Union, Discriminator>>,
+    Fallback,
+>(
+    value: Union,
+    discriminator: Discriminator,
+    arms: Restrict<Arms, Partial<DiscriminateArms<Union, Discriminator>>>,
+    fallback?: (value: Union) => Fallback,
+): DiscriminateResult<Union, Discriminator, Arms> | Fallback {
+    // Implementing this so that TS accepts it is hard to impossible.
+    // The code is simple enough, though.
+    // See also `match` above.
+    type Result = DiscriminateResult<Union, Discriminator, Arms>;
+    const arm = arms[value[discriminator]] as (
+        <Variant extends Union>(value: Variant) => Result
+    ) | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return (arm ?? fallback)!(value);
+}
+
+type Discriminated<Discriminator extends string | number> = {
+    [Discriminant in Discriminator]: string | number;
+};
+
+type Discriminators<Union> = keyof Union & (string | number);
+
+type DiscriminateArms<
+    Union extends Discriminated<Discriminator>,
+    Discriminator extends Discriminators<Union>,
+    Out = unknown,
+> = {
+    [Discriminant in Union[Discriminator]]: (
+        variant: Extract<Union, Record<Discriminator, Discriminant>>,
+    ) => Out;
+};
+
+type Restrict<T, U> = Exclude<keyof T, keyof U> extends never ? T : U;
+
+type DiscriminateResult<
+    Union extends Discriminated<Discriminator>,
+    Discriminator extends Discriminators<Union>,
+    Arms extends Partial<DiscriminateArms<Union, Discriminator>>,
+> = Arms extends Partial<DiscriminateArms<Union, Discriminator, infer Out>>
+    ? Out
+    : never;
+
 /** Retrieves the key of an ID by stripping the "kind" prefix. */
 export function keyOfId(id: string): string {
     return id.substring(2);

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -7,15 +7,17 @@ declare
     events_realm_id realms.id%type;
 begin
     -- Add a few series
-    insert into series (opencast_id, title, description, updated)
-        values ('6d3f7e0c-c18f-4806-acc1-219a02cc7343', 'University Highlights', 'Some of the nicest videos this university has to offer!', now())
+    insert into series (opencast_id, state, title, description, updated)
+        values ('6d3f7e0c-c18f-4806-acc1-219a02cc7343', 'ready', 'University Highlights', 'Some of the nicest videos this university has to offer!', now())
         returning id into series_university_highlights;
-    insert into series (opencast_id, title, description, updated)
-        values ('f52ce5fd-fcde-4cd2-9c4b-7e8c7a9ff31d', 'Christmas Chemistry', 'Prof goes boom', now())
+    insert into series (opencast_id, state, title, description, updated)
+        values ('f52ce5fd-fcde-4cd2-9c4b-7e8c7a9ff31d', 'ready', 'Christmas Chemistry', 'Prof goes boom', now())
         returning id into series_christmas;
-    -- Empty series for testing edge cases
-    insert into series (opencast_id, title, updated)
-        values ('68612b2e-423b-40c2-8933-92c3dd4a47a9', 'Empty series', now());
+    -- Some series for testing edge cases
+    insert into series (opencast_id, state, title, updated)
+        values ('68612b2e-423b-40c2-8933-92c3dd4a47a9', 'ready', 'Empty series', now());
+    insert into series (opencast_id, state, updated)
+        values ('d9c9402d-2966-48a1-b082-ad5849202bca', 'waiting', '-infinity');
 
     -- Add lots of realms
     perform create_departments();


### PR DESCRIPTION
In some situations, like when mounting a series via the OC Admin UI (#352), Tobira might know *about* a Series, but not actually any of its (meta-)data. This patch teaches Tobira to deal with series like that.

Commits can be reviewed individually, but the first two are just minor cleanup things. The last one is still one big blob. x)