### PR TITLE
Install and configure Paella Zoom plugin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "i18next-browser-languagedetector": "^6.1.4",
         "paella-basic-plugins": "^1.0.16",
         "paella-core": "^1.1.3",
+        "paella-zoom-plugin": "^1.0.11",
         "plyr-react": "^5.0.2",
         "raw-loader": "^4.0.2",
         "react": "^18.1.0",
@@ -6626,6 +6627,14 @@
         "hls.js": "^1.0.4"
       }
     },
+    "node_modules/paella-zoom-plugin": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/paella-zoom-plugin/-/paella-zoom-plugin-1.0.11.tgz",
+      "integrity": "sha512-tEZ8KcV5smq5ndxqMnjpcmK3onYyxqu2jDIAwwgcekHUiBb5zQlkTWg2V6+Xwy5lnrgULcDqS/QzOp+Gdd0twA==",
+      "dependencies": {
+        "paella-core": "^1.0.36"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12952,6 +12961,14 @@
       "requires": {
         "core-js": "^3.8.2",
         "hls.js": "^1.0.4"
+      }
+    },
+    "paella-zoom-plugin": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/paella-zoom-plugin/-/paella-zoom-plugin-1.0.11.tgz",
+      "integrity": "sha512-tEZ8KcV5smq5ndxqMnjpcmK3onYyxqu2jDIAwwgcekHUiBb5zQlkTWg2V6+Xwy5lnrgULcDqS/QzOp+Gdd0twA==",
+      "requires": {
+        "paella-core": "^1.0.36"
       }
     },
     "parent-module": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "i18next-browser-languagedetector": "^6.1.4",
     "paella-basic-plugins": "^1.0.16",
     "paella-core": "^1.1.3",
+    "paella-zoom-plugin": "^1.0.11",
     "plyr-react": "^5.0.2",
     "raw-loader": "^4.0.2",
     "react": "^18.1.0",

--- a/frontend/src/typings/paella-zoom-plugin.d.ts
+++ b/frontend/src/typings/paella-zoom-plugin.d.ts
@@ -1,0 +1,3 @@
+declare module "paella-zoom-plugin" {
+    export default function (): __WebpackModuleApi.RequireContext;
+}

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
-import { Config, Manifest, Paella, Source, Stream } from "paella-core";
+import { Config, Paella, Source, Stream } from "paella-core";
 import getBasicPluginsContext from "paella-basic-plugins";
+import getZoomPluginContext from "paella-zoom-plugin";
 
 import { isHlsTrack, Track } from ".";
 import { SPEEDS } from "./consts";
@@ -55,9 +56,10 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ tracks, title, duration, is
                 getVideoId: async () => "dummy-id",
                 getManifestUrl: async () => "dummy-url",
                 getManifestFileUrl: async () => "dummy-file-url",
-                loadVideoManifest: async (): Promise<Manifest> => manifest,
+                loadVideoManifest: async () => manifest,
                 customPluginContext: [
                     getBasicPluginsContext(),
+                    getZoomPluginContext(),
                 ],
             });
             paella.current.loadManifest();
@@ -137,10 +139,18 @@ const PAELLA_CONFIG = {
                 },
             ],
         },
+
+        // Canvas plugins
         "es.upv.paella.videoCanvas": {
             enabled: true,
             order: 1,
         },
+        "es.upv.paella.zoomPlugin": {
+            enabled: true,
+            order: 0,
+        },
+
+        // Format plugins
         "es.upv.paella.mp4VideoFormat": {
             enabled: true,
             order: 1,


### PR DESCRIPTION
Closes #461.

This only installs and enables the zoom plugin. You can zoom using the Alt key plus the scroll wheel and you get an overlay with a hint to that effect when you zoom the whole page (overlay appears over one of the tracks; which one is configurable) and/or scroll over one of the videos (overlay appears over the corresponding track).

All of this is default behavior of the zoom plugin. Specifically, there are no buttons to enable zooming. We might want to discuss how exactly we prefer to add them, using the options provided by the plugin. See also [here](https://github.com/polimediaupv/paella-zoom-plugin/blob/main/README.md).