### PR TITLE
Fix video page for videos with an audio(-only) track, and fix the infinite loop in our error handling caused by it

### DIFF
--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -45,8 +45,8 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
             return { error };
         }
 
-        // Not our problem
-        return { error: undefined };
+        // Not our problem, but still an error, so we throw it up to the next boundary
+        throw error;
     }
 
     public render(): ReactNode {


### PR DESCRIPTION
Thanks to @CGreweling for point this out to us!