### PR TITLE
Fix and improve `db clear` (and related) subcommands

### DIFF
--- a/backend/src/db/cmd.rs
+++ b/backend/src/db/cmd.rs
@@ -15,7 +15,10 @@ use super::{Db, DbConfig, create_pool, query, migrations::unsafe_overwrite_migra
 #[derive(Debug, clap::Subcommand)]
 pub(crate) enum DbCommand {
     /// Removes all data and tables from the database. Also clears search index.
-    Clear,
+    Clear {
+        #[clap(flatten)]
+        options: ClearOptions,
+    },
 
     /// Runs an `.sql` script with the configured database connection.
     Script {
@@ -33,13 +36,23 @@ pub(crate) enum DbCommand {
     Console,
 
     /// Equivalent to `db clear` followed by `db migrate`.
-    Reset,
+    Reset {
+        #[clap(flatten)]
+        clear: ClearOptions,
+    },
 
     /// Updates the migrations scripts in the table `__db_migrations` to match
     /// the ones expected by this Tobira binary. Does not add new entries to
     /// the table, but might delete unknown migrations. This is intended for
     /// developers only, do not use if you don't know what you're doing!
     UnsafeOverwriteMigrations,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct ClearOptions {
+    /// If specified, skips the "Are you sure?" question.
+    #[clap(long)]
+    pub(crate) yes_absolutely_clear_db: bool,
 }
 
 /// Entry point for `db` commands.
@@ -54,10 +67,11 @@ pub(crate) async fn run(cmd: &DbCommand, config: &Config) -> Result<()> {
 
     // Dispatch command
     match cmd {
-        DbCommand::Clear => clear(&mut db, config).await?,
+        DbCommand::Clear { options: ClearOptions { yes_absolutely_clear_db: yes } }
+            => clear(&mut db, config, *yes).await?,
         DbCommand::Migrate => super::migrate(&mut db).await?,
-        DbCommand::Reset => {
-            clear(&mut db, config).await?;
+        DbCommand::Reset { clear: ClearOptions { yes_absolutely_clear_db: yes } } => {
+            clear(&mut db, config, *yes).await?;
             super::migrate(&mut db).await?;
         }
         DbCommand::Script { script } => run_script(&db, &script).await?,
@@ -74,7 +88,7 @@ pub(crate) async fn run(cmd: &DbCommand, config: &Config) -> Result<()> {
 /// This also has a interactive check, asking the user to confirm the removal.
 /// If the user did not confirm and the database is not changed, `false` is
 /// returned; `true` otherwise.
-async fn clear(db: &mut Db, config: &Config) -> Result<()> {
+async fn clear(db: &mut Db, config: &Config, yes: bool) -> Result<()> {
     let tx = db.build_transaction()
         .isolation_level(IsolationLevel::Serializable)
         .start()
@@ -101,13 +115,15 @@ async fn clear(db: &mut Db, config: &Config) -> Result<()> {
         println!(" - {} ({} rows)", name, num_rows);
     }
 
-    println!();
-    println!("Are you sure you want to completely remove everything in this database \
-        and clear the search index? \
-        This completely drops the 'public' schema. \
-        Please double-check the server you are running this on!\n\
-        Type 'yes' to proceed to delete the data.");
-    crate::cmd::prompt_for_yes()?;
+    if !yes {
+        println!();
+        println!("Are you sure you want to completely remove everything in this database \
+            and clear the search index? \
+            This completely drops the 'public' schema. \
+            Please double-check the server you are running this on!\n\
+            Type 'yes' to proceed to delete the data.");
+        crate::cmd::prompt_for_yes()?;
+    }
 
     // We clear everything by dropping the 'public' schema. This is suggested
     // here, for example: https://stackoverflow.com/a/21247009/2408867

--- a/backend/src/search/writer.rs
+++ b/backend/src/search/writer.rs
@@ -14,6 +14,16 @@ use super::Client;
 /// just a bit of non-enforced semantic typing.
 pub(crate) struct MeiliWriter<'a>(&'a Client);
 
+impl<'a> MeiliWriter<'a> {
+    /// Create a `MeiliWriter` without acquiring an exclusive lock first.
+    /// This should only be used when you are absolutely sure this is okay to do,
+    /// i.e. when concurrent access during your operation is either irrelevant
+    /// or not expected.
+    pub(crate) fn without_lock(client: &'a Client) -> Self {
+        Self(client)
+    }
+}
+
 impl std::ops::Deref for MeiliWriter<'_> {
     type Target = Client;
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
Changing the order of clearing the database vs. clearing the search index was tricky, mostly because of Rust oddities (borrow checker, missing trait impls, ...). The easiest way I could find was to just use the transaction that `with_write_lock` provides to its closure for clearing the DB as well. This is at least kinda sorta suspicious because that of course drops the table that is locked by that function. It seems to work though; I think dropping the table just releases the lock, which is fine in this situation. :shrug: 

Regarding the added flags: I think they really should exist for every command where we prompt for scriptability; it's just good form. I had to resist the urge to overengineer the duplication that this revealed out of the corresponding code, but if you agree that it should go, I can look into it further. :wink: 