### PR TITLE
Fix and improve host realm queries

### DIFF
--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -43,9 +43,13 @@ pub(crate) trait Series {
         let query = format!("\
             select {cols} \
             from realms \
-            inner join blocks \
-                on realms.id = blocks.realm_id and
-                type = 'series' and blocks.series_id = $1 \
+            where exists ( \
+                select 1 as contains \
+                from blocks \
+                where realm_id = realms.id \
+                and type = 'series' \
+                and series_id = $1 \
+            ) \
         ");
         context.db.query_mapped(
             &query,


### PR DESCRIPTION
The host realm queries reported realms more than once if the
corresponding entity was included in a realm more than once.
(For example an event could be included directly because it is
featured, but the series is included as well.)
The easy fix would be to throw in a `distinct`, but these queries
actually perform ever so slightly better, and I happen to think
that they capture the intent better as well.