### PR TITLE
Improve icon for going to "my videos" from "manage single video" page

### DIFF
--- a/frontend/src/routes/manage/Video/Single.tsx
+++ b/frontend/src/routes/manage/Video/Single.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { FiArrowLeft, FiExternalLink } from "react-icons/fi";
+import { FiCornerLeftUp, FiExternalLink } from "react-icons/fi";
 import { graphql } from "react-relay";
 
 import { RootLoader } from "../../../layout/Root";
@@ -55,7 +55,7 @@ const BackLink: React.FC = () => {
     const { t } = useTranslation();
     const items = [
         <LinkWithIcon key={MANAGE_VIDEOS_PATH} to={MANAGE_VIDEOS_PATH} iconPos="left">
-            <FiArrowLeft />
+            <FiCornerLeftUp />
             {t("manage.nav.my-videos")}
         </LinkWithIcon>,
     ];


### PR DESCRIPTION
It was previously confused with just "going back", but since one can also get from the main video page to the "manage single" page, it was confusing.

Old icon:

![image](https://user-images.githubusercontent.com/7419664/185886599-fc5eb6ea-eb1d-40a2-b85b-49e4ecab82c8.png)


New icon:

![image](https://user-images.githubusercontent.com/7419664/185886519-d747aecf-1288-4b69-8c1f-dd8398ca328f.png)
