### PR TITLE
Make Tobira properly handle multi-quality HLS streams

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -106,6 +106,7 @@ pub(crate) struct Track {
     // TODO: this should be `[i32; 2]` but the relevant patch is not released
     // yet: https://github.com/graphql-rust/juniper/pull/966
     resolution: Option<Vec<i32>>,
+    is_master: Option<bool>,
 }
 
 #[derive(Debug, GraphQLObject)]
@@ -448,6 +449,7 @@ impl From<EventTrack> for Track {
             flavor: src.flavor,
             mimetype: src.mimetype,
             resolution: src.resolution.map(Into::into),
+            is_master: src.is_master,
         }
     }
 }

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -301,4 +301,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     13: "series-block-show-metadata",
     14: "event-captions",
     15: "fix-event-constraints",
+    16: "master-track",
 ];

--- a/backend/src/db/migrations/16-master-track.sql
+++ b/backend/src/db/migrations/16-master-track.sql
@@ -1,0 +1,5 @@
+alter type event_track
+    -- Identifies the master playlist of an event with multiple HLS tracks.
+    -- These can happen for example when you encode multiple qualities
+    -- using `multiencode` in Opencast.
+    add attribute is_master bool;

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -57,6 +57,7 @@ pub struct EventTrack {
     pub flavor: String,
     pub mimetype: Option<String>,
     pub resolution: Option<[i32; 2]>,
+    pub is_master: Option<bool>,
 }
 
 /// Represents the `event_caption` type defined in `14-event-captions.sql`.

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -86,6 +86,7 @@ pub(crate) struct Track {
     flavor: String,
     mimetype: Option<String>,
     resolution: Option<[i32; 2]>,
+    is_master: Option<bool>,
 }
 
 impl Into<EventTrack> for Track {
@@ -95,6 +96,7 @@ impl Into<EventTrack> for Track {
             flavor: self.flavor,
             mimetype: self.mimetype,
             resolution: self.resolution.map(Into::into),
+            is_master: self.is_master,
         }
     }
 }

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -29,7 +29,7 @@ const query = graphql`
                     endTime
                     duration
                     thumbnail
-                    tracks { uri flavor mimetype resolution }
+                    tracks { uri flavor mimetype resolution isMaster }
                     captions { uri lang }
                 }
             }

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -217,7 +217,7 @@ const eventFragment = graphql`
                 thumbnail
                 startTime
                 endTime
-                tracks { uri flavor mimetype resolution }
+                tracks { uri flavor mimetype resolution isMaster }
                 captions { uri lang }
             }
             series {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -213,6 +213,7 @@ type Track {
   flavor: String!
   mimetype: String
   resolution: [Int!]
+  isMaster: Boolean
 }
 
 type SearchResults {

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -30,7 +30,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
                         startTime
                         endTime
                         thumbnail
-                        tracks { uri flavor mimetype resolution }
+                        tracks { uri flavor mimetype resolution isMaster }
                         captions { uri lang }
                     }
                 }

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -265,7 +265,9 @@ const tracksToPaellaSources = (tracks: VideoTrack[], isLive: boolean): Stream["s
         };
     };
 
-    const hlsTracks = tracks.filter(isHlsTrack);
+    const hlsTracks = tracks.filter(isHlsTrack)
+        // Make sure a/the master playlist is in front, so that quality selection works
+        .sort((a, b) => Number(b.isMaster) - Number(a.isMaster));
     const mp4Tracks = tracks.filter(t => !isHlsTrack(t));
 
     const hlsKey = isLive ? "hlsLive" : "hls";

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -41,6 +41,7 @@ export type Track = {
     flavor: string;
     mimetype: string | null;
     resolution: readonly number[] | null;
+    isMaster: boolean | null;
 };
 
 export type Caption = {


### PR DESCRIPTION
Currently we just pass all HLS tracks we find to Paella indiscriminately. Paella only ever uses the first of those, though. If there are more than one, and these represent different qualities, there should also be a special track marked as "master" in Opencast which needs to be passed to Paella for quality switching to work. (See #573.)

In opencast/opencast#4370 we expose this information in the Tobira harvest. This PR uses it to make sure we pass the right track.

## Meta

Needs opencast/opencast#4370.
Fixes #573.