### PR TITLE
Search on pressing enter

### DIFF
--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -61,6 +61,17 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
         ? new URLSearchParams(document.location.search).get("q") ?? undefined
         : undefined;
 
+    const search = (expression: string) => {
+        if (lastTimeout.current !== null) {
+            clearTimeout(lastTimeout.current);
+        }
+        lastTimeout.current = setTimeout(() => {
+            const newUrl = `/~search?q=${encodeURIComponent(expression)}`;
+            const replace = document.location.pathname === "/~search";
+            router.goto(newUrl, replace);
+        }, 30);
+    };
+
     return <div css={{ position: "relative", margin: "0 8px", ...extraCss }}>
         <HiOutlineSearch css={{
             position: "absolute",
@@ -76,15 +87,13 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
             title={t("search.input-label")}
             defaultValue={defaultValue}
             autoFocus={variant === "mobile"}
-            onChange={e => {
-                if (lastTimeout.current !== null) {
-                    clearTimeout(lastTimeout.current);
+            onKeyDown={e => {
+                if (e.key === "Enter") {
+                    search(e.target.value);
                 }
-                lastTimeout.current = setTimeout(() => {
-                    const newUrl = `/~search?q=${encodeURIComponent(e.target.value)}`;
-                    const replace = document.location.pathname === "/~search";
-                    router.goto(newUrl, replace);
-                }, 30);
+            }}
+            onChange={e => {
+                search(e.target.value);
             }}
             css={{
                 flex: "1 1 0px",

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -62,14 +62,9 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
         : undefined;
 
     const search = (expression: string) => {
-        if (lastTimeout.current !== null) {
-            clearTimeout(lastTimeout.current);
-        }
-        lastTimeout.current = setTimeout(() => {
-            const newUrl = `/~search?q=${encodeURIComponent(expression)}`;
-            const replace = document.location.pathname === "/~search";
-            router.goto(newUrl, replace);
-        }, 30);
+        const newUrl = `/~search?q=${encodeURIComponent(expression)}`;
+        const replace = document.location.pathname === "/~search";
+        router.goto(newUrl, replace);
     };
 
     return <div css={{ position: "relative", margin: "0 8px", ...extraCss }}>
@@ -93,7 +88,12 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                 }
             }}
             onChange={e => {
-                search(e.target.value);
+                if (lastTimeout.current !== null) {
+                    clearTimeout(lastTimeout.current);
+                }
+                lastTimeout.current = setTimeout(() => {
+                    search(e.target.value);
+                }, 30);
             }}
             css={{
                 flex: "1 1 0px",


### PR DESCRIPTION
If the search field is focused, pressing enter does not start a new search. This behavior is especially noticeable when you click on a search result and want to start the search again. Starting the search with onKeyDown and onChange events resolves that problem.

Fixes issue https://github.com/elan-ev/tobira/issues/463