### PR TITLE
Add `check` subcommand

### DIFF
--- a/backend/src/args.rs
+++ b/backend/src/args.rs
@@ -62,6 +62,17 @@ pub(crate) enum Command {
         shared: Shared,
     },
 
+    /// Checks config, DB connection, and much more to find problems in Tobira's
+    /// environment.
+    ///
+    /// Useful for updates as you can catch many errors early, without needing
+    /// to restart the running Tobira process. Exits with 0 if everything is
+    /// Ok, and with 1 otherwise.
+    Check {
+        #[structopt(flatten)]
+        shared: Shared,
+    },
+
     /// Outputs a template for the configuration file (which includes
     /// descriptions or all options).
     WriteConfig {

--- a/backend/src/auth/jwt.rs
+++ b/backend/src/auth/jwt.rs
@@ -29,7 +29,7 @@ pub(crate) struct JwtConfig {
     ///
     /// Here, the `sec1.pem` is encoded as SEC1 instead of PKCS#8. The second
     /// command converts the key.
-    secret_key: PathBuf,
+    pub(crate) secret_key: PathBuf,
 
 
     /// The duration for which a JWT is valid. JWTs are just used as temporary

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -1,0 +1,95 @@
+//! A subcommand making sure various things are working. Useful for updating
+//! Tobira where you want to check as many things as possible as early as
+//! possible.
+
+use anyhow::Result;
+
+use crate::{
+    args,
+    load_config_and_init_logger,
+    config::Config,
+    prelude::*, db,
+};
+
+
+pub(crate) async fn run(shared: &args::Shared) -> Result<()> {
+    let config = load_config_and_init_logger(shared)
+        .context("failed to load config: cannot proceed with `check` command")?;
+
+
+    // Perform main checks
+    info!("Starting to verify various things...");
+    let referenced_files = check_referenced_files(&config).await;
+    let meili = check_meili(&config).await;
+    let db_pool = db::create_pool(&config.db).await;
+    info!("Done verifing various things");
+
+
+    // Print summary after all log output
+    let mut any_errors = false;
+    println!();
+    bunt::println!("{$bold+blue+intense}Summary{/$}");
+    println!();
+    print_outcome(&mut any_errors, "Load configuration", &Ok(()));
+    print_outcome(&mut any_errors, "Checking all referenced files", &referenced_files);
+    print_outcome(&mut any_errors, "Connection to MeiliSearch", &meili);
+    print_outcome(&mut any_errors, "Connection to DB", &db_pool);
+
+    println!();
+    if any_errors {
+        bunt::println!("{$red+intense}➡  Errors have occured!{/$}");
+        std::process::exit(1);
+    } else {
+        bunt::println!("{$green+intense}⮕  Everything OK{/$} \
+            {$dimmed}(Tobira probably works in this environment){/$}");
+        println!("   ");
+        Ok(())
+    }
+}
+
+fn print_outcome<T>(any_errors: &mut bool, label: &str, result: &Result<T>) {
+    match result {
+        Ok(_) => {
+            bunt::println!(" ▸ {[bold+intense]}  {$green+bold}✔ ok{/$}", label);
+        }
+        Err(e) => {
+            *any_errors = true;
+            bunt::println!(" ▸ {[bold+intense]}  {$red+bold}✘ error{/$}", label);
+            bunt::println!("      {$red}▶▶▶ {$bold}Error:{/$}{/$} {[yellow+intense]}", e);
+            println!();
+            bunt::println!("      {$red+italic}Caused by:{/$}");
+
+            for (i, cause) in e.chain().skip(1).enumerate() {
+                print!("       {: >1$}", "", i * 2);
+                println!("‣ {cause}");
+            }
+            println!();
+        }
+    }
+}
+
+async fn check_referenced_files(config: &Config) -> Result<()> {
+    // TODO: log file & unix socket?
+
+    let files = [
+        &config.theme.logo.large.path,
+        &config.theme.logo.small.path,
+        &config.theme.favicon,
+        &config.auth.jwt.secret_key,
+    ];
+
+    for path in files {
+        debug!("Trying to open '{}' for reading...", path.display());
+        let _ = tokio::fs::File::open(path)
+            .await
+            .context(format!("could not open '{}' for reading", path.display()))?;
+    }
+
+    Ok(())
+}
+
+async fn check_meili(config: &Config) -> Result<()> {
+    // TODO: maybe check additional things?
+    let _meili = config.meili.connect_only().await?;
+    Ok(())
+}

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -59,13 +59,16 @@ fn print_outcome<T>(any_errors: &mut bool, label: &str, result: &Result<T>) {
             *any_errors = true;
             bunt::println!(" ▸ {[bold+intense]}  {$red+bold}✘ error{/$}", label);
             bunt::println!("      {$red}▶▶▶ {$bold}Error:{/$}{/$} {[yellow+intense]}", e);
-            println!();
-            bunt::println!("      {$red+italic}Caused by:{/$}");
 
-            for (i, cause) in e.chain().skip(1).enumerate() {
-                print!("       {: >1$}", "", i * 2);
-                println!("‣ {cause}");
+            if e.chain().len() > 1 {
+                bunt::println!("      {$red+italic}Caused by:{/$}");
+
+                for (i, cause) in e.chain().skip(1).enumerate() {
+                    print!("       {: >1$}", "", i * 2);
+                    println!("‣ {cause}");
+                }
             }
+
             println!();
         }
     }

--- a/backend/src/cmd/mod.rs
+++ b/backend/src/cmd/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod export_api_schema;
 pub(crate) mod import_realm_tree;
+pub(crate) mod check;

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -138,6 +138,8 @@ impl Config {
 
         fix_path(&base, &mut self.theme.logo.large.path);
         fix_path(&base, &mut self.theme.logo.small.path);
+        fix_path(&base, &mut self.theme.favicon);
+        fix_path(&base, &mut self.auth.jwt.secret_key);
 
         Ok(())
     }

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -10,7 +10,7 @@ use super::Db;
 
 /// Describes the actions needed to bring the database into a state that we
 /// expect.
-enum MigrationPlan {
+pub(crate) enum MigrationPlan {
     /// The database is completely empty: we need to create the meta table and
     /// apply all migrations.
     EmptyDb,

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -15,9 +15,9 @@ mod tx;
 pub(crate) mod types;
 pub(crate) mod util;
 
-pub use self::{
+pub(crate) use self::{
     tx::Transaction,
-    migrations::migrate,
+    migrations::{migrate, MigrationPlan},
 };
 
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -88,6 +88,7 @@ async fn run() -> Result<()> {
             let config = load_config_and_init_logger(shared)?;
             start_worker(config).await?;
         }
+        Command::Check { shared } => cmd::check::run(shared).await?,
         Command::WriteConfig { target } => config::write_template(target.as_ref())?,
         Command::ExportApiSchema { args } => cmd::export_api_schema::run(args)?,
         Command::ImportRealmTree { options, shared } => {

--- a/backend/src/sync/harvest/client.rs
+++ b/backend/src/sync/harvest/client.rs
@@ -16,7 +16,7 @@ use super::HarvestResponse;
 
 
 /// Used to send request to the harvesting API.
-pub(super) struct HarvestClient {
+pub(crate) struct HarvestClient {
     http_client: Client<HttpsConnector<HttpConnector>, Body>,
     scheme: Scheme,
     authority: Authority,
@@ -26,7 +26,7 @@ pub(super) struct HarvestClient {
 impl HarvestClient {
     const API_PATH: &'static str = "/tobira/harvest";
 
-    pub(super) fn new(config: &Config) -> Self {
+    pub(crate) fn new(config: &Config) -> Self {
         // Prepare HTTP client
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
@@ -50,6 +50,12 @@ impl HarvestClient {
             authority: config.opencast.sync_node().authority.clone(),
             auth_header: Secret::new(auth_header),
         }
+    }
+
+    pub(crate) async fn test_connection(&self) -> Result<()> {
+        self.send(Utc.timestamp(0, 0), 2).await
+            .map(|_| ())
+            .context("test harvest request failed")
     }
 
     /// Sends a request to the harvesting API, checks and deserializes the

--- a/backend/src/sync/harvest/client.rs
+++ b/backend/src/sync/harvest/client.rs
@@ -1,19 +1,18 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Utc, TimeZone};
 use hyper::{
     Request, Body,
-    body::Bytes,
     client::{Client, HttpConnector},
-    http::{
-        response,
-        uri::{Authority, Scheme, Uri},
-    }
+    http::uri::{Authority, Scheme, Uri},
+    StatusCode
 };
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use secrecy::{ExposeSecret, Secret};
+use tap::TapFallible;
 
 use crate::{prelude::*, config::Config};
+use super::HarvestResponse;
 
 
 /// Used to send request to the harvesting API.
@@ -53,13 +52,15 @@ impl HarvestClient {
         }
     }
 
-    /// Sends a request to the harvesting API. Returns the response "meta data"
-    /// and the downloaded response body.
+    /// Sends a request to the harvesting API, checks and deserializes the
+    /// response.
     pub(super) async fn send(
         &self,
         since: DateTime<Utc>,
         preferred_amount: u64,
-    ) -> Result<(response::Parts, Bytes)> {
+    ) -> Result<HarvestResponse> {
+        let before = Instant::now();
+
         let pq = format!(
             "{}?since={}&preferredAmount={}",
             Self::API_PATH,
@@ -82,13 +83,31 @@ impl HarvestClient {
 
         debug!("Sending harvest request (since = {:?}): GET {}", since, uri);
 
-        let response = tokio::time::timeout(Duration::from_secs(60), self.http_client.request(req)).await
-            .with_context(|| format!("client request timed out"))?
-            .with_context(|| format!("failed to GET {}", uri))?;
+        let response = tokio::time::timeout(Duration::from_secs(60), self.http_client.request(req))
+            .await
+            .with_context(|| format!("Harvest request timed out (to '{uri}')"))?
+            .with_context(|| format!("Harvest request failed (to '{uri}')"))?;
 
         let (parts, body) = response.into_parts();
         let body = hyper::body::to_bytes(body).await
-            .with_context(|| format!("failed to download body from {}", uri))?;
-        Ok((parts, body))
+            .with_context(|| format!("failed to download body from '{uri}'"))?;
+
+        if parts.status != StatusCode::OK {
+            trace!("HTTP response: {:#?}", parts);
+            bail!("Harvest API returned unexpected HTTP code {}", parts.status);
+        }
+
+        let out = serde_json::from_slice::<HarvestResponse>(&body)
+            .context("Failed to deserialize response from harvesting API")
+            .tap_err(|_| trace!("HTTP response: {:#?}", parts))?;
+
+        debug!(
+            "Received {} KiB ({} items) from the harvest API (in {:.2?})",
+            body.len() / 1024,
+            out.items.len(),
+            before.elapsed(),
+        );
+
+        Ok(out)
     }
 }

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -3,7 +3,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use hyper::http::status::StatusCode;
 use tokio_postgres::types::ToSql;
 
 use crate::{
@@ -37,62 +36,32 @@ pub(crate) async fn run(
     // case of an error.
     let mut backoff = INITIAL_BACKOFF;
 
-    /// Helper macro to call in case of not being able to get a proper response
-    /// from Opencast. Forwards all arguments to `error!`, increases `backoff`
-    /// and sleeps for the backoff period.
-    macro_rules! request_failed {
-        ($($t:tt)*) => {{
-            error!($($t)*);
-
-            // We increase the backoff duration exponentially until we hit the
-            // defined maximum.
-            info!("Waiting {:.1?} due to error before trying again", backoff);
-            tokio::time::sleep(backoff).await;
-            backoff = min(MAX_BACKOFF, backoff.mul_f32(1.5));
-
-            continue;
-        }};
-    }
-
     let client = HarvestClient::new(config);
+    let preferred_amount = config.sync.preferred_harvest_size.into();
 
     loop {
         let sync_status = SyncStatus::fetch(&**db).await
             .context("failed to fetch sync status from DB")?;
 
-
         // Send request to API and deserialize data.
-        let before = Instant::now();
-        let req = client.send(
-            sync_status.harvested_until,
-            config.sync.preferred_harvest_size.into(),
-        );
-        let (response, body) = match req.await {
-            Ok(v) => v,
-            Err(e) => request_failed!("Harvest request failed: {:?}", e),
-        };
-
-        if response.status != StatusCode::OK {
-            trace!("HTTP response: {:#?}", response);
-            request_failed!("Harvest API returned unexpected HTTP code {}", response.status);
-        }
-
-        let harvest_data = match serde_json::from_slice::<HarvestResponse>(&body) {
+        let harvest_data = match client.send(sync_status.harvested_until, preferred_amount).await {
             Ok(v) => v,
             Err(e) => {
-                trace!("HTTP response: {:#?}", response);
-                request_failed!("Failed to deserialize response from harvesting API: {}", e);
-            }
+                error!("Harvest request failed: {:?}", e);
+
+                // We increase the backoff duration exponentially until we hit the
+                // defined maximum.
+                info!("Waiting {:.1?} due to error before trying again", backoff);
+                tokio::time::sleep(backoff).await;
+                backoff = min(MAX_BACKOFF, backoff.mul_f32(1.5));
+
+                continue;
+            },
         };
 
         // Communication with Opencast succeeded: reset backoff time.
         backoff = INITIAL_BACKOFF;
-        debug!(
-            "Received {} KiB ({} items) from the harvest API (in {:.2?})",
-            body.len() / 1024,
-            harvest_data.items.len(),
-            before.elapsed(),
-        );
+
 
         if harvest_data.includes_items_until == sync_status.harvested_until {
             bail!("Opencast's harvest response has 'includesItemsUntil' == 'since'. This means \

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -11,8 +11,9 @@ use crate::{
     search::{self, IndexItemKind}, config::Config,
 };
 use super::status::SyncStatus;
-use self::{client::HarvestClient, response::{HarvestItem, HarvestResponse}};
+use self::response::{HarvestItem, HarvestResponse};
 
+pub(crate) use self::client::HarvestClient;
 
 
 mod client;

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -5,7 +5,7 @@ use crate::{config::Config, db::DbConnection, prelude::*};
 
 
 pub(crate) mod cmd;
-mod harvest;
+pub(crate) mod harvest;
 mod status;
 
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -33,6 +33,8 @@ That file also serves as a good template to copy to your server and then adjust.
 You usually have some additional files that Tobira needs access to (e.g. the logo).
 All file paths you use in the configuration file are relative to the configuration file itself.
 
+You can check the configuration file and all connections by running `tobira check`.
+
 
 ## 6. Run server and sync daemon
 


### PR DESCRIPTION
Closes #272 

This subcommand allows it to easily check for the most likely problems before restarting your tobira service. This should help reduce downtime during updates by knowing about problems early. This PR already contains quite a few useful checks, but I imagine we will add more in the future.

This was just something small to do in between main tasks (I was medium blocked right now). But this PR also contains two commits that refactor some other code, both commits are an improvement IMO.

Can be reviewed commit by commit or also as a whole. 

# Screenshots

**Good:**

![image](https://user-images.githubusercontent.com/7419664/167663402-f75036b2-3830-4956-8150-b53113364a10.png)

**Bad**:

![image](https://user-images.githubusercontent.com/7419664/167663297-c8cc1b8e-454e-4687-8f0f-cec3e6da82a3.png)
