### PR TITLE
Remove font configuration

### DIFF
--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -11,20 +11,6 @@ pub(crate) struct ThemeConfig {
     #[config(default = 100)]
     pub(crate) header_height: u32,
 
-    /// Path to CSS file that includes all used font files and sets the variable
-    /// `--main-font` in the `:root` selector. For example:
-    ///
-    /// ```text
-    /// :root {
-    ///     --main-font: 'Open Sans';
-    /// }
-    ///
-    /// @font-face { font-family: 'Open Sans'; src: ...; }
-    /// ```
-    ///
-    /// If not set, the default font will be used.
-    pub(crate) fonts: Option<String>,
-
     #[config(nested)]
     pub(crate) logo: LogoConfig,
 

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -74,9 +74,6 @@ impl Assets {
         path_overrides.insert("logo-large.svg".into(), config.theme.logo.large.path.clone());
         path_overrides.insert("logo-small.svg".into(), config.theme.logo.small.path.clone());
         path_overrides.insert("favicon.svg".into(), config.theme.favicon.clone());
-        if let Some(fonts_css) = &config.theme.fonts {
-            path_overrides.insert("fonts.css".into(), fonts_css.into());
-        }
 
         let mut variables = <HashMap<String, String>>::new();
         variables.insert("version".into(), crate::version());

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -390,20 +390,6 @@
 # Default value: 100
 #header_height = 100
 
-# Path to CSS file that includes all used font files and sets the variable
-# `--main-font` in the `:root` selector. For example:
-#
-# ```text
-# :root {
-#     --main-font: 'Open Sans';
-# }
-#
-# @font-face { font-family: 'Open Sans'; src: ...; }
-# ```
-#
-# If not set, the default font will be used.
-#fonts =
-
 # Path to an SVG file that is used as favicon.
 #
 # Required! This value must be specified.


### PR DESCRIPTION
This will likely change in the future anyway, but not before
the release. This way we avoid breaking a (not fully functioning)
configuration option down the line.