### PR TITLE
Move "queue for search index" logic completely to DB triggers

### DIFF
--- a/backend/src/cmd/import_realm_tree.rs
+++ b/backend/src/cmd/import_realm_tree.rs
@@ -68,18 +68,6 @@ pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
     insert_realm(&**conn, &root, 0, &mut dummy_blocks).await?;
     info!("Done inserting realms");
 
-    // To reindex them, we just queue them all. This tool is currently only used
-    // as intial import, so it's fine.
-    info!("Queue all realms for reindexing...");
-    let sql = "\
-        insert into search_index_queue (item_id, kind) \
-        select id, 'realm' \
-        from realms \
-        on conflict do nothing\
-    ";
-    conn.execute(sql, &[]).await?;
-    info!("Queued all realms");
-
     Ok(())
 }
 

--- a/backend/src/db/migrations/10-search-index-queue.sql
+++ b/backend/src/db/migrations/10-search-index-queue.sql
@@ -110,7 +110,7 @@ begin
     insert into search_index_queue (item_id, kind)
     select affected.id, 'realm'
     from blocks
-    inner join realms on blocks.realm_id = realms.id
+    inner join realms on blocks.id = realms.name_from_block
     inner join realms affected on affected.full_path like realms.full_path || '%'
     -- Ho ho ho, this is interesting. To deduplicate some code, we use this
     -- function with both, events and series. And we don't even care which kind

--- a/backend/src/db/migrations/10-search-index-queue.sql
+++ b/backend/src/db/migrations/10-search-index-queue.sql
@@ -62,7 +62,7 @@ for each row
 execute procedure queue_blocks_for_reindex();
 
 
--- Triggers to queue realms.
+-- On realm changes, some realms and events have to be queued.
 
 create function queue_realm_for_reindex(realm realms) returns void language sql as $$
     insert into search_index_queue (item_id, kind)
@@ -93,6 +93,20 @@ begin
         from realms
         where full_path like new.full_path || '/%'
         on conflict do nothing;
+
+        -- We also need to queue all events that are included on any of those
+        -- sub realms as they store their host realms. This time, we include
+        -- the realm itself (note the '%' instead of '/%' above).
+        insert into search_index_queue (item_id, kind)
+        select events.id, 'event'
+        from events
+        inner join blocks on (
+            type = 'series' and series_id = events.series
+            or type = 'video' and video_id = events.id
+        )
+        inner join realms on realms.id = blocks.realm_id
+        where full_path like new.full_path || '%'
+        on conflict do nothing;
     end if;
     return null;
 end;
@@ -105,20 +119,38 @@ for each row
 execute procedure queue_touched_realm_for_reindex();
 
 
+-- On series or event title changes, some realms and events have to be queued.
+
 create function queue_realm_on_updated_title() returns trigger language plpgsql as $$
 begin
+    -- A realm is affected if it is a decendant of a realm which resolved names
+    -- has changed due to the series/video title change.
+    with affected_realms as (
+        select affected.*
+        from blocks
+        inner join realms on blocks.id = realms.name_from_block
+        inner join realms as affected on affected.full_path like realms.full_path || '%'
+        -- Ho ho ho, this is interesting. To deduplicate some code, we use this
+        -- function with both, events and series. And we don't even care which kind
+        -- this function is called with. We just accept both. This is fine
+        -- because: (a) a series and event having the same ID is exceeeeedingly
+        -- rare, and (b) if this virtually impossible case actually arises, we just
+        -- unnecessarily queue some events -> no harm done.
+        where blocks.series_id = new.id or blocks.video_id = new.id
+    )
     insert into search_index_queue (item_id, kind)
-    select affected.id, 'realm'
-    from blocks
-    inner join realms on blocks.id = realms.name_from_block
-    inner join realms affected on affected.full_path like realms.full_path || '%'
-    -- Ho ho ho, this is interesting. To deduplicate some code, we use this
-    -- function with both, events and series. And we don't even care which kind
-    -- this function is called with. We just accept both. This is fine
-    -- because: (a) a series and event having the same ID is exceeeeedingly
-    -- rare, and (b) if this virtually impossible case actually arises, we just
-    -- unnecessarily queue some events -> no harm done.
-    where blocks.series_id = new.id or blocks.video_id = new.id
+    -- The realms themselves have to be queued.
+    select id, 'realm'::search_index_item_kind
+    from affected_realms
+    union all
+    -- But also all events included somewhere in those realms.
+    select events.id, 'event'::search_index_item_kind
+    from affected_realms
+    inner join blocks on affected_realms.id = blocks.realm_id
+    inner join events on (
+        type = 'series' and series_id = events.series
+        or type = 'video' and video_id = events.id
+    )
     on conflict do nothing;
 
     return null;
@@ -136,3 +168,65 @@ after update of title
 on events
 for each row
 execute procedure queue_realm_on_updated_title();
