### PR TITLE
Remove "generate backend documentation" step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
     - name: Test backend
       working-directory: backend
       run: cargo test
-    - name: Generate documenation for backend
-      working-directory: backend
-      run: cargo doc --no-deps
     - name: Make sure `schema.graphql` is up to date
       working-directory: backend
       run: cargo run -- export-api-schema | diff -u --color=always - ../frontend/src/schema.graphql


### PR DESCRIPTION
It serves basically no purpose except maybe catching invalid intra-doc
links. But really, we haven't been saved by it at all. This is not a
library with tons of documentation. It just costs time as it has to
check all dependencies again.