### PR TITLE
Link `libssl` and `libz` statically

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2195,6 +2195,7 @@ dependencies = [
  "isahc",
  "juniper",
  "juniper_hyper",
+ "libz-sys",
  "log",
  "meilisearch-sdk",
  "mime_guess",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1367,6 +1367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1384,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2182,6 +2192,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyperlocal",
+ "isahc",
  "juniper",
  "juniper_hyper",
  "log",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,6 +39,7 @@ hyperlocal = { version = "0.8", default-features = false, features = ["server"] 
 isahc = { version = "1", features = ["static-ssl"] }
 juniper = { version = "0.15.10", default-features = false, features = ["chrono", "schema-language"] }
 juniper_hyper = "0.8.0"
+libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", features = ["serde", "std"] }
 meilisearch-sdk = "0.18.0"
 mime_guess = { version = "2", default-features = false }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,6 +36,7 @@ hostname = "0.3"
 hyper = { version = "0.14", features = ["client", "http1", "http2"] }
 hyper-rustls = { version = "0.23", features = ["http2"] }
 hyperlocal = { version = "0.8", default-features = false, features = ["server"] }
+isahc = { version = "1", features = ["static-ssl"] }
 juniper = { version = "0.15.10", default-features = false, features = ["chrono", "schema-language"] }
 juniper_hyper = "0.8.0"
 log = { version = "0.4", features = ["serde", "std"] }


### PR DESCRIPTION
CC #537 

See first commit for reasoning. This leaves Tobira only linking to "libstd libraries" basically. 