### PR TITLE
Make the naming of the trusted external key header consistent

### DIFF
--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -95,7 +95,7 @@ pub(crate) struct AuthConfig {
     pub(crate) session_duration: Duration,
 
     /// A shared secret for **trusted** external applications.
-    /// Send this value as the `x-tobira-trusted-key`-header
+    /// Send this value as the `x-tobira-trusted-external-key`-header
     /// to use certain APIs without having to invent a user.
     /// Note that this should be hard to guess, and kept secret.
     /// Specifically, you are going to want to encrypt every channel

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -185,7 +185,7 @@
 #session_duration = "30d"
 
 # A shared secret for **trusted** external applications.
-# Send this value as the `x-tobira-trusted-key`-header
+# Send this value as the `x-tobira-trusted-external-key`-header
 # to use certain APIs without having to invent a user.
 # Note that this should be hard to guess, and kept secret.
 # Specifically, you are going to want to encrypt every channel


### PR DESCRIPTION
In #431 we discussed the naming of the "backdoor header" which was subsequently not changed everywhere. This fixes that.