### PR TITLE
Fix DB deserialization failure for metadata without `dcterms`

### DIFF
--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -81,6 +81,7 @@ pub enum SeriesState {
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ExtraMetadata {
     /// Metadata of the dcterms
+    #[serde(default)]
     pub(crate) dcterms: MetadataMap,
 
     /// Extended metadata.


### PR DESCRIPTION
Replaces #430