### PR TITLE
Use nonce with emotion-js to make it work without `unsafe-inline` CSP

### DIFF
--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -4,7 +4,6 @@ use bstr::ByteSlice;
 use cookie::Cookie;
 use hyper::{HeaderMap, header};
 use postgres_types::ToSql;
-use rand::{CryptoRng, RngCore};
 use secrecy::{ExposeSecret, Secret};
 use std::time::Duration;
 use tokio_postgres::Error as PgError;
@@ -24,22 +23,7 @@ pub(crate) struct SessionId(pub(crate) Secret<[u8; LENGTH]>);
 impl SessionId {
     /// Creates a new, random session ID.
     pub(crate) fn new() -> Self {
-        // We use this extra function here to make sure we use a
-        // cryptographically secure RNG, even after updating to newer `rand`
-        // versions. Right now, we use `thread_rng` and it is cryptographically
-        // secure. But if the `rand` authors make `thread_rng` return a
-        // non-cryptographically secure RNG in future major version(a dangerous
-        // API decision in my opinion) and if the Tobira dev updating the
-        // library does not check the changelog, then we would have a problem.
-        // This explicit `CryptoRng` bound makes sure that such a change would
-        // not silently compile.
-        fn generate(mut rng: impl RngCore + CryptoRng) -> [u8; LENGTH] {
-            let mut bytes = [0; LENGTH];
-            rng.fill_bytes(&mut bytes);
-            bytes
-        }
-
-        Self(Secret::new(generate(rand::thread_rng())))
+        Self(crate::util::gen_random_bytes_crypto())
     }
 
     /// Tries to read the session ID from the session cookie. Returns `None` if

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,10 +19,10 @@ type Props = {
 };
 
 export const App: React.FC<Props> = ({ initialRoute }) => (
-    <GlobalErrorBoundary>
-        <RelayEnvironmentProvider {...{ environment }}>
-            <GlobalStyle />
-            <SilenceEmotionWarnings>
+    <SilenceEmotionWarnings>
+        <GlobalErrorBoundary>
+            <RelayEnvironmentProvider {...{ environment }}>
+                <GlobalStyle />
                 <Router initialRoute={initialRoute}>
                     <APIWrapper>
                         <MenuProvider>
@@ -31,9 +31,9 @@ export const App: React.FC<Props> = ({ initialRoute }) => (
                         </MenuProvider>
                     </APIWrapper>
                 </Router>
-            </SilenceEmotionWarnings>
-        </RelayEnvironmentProvider>
-    </GlobalErrorBoundary>
+            </RelayEnvironmentProvider>
+        </GlobalErrorBoundary>
+    </SilenceEmotionWarnings>
 );
 
 /**
@@ -46,7 +46,10 @@ export const App: React.FC<Props> = ({ initialRoute }) => (
  * Full story: https://github.com/emotion-js/emotion/issues/1105
  */
 const SilenceEmotionWarnings: React.FC<{ children: ReactNode }> = ({ children }) => {
-    const cache = createEmotionCache({ key: "css" });
+    const cache = createEmotionCache({
+        key: "css",
+        nonce: document.documentElement.dataset.tobiraStyleNonce,
+    });
     cache.compat = true;
 
     return <CacheProvider value={cache}>{children}</CacheProvider>;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html data-tobira-style-nonce="{{ nonce }}">
   <head>
     <title>{{: var:html-title :}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="/~assets/{{: path:favicon.svg :}}" sizes="any" type="image/svg+xml">
     <link rel="stylesheet" href="/~assets/{{: path:fonts.css :}}">
-    <style>
+    <style nonce="{{ nonce }}">
       {{: var:global-style :}}
     </style>
     <script id="tobira-frontend-config" type="application/json">


### PR DESCRIPTION
We want to remove 'unsafe-inline' from the `style-src` CSP. We can't yet
do that because Paella emits inline CSS. But this already fixes all 
other sources of inline CSS by using a nonce.

Paella issue: https://github.com/polimediaupv/paella-core/issues/74

Note: you might wonder how this nonce thing helps with anything since
the nonce is sent inside the HTML file. And yes, if an attacker also
injects JS code, then they can read the nonce and also insert CSS that 
way. But we still prevent the case where the attacker is only able to 
inject CSS (think a comment).