### PR TITLE
Make thumbnail images `loading="lazy"`

### DIFF
--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -196,6 +196,7 @@ const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
         : <img
             {...{ src, alt }}
             onError={() => setLoadError(true)}
+            loading="lazy"
             width={16}
             height={9}
             css={{


### PR DESCRIPTION
Especially on long pages with lots of events in series block, this avoids useless image downloads.