### PR TITLE
Add security headers to Tobira/test deployment nginx

### DIFF
--- a/.deployment/templates/nginx-host.conf
+++ b/.deployment/templates/nginx-host.conf
@@ -17,7 +17,13 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header Host $http_host;
+
       proxy_pass http://unix:///opt/tobira/{{ id }}/socket/tobira.sock;
+
+      add_header X-Frame-Options deny always;
+      add_header X-Content-Type-Options nosniff always;
+      add_header Referrer-Policy no-referrer-when-downgrade always;
+      add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains' always;
    }
 
 

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -5,7 +5,7 @@ use reinda::{assets, Setup};
 use serde_json::json;
 
 use crate::{config::Config, prelude::*};
-use super::Response;
+use super::{Response, handlers::CommonHeadersExt};
 
 
 const ASSETS: Setup = assets! {
@@ -167,17 +167,17 @@ impl Assets {
     /// Serves the main entry point of the application. This is replied to `/`
     /// and other "public routes", like `/lectures`. Basically everywhere where
     /// the user is supposed to see the website.
-    pub(crate) async fn serve_index(&self) -> Response {
+    pub(crate) async fn serve_index(&self, config: &Config) -> Response {
         let html = self.index().await;
 
         // TODO: include useful data into the HTML file
 
-        let mut builder = Response::builder();
-        builder = builder.header("Content-Type", "text/html; charset=UTF-8");
-
         // TODO: content length
         // TODO: lots of other headers maybe
-
-        builder.body(html).expect("bug: invalid response")
+        Response::builder()
+            .header("Content-Type", "text/html; charset=UTF-8")
+            .with_content_security_policies(config)
+            .body(html)
+            .expect("bug: invalid response")
     }
 }

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -27,10 +27,7 @@ const ASSETS: Setup = assets! {
     "logo-small.svg": { hash, dynamic },
     "favicon.svg": { hash, dynamic },
 
-    "fonts.css": {
-        template,
-        serve: false,
-    },
+    "fonts.css": { hash, template },
 
     // Font files
     "fonts/cyrillic-400.woff2": { hash },

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,7 @@
     <title>{{: var:html-title :}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="/~assets/{{: path:favicon.svg :}}" sizes="any" type="image/svg+xml">
-    <style>{{: include:fonts.css :}}</style>
+    <link rel="stylesheet" href="/~assets/{{: path:fonts.css :}}">
     <style>
       {{: var:global-style :}}
     </style>


### PR DESCRIPTION
See commits. I found [this page](https://securityheaders.com/?q=tobira.opencast.org&hide=on&followRedirects=on) which screamed at me for Tobira not having any relevant headers. That said, most of those are task of the web server, not Tobira itself. I just think Tobira can set an appropriate Content-Security-Policy header, because Tobira knows what scripts and styles and stuff it includes.