### PR TITLE
Fix `mountSeries` API by allowing last realm name to be empty

### DIFF
--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -248,7 +248,7 @@ pub(crate) struct NewRealm {
 
 #[derive(Clone, juniper::GraphQLInputObject)]
 pub(crate) struct RealmSpecifier {
-    pub(crate) name: String,
+    pub(crate) name: Option<String>,
     pub(crate) path_segment: String,
 }
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -191,7 +191,7 @@ type TitleBlock implements Block {
 }
 
 input RealmSpecifier {
-  name: String!
+  name: String
   pathSegment: String!
 }
 


### PR DESCRIPTION
The Admin UI now allows leaving the last realm name empty, but somehow the Tobira API side was not updated to deal with that.