### PR TITLE
Check for changes to APIs used by the admin UI integraiton in PRs

### DIFF
--- a/.github/workflows/check-admin-ui-api.yml
+++ b/.github/workflows/check-admin-ui-api.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Hide previous comments made by this workflow
         uses: int128/hide-comment-action@v1
         with:
+          # We have to specify an empty author-filter here so that this step doesn't try to remove
+          # the deployment comments we create in another step (or any other comments by github-actions
+          # for that matter).
+          authors:
           starts-with: "<!-- admin-ui-api-check -->"
 
       - name: Add a comment when there are relevant changes

--- a/.github/workflows/check-admin-ui-api.yml
+++ b/.github/workflows/check-admin-ui-api.yml
@@ -1,0 +1,50 @@
+name: Admin UI API Check
+on: [pull_request]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Check for changes to the APIs the admin UI integration uses
+        id: graphql_inspector
+        run: |
+          npx @graphql-inspector/cli@3.4.0 diff \
+            --rule .github/workflows/check-admin-ui-api/rule.js \
+            --onComplete .github/workflows/check-admin-ui-api/onComplete.js \
+            git:${{ github.event.pull_request.base.sha }}:frontend/src/schema.graphql \
+            git:${{ github.event.pull_request.head.sha }}:frontend/src/schema.graphql \
+            | tee >( \
+              grep -v ^::set-output \
+              | sed -e 's/\[\(log\|success\|info\|error\|warn\)\] //' \
+              > diff \
+            )
+
+      - name: Read diff output
+        id: diff_output
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: diff
+          trim: true
+        if: steps.graphql_inspector.outputs.changes == 'true'
+
+      - name: Hide previous comments made by this workflow
+        uses: int128/hide-comment-action@v1
+        with:
+          starts-with: "<!-- admin-ui-api-check -->"
+
+      - name: Add a comment when there are relevant changes
+        uses: int128/comment-action@v1
+        with:
+          post: |
+            <!-- admin-ui-api-check -->
+            🚨🚨🚨 This PR changes APIs used by the Opencast Admin UI integration 🚨🚨🚨
+
+            ```
+            ${{ steps.diff_output.outputs.content }}
+            ```
+        if: steps.graphql_inspector.outputs.changes == 'true'

--- a/.github/workflows/check-admin-ui-api.yml
+++ b/.github/workflows/check-admin-ui-api.yml
@@ -10,10 +10,18 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Install GraphQL Inspector
+        run: |
+          npm install \
+            @graphql-inspector/ci@3.4.0 \
+            @graphql-inspector/diff-command@3.4.0 \
+            @graphql-inspector/graphql-loader@3.4.0 \
+            @graphql-inspector/git-loader@3.4.0
+
       - name: Check for changes to the APIs the admin UI integration uses
         id: graphql_inspector
         run: |
-          npx @graphql-inspector/cli@3.4.0 diff \
+          npx graphql-inspector diff \
             --rule .github/workflows/check-admin-ui-api/rule.js \
             --onComplete .github/workflows/check-admin-ui-api/onComplete.js \
             git:${{ github.event.pull_request.base.sha }}:frontend/src/schema.graphql \

--- a/.github/workflows/check-admin-ui-api/onComplete.js
+++ b/.github/workflows/check-admin-ui-api/onComplete.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+    console.log(`::set-output name=changes::true`);
+};

--- a/.github/workflows/check-admin-ui-api/rule.js
+++ b/.github/workflows/check-admin-ui-api/rule.js
@@ -1,0 +1,20 @@
+const adminUIPaths = [
+    "Query.realmByPath",
+    "Realm.name",
+    "Realm.pathSegment",
+    "Realm.path",
+    "Realm.children",
+    "Realm.blocks",
+    "Block.id",
+
+    "Query.seriesByOpencastId",
+    "Series.hostRealms",
+    "Realm.ancestors",
+
+    "Mutation.mountSeries",
+    "NewSeries",
+    "RealmSpecifier",
+];
+module.exports = ({ changes }) => changes.filter(
+    ({ path }) => adminUIPaths.some(adminUIPath => path.startsWith(adminUIPath)),
+);


### PR DESCRIPTION
Some notes:

* I tried to reproduce the behavior of our conflict check, running even when the base branch changes. This is not trivial, though. It's a feature of the action we use in that check, not of the actions/workflow system. It reacts to `push` events and then **manually** goes through all the PRs to check and mark them.
* I opted not to let this action label the PR, yet, simply because I'm not sure what label to use. I welcome in put on this point.