### PR TITLE
Normalize `margin` for some elements

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -108,4 +108,7 @@ const GLOBAL_STYLE = css({
         border: "none",
         borderTop: "1px solid var(--grey80)",
     },
+    "input, button": {
+        margin: 0,
+    },
 });


### PR DESCRIPTION
Safari has a minimal margin around `input`-s and `button`-s,
leading to some alignment issues in our UI.