### PR TITLE
Remove `_id` suffix from foreign key columns in the database

### DIFF
--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -246,10 +246,11 @@ impl_from_db!(
             ty: "type",
             index,
             text_content,
-            series_id,
+            series,
             videolist_order,
-            video_id, show_title,
-            realm_id,
+            video,
+            show_title,
+            realm,
         },
     },
     |row| {
@@ -257,7 +258,7 @@ impl_from_db!(
         let shared = SharedData {
             id: Id::block(row.id()),
             index: row.index::<i16>().into(),
-            realm_key: row.realm_id(),
+            realm_key: row.realm(),
         };
 
         match ty {
@@ -273,14 +274,14 @@ impl_from_db!(
 
             BlockType::Series => SeriesBlock {
                 shared,
-                series: row.series_id::<Option<Key>>().map(Id::series),
+                series: row.series::<Option<Key>>().map(Id::series),
                 order: unwrap_type_dep(row.videolist_order(), "series", "videolist_order"),
                 show_title: unwrap_type_dep(row.show_title(), "series", "show_title"),
             }.into(),
 
             BlockType::Video => VideoBlock {
                 shared,
-                event: row.video_id::<Option<Key>>().map(Id::event),
+                event: row.video::<Option<Key>>().map(Id::event),
                 show_title: unwrap_type_dep(row.show_title(), "event", "show_title"),
             }.into(),
         }
@@ -304,7 +305,7 @@ impl BlockValue {
         let query = format!(
             "select {selection} \
                 from blocks \
-                where realm_id = $1 \
+                where realm = $1 \
                 order by index asc",
         );
         context.db

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -163,10 +163,10 @@ impl AuthorizedEvent {
             where exists ( \
                 select 1 as contains \
                 from blocks \
-                where realm_id = realms.id \
+                where realm = realms.id \
                 and ( \
-                    type = 'video' and video_id = $1 \
-                    or type = 'series' and series_id = ( \
+                    type = 'video' and video = $1 \
+                    or type = 'series' and series = ( \
                         select series from events where id = $1 \
                     ) \
                 ) \

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -104,8 +104,8 @@ pub(crate) struct Realm {
 /// SQL join expression that is used in almost all realm-related queries.
 pub(crate) const REALM_JOINS: &str = "\
     left join blocks on blocks.id = name_from_block \
-    left join events on blocks.video_id = events.id \
-    left join series on blocks.series_id = series.id \
+    left join events on blocks.video = events.id \
+    left join series on blocks.series = series.id \
 ";
 
 impl_from_db!(
@@ -351,9 +351,9 @@ impl Realm {
             let query = "select exists(\
                 select 1 \
                 from blocks \
-                where realm_id = $1 and ( \
-                    video_id = $2 or \
-                    series_id = (select series from events where id = $2) \
+                where realm = $1 and ( \
+                    video = $2 or \
+                    series = (select series from events where id = $2) \
                 )\
             )";
             context.db.query_one(&query, &[&self.key, &event_key])
@@ -362,7 +362,7 @@ impl Realm {
                 .pipe(Ok)
         } else if let Some(series_key) = id.key_for(Id::SERIES_KIND) {
             let query = "select exists(\
-                select 1 from blocks where realm_id = $1 and series_id = $2\
+                select 1 from blocks where realm = $1 and series = $2\
             )";
             context.db.query_one(&query, &[&self.key, &series_key])
                 .await?

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -46,9 +46,9 @@ pub(crate) trait Series {
             where exists ( \
                 select 1 as contains \
                 from blocks \
-                where realm_id = realms.id \
+                where realm = realms.id \
                 and type = 'series' \
-                and series_id = $1 \
+                and series = $1 \
             ) \
         ");
         let id = self.id().key_for(Id::SERIES_KIND).unwrap();

--- a/backend/src/cmd/import_realm_tree.rs
+++ b/backend/src/cmd/import_realm_tree.rs
@@ -153,14 +153,14 @@ impl Block {
         match self {
             Block::Title(title) => {
                 let query = "
-                    insert into blocks (realm_id, type, index, text_content)
+                    insert into blocks (realm, type, index, text_content)
                     values ($1, 'title', $2, $3)
                 ";
                 db.execute(query, &[&realm_id, &(index as i16), title]).await?;
             }
             Block::Text(text) => {
                 let query = "
-                    insert into blocks (realm_id, type, index, text_content)
+                    insert into blocks (realm, type, index, text_content)
                     values ($1, 'text', $2, $3)
                 ";
                 db.execute(query, &[&realm_id, &(index as i16), text]).await?;
@@ -193,7 +193,7 @@ impl Block {
                 // Insert block
                 let query = "
                     insert into blocks
-                    (realm_id, type, index, series_id, videolist_order, show_title)
+                    (realm, type, index, series, videolist_order, show_title)
                     values ($1, 'series', $2, $3, 'new_to_old', true)
                 ";
                 db.execute(query, &[&realm_id, &(index as i16), &series_id]).await?;

--- a/backend/src/db/migrations/06-blocks.sql
+++ b/backend/src/db/migrations/06-blocks.sql
@@ -13,7 +13,7 @@ create type video_list_order as enum ('new_to_old', 'old_to_new');
 create table blocks (
     -- Shared properties
     id bigint primary key default randomized_id('block'),
-    realm_id bigint not null references realms on delete cascade,
+    realm bigint not null references realms on delete cascade,
     type block_type not null,
     index smallint not null,
 
@@ -21,20 +21,20 @@ create table blocks (
     text_content text,
 
     -- Series blocks
-    series_id bigint references series on delete set null,
+    series bigint references series on delete set null,
 
     -- All videolist-like blocks
     videolist_order video_list_order,
 
     -- Video blocks
-    video_id bigint references events on delete set null,
+    video bigint references events on delete set null,
 
     -- Blocks with a "natural title"
     show_title boolean default true,
 
 
     -- Enforce several constraints
-    constraint index_unique_in_realm unique(realm_id, index) deferrable initially immediate,
+    constraint index_unique_in_realm unique(realm, index) deferrable initially immediate,
     constraint index_positive check (index >= 0),
 
     constraint title_block_has_fields check (type <> 'title' or (
@@ -53,8 +53,8 @@ create table blocks (
 );
 
 -- Blocks are almost always looked up by realm ID.
-create index idx_block_realm_id on blocks (realm_id);
+create index idx_block_realm on blocks (realm);
 
 -- Sometimes, we quickly need to find out which blocks reference a specific event or series.
-create index idx_block_series_id on blocks (series_id);
-create index idx_block_video_id on blocks (video_id);
+create index idx_block_series on blocks (series);
+create index idx_block_video on blocks (video);

--- a/backend/src/db/migrations/11-search-views.sql
+++ b/backend/src/db/migrations/11-search-views.sql
@@ -14,8 +14,8 @@ create view search_realms as
         ) as ancestor_names
     from realms
     left join blocks on blocks.id = realms.name_from_block
-    left join events on blocks.video_id = events.id
-    left join series on blocks.series_id = series.id;
+    left join events on blocks.video = events.id
+    left join series on blocks.series = series.id;
 
 
 create view search_events as
@@ -36,8 +36,8 @@ create view search_events as
     from events
     left join series on events.series = series.id
     left join blocks on (
-        type = 'series' and series_id = events.series
-        or type = 'video' and video_id = events.id
+        type = 'series' and blocks.series = events.series
+        or type = 'video' and blocks.video = events.id
     )
-    left join search_realms on search_realms.id = blocks.realm_id
+    left join search_realms on search_realms.id = blocks.realm
     group by events.id, series.id;

--- a/util/fixtures.sql
+++ b/util/fixtures.sql
@@ -28,7 +28,7 @@ begin
     perform create_top_level_realm('Conferences', E'Videos from conferences our university hosts. Like: '
         '\n- Gamescom \n- ComicCon \n- BlizzCon \n- recon \n- RustFest.eu');
 
-    insert into blocks (realm_id, type, index, text_content)
+    insert into blocks (realm, type, index, text_content)
         values (
             0, 'text', 0,
             E'**Welcome to Tobira!**\n\n'
@@ -40,10 +40,10 @@ begin
             'containing a bunch of dummy data. All text and videos you can see here are just for '
             'testing.'
         );
-    insert into blocks (realm_id, type, index, series_id, videolist_order, show_title)
+    insert into blocks (realm, type, index, series, videolist_order, show_title)
         values (0, 'series', 1, series_university_highlights, 'new_to_old', true);
 
-    insert into blocks (realm_id, type, index, series_id, videolist_order, show_title)
+    insert into blocks (realm, type, index, series, videolist_order, show_title)
         values (events_realm_id, 'series', 1, series_christmas, 'new_to_old', true);
 
 
@@ -256,7 +256,7 @@ begin
         values (name, 0, replace(lower(name), ' ', '-'))
         returning id into realm_id;
 
-    insert into blocks (realm_id, type, index, text_content)
+    insert into blocks (realm, type, index, text_content)
         values (realm_id, 'text', '0', description);
 
     return realm_id;
@@ -274,7 +274,7 @@ begin
         values ('Lectures', 0, 'lectures')
         returning id into root;
 
-    insert into blocks (realm_id, type, index, text_content)
+    insert into blocks (realm, type, index, text_content)
         values (root, 'text', '0', 'Here you can see all lecture recordings.');
 
     perform department(root, 'Mathematics');
@@ -298,7 +298,7 @@ begin
         values (name, lectures_root, replace(lower(name), ' ', '-'))
         returning id into root;
 
-    insert into blocks (realm_id, type, index, text_content)
+    insert into blocks (realm, type, index, text_content)
         values (root, 'text', '0', format(
             'Hello to the department of %s! We are very proud of what we have achieved in '
                 || 'this department and there is a lot of interesting stuff around here. '


### PR DESCRIPTION
Based on #487, thus draft.