### PR TITLE
Update to MeiliSearch 0.27.2

### DIFF
--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -32,7 +32,7 @@
     - name: install MeiliSearch
       become: true
       get_url:
-        url: https://github.com/meilisearch/meilisearch/releases/download/v0.26.1/meilisearch-linux-amd64
+        url: https://github.com/meilisearch/meilisearch/releases/download/v0.27.2/meilisearch-linux-amd64
         dest: /opt/meili/meilisearch
         mode: '0755'
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1062,6 +1062,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
+dependencies = [
+ "base64",
+ "ring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "juniper"
 version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,15 +1235,16 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-sdk"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eae404a5052ee03460ad87998e00cc78e5c68ec3eb23f673f1c13007d150697"
+checksum = "e980fc979f653877693451f5b31d065a6f607c45988ac117a8316c90f73c7cdc"
 dependencies = [
  "async-trait",
  "futures",
  "isahc",
  "iso8601-duration",
  "js-sys",
+ "jsonwebtoken",
  "log",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -40,7 +40,7 @@ hyperlocal = { version = "0.8", default-features = false, features = ["server"] 
 juniper = { version = "0.15.7", default-features = false, features = ["chrono", "schema-language"] }
 juniper_hyper = "0.8.0"
 log = { version = "0.4", features = ["serde", "std"] }
-meilisearch-sdk = "0.15.0"
+meilisearch-sdk = "0.17.0"
 mime_guess = { version = "2", default-features = false }
 once_cell = "1.5"
 p256 = { version = "0.11", features = ["jwk"] }

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -2,7 +2,7 @@ use meilisearch_sdk::indexes::Index;
 
 use crate::{prelude::*, config::Config, db};
 
-use super::{Client, util};
+use super::Client;
 
 
 #[derive(Debug, clap::Subcommand)]
@@ -144,19 +144,9 @@ async fn status(meili: &Client) -> Result<()> {
 async fn index_status(name: &str, index: &Index) -> Result<()> {
     bunt::println!("{$bold}# Index `{[green+intense]}`:{/$}", name);
 
-    let info = match index.fetch_info().await {
-        Ok(info) => info,
-        Err(e) if util::is_index_not_found(&e) => {
-            bunt::println!("{$red+intense}Does not exist!{/$}");
-            return Ok(());
-        },
-        Err(e) => return Err(e.into()),
-    };
     let stats = index.get_stats().await?;
     info_line!("Number of documents", stats.number_of_documents);
     info_line!("Is currently indexing", stats.is_indexing);
-    info_line!("Created", info.createdAt);
-    info_line!("Updated", info.updatedAt);
 
     Ok(())
 }

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use meilisearch_sdk::{document::Document, indexes::Index};
+use meilisearch_sdk::indexes::Index;
 use serde::{Serialize, Deserialize};
 use tokio_postgres::GenericClient;
 
@@ -44,15 +44,11 @@ pub(crate) struct Event {
     pub(crate) host_realms: Vec<Realm>,
 }
 
-impl Document for Event {
-   type UIDType = SearchId;
-   fn get_uid(&self) -> &Self::UIDType {
-       &self.id
-   }
-}
-
 impl IndexItem for Event {
     const KIND: IndexItemKind = IndexItemKind::Event;
+    fn id(&self) -> SearchId {
+        self.id
+    }
 }
 
 impl_from_db!(

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -195,12 +195,9 @@ impl IndexItemKind {
     }
 }
 
-pub(crate) trait IndexItem: meilisearch_sdk::document::Document<UIDType = SearchId> {
+pub(crate) trait IndexItem: serde::Serialize {
     const KIND: IndexItemKind;
-
-    fn id(&self) -> SearchId {
-        *self.get_uid()
-    }
+    fn id(&self) -> SearchId;
 }
 
 

--- a/backend/src/search/realm.rs
+++ b/backend/src/search/realm.rs
@@ -1,4 +1,4 @@
-use meilisearch_sdk::{document::Document, indexes::Index};
+use meilisearch_sdk::indexes::Index;
 use postgres_types::FromSql;
 use serde::{Serialize, Deserialize};
 use tokio_postgres::GenericClient;
@@ -22,15 +22,11 @@ pub(crate) struct Realm {
     pub(crate) ancestor_names: Vec<Option<String>>,
 }
 
-impl Document for Realm {
-   type UIDType = SearchId;
-   fn get_uid(&self) -> &Self::UIDType {
-       &self.id
-   }
-}
-
 impl IndexItem for Realm {
     const KIND: IndexItemKind = IndexItemKind::Realm;
+    fn id(&self) -> SearchId {
+        self.id
+    }
 }
 
 impl_from_db!(

--- a/scripts/meilisearch/docker-compose.yml
+++ b/scripts/meilisearch/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   meili:
-    image: getmeili/meilisearch:v0.25.2
+    image: getmeili/meilisearch:v0.27.2
     restart: unless-stopped
     ports:
       - 127.0.0.1:7700:7700


### PR DESCRIPTION
Nothing interesting about the update. Hopefully we can update to 0.28
soon -- we are only waiting for `meilisearch_sdk` to be updated. That
could take a while though, as 0.28 brought a lot of API changes.

The `status` command now doesn't show the "created" and "modified" dates
anymore as the documentation is really unclear on how to get them and
what they represent.

Sadly, the `meilisearch_sdk` crate doesn't seem to get updated very quickly. It is still missing the typo tolerance configuration APIs from 0.27, so we couldn't use them here. Well, we can always send raw HTTP requests, but uff. 