### PR TITLE
Print newlines (soft `clear`) in dev watch scripts to make terminal output easier to read

### DIFF
--- a/util/scripts/clr.sh
+++ b/util/scripts/clr.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Just print a bunch of newlines. This is useful to kind of "clear" the screen,
+# but still having previous output accessible. We only do anything if this has
+# been invoked in response to a file change, so that we don't print a bunch of
+# newlines when starting dev scripts.
+if [[ ! -z "$WATCHEXEC_COMMON_PATH" ]]; then
+    for i in {1..40}; do
+       echo
+    done
+fi

--- a/util/scripts/on-backend-change.sh
+++ b/util/scripts/on-backend-change.sh
@@ -13,12 +13,18 @@ reload_once_port_is_open() {
     $reload_command
 }
 
-
+"$basedir"/clr.sh
 cd "$basedir"/../../backend || exit 1
 
 cargo build || exit 1
 
-./target/debug/tobira export-api-schema ../frontend/src/schema.graphql
+# Only override schema if it changed. This is mainly to avoid 'clr.sh' being run
+# needlessly. We invoke tobira twice to avoid having to deal with temporary
+# files. The invocation is super fast anyway.
+schema_out=../frontend/src/schema.graphql
+./target/debug/tobira export-api-schema | cmp --silent - $schema_out \
+    || ./target/debug/tobira export-api-schema $schema_out
+
 ./target/debug/tobira write-config ../docs/config.toml
 reload_once_port_is_open &
 ./target/debug/tobira serve

--- a/util/scripts/on-backend-change.sh
+++ b/util/scripts/on-backend-change.sh
@@ -18,7 +18,7 @@ cd "$basedir"/../../backend || exit 1
 
 cargo build || exit 1
 
-cargo run -- export-api-schema ../frontend/src/schema.graphql
-cargo run -- write-config ../docs/config.toml
+./target/debug/tobira export-api-schema ../frontend/src/schema.graphql
+./target/debug/tobira write-config ../docs/config.toml
 reload_once_port_is_open &
-cargo run -- serve
+./target/debug/tobira serve

--- a/util/scripts/watch-frontend.sh
+++ b/util/scripts/watch-frontend.sh
@@ -19,7 +19,7 @@ mkdir -p build
     # compiler. We start it via explicit part as 'npx' adds about 200ms startup time.
     watchexec \
         --watch src \
-        --ignore '*__generated__*' \
+        --ignore '**/__generated__/*' \
         -- ./node_modules/.bin/relay-compiler --output quiet-with-errors &
 
     # Let webpack do the watching itself as startup time for webpack are really bad.

--- a/util/scripts/watch-frontend.sh
+++ b/util/scripts/watch-frontend.sh
@@ -20,7 +20,7 @@ mkdir -p build
     watchexec \
         --watch src \
         --ignore '**/__generated__/*' \
-        -- ./node_modules/.bin/relay-compiler --output quiet-with-errors &
+        -- '../util/scripts/clr.sh; ./node_modules/.bin/relay-compiler --output quiet-with-errors' &
 
     # Let webpack do the watching itself as startup time for webpack are really bad.
     npx webpack watch --mode=development --no-stats &


### PR DESCRIPTION
See commits.