### PR TITLE
Automatically rebuild search index when necessary (plus refactoring)

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -30,14 +30,8 @@ pub(crate) trait Node {
 /// deal with the "not allowed" case.
 pub(crate) struct NotAllowed;
 
-#[juniper::graphql_object(Context = Context)]
-impl NotAllowed {
-    /// Unused dummy field for this marker type. GraphQL requires all objects to
-    /// have at least one field. Always returns `null`.
-    fn dummy() -> Option<bool> {
-        None
-    }
-}
+super::util::impl_object_with_dummy_field!(NotAllowed);
+
 
 /// Opaque cursor for pagination. Serializes as string.
 ///

--- a/backend/src/api/err.rs
+++ b/backend/src/api/err.rs
@@ -66,6 +66,20 @@ impl From<tokio_postgres::Error> for ApiError {
     }
 }
 
+impl From<meilisearch_sdk::errors::Error> for ApiError {
+    fn from(src: meilisearch_sdk::errors::Error) -> Self {
+        // Logging the error here is not _ideal_ but it's probably totally fine
+        // for us.
+        error!("Meili error: {}", src);
+        debug!("Detailed error: {:#?}", src);
+        Self {
+            msg: format!("Error with Meili: {src}"),
+            kind: ApiErrorKind::InternalServerError,
+            key: None,
+        }
+    }
+}
+
 impl<S: ScalarValue> IntoFieldError<S> for ApiError {
     fn into_field_error(self) -> juniper::FieldError<S> {
         let msg = format!("{}: {}", self.kind.message_prefix(), self.msg);

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -9,12 +9,13 @@ use self::{
 pub(crate) mod mutation;
 pub(crate) mod query;
 pub(crate) mod subscription;
+pub(crate) mod util;
 
+mod common;
 mod context;
 mod err;
 mod id;
 mod model;
-mod common;
 
 pub(crate) use self::{
     id::Id,

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -12,7 +12,7 @@ use super::{
         realm::Realm,
         event::{AuthorizedEvent, Event},
         series::Series,
-        search::{self, SearchResults},
+        search::{self, SearchOutcome},
     },
 };
 
@@ -103,7 +103,7 @@ impl Query {
     }
 
     /// Returns `null` if the query is too short.
-    async fn search(query: String, context: &Context) -> ApiResult<Option<SearchResults>> {
+    async fn search(query: String, context: &Context) -> ApiResult<SearchOutcome> {
         search::perform(&query, context).await
     }
 }

--- a/backend/src/api/util.rs
+++ b/backend/src/api/util.rs
@@ -1,0 +1,14 @@
+macro_rules! impl_object_with_dummy_field {
+    ($ty:ident) => {
+        #[juniper::graphql_object(Context = crate::api::Context)]
+        impl $ty {
+            /// Unused dummy field for this marker type. GraphQL requires all objects to
+            /// have at least one field. Always returns `null`.
+            fn dummy() -> Option<bool> {
+                None
+            }
+        }
+    };
+}
+
+pub(crate) use impl_object_with_dummy_field;

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -51,7 +51,11 @@ pub(crate) async fn run(shared: &args::Shared) -> Result<()> {
                 => println!("    ▸ DB is compatible, {new_migrations} new migrations will be applied"),
         }
     }
-    print_outcome(&mut any_errors, "Connection to MeiliSearch", &meili);
+    print_outcome(&mut any_errors, "MeiliSearch", &meili);
+    match meili {
+        Ok(true) => println!("    ▸ Requires rebuild (is automatically done by 'tobira worker')"),
+        _ => {},
+    }
     print_outcome(&mut any_errors, "Connection to Opencast harvesting API", &opencast_sync);
 
     println!();
@@ -112,7 +116,8 @@ async fn check_referenced_files(config: &Config) -> Result<()> {
     Ok(())
 }
 
-async fn check_meili(config: &Config) -> Result<()> {
+/// Returns `true` if a rebuild is necessary
+async fn check_meili(config: &Config) -> Result<bool> {
     let meili = config.meili.connect().await?;
 
     // Check that the API key is valid and can access the indexes.
@@ -120,7 +125,10 @@ async fn check_meili(config: &Config) -> Result<()> {
     let _ = meili.event_index.get_stats().await?;
     let _ = meili.realm_index.get_stats().await?;
 
-    Ok(())
+    let state = crate::search::IndexState::fetch(&meili.meta_index).await?;
+    info!("Search index state: {state:?}");
+
+    Ok(state.needs_rebuild())
 }
 
 async fn check_opencast_sync(config: &Config) -> Result<()> {

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -113,7 +113,7 @@ async fn check_referenced_files(config: &Config) -> Result<()> {
 }
 
 async fn check_meili(config: &Config) -> Result<()> {
-    let meili = config.meili.connect_only().await?;
+    let meili = config.meili.connect().await?;
 
     // Check that the API key is valid and can access the indexes.
     let _ = meili.client.get_stats().await?;

--- a/backend/src/db/cmd.rs
+++ b/backend/src/db/cmd.rs
@@ -113,7 +113,7 @@ async fn clear(db: &mut Db, config: &Config) -> Result<()> {
 
     info!("Dropped and recreated schema 'public'");
 
-    let meili = config.meili.connect_only().await?;
+    let meili = config.meili.connect().await?;
     crate::search::clear(meili).await?;
 
     Ok(())

--- a/backend/src/db/cmd.rs
+++ b/backend/src/db/cmd.rs
@@ -114,7 +114,10 @@ async fn clear(db: &mut Db, config: &Config) -> Result<()> {
     info!("Dropped and recreated schema 'public'");
 
     let meili = config.meili.connect().await?;
-    crate::search::clear(meili).await?;
+    crate::search::writer::with_write_lock(db, &meili, |_tx, meili| Box::pin(async move {
+        crate::search::clear(&meili).await
+    })).await.context("failed to clear search index")?;
+    info!("Cleared search index");
 
     Ok(())
 }

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -206,7 +206,6 @@ async fn handle_api(req: Request<Body>, ctx: &Context) -> Result<Response, Respo
                 if let Err(e) = tx.rollback().await {
                     error!("Failed to rollback transaction: {e}\nWill give up now. Transaction \
                         should be rolled back automatically since it won't be committed.");
-
                 }
 
                 return Ok(response::internal_server_error());

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -127,7 +127,6 @@ async fn start_worker(config: Config) -> Result<Never> {
 
     let db = connect_and_migrate_db(&config).await?;
     let search = config.meili.connect().await.context("failed to connect to MeiliSearch")?;
-    search.prepare(&mut db.get().await?).await.context("failed to prepare search index")?;
 
     let mut search_conn = db.get().await?;
     let sync_conn = db.get().await?;

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -37,7 +37,7 @@ pub(crate) enum SearchIndexCommand {
 
 /// Entry point for `search-index` commands.
 pub(crate) async fn run(cmd: &SearchIndexCommand, config: &Config) -> Result<()> {
-    let meili = config.meili.connect_only().await?;
+    let meili = config.meili.connect().await?;
 
     match cmd {
         SearchIndexCommand::Status => status(&meili).await?,

--- a/backend/src/search/meta.rs
+++ b/backend/src/search/meta.rs
@@ -18,6 +18,13 @@ pub(crate) struct Meta {
     /// A flag that is set to `true` while transitioning to a new index version.
     /// If the transition fails or is interrupted, the flag stays set and
     /// Tobira will rebuild again next time.
+    ///
+    /// Example: Search index schema version is currently 5. Tobira executable
+    /// is updated and requires schema version 6, thus needs to rebuild
+    /// everything. Halfway through the rebuild, something breaks and the
+    /// rebuild is aborted. Now the Tobira binary gets rolled back to require
+    /// schema version 5. If we didn't have a dirty flag, the search index
+    /// (in its broken state) would just be accepted.
     pub(crate) dirty: bool,
 }
 

--- a/backend/src/search/meta.rs
+++ b/backend/src/search/meta.rs
@@ -21,6 +21,26 @@ pub(crate) struct Meta {
     pub(crate) dirty: bool,
 }
 
+impl Meta {
+    pub(crate) const ID: &'static str = "meta";
+
+    pub(crate) fn current_dirty() -> Self {
+        Self {
+            id: Self::ID.into(),
+            version: VERSION,
+            dirty: true,
+        }
+    }
+
+    pub(crate) fn current_clean() -> Self {
+        Self {
+            id: Self::ID.into(),
+            version: VERSION,
+            dirty: false,
+        }
+    }
+}
+
 /// Versioning state of the index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum IndexState {

--- a/backend/src/search/meta.rs
+++ b/backend/src/search/meta.rs
@@ -1,0 +1,58 @@
+use meilisearch_sdk::indexes::Index;
+use serde::{Serialize, Deserialize};
+
+use crate::prelude::*;
+
+use super::VERSION;
+
+
+/// Data stored in the 'meta' index.
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Meta {
+    pub(crate) id: String,
+
+    /// A number simply counting up whenever we change the search index in a way
+    /// that requires a rebuild.
+    pub(crate) version: u32,
+
+    /// A flag that is set to `true` while transitioning to a new index version.
+    /// If the transition fails or is interrupted, the flag stays set and
+    /// Tobira will rebuild again next time.
+    pub(crate) dirty: bool,
+}
+
+/// Versioning state of the index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IndexState {
+    NoVersionInfo,
+    BrokenVersionInfo,
+    Info {
+        dirty: bool,
+        version: u32,
+    },
+}
+
+impl IndexState {
+    pub(crate) fn needs_rebuild(self) -> bool {
+        self != Self::Info { dirty: false, version: VERSION }
+    }
+
+    pub(crate) async fn fetch(index: &Index) -> Result<Self> {
+        let mut documents = index.get_documents::<serde_json::Value>(None, None, None)
+            .await
+            .context("failed to fetch search index meta info")?;
+
+        if documents.is_empty() {
+            return Ok(Self::NoVersionInfo);
+        }
+
+        if documents.len() > 1 {
+            bail!("More than one document in meta search index");
+        }
+
+        match serde_json::from_value::<Meta>(documents.remove(0)) {
+            Err(_) => Ok(Self::BrokenVersionInfo),
+            Ok(Meta { version, dirty, .. }) => Ok(Self::Info { version, dirty }),
+        }
+    }
+}

--- a/backend/src/search/meta.rs
+++ b/backend/src/search/meta.rs
@@ -34,7 +34,12 @@ pub(crate) enum IndexState {
 
 impl IndexState {
     pub(crate) fn needs_rebuild(self) -> bool {
-        self != Self::Info { dirty: false, version: VERSION }
+        match self {
+            // Tobira versions that did not store any meta info were on version 1.
+            IndexState::NoVersionInfo => VERSION != 1,
+            IndexState::BrokenVersionInfo => true,
+            IndexState::Info { dirty, version } => dirty || version != VERSION,
+        }
     }
 
     pub(crate) async fn fetch(index: &Index) -> Result<Self> {

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -27,6 +27,7 @@ mod util;
 use self::writer::MeiliWriter;
 pub(crate) use self::{
     event::Event,
+    meta::IndexState,
     realm::Realm,
     update::{update_index, update_index_daemon},
 };

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -56,9 +56,7 @@ pub(crate) struct MeiliConfig {
 impl MeiliConfig {
     /// Connects to Meili, tests the connections and prepares all indexes.
     pub(crate) async fn connect_and_prepare(&self, db: &mut DbConnection) -> Result<Client> {
-        let client = Client::new(self.clone()).await
-            .with_context(|| format!("failed to connect to MeiliSearch at '{}'", self.host))?;
-
+        let client = self.connect_only().await?;
         client.prepare(db).await?;
 
         Ok(client)

--- a/backend/src/search/update.rs
+++ b/backend/src/search/update.rs
@@ -18,9 +18,7 @@ use super::{
 
 /// Calls `update_index` roughly every `config.update_interval` and never returns.
 pub(crate) async fn update_index_daemon(meili: &Client, db: &mut DbConnection) -> Result<Never> {
-    super::writer::with_write_lock(db, meili, |_tx, meili| Box::pin(async move {
-        super::prepare_indexes(&meili).await
-    })).await.context("failed to prepare search index")?;
+    meili.prepare_and_rebuild_if_necessary(db).await?;
 
     loop {
         let loop_started_at = Instant::now();

--- a/backend/src/search/update.rs
+++ b/backend/src/search/update.rs
@@ -18,6 +18,10 @@ use super::{
 
 /// Calls `update_index` roughly every `config.update_interval` and never returns.
 pub(crate) async fn update_index_daemon(meili: &Client, db: &mut DbConnection) -> Result<Never> {
+    super::writer::with_write_lock(db, meili, |_tx, meili| Box::pin(async move {
+        super::prepare_indexes(&meili).await
+    })).await.context("failed to prepare search index")?;
+
     loop {
         let loop_started_at = Instant::now();
 

--- a/backend/src/search/writer.rs
+++ b/backend/src/search/writer.rs
@@ -1,11 +1,9 @@
 use std::{time::Duration, future::Future, pin::Pin};
 
+use deadpool_postgres::ClientWrapper;
 use tokio_postgres::IsolationLevel;
 
-use crate::{
-    db::DbConnection,
-    prelude::*,
-};
+use crate::prelude::*;
 
 use super::Client;
 
@@ -44,7 +42,7 @@ impl std::ops::Deref for MeiliWriter<'_> {
 /// references a reference-type argument is hard to impossible to implement
 /// right now. It's sad. After testing quite a few things, I decided to simply go
 /// with a `dyn Future`.
-pub(crate) async fn with_write_lock<F, T>(db: &mut DbConnection, meili: &Client, f: F) -> Result<T>
+pub(crate) async fn with_write_lock<F, T>(db: &mut ClientWrapper, meili: &Client, f: F) -> Result<T>
 where
     F: for<'a> FnOnce(&'a deadpool_postgres::Transaction<'a>, MeiliWriter<'a>)
         -> Pin<Box<dyn 'a + Future<Output = Result<T>>>>,

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -157,6 +157,7 @@ search:
   title: Suchergebnisse für „{{query}}“
   no-results: Keine Ergebnisse
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
+  unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.
 
 upload:
   title: Video hochladen

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -155,6 +155,7 @@ search:
   title: Search results for “{{query}}”
   no-results: No results
   too-few-characters: Please type more characters to start the search.
+  unavailable: The search is currently unavailable. Try again later.
 
 upload:
   title: Upload video

--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -81,7 +81,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                                 marginTop: "min(150px, 12vh)",
                                 marginBottom: 16,
                             }}>
-                                <summary css={{ }}>
+                                <summary css={{ cursor: "pointer" }}>
                                     {t("errors.detailed-error-info")}
                                 </summary>
                                 <pre css={{

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -44,6 +44,14 @@ type RealmNameFromBlock {
 "An opaque cursor used for pagination"
 scalar Cursor
 
+"""
+  Return type of the search API. `EmptyQuery` is only returned if the passed
+  search query is empty. `SearchUnavailable` is returned if the backend
+  search service is, for some reason, not available. Otherwise
+  `SearchResults` is returned.
+"""
+union SearchOutcome = SearchUnavailable | EmptyQuery | SearchResults
+
 type RemovedRealm {
   parent: Realm!
 }
@@ -147,6 +155,14 @@ type VideoBlock implements Block & RealmNameSourceBlock {
   id: ID!
   index: Int!
   realm: Realm!
+}
+
+type SearchUnavailable {
+  """
+    Unused dummy field for this marker type. GraphQL requires all objects to
+    have at least one field. Always returns `null`.
+  """
+  dummy: Boolean
 }
 
 type AuthorizedEvent implements Node {
@@ -387,7 +403,7 @@ type Query {
   "Retrieve a node by globally unique ID. Mostly useful for relay."
   node(id: ID!): Node
   "Returns `null` if the query is too short."
-  search(query: String!): SearchResults
+  search(query: String!): SearchOutcome!
 }
 
 interface RealmNameSourceBlock {
@@ -398,6 +414,14 @@ enum RealmOrder {
   BY_INDEX
   ALPHABETIC_ASC
   ALPHABETIC_DESC
+}
+
+type EmptyQuery {
+  """
+    Unused dummy field for this marker type. GraphQL requires all objects to
+    have at least one field. Always returns `null`.
+  """
+  dummy: Boolean
 }
 
 input UpdateSeriesBlock {


### PR DESCRIPTION
This got a bit more complex than I thought. The main changes of this PR:

- There is a new `tobira_meta` index in Meili that stores a version number, representing the version of our search index schema.
- `tobira search-index update` and `tobira worker` will now automatically rebuild the search index when the schema version is incompatible.
- `tobira serve` is able to start without Meili (fixes #394) and does not mutate the search index at all. The frontend now shows a slightly nicer "search unavailable" when Meili is still not reachable when a search is being done.

But there are more changes. Please take a look at the commits.

---

As an overview, what sub-command does what with Meili?

- `serve`
  - Does not require Meili at startup. Only contacts Meili when a search is being done.
  - Does not (anymore) prepare the indexes -> only uses Meili read-only. 
  - Key insight: there is no point in preparing the indexes, if the subcommand doesn't also populate them! And it doesn't and shouldn't. So we leave the index preparation to `worker`, for example.

- `db clear`, `search-index clear`, `search-index status`, and `check`
  - Connect to Meili and error if not reachable.
  - Do not prepare indexes: the latter two commands are clearly "read only" ones. And for `clear`, all indexes are removed anyway as part of the command.

- `search-index rebuild`
  - Connects to Meili and errors if not reachable.
  - All indexes are cleared and prepared as part of the command.

- `search-index update` and `worker`
  - Connects to Meili and errors if not reachable.
  - Prepares indexes AND rebuilds everything if necessary. 

---

Also, this removes the `--without-clear` flag from `search-index rebuild`, so I guess this is a breaking change? Seems so super minor and useless to highlight in the release notes? Opinions?