### PR TITLE
Add TLS support to PostgreSQL connections and enable TLS by default

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -10,6 +10,7 @@ dcterms.spatial = { en = "Location", de = "Ort" }
 database = "tobira-{{ id }}"
 user = "tobira-{{ id }}"
 password = "tobira-{{ id }}"
+tls_mode = "off"
 
 [meili]
 key = "tobira"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2150,6 +2150,9 @@ dependencies = [
  "rand",
  "reinda",
  "ring",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -2161,6 +2164,7 @@ dependencies = [
  "time 0.3.9",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "toml",
 ]
 
@@ -2214,6 +2218,20 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606f2b73660439474394432239c82249c0d45eb5f23d91f401be1e33590444a7"
+dependencies = [
+ "futures",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -49,6 +49,9 @@ postgres-types = { version = "0.2.2", features = ["derive", "array-impls"] }
 rand = "0.8.4"
 reinda = "0.2"
 ring = "0.16"
+rustls = { version = "0.20", features = ["dangerous_configuration"] }
+rustls-native-certs = "0.6.2"
+rustls-pemfile = "1.0.0"
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -60,6 +63,7 @@ termcolor = "1.1.1"
 time = "0.3"
 tokio = { version = "1.0", features = ["fs", "rt-multi-thread", "macros", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = "0.9"
 toml = "0.5"
 
 

--- a/backend/config.toml
+++ b/backend/config.toml
@@ -6,6 +6,7 @@ site_title.en = "Tobira Videoportal"
 
 [db]
 password = "tobira"
+tls_mode = "off"
 
 [meili]
 key = "tobira"

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -107,6 +107,8 @@ async fn check_referenced_files(config: &Config) -> Result<()> {
             .context(format!("could not open '{}' for reading", path.display()))?;
     }
 
+    config.db.check_server_cert()?;
+
     Ok(())
 }
 

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -110,6 +110,7 @@ impl Config {
     fn validate(&self) -> Result<()> {
         debug!("Validating configuration...");
         self.opencast.validate()?;
+        self.db.validate()?;
 
         Ok(())
     }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -2,7 +2,17 @@
 
 use deadpool_postgres::{Config as PoolConfig, Pool, Runtime};
 use secrecy::{ExposeSecret, Secret};
-use std::time::{Duration, Instant};
+use rustls::{
+    Error,
+    client::{ServerCertVerifier, ServerCertVerified, HandshakeSignatureValid},
+    internal::msgs::handshake::DigitallySignedStruct,
+};
+use std::{
+    fs,
+    path::{PathBuf, Path},
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio_postgres::NoTls;
 
 use crate::{http::{self, Response}, prelude::*};
@@ -42,8 +52,53 @@ pub(crate) struct DbConfig {
     /// The name of the database to use.
     #[config(default = "tobira")]
     database: String,
+
+    /// The TLS mode for the database connection.
+    ///
+    /// - "on": encryption is required and the server certificate is validated
+    ///    against trusted certificates which are loaded from the system's
+    ///    native certificate store. If `server_cert` is set, that's also
+    ///    loaded and trusted.
+    /// - "without-verify-cert": encryption is required, but the server
+    ///   certificate is not checked. Allows MiiM attacks! Discouraged.
+    /// - "off": no encryption. Discouraged even more.
+    #[config(default = "on")]
+    tls_mode: TlsMode,
+
+    /// Path to the server certificate. This makes sense if you don't want to
+    /// install the certificate globally on the system. Has to be a PEM encoded
+    /// file containing one or more X509 certificates.
+    server_cert: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TlsMode {
+    Off,
+    On,
+    WithoutVerifyCert,
+}
+
+impl DbConfig {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.server_cert.is_some() && self.tls_mode != TlsMode::On {
+            bail!(r#"`db.server_cert` is set, but TLS mode is NOT "on", which makes no sense"#);
+        }
+
+        Ok(())
+    }
+
+    /// Checks that the server certificate file, if given, exists and is valid.
+    /// Basically only for the `check` subcommand.
+    pub(crate) fn check_server_cert(&self) -> Result<()> {
+        if let Some(path) = &self.server_cert {
+            let mut root_certs = rustls::RootCertStore::empty();
+            load_pem_file(path, &mut root_certs)
+                .with_context(|| format!("failed to load '{}'", path.display()))?;
+        }
+        Ok(())
+    }
+}
 
 /// Convenience type alias. Every function that needs to operate on the database
 /// can just accept a `db: &Db` parameter.
@@ -61,19 +116,67 @@ pub(crate) async fn create_pool(config: &DbConfig) -> Result<Pool> {
         host: Some(config.host.clone()),
         port: Some(config.port),
         dbname: Some(config.database.clone()),
+        ssl_mode: Some(if config.tls_mode == TlsMode::Off {
+            deadpool_postgres::SslMode::Disable
+        } else {
+            deadpool_postgres::SslMode::Require
+        }),
         .. PoolConfig::default()
     };
 
     debug!(
-        "Connecting to postgresql://{}:*****@{}:{}/{}",
+        "Connecting to 'postgresql://{}:*****@{}:{}/{}' (TLS: {:?})",
         config.user,
         config.host,
         config.port,
         config.database,
+        config.tls_mode,
     );
 
-    let pool = pool_config.create_pool(Some(Runtime::Tokio1), NoTls)?;
+    // Handle TLS and create pool.
+    let pool = if config.tls_mode == TlsMode::Off {
+        pool_config.create_pool(Some(Runtime::Tokio1), NoTls)?
+    } else {
+        // Prepare certificate store. If we do not verify the certificate, it's
+        // just empty. Otherwise we load system-wide root CAs.
+        let mut root_certs = rustls::RootCertStore::empty();
+        if config.tls_mode == TlsMode::On {
+            let system_certs = rustls_native_certs::load_native_certs()
+                .context("failed to load all system-wide certificates")?;
+
+            let count = system_certs.len();
+            for cert in system_certs {
+                root_certs.add(&rustls::Certificate(cert.0))
+                    .context("failed to load system-wide certificate")?;
+            }
+            debug!("Loaded {count} system-wide certificates");
+
+            if let Some(cert_path) = &config.server_cert {
+                load_pem_file(cert_path, &mut root_certs)
+                    .with_context(|| format!("failed to load '{}'", cert_path.display()))?;
+                debug!(
+                    "Loaded {} certificates from '{}'",
+                    root_certs.len() - count,
+                    cert_path.display(),
+                );
+            }
+        }
+
+        let mut tls_config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_certs)
+            .with_no_client_auth();
+
+        // Disable certificate validation if requested.
+        if config.tls_mode == TlsMode::WithoutVerifyCert {
+            tls_config.dangerous().set_certificate_verifier(Arc::new(DangerousAlwaysAcceptCerts));
+        }
+
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+        pool_config.create_pool(Some(Runtime::Tokio1), tls)?
+    };
     info!("Created database pool");
+
 
     // Test the connection by executing a simple query.
     let client = pool.get().await
@@ -81,6 +184,7 @@ pub(crate) async fn create_pool(config: &DbConfig) -> Result<Pool> {
     client.execute("select 1", &[]).await
         .context("failed to execute DB test query")?;
     debug!("Successfully tested database connection with test query");
+
 
     // Make sure the database uses UTF8 encoding. There is no good reason to use
     // anything else.
@@ -110,4 +214,60 @@ pub(crate) async fn get_conn_or_service_unavailable(pool: &Pool) -> Result<DbCon
     }
 
     Ok(connection)
+}
+
+
+/// Loads the PEM file at `path` and adds all X509 certificates in it to
+/// `root_certs`. Returns an error if a non-x509 item is found.
+fn load_pem_file(path: &Path, root_certs: &mut rustls::RootCertStore) -> Result<()> {
+    let file = fs::read(path).context("could not read file")?;
+
+    let items = rustls_pemfile::read_all(&mut &*file).context("could not parse file as PEM")?;
+    for item in items {
+        if let rustls_pemfile::Item::X509Certificate(cert) = item {
+            root_certs.add(&rustls::Certificate(cert)).context("failed to load X509 certificate")?;
+        } else {
+            bail!("found unexpected item, expected X509 certificate");
+        }
+    }
+
+    Ok(())
+}
+
+/// Dummy certificate verifier, that blindly always says "it's valid". This is
+/// used in the "don't check certificates" mode. Unfortunately, as rustls
+/// values an API where it's hard to do potentially insecure things, it's a bit
+/// of boilerplate.
+pub(crate) struct DangerousAlwaysAcceptCerts;
+
+impl ServerCertVerifier for DangerousAlwaysAcceptCerts {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::client::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+
+    }
 }

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -90,6 +90,24 @@
 # Default value: "tobira"
 #database = "tobira"
 
+# The TLS mode for the database connection.
+#
+# - "on": encryption is required and the server certificate is validated
+#    against trusted certificates which are loaded from the system's
+#    native certificate store. If `server_cert` is set, that's also
+#    loaded and trusted.
+# - "without-verify-cert": encryption is required, but the server
+#   certificate is not checked. Allows MiiM attacks! Discouraged.
+# - "off": no encryption. Discouraged even more.
+#
+# Default value: "on"
+#tls_mode = "on"
+
+# Path to the server certificate. This makes sense if you don't want to
+# install the certificate globally on the system. Has to be a PEM encoded
+# file containing one or more X509 certificates.
+#server_cert =
+
 
 [http]
 # The TCP port the HTTP server should listen on.


### PR DESCRIPTION
Closes #406 

Some notes:
- I used rustls instead of openssl or native-tls as we already use it elsewhere.
- I did not include the postgres `prefer` or `allow` as ssl modes as our postgres lib only supports `prefer` and I don't really see the point in that.