+
+
+-- On event changes, the event has to be queued.
+
+create function queue_event_for_reindex(event events) returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    values (event.id, 'event')
+    on conflict do nothing
+$$;
+
+create function queue_touched_event_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_event_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_event_for_reindex(new);
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_touched_event_for_reindex
+after insert or delete or update
+on events
+for each row
+execute procedure queue_touched_event_for_reindex();
+
+
+-- On series changes, all events of that series has to be queued.
+
+create function queue_all_events_of_series_for_reindex(series series) returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    select events.id, 'event'
+    from events
+    where events.series = series.id
+    on conflict do nothing
+$$;
+
+create function queue_all_events_of_touched_series_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_all_events_of_series_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_all_events_of_series_for_reindex(new);
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_all_events_of_touched_series_for_reindex
+after insert or delete or update
+on series
+for each row
+execute procedure queue_all_events_of_touched_series_for_reindex();

--- a/backend/src/db/migrations/10-search-index-queue.sql
+++ b/backend/src/db/migrations/10-search-index-queue.sql
@@ -82,6 +82,8 @@ begin
         perform queue_realm_for_reindex(new);
     end if;
 
+    -- If the name of this realm has changed, we also need to queue all child
+    -- realms as their 'ancestor_names' have changed.
     if tg_op = 'UPDATE' and (
         old.name is distinct from new.name or
         old.name_from_block is distinct from new.name_from_block

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -1,6 +1,5 @@
 use std::{time::{Duration, Instant}, fmt};
 
-use futures::pin_mut;
 use meilisearch_sdk::{
     client::Client as MeiliClient,
     indexes::Index,
@@ -10,7 +9,6 @@ use meilisearch_sdk::{
 use postgres_types::{FromSql, ToSql};
 use secrecy::{Secret, ExposeSecret};
 use serde::{Deserialize, Serialize};
-use tokio_postgres::{binary_copy::BinaryCopyInWriter, GenericClient};
 
 use crate::{
     db::{DbConnection, types::Key},
@@ -241,61 +239,6 @@ impl fmt::Debug for SearchId {
 
 // ===== Various functions ========================================================================
 
-/// Adds many items to the "search index queue" to mark them as "needs update in
-/// index".
-pub(crate) async fn queue_many(
-    db: &mut impl GenericClient,
-    items: impl IntoIterator<Item = (Key, IndexItemKind)>,
-) -> Result<()> {
-    let tx = db.transaction().await?;
-
-    // Here we prepare a dummy statement in order to acquire the `Type`s of the
-    // two fields.
-    let statement = tx
-        .prepare("insert into search_index_queue (item_id, kind) values ($1, $2)")
-        .await?;
-    let id_type = statement.params()[0].clone();
-    let kind_type = statement.params()[1].clone();
-
-    // Unfortunately, upserting via `COPY IN` is not trivially possible, so we
-    // have to use a workaround. We create a new temporary table in which we
-    // `COPY IN`.
-    let temp_table = format!(
-        "temp_search_index_queue_bulk_upsert_helper_{}",
-        rand::random::<u128>(),
-    );
-    let sql = format!("create temp table {temp_table} \
-        (like search_index_queue including defaults including identity)
-        on commit drop");
-    tx.execute(&sql, &[]).await
-        .context("failed to create temporary table for bulk upsert")?;
-
-    // We insert the data via `COPY IN`, one of the fastest ways to bulk insert.
-    let sql = format!("copy {temp_table} (item_id, kind) from stdin binary");
-    let sink = tx.copy_in(&sql).await?;
-    let writer = BinaryCopyInWriter::new(sink, &[id_type, kind_type]);
-    pin_mut!(writer);
-    for (id, kind) in items {
-        writer.as_mut().write(&[&id, &kind]).await?;
-    }
-    writer.finish().await?;
-
-    // Now we still have to move the data from the temporary table to the main
-    // table.
-    let sql = format!("insert into search_index_queue (item_id, kind) \
-        select item_id, kind \
-        from {temp_table} \
-        on conflict do nothing");
-    let affected = tx.execute(&sql, &[]).await?;
-
-    // Commit transaction, which also drops the temporary table.
-    tx.commit().await
-        .context("failed to commit bulk search queue insert")?;
-
-    debug!("Enqueued {affected} items into search index queue");
-
-    Ok(())
-}
 
 /// Deletes all indexes (used by Tobira) including all their data! If any index
 /// does not exist, this function just does nothing.

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -102,7 +102,7 @@ impl OcClient {
         let (out, body_len) = Self::deserialize_response::<HarvestResponse>(response, &uri).await?;
         debug!(
             "Received {} KiB ({} items) from the harvest API (in {:.2?})",
-            body_len,
+            body_len / 1024,
             out.items.len(),
             before.elapsed(),
         );


### PR DESCRIPTION
This change slowed down the sync process a small bit (the majority of time is still spent waiting for Opencast). It also slowed down the `import-realm-tree` utility notably, but that's not for production and should be optimized anyway (it's using many singular `insert`s).

Using the big test data, changing the name of the `/lectures` page (which has >2000 descendants) either directly or indirectly (via series name), was very quick. I couldn't tell the difference to before this change. So I think that's totally fine.