### PR TITLE
Store and show arbitrary metadata

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -1,6 +1,11 @@
 [general]
 site_title.en = "Tobira Test Deployment"
 
+[general.metadata]
+dcterms.source = "builtin:source"
+dcterms.license = "builtin:license"
+dcterms.spatial = { en = "Location", de = "Ort" }
+
 [db]
 database = "tobira-{{ id }}"
 user = "tobira-{{ id }}"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1555,6 +1555,8 @@ dependencies = [
  "fallible-iterator",
  "postgres-derive",
  "postgres-protocol",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -58,7 +58,7 @@ tap = "1"
 termcolor = "1.1.1"
 time = "0.3"
 tokio = { version = "1.0", features = ["fs", "rt-multi-thread", "macros", "time"] }
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 toml = "0.5"
 
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -12,7 +12,7 @@ use crate::{
         err::{self, ApiResult, invalid_input},
         model::{series::{SeriesValue, ReadySeries}, realm::Realm},
     },
-    db::types::{EventTrack, Key},
+    db::types::{EventTrack, Key, ExtraMetadata},
     prelude::*,
     util::lazy_format,
 };
@@ -32,6 +32,7 @@ pub(crate) struct Event {
     updated: DateTime<Utc>,
     creators: Vec<String>,
 
+    metadata: ExtraMetadata,
     thumbnail: Option<String>,
     tracks: Vec<Track>,
     can_write: bool,
@@ -88,6 +89,9 @@ impl Event {
     }
     fn creators(&self) -> &Vec<String> {
         &self.creators
+    }
+    fn metadata(&self) -> &ExtraMetadata {
+        &self.metadata
     }
 
     /// Whether the current user has write access to this event.
@@ -359,7 +363,7 @@ impl Event {
 
     pub(crate) const COL_NAMES: &'static str = "id, series, opencast_id, is_live, \
         title, description, duration, created, updated, creators, \
-        thumbnail, tracks, write_roles && $1 as can_write";
+        thumbnail, tracks, metadata, write_roles && $1 as can_write";
 
     pub(crate) fn from_row(row: Row) -> Self {
         Self {
@@ -375,7 +379,8 @@ impl Event {
             creators: row.get(9),
             thumbnail: row.get(10),
             tracks: row.get::<_, Vec<EventTrack>>(11).into_iter().map(Track::from).collect(),
-            can_write: row.get(12),
+            metadata: row.get(12),
+            can_write: row.get(13),
         }
     }
 }

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -44,7 +44,7 @@ impl Query {
     }
 
     /// Returns an event by its ID.
-    async fn event(id: Id, context: &Context) -> ApiResult<Option<Event>> {
+    async fn event_by_id(id: Id, context: &Context) -> ApiResult<Option<Event>> {
         Event::load_by_id(id, context).await
     }
 

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -48,7 +48,7 @@ impl Query {
         Event::load_by_id(id, context).await
     }
 
-    /// Returns a list of all events the current user has read access to
+    /// Returns a list of all events the current user has read access to.
     async fn all_events(context: &Context) -> ApiResult<Vec<Event>> {
         Event::load_all(context).await
     }
@@ -63,7 +63,7 @@ impl Query {
         SeriesValue::load_by_id(id, context).await
     }
 
-    /// Returns a list of all series
+    /// Returns a list of all series.
     async fn all_series(context: &Context) -> ApiResult<Vec<SeriesValue>> {
         SeriesValue::load_all(context).await
     }

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -49,7 +49,7 @@ impl Query {
     }
 
     /// Returns a list of all events the current user has read access to
-    async fn events(context: &Context) -> ApiResult<Vec<Event>> {
+    async fn all_events(context: &Context) -> ApiResult<Vec<Event>> {
         Event::load_all(context).await
     }
 
@@ -59,7 +59,7 @@ impl Query {
     }
 
     /// Returns a list of all series
-    async fn series(context: &Context) -> ApiResult<Vec<SeriesValue>> {
+    async fn all_series(context: &Context) -> ApiResult<Vec<SeriesValue>> {
         SeriesValue::load_all(context).await
     }
 

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -58,6 +58,11 @@ impl Query {
         SeriesValue::load_by_opencast_id(id, context).await
     }
 
+    /// Returns a series by its ID.
+    async fn series_by_id(id: Id, context: &Context) -> ApiResult<Option<SeriesValue>> {
+        SeriesValue::load_by_id(id, context).await
+    }
+
     /// Returns a list of all series
     async fn all_series(context: &Context) -> ApiResult<Vec<SeriesValue>> {
         SeriesValue::load_all(context).await

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -6,28 +6,6 @@ use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 
 
-/// Represents the `event_track` type defined in `5-events.sql`.
-#[derive(Debug, FromSql, ToSql)]
-#[postgres(name = "event_track")]
-pub struct EventTrack {
-    pub uri: String,
-    pub flavor: String,
-    pub mimetype: Option<String>,
-    pub resolution: Option<[i32; 2]>,
-}
-
-/// Represents the `series_state` type defined in `04-series.sql`.
-#[derive(Debug, Clone, Copy, FromSql, ToSql, GraphQLEnum)]
-#[postgres(name = "series_state")]
-#[graphql(description = "Represents the different states a series can be in during its lifecycle")]
-pub enum SeriesState {
-    #[postgres(name = "ready")]
-    Ready,
-    #[postgres(name = "waiting")]
-    Waiting,
-}
-
-
 /// Our primary database ID type, which we call "key". In the database, it's a
 /// `bigint` (`i64`), but we have a separate Rust type for it for several
 /// reasons. Implements `ToSql` and `FromSql` by casting to/from `i64`.
@@ -68,4 +46,26 @@ impl fmt::Debug for Key {
         let mut buf = [0; 11];
         write!(f, "Key({} :: {})", self.0 as i64, self.to_base64(&mut buf))
     }
+}
+
+
+/// Represents the `event_track` type defined in `5-events.sql`.
+#[derive(Debug, FromSql, ToSql)]
+#[postgres(name = "event_track")]
+pub struct EventTrack {
+    pub uri: String,
+    pub flavor: String,
+    pub mimetype: Option<String>,
+    pub resolution: Option<[i32; 2]>,
+}
+
+/// Represents the `series_state` type defined in `04-series.sql`.
+#[derive(Debug, Clone, Copy, FromSql, ToSql, GraphQLEnum)]
+#[postgres(name = "series_state")]
+#[graphql(description = "Represents the different states a series can be in during its lifecycle")]
+pub enum SeriesState {
+    #[postgres(name = "ready")]
+    Ready,
+    #[postgres(name = "waiting")]
+    Waiting,
 }

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -97,6 +97,7 @@ impl Assets {
         variables.insert("html-title".into(), config.general.site_title.en().into());
         variables.insert("site-title".into(), config.general.site_title.to_json());
         variables.insert("footer-links".into(), json!(config.general.footer_links()).to_string());
+        variables.insert("metadata-labels".into(), json!(config.general.metadata()).to_string());
         variables.insert(
             "large-logo-resolution".into(),
             format!("{:?}", config.theme.logo.large.resolution.0),

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -183,6 +183,7 @@ async fn store_in_db(
                 thumbnail,
                 acl,
                 is_live,
+                metadata,
                 updated,
             } => {
                 let series_id = match &part_of {
@@ -207,6 +208,7 @@ async fn store_in_db(
                     ("updated", &updated),
                     ("creators", &creators),
                     ("thumbnail", &thumbnail),
+                    ("metadata", &metadata),
                     ("read_roles", &acl.read),
                     ("write_roles", &acl.write),
                     ("tracks", &tracks.into_iter().map(Into::into).collect::<Vec<EventTrack>>()),

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use crate::db::types::EventTrack;
+use crate::db::types::{EventTrack, ExtraMetadata};
 
 
 /// What the harvesting API returns.
@@ -32,6 +32,7 @@ pub(super) enum HarvestItem {
         thumbnail: Option<String>,
         acl: Acl,
         is_live: bool,
+        metadata: ExtraMetadata,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
     },

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -40,6 +40,28 @@
 # ```
 #footer_links =
 
+# Additional metadata that is shown below a video. Example:
+#
+#     [general.metadata]
+#     dcterms.spatial = { en = "Location", de = "Ort" }
+#     "http://my.domain/xml/namespace".courseLink = { en = "Course", de = "Kurs"}
+#
+# As you can see, this is a mapping of a metadata location (the XML
+# namespace and the name) to a translated label. For the XML namespace
+# URL, there is one shortcut: the "http://purl.org/dc/terms/" is
+# abbreviated as just "dcterms".
+#
+# Instead of the manually translated label, you can use some builtin
+# labels like this:
+#
+#     dcterms.license = "builtin:license"
+#     dcterms.source = "builtin:source"
+#
+# As soon as you add your own metadata fields, this default is
+# overwritten. If you want to keep showing the license and source data,
+# you have to add those two lines to your configuration.
+#metadata =
+
 
 [db]
 # The username of the database user.

--- a/frontend/relay.config.js
+++ b/frontend/relay.config.js
@@ -10,6 +10,7 @@ module.exports = {
     customScalars: {
         "DateTimeUtc": "string",
         "Cursor": "string",
+        "ExtraMetadata": "Record<string, Record<string, string[]>>",
     },
     schemaExtensions: [APP_PATH],
 };

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -104,4 +104,8 @@ const GLOBAL_STYLE = css({
             color: "var(--nav-color-darker)",
         },
     },
+    hr: {
+        border: "none",
+        borderTop: "1px solid var(--grey80)",
+    },
 });

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -7,7 +7,8 @@ export const GlobalStyle: React.FC = () => <>
     <Global styles={GLOBAL_STYLE} />
 </>;
 
-export const SMALLER_FONT_BREAKPOINT = 450;
+export const BREAKPOINT_SMALL = 450;
+export const BREAKPOINT_MEDIUM = 650;
 
 /**
  * The following is a minimal set of CSS reset rules in order to get rid of
@@ -80,19 +81,19 @@ const GLOBAL_STYLE = css({
         fontSize: 30,
         lineHeight: 1.3,
         marginBottom: 16,
-        [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+        [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
             fontSize: 26,
         },
     },
     h2: {
         fontSize: 23,
-        [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+        [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
             fontSize: 20,
         },
     },
     h3: {
         fontSize: 19,
-        [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+        [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
             fontSize: 18,
         },
     },

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -26,6 +26,7 @@ type Config = {
     siteTitle: TranslatedString;
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
+    metadataLabels: Record<string, Record<string, MetadataLabel>>;
     logo: LogoConfig;
     plyr: PlyrConfig;
 };
@@ -63,6 +64,8 @@ type OpencastConfig = {
     studioUrl: string;
     editorUrl: string;
 };
+
+type MetadataLabel = "builtin:license" | "builtin:source" | TranslatedString;
 
 export type TranslatedString = { en: string } & Record<"de", string | undefined>;
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -98,10 +98,9 @@ login-page:
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
 
 video:
-  creator: Von
   created: Erstellt
   updated: Zuletzt angepasst
-  part-of-series: Teil von
+  part-of-series: Teil von Serie
   more-from-series: Mehr von „{{series}}“
   deleted-video-block: Das hier referenzierte Video wurde gelöscht.
   thumbnail-for: Vorschaubild für „{{video}}“

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -105,6 +105,8 @@ video:
   deleted-video-block: Das hier referenzierte Video wurde gelöscht.
   thumbnail-for: Vorschaubild für „{{video}}“
   live: Live
+  license: Lizenz
+  source: Quelle
 
 series:
   deleted-series-block: Die hier referenzierte Serie wurde gelöscht.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -94,10 +94,9 @@ login-page:
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
 
 video:
-  creator: By
   created: Created
-  updated: Last update
-  part-of-series: Part of
+  updated: Last updated
+  part-of-series: Part of series
   more-from-series: More from “{{series}}”
   deleted-video-block: The video referenced here was deleted.
   thumbnail-for: Thumbnail for “{{video}}”

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -101,6 +101,8 @@ video:
   deleted-video-block: The video referenced here was deleted.
   thumbnail-for: Thumbnail for “{{video}}”
   live: Live
+  license: License
+  source: Source
 
 series:
   deleted-series-block: The series referenced here was deleted.

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,6 +14,7 @@
         "auth": {{: var:auth :}},
         "siteTitle": {{: var:site-title :}},
         "footerLinks": {{: var:footer-links :}},
+        "metadataLabels": {{: var:metadata-labels :}},
         "opencast": {
           "uploadNode": "{{: var:upload-node :}}",
           "studioUrl": "{{: var:studio-url :}}",

--- a/frontend/src/layout/header/Logo.tsx
+++ b/frontend/src/layout/header/Logo.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import CONFIG from "../../config";
-import { SMALLER_FONT_BREAKPOINT } from "../../GlobalStyle";
+import { BREAKPOINT_SMALL } from "../../GlobalStyle";
 import { Link } from "../../router";
 import { translatedConfig } from "../../util";
 import { BASE_LOGO_MARGIN, BUTTONS_WIDTH } from "./ui";
@@ -65,7 +65,7 @@ export const Logo: React.FC = () => {
                 height: "100%",
                 flex: `0 1 calc(var(--inner-header-height) * ${largeAr})`,
                 margin: `0 ${actualMargin(largeAr)}`,
-                [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+                [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
                     flex: `0 1 calc(var(--inner-header-height) * ${smallAr})`,
                     margin: `0 ${actualMargin(smallAr)}`,
                 },
@@ -82,7 +82,7 @@ export const Logo: React.FC = () => {
                 src={large.path}
                 alt={alt}
                 css={{
-                    [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+                    [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
                         display: "none",
                     },
                 }}
@@ -93,7 +93,7 @@ export const Logo: React.FC = () => {
                 src={small.path}
                 alt={alt}
                 css={{
-                    [`@media not all and (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+                    [`@media not all and (max-width: ${BREAKPOINT_SMALL}px)`]: {
                         display: "none",
                     },
                 }}

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-icons/fi";
 import { HiOutlineTranslate } from "react-icons/hi";
 
-import { SMALLER_FONT_BREAKPOINT } from "../../GlobalStyle";
+import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { languages } from "../../i18n";
 import { Link } from "../../router";
 import { useOnOutsideClick } from "../../util";
@@ -22,9 +22,6 @@ import { LOGIN_PATH } from "../../routes/paths";
 import { REDIRECT_STORAGE_KEY } from "../../routes/Login";
 import { FOCUS_STYLE_INSET } from "../../ui";
 
-
-/** Viewport width in pixels where the user UI switches between narrow and wide */
-const BREAKPOINT = 650;
 
 /** User-related UI in the header. */
 export const UserBox: React.FC = () => {
@@ -98,7 +95,7 @@ const LoggedOut: React.FC<LoggedOutProps> = ({ menu }) => {
                         outline: "none",
                         boxShadow: "0 0 0 2px black",
                     },
-                    [`@media (max-width: ${BREAKPOINT}px)`]: {
+                    [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
                         display: "none",
                     },
                 }}
@@ -140,7 +137,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user, menu }) => {
                     lineHeight: 1.3,
                     paddingRight: 16,
                     opacity: 0.75,
-                    [`@media (max-width: ${BREAKPOINT}px)`]: {
+                    [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
                         display: "none",
                     },
                 }}>
@@ -177,7 +174,7 @@ const UserSettingsIcon: React.FC<UserSettingsIconProps> = ({ t, onClick }) => (
     <ActionIcon title={t("user.settings")} onClick={onClick}>
         <FiMoreVertical css={{
             fontSize: 26,
-            [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+            [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
                 fontSize: 22,
             },
         }} />
@@ -217,7 +214,7 @@ const Menu: React.FC<MenuProps> = ({ close, container }) => {
                     htmlLink={!!CONFIG.auth.loginLink}
                     css={{
                         color: "var(--nav-color)",
-                        [`@media not all and (max-width: ${BREAKPOINT}px)`]: {
+                        [`@media not all and (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
                             display: "none",
                         },
                     }}

--- a/frontend/src/layout/header/ui.tsx
+++ b/frontend/src/layout/header/ui.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 
-import { SMALLER_FONT_BREAKPOINT } from "../../GlobalStyle";
+import { BREAKPOINT_SMALL } from "../../GlobalStyle";
 import { useTitle } from "../../util";
 
 
@@ -43,7 +43,7 @@ export const ActionIcon: React.FC<ActionIconProps> = ({ title, onClick, children
                 "&:hover": {
                     opacity: "1",
                 },
-                [`@media (max-width: ${SMALLER_FONT_BREAKPOINT}px)`]: {
+                [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {
                     fontSize: 24,
                 },
             }}

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -1,4 +1,4 @@
-import { graphql } from "react-relay";
+import { graphql, useFragment } from "react-relay";
 import { useTranslation } from "react-i18next";
 
 import { discriminate } from "../util";
@@ -12,14 +12,13 @@ import { Nav } from "../layout/Navigation";
 import { PageTitle } from "../layout/header/ui";
 
 import { NotFound } from "./NotFound";
-import {
-    SeriesByOpencastIdQuery,
-    SeriesByOpencastIdQuery$data,
-} from "./__generated__/SeriesByOpencastIdQuery.graphql";
+import { SeriesByOpencastIdQuery } from "./__generated__/SeriesByOpencastIdQuery.graphql";
+import { b64regex } from "./util";
+import { SeriesByIdQuery } from "./__generated__/SeriesByIdQuery.graphql";
+import { SeriesRouteData$key } from "./__generated__/SeriesRouteData.graphql";
 
 
-export const DirectSeriesRoute = makeRoute(url => {
-
+export const DirectSeriesOCRoute = makeRoute(url => {
     const regex = new RegExp("^/!s/:([^/]+)$", "u");
     const matches = regex.exec(url.pathname);
 
@@ -32,18 +31,8 @@ export const DirectSeriesRoute = makeRoute(url => {
     const query = graphql`
         query SeriesByOpencastIdQuery($id: String!) {
             ... UserData
-            series: seriesByOpencastId(id: $id) {
-                __typename
-                ... on WaitingSeries { id } # only for correct type generation ...
-                ... on ReadySeries {
-                    title
-                    description
-                    ... SeriesBlockReadySeriesData
-                }
-            }
-            rootRealm {
-               ... NavigationData
-            }
+            series: seriesByOpencastId(id: $id) { ...SeriesRouteData }
+            rootRealm { ... NavigationData }
         }
     `;
     const queryRef = loadQuery<SeriesByOpencastIdQuery>(query, { id: opencastId });
@@ -53,14 +42,61 @@ export const DirectSeriesRoute = makeRoute(url => {
         render: () => <RootLoader
             {...{ query, queryRef }}
             nav={data => <Nav fragRef={data.rootRealm} />}
-            render={result => <SeriesPage {...result} />}
+            render={result => <SeriesPage seriesFrag={result.series} />}
         />,
         dispose: () => queryRef.dispose(),
     };
 });
 
-const SeriesPage: React.FC<SeriesByOpencastIdQuery$data> = ({ series }) => {
+export const DirectSeriesRoute = makeRoute(url => {
+    const regex = new RegExp(`^/!s/(${b64regex}+)$`, "u");
+    const matches = regex.exec(url.pathname);
+
+    if (!matches) {
+        return null;
+    }
+
+
+    const id = decodeURIComponent(matches[1]);
+    const query = graphql`
+        query SeriesByIdQuery($id: ID!) {
+            ... UserData
+            series: seriesById(id: $id) { ...SeriesRouteData }
+            rootRealm { ... NavigationData }
+        }
+    `;
+    const queryRef = loadQuery<SeriesByIdQuery>(query, { id: `sr${id}` });
+
+
+    return {
+        render: () => <RootLoader
+            {...{ query, queryRef }}
+            nav={data => <Nav fragRef={data.rootRealm} />}
+            render={result => <SeriesPage seriesFrag={result.series} />}
+        />,
+        dispose: () => queryRef.dispose(),
+    };
+});
+
+const fragment = graphql`
+    fragment SeriesRouteData on Series {
+        __typename
+        ... on WaitingSeries { id } # only for correct type generation ...
+        ... on ReadySeries {
+            title
+            description
+            ... SeriesBlockReadySeriesData
+        }
+    }
+`;
+
+type SeriesPageProps = {
+    seriesFrag: SeriesRouteData$key | null;
+};
+
+const SeriesPage: React.FC<SeriesPageProps> = ({ seriesFrag }) => {
     const { t } = useTranslation();
+    const series = useFragment(fragment, seriesFrag);
 
     if (!series) {
         return <NotFound kind="series" />;

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -108,7 +108,7 @@ const query = graphql`
             isLive
             metadata
             canWrite
-            series { title ... SeriesBlockReadySeriesData }
+            series { id, title ... SeriesBlockReadySeriesData }
             tracks { uri flavor mimetype resolution }
         }
         realm: realmByPath(path: $realmPath) {
@@ -357,7 +357,11 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ event }) => {
     const pairs: [string, ReactNode][] = [];
 
     if (event.series !== null) {
-        pairs.push([t("video.part-of-series"), event.series.title]);
+        pairs.push([
+            t("video.part-of-series"),
+            // eslint-disable-next-line react/jsx-key
+            <Link to={`/!s/${event.series.id.slice(2)}`}>{event.series.title}</Link>,
+        ]);
     }
 
     for (const [namespace, fields] of Object.entries(CONFIG.metadataLabels)) {

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode, useState } from "react";
 import { graphql } from "react-relay/hooks";
 
 import type { VideoQuery, VideoQuery$data } from "./__generated__/VideoQuery.graphql";
@@ -6,17 +6,17 @@ import { loadQuery } from "../relay";
 import { RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
 import { Nav } from "../layout/Navigation";
-import { TextBlock } from "../ui/Blocks/Text";
 import { Player, Track } from "../ui/player";
 import { useTranslation } from "react-i18next";
 import { SeriesBlockFromReadySeries } from "../ui/Blocks/Series";
 import { makeRoute, MatchedRoute } from "../rauta";
-import { Link } from "../router";
-import { FiChevronRight } from "react-icons/fi";
 import { isValidPathSegment } from "./Realm";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { PageTitle } from "../layout/header/ui";
 import { unreachable } from "../util/err";
+import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
+import { HiOutlineUserCircle } from "react-icons/hi";
+import { LinkButton } from "../ui/Button";
 
 
 export const b64regex = "[a-zA-Z0-9\\-_]";
@@ -103,6 +103,7 @@ const query = graphql`
             duration
             thumbnail
             isLive
+            metadata
             canWrite
             series { title ... SeriesBlockReadySeriesData }
             tracks { uri flavor mimetype resolution }
@@ -126,19 +127,7 @@ type Props = {
 };
 
 const VideoPage: React.FC<Props> = ({ event, realm, id, basePath }) => {
-    const { t, i18n } = useTranslation();
-
-    const createdDate = new Date(event.created);
-    const created = createdDate.toLocaleString(i18n.language);
-
-    // If the event was updated only shortly after the creation date, we don't
-    // want to show it.
-    const updatedDate = new Date(event.updated);
-    const updated = updatedDate.getTime() - createdDate.getTime() > 5 * 60 * 1000
-        ? updatedDate.toLocaleString(i18n.language)
-        : null;
-
-    const { title, tracks, description } = event;
+    const { t } = useTranslation();
 
     const breadcrumbs = (realm.isRoot ? realm.ancestors : realm.ancestors.concat(realm))
         .map(({ name, path }) => ({ label: name, link: path }));
@@ -146,42 +135,14 @@ const VideoPage: React.FC<Props> = ({ event, realm, id, basePath }) => {
     return <>
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
         <Player
-            tracks={tracks as Track[]}
-            title={title}
+            tracks={event.tracks as Track[]}
+            title={event.title}
             isLive={event.isLive}
             duration={event.duration}
             coverImage={event.thumbnail}
             css={{ margin: "0 auto" }}
         />
-        <PageTitle title={title} css={{ marginTop: 24, fontSize: 24 }} />
-        {description !== null && <TextBlock content={description} />}
-        <table css={{
-            marginBottom: 16,
-            "& tr": {
-                "& > td:first-child": {
-                    color: "var(--grey40)",
-                    paddingRight: 32,
-                },
-            },
-        }}>
-            <tbody>
-                {/* TODO: improve upon join */}
-                <MetaDatum label={t("video.creator")} value={event.creators.join(", ")} />
-                <MetaDatum label={t("video.created")} value={created} />
-                <MetaDatum label={t("video.updated")} value={updated} />
-                <MetaDatum label={t("video.part-of-series")} value={event.series?.title} />
-            </tbody>
-        </table>
-
-        {event.canWrite && (
-            <Link
-                to={`/~manage/videos/${id.slice(2)}`}
-                css={{ display: "inline-flex", alignItems: "center" }}
-            >
-                {t("manage.my-videos.manage-video")}
-                <FiChevronRight css={{ fontSize: 22 }} />
-            </Link>
-        )}
+        <Metadata id={id} event={event} />
 
         <div css={{ height: 80 }} />
 
@@ -194,18 +155,228 @@ const VideoPage: React.FC<Props> = ({ event, realm, id, basePath }) => {
     </>;
 };
 
-type MetaDatumProps = {
-    label: string;
-    value: string | null | undefined;
+type MetadataProps = {
+    id: string;
+    event: NonNullable<VideoQuery$data["event"]>;
 };
 
-const MetaDatum: React.FC<MetaDatumProps> = ({ label, value }) => {
-    if (value == null) {
+const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
+    const { t } = useTranslation();
+
+    return <>
+        <div css={{ display: "flex", alignItems: "center", marginTop: 24 }}>
+            <div css={{ flex: "1" }}>
+                <VideoTitle title={event.title} />
+                <VideoDate created={event.created} updated={event.updated} />
+            </div>
+            <div>
+                {event.canWrite && (
+                    <LinkButton to={`/~manage/videos/${id.slice(2)}`}>
+                        {t("manage.my-videos.manage-video")}
+                    </LinkButton>
+                )}
+            </div>
+        </div>
+        <hr />
+        <div css={{
+            display: "grid",
+            gridTemplate: "1fr / 1fr fit-content(30%)",
+            columnGap: 48,
+            rowGap: 24,
+            [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
+                gridTemplate: "auto auto / 1fr",
+            },
+        }}>
+            <div css={{ maxWidth: 700 }}>
+                <Creators creators={event.creators} />
+                <Description description={event.description} />
+            </div>
+            <div css={{ paddingTop: 8 }}>
+                <MetadataTable event={event} />
+            </div>
+        </div>
+
+    </>;
+};
+
+type VideoTitleProps = {
+    title: string;
+};
+
+const VideoTitle: React.FC<VideoTitleProps> = ({ title }) => (
+    <PageTitle title={title} css={{
+        marginBottom: 4,
+        fontSize: 22,
+        [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: { fontSize: 20 },
+        [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: { fontSize: 18 },
+        lineHeight: 1.2,
+
+        // Truncate title after two lines
+        display: "-webkit-box",
+        WebkitBoxOrient: "vertical",
+        textOverflow: "ellipsis",
+        WebkitLineClamp: 2,
+        overflow: "hidden",
+    }} />
+);
+
+type CreatorsProps = {
+    creators: readonly string[];
+};
+
+const Creators: React.FC<CreatorsProps> = ({ creators }) => (
+    <div css={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        <HiOutlineUserCircle css={{ color: "var(--grey40)" }} />
+        <ul css={{
+            display: "inline-block",
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            fontSize: 14,
+            fontWeight: "bold",
+            "& > li": {
+                display: "inline-block",
+                "&:not(:last-child)::after": {
+                    content: "'•'",
+                    margin: "0 8px",
+                    color: "var(--grey65)",
+                },
+            },
+        }}>
+            {creators.map((c, i) => <li key={i}>{c}</li>)}
+        </ul>
+    </div>
+);
+
+type DescriptionProps = {
+    description: string | null;
+};
+
+const Description: React.FC<DescriptionProps> = ({ description }) => {
+    if (description === null) {
         return null;
     }
 
-    return <tr>
-        <td>{label}:</td>
-        <td>{value}</td>
-    </tr>;
+    // We ignore all leading or trailing newlines and then split the whole
+    // description by empty lines (two or more consecutive newlines). That's
+    // the typical "make paragraphs from text" algorithm also used by Markdown.
+    // However, we capture those newlines to be able to output any extra
+    // (in addition to two) newlines. If a user typed many newlines in their
+    // description, they probably want to have more space there. The newlines
+    // between and within the paragraphs are then displayed via `white-space:
+    // pre-line` below.
+    const paragraphs = description.replace(/^\n*|\n*$/g, "").split(/(\n{2,})/);
+
+    // TODO: auto link URL-like things?
+    return (
+        <div css={{
+            color: "var(--grey20)",
+            fontSize: 14,
+            lineHeight: "20px",
+            whiteSpace: "pre-line",
+            "& > p:not(:first-child)": {
+                marginTop: 8,
+            },
+        }}>
+            {paragraphs.map((s, i) => i % 2 === 0
+                ? <p key={i}>{s}</p>
+                : s.slice(2))}
+        </div>
+    );
+};
+
+type VideoDateProps = {
+    created: string;
+    updated: string;
+};
+
+const VideoDate: React.FC<VideoDateProps> = props => {
+    const { t, i18n } = useTranslation();
+    const [hovering, setHovering] = useState(false);
+
+    const created = new Date(props.created);
+    const updated = new Date(props.updated);
+
+    const fullOptions = { dateStyle: "long", timeStyle: "short" } as const;
+    const createdDate = created.toLocaleDateString(i18n.language, { dateStyle: "long" });
+    const createdFull = created.toLocaleString(i18n.language, fullOptions);
+    const updatedFull = updated.getTime() - created.getTime() > 5 * 60 * 1000
+        ? updated.toLocaleString(i18n.language, fullOptions)
+        : null;
+
+    return (
+        <div
+            onMouseEnter={() => setHovering(true)}
+            onMouseLeave={() => setHovering(false)}
+            css={{
+                display: "inline-block",
+                position: "relative",
+                color: "var(--grey40)",
+                fontSize: 14,
+            }}
+        >
+            {createdDate}
+            {hovering && <div css={{
+                position: "absolute",
+                left: 2,
+                bottom: "calc(100% + 10px)",
+                width: "max-content",
+                padding: "5px 10px",
+                backgroundColor: "var(--grey86)",
+                borderRadius: 5,
+                color: "black",
+            }}>
+                <div css={{
+                    position: "absolute",
+                    width: 12,
+                    height: 12,
+                    bottom: -5,
+                    left: 20,
+                    backgroundColor: "inherit",
+                    transform: "rotate(45deg)",
+                }} />
+                <i>{t("video.created")}</i>: {createdFull}
+                <br/>
+                <i>{t("video.updated")}</i>: {updatedFull}
+            </div>}
+        </div>
+    );
+};
+
+type MetadataTableProps = {
+    event: NonNullable<VideoQuery$data["event"]>;
+};
+
+const MetadataTable: React.FC<MetadataTableProps> = ({ event }) => {
+    const { t } = useTranslation();
+
+    const pairs: [string, ReactNode][] = [];
+
+    if (event.series !== null) {
+        pairs.push([t("video.part-of-series"), event.series.title]);
+    }
+
+    // TODO: show additional metadata here
+
+    return (
+        <dl css={{
+            display: "grid",
+            columnGap: 16,
+            rowGap: 6,
+            fontSize: 14,
+            lineHeight: 1.3,
+            gridTemplateColumns: "max-content 1fr",
+            "& > dt::after": {
+                content: "':'",
+            },
+            "& > dd": {
+                color: "var(--grey40)",
+            },
+        }}>
+            {pairs.map(([label, value], i) => <React.Fragment key={i}>
+                <dt>{label}</dt>
+                <dd>{value}</dd>
+            </React.Fragment>)}
+        </dl>
+    );
 };

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode } from "react";
 import { graphql } from "react-relay/hooks";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import { useTranslation } from "react-i18next";
@@ -296,7 +296,6 @@ type VideoDateProps = {
 
 const VideoDate: React.FC<VideoDateProps> = props => {
     const { t, i18n } = useTranslation();
-    const [hovering, setHovering] = useState(false);
 
     const created = new Date(props.created);
     const updated = new Date(props.updated);
@@ -309,18 +308,18 @@ const VideoDate: React.FC<VideoDateProps> = props => {
         : null;
 
     return (
-        <div
-            onMouseEnter={() => setHovering(true)}
-            onMouseLeave={() => setHovering(false)}
-            css={{
-                display: "inline-block",
-                position: "relative",
-                color: "var(--grey40)",
-                fontSize: 14,
-            }}
-        >
+        <div css={{
+            display: "inline-block",
+            position: "relative",
+            color: "var(--grey40)",
+            fontSize: 14,
+            "&:hover > div": {
+                display: "initial",
+            },
+        }}>
             {createdDate}
-            {hovering && <div css={{
+            <div css={{
+                display: "none",
                 position: "absolute",
                 left: 2,
                 bottom: "calc(100% + 10px)",
@@ -342,7 +341,7 @@ const VideoDate: React.FC<VideoDateProps> = props => {
                 <i>{t("video.created")}</i>: {createdFull}
                 <br/>
                 <i>{t("video.updated")}</i>: {updatedFull}
-            </div>}
+            </div>
         </div>
     );
 };

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useState } from "react";
 import { graphql } from "react-relay/hooks";
+import { HiOutlineUserCircle } from "react-icons/hi";
+import { useTranslation } from "react-i18next";
 
 import type { VideoQuery, VideoQuery$data } from "./__generated__/VideoQuery.graphql";
 import { loadQuery } from "../relay";
@@ -7,7 +9,6 @@ import { RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
 import { Nav } from "../layout/Navigation";
 import { Player, Track } from "../ui/player";
-import { useTranslation } from "react-i18next";
 import { SeriesBlockFromReadySeries } from "../ui/Blocks/Series";
 import { makeRoute, MatchedRoute } from "../rauta";
 import { isValidPathSegment } from "./Realm";
@@ -15,15 +16,13 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { PageTitle } from "../layout/header/ui";
 import { unreachable } from "../util/err";
 import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
-import { HiOutlineUserCircle } from "react-icons/hi";
 import { LinkButton } from "../ui/Button";
 import CONFIG from "../config";
 import { translatedConfig, match } from "../util";
 import { Link } from "../router";
 import { useUser } from "../User";
+import { b64regex } from "./util";
 
-
-export const b64regex = "[a-zA-Z0-9\\-_]";
 
 export const VideoRoute = makeRoute(url => {
     const urlPath = url.pathname.replace(/^\/|\/$/g, "");

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -98,7 +98,7 @@ const prepare = (id: string, realmPath?: string): MatchedRoute => {
 const query = graphql`
     query VideoQuery($id: ID!, $realmPath: String!) {
         ... UserData
-        event(id: $id) {
+        event: eventById(id: $id) {
             title
             description
             creators

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -17,6 +17,7 @@ import { unreachable } from "../util/err";
 import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
 import { HiOutlineUserCircle } from "react-icons/hi";
 import { LinkButton } from "../ui/Button";
+import { useUser } from "../User";
 
 
 export const b64regex = "[a-zA-Z0-9\\-_]";
@@ -162,6 +163,7 @@ type MetadataProps = {
 
 const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
     const { t } = useTranslation();
+    const user = useUser();
 
     return <>
         <div css={{ display: "flex", alignItems: "center", marginTop: 24 }}>
@@ -170,7 +172,7 @@ const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
                 <VideoDate created={event.created} updated={event.updated} />
             </div>
             <div>
-                {event.canWrite && (
+                {event.canWrite && user !== "none" && user !== "unknown" && (
                     <LinkButton to={`/~manage/videos/${id.slice(2)}`}>
                         {t("manage.my-videos.manage-video")}
                     </LinkButton>

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -34,9 +34,9 @@ type EditSeriesBlockProps = {
 
 export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRef }) => {
 
-    const { series: allSeries } = useFragment(graphql`
+    const { allSeries } = useFragment(graphql`
         fragment SeriesEditModeSeriesData on Query {
-            series {
+            allSeries {
                 id
                 __typename
                 ... on ReadySeries {

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -26,7 +26,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
 
     const { events } = useFragment(graphql`
         fragment VideoEditModeEventData on Query {
-            events { id title }
+            events: allEvents { id title }
         }
     `, useContext(ContentManageQueryContext) as VideoEditModeEventData$key);
 

--- a/frontend/src/routes/manage/Video/Single.tsx
+++ b/frontend/src/routes/manage/Video/Single.tsx
@@ -66,7 +66,7 @@ const BackLink: React.FC = () => {
 const query = graphql`
     query SingleVideoManageQuery($id: ID!) {
         ...UserData
-        event(id: $id) {
+        event: eventById(id: $id) {
             id
             title
             description

--- a/frontend/src/routes/manage/Video/Single.tsx
+++ b/frontend/src/routes/manage/Video/Single.tsx
@@ -17,13 +17,13 @@ import { CopyableInput, Input, TextArea } from "../../../ui/Input";
 import { InputContainer, TitleLabel } from "../../../ui/metadata";
 import { Thumbnail } from "../../../ui/Video";
 import { NotFound } from "../../NotFound";
-import { b64regex } from "../../Video";
 import { PATH as MANAGE_VIDEOS_PATH } from ".";
 import { useUser } from "../../../User";
 import { LinkButton } from "../../../ui/Button";
 import CONFIG from "../../../config";
 import { Breadcrumbs } from "../../../ui/Breadcrumbs";
 import { PageTitle } from "../../../layout/header/ui";
+import { b64regex } from "../../util";
 
 
 export const ManageSingleVideoRoute = makeRoute(url => {

--- a/frontend/src/routes/util.ts
+++ b/frontend/src/routes/util.ts
@@ -1,0 +1,1 @@
+export const b64regex = "[a-zA-Z0-9\\-_]";

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -147,11 +147,11 @@ type Query {
   "Returns an event by its ID."
   event(id: ID!): Event
   "Returns a list of all events the current user has read access to"
-  events: [Event!]!
+  allEvents: [Event!]!
   "Returns a series by its Opencast ID"
   seriesByOpencastId(id: String!): Series
   "Returns a list of all series"
-  series: [Series!]!
+  allSeries: [Series!]!
   "Returns the current user."
   currentUser: User
   "Returns a new JWT that can be used to authenticate against Opencast for uploading videos."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -146,13 +146,13 @@ type Query {
   realmByPath(path: String!): Realm
   "Returns an event by its ID."
   eventById(id: ID!): Event
-  "Returns a list of all events the current user has read access to"
+  "Returns a list of all events the current user has read access to."
   allEvents: [Event!]!
   "Returns a series by its Opencast ID"
   seriesByOpencastId(id: String!): Series
   "Returns a series by its ID."
   seriesById(id: ID!): Series
-  "Returns a list of all series"
+  "Returns a list of all series."
   allSeries: [Series!]!
   "Returns the current user."
   currentUser: User

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -150,6 +150,8 @@ type Query {
   allEvents: [Event!]!
   "Returns a series by its Opencast ID"
   seriesByOpencastId(id: String!): Series
+  "Returns a series by its ID."
+  seriesById(id: ID!): Series
   "Returns a list of all series"
   allSeries: [Series!]!
   "Returns the current user."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -145,7 +145,7 @@ type Query {
   """
   realmByPath(path: String!): Realm
   "Returns an event by its ID."
-  event(id: ID!): Event
+  eventById(id: ID!): Event
   "Returns a list of all events the current user has read access to"
   allEvents: [Event!]!
   "Returns a series by its Opencast ID"

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -16,6 +16,7 @@ type Event implements Node {
   created: DateTimeUtc!
   updated: DateTimeUtc!
   creators: [String!]!
+  metadata: ExtraMetadata!
   "Whether the current user has write access to this event."
   canWrite: Boolean!
   series: ReadySeries
@@ -99,6 +100,9 @@ type Mutation {
 input NewTextBlock {
   content: String!
 }
+
+"Arbitrary metadata for events/series. Serialized as JSON object."
+scalar ExtraMetadata
 
 enum VideoListOrder {
   NEW_TO_OLD

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -46,7 +46,7 @@ begin
 
 
     -- Add a bunch of events/videos
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'bbb',
             'Big Buck Bunny',
@@ -66,9 +66,10 @@ begin
             now(),
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'cosmos-laundromat',
             'Cosmos Laundromat',
@@ -88,9 +89,10 @@ begin
             now() - interval '1 week',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'spring',
             'Spring',
@@ -110,10 +112,11 @@ begin
             now() - interval '2 weeks',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
 
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'bee',
             'Guest Lecture: Group Intelligence of Bumblebees',
@@ -133,10 +136,11 @@ begin
             now(),
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
 
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'pir-introduction',
             'Programmieren in Rust: Einführung',
@@ -156,9 +160,10 @@ begin
             now() - interval '3 weeks',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'pir-modules',
             'Programmieren in Rust: Module',
@@ -178,9 +183,10 @@ begin
             now() - interval '4 weeks',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'pir-stack-heap',
             'Programmieren in Rust: Stack & Heap',
@@ -200,9 +206,10 @@ begin
             now() - interval '5 weeks',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
-    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live)
+    insert into events (opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata)
         values (
             'pir-performance',
             'Programmieren in Rust: Performance & Effizienz',
@@ -222,7 +229,8 @@ begin
             now() - interval '6 weeks',
             '{"ROLE_ANONYMOUS"}',
             '{}',
-            false
+            false,
+            '{}'
         );
 end; $$;
 


### PR DESCRIPTION
This PR receives the extra metadata from Opencast  (see https://github.com/elan-ev/opencast-tobira/pull/69) and stores it in our own DB. This metadata can then be shown on the video page. This is all configurable. It was convenient to implement a better video page design while working on this. There are also some other cleanup commits.

Should be fine to review commit by commit.

CC #376 (does not yet close it because the Opencast side currently only sends dcterms, not extended metadata)

One future improvement I can already think of: if the description is long, truncate it and make it expandable. I don't want to be as aggressive as YouTube for example. But in mobile view, the metadata table shouldn't be pushed down too far.
