### PR TITLE
Add `no-unused-expressions` lint

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -8,6 +8,10 @@ const noUnusedVarsOptions = {
     caughtErrorsIgnorePattern: "^_",
     ignoreRestSiblings: true,
 };
+const noUnusedExpressionsOptions = {
+    allowTernary: true,
+    enforceForJSX: true,
+};
 const braceStyle = ["warn", "1tbs", { allowSingleLine: true }];
 const quoteOptions = ["double", { avoidEscape: true }];
 
@@ -64,6 +68,7 @@ module.exports = {
         "no-multiple-empty-lines": ["warn", { max: 5 }],
         "no-tabs": "warn",
         "no-unused-vars": ["warn", noUnusedVarsOptions],
+        "no-unused-expressions": ["warn", noUnusedExpressionsOptions],
         "object-curly-spacing": ["warn", "always"],
         "object-property-newline": ["warn", {
             allowAllPropertiesOnSameLine: true,
@@ -115,10 +120,12 @@ module.exports = {
             "indent": "off",
             "lines-between-class-members": "off",
             "no-unused-vars": "off",
+            "no-unused-expressions": "off",
             "semi": "off",
             "no-extra-semi": "off",
 
             "@typescript-eslint/no-unused-vars": ["warn", noUnusedVarsOptions],
+            "@typescript-eslint/no-unused-expressions": ["warn", noUnusedExpressionsOptions],
 
             // Make style issues warnings
             "react/jsx-curly-spacing": ["warn", { children: true }],

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -790,7 +790,7 @@ const uploadTracks = async (
                     resolve(xhr.responseText);
                 }
             };
-            xhr.onerror = () => reject(new OcNetworkError()),
+            xhr.onerror = () => reject(new OcNetworkError());
             xhr.upload.onprogress = e => {
                 const uploadedBytes = e.loaded + sizeFinishedTracks;
                 onProgress(uploadedBytes / totalBytes);

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -244,12 +244,10 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
     if (event.__typename !== "AuthorizedEvent") {
         return unreachable();
     }
-    event;
 
     if (!isSynced(event)) {
         return <WaitingPage type="video" />;
     }
-    event;
 
     const breadcrumbs = (realm.isRoot ? realm.ancestors : realm.ancestors.concat(realm))
         .map(({ name, path }) => ({ label: name, link: path }));

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -80,6 +80,8 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = props => (
 );
 
 // For use in block mutations that might have an effect on the realm name.
+// Only used to be included in queries in order to update the store
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 graphql`
     fragment EditBlockUpdateRealmNameData on Block {
         realm {


### PR DESCRIPTION
Also fixes all the violations we already had, of course.