### PR TITLE
Provide DB dump with useful data and use it for CI checks, deployment, and DX

### DIFF
--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -96,8 +96,8 @@
         state: started
         enabled: yes
 
-    # Migration with data currently does not work.
-    # That is why we drop and re-create the database for now.
+    # We always recreate the DB from the last release dump. To do that, we have
+    # to stop Tobira in case it's already running.
     - name: stop and disable tobira
       become: true
       systemd:
@@ -114,7 +114,6 @@
       community.postgresql.postgresql_db:
         name: tobira-{{ id }}
         state: absent
-    # End of migration hack.
 
     - name: create tobira postgres user
       become: true
@@ -209,14 +208,40 @@
         mode: '0644'
       notify: restart tobira
 
-    - name: copy realm demo data
+    - name: Download latest DB dump
       become: true
-      copy:
-        src: realms.yaml
-        dest: /opt/tobira/{{ id }}/
+      get_url:
+        url: 'https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz'
+        dest: /opt/tobira/{{ id }}/db-dump.pgc.xz
         owner: root
         group: root
-        mode: '0644'
+        mode: '0755'
+
+    - name: Decompress DB dump
+      become: true
+      shell: xz -d db-dump.pgc.xz
+      args:
+        chdir: /opt/tobira/{{ id }}/
+        creates: /opt/tobira/{{ id }}/db-dump.pgc
+        removes: /opt/tobira/{{ id }}/db-dump.pgc.xz
+
+    - name: Restore DB dump
+      become: true
+      become_user: postgres
+      community.postgresql.postgresql_db:
+        state: restore
+        # The ending `pgc` is important so that `pg_restore` (and not psql) is used.
+        target: /opt/tobira/{{ id }}/db-dump.pgc
+        name:  tobira-{{ id }}
+        target_opts: '--no-owner --role=tobira-{{ id }}'
+      # Unfortunately, we have to add this here as the command fails when adding
+      # comments to the 'public' schema and to two extensions. That fails
+      # because the user can't access those. In the future, with a newer
+      # `pg_restore` function we can specify `--no-comments` which should fix
+      # this. Also note: despite those errors, the dump is correctly restored.
+      # Of course this now ignores all errors, so we might miss other stuff
+      # that goes wrong.
+      ignore_errors: true
 
     - name: run database migration
       become: true
@@ -230,13 +255,6 @@
       become_user: tobira
       command:
         cmd: /opt/tobira/{{ id }}/tobira sync run
-        chdir: /opt/tobira/{{ id }}/
-
-    - name: insert demo realms
-      become: true
-      become_user: tobira
-      command:
-        cmd: /opt/tobira/{{ id }}/tobira import-realm-tree realms.yaml --dummy-blocks
         chdir: /opt/tobira/{{ id }}/
 
     - name: Clear search index

--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -8,94 +8,6 @@
     opencast_admin_password: '{{ lookup("env", "OPENCAST_ADMIN_PASSWORD") }}'
 
   tasks:
-
-    - name: install dependencies
-      become: true
-      package:
-        state: present
-        name:
-          - postgresql-server
-          - postgresql-contrib
-          - python3
-          - python3-psycopg2
-          - nginx
-
-    # MeiliSearch
-
-    - name: create MeiliSearch directory
-      become: true
-      file:
-        path: /opt/meili
-        state: directory
-        mode: '0755'
-
-    - name: install MeiliSearch
-      become: true
-      get_url:
-        url: https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
-        dest: /opt/meili/meilisearch
-        mode: '0755'
-        checksum: sha256:d394626b43c71acba0516336016285a963046b5ccf6f2c5ea6d5ef17085a3b40
-      register: meili_changed
-
-    - name: install MeiliSearch service file
-      become: true
-      template:
-        src: meili.service
-        dest: /etc/systemd/system/meili.service
-        mode: '0644'
-        owner: root
-        group: root
-      register: meili_changed
-
-    - name: start and enable Meili
-      become: true
-      service:
-        name: meili
-        state: started
-        enabled: yes
-
-    - name: restart Meili
-      become: true
-      service:
-        name: meili
-        state: restarted
-        enabled: yes
-      when: meili_changed.changed
-
-    # DATABASE
-
-    - name: initialize database
-      become: true
-      command:
-        cmd: postgresql-setup --initdb
-        creates: /var/lib/pgsql/data/postgresql.conf
-
-    - name: set auth to scram-sha-256
-      become: true
-      lineinfile:
-        path: /var/lib/pgsql/data/postgresql.conf
-        regexp: '^password_encryption'
-        line: "password_encryption = 'scram-sha-256'"
-      notify: restart postgresql
-
-    - name: configure postgres access
-      become: true
-      copy:
-        src: pg_hba.conf
-        dest: /var/lib/pgsql/data/pg_hba.conf
-        owner: postgres
-        group: postgres
-        mode: '0644'
-      notify: restart postgresql
-
-    - name: start and enable database
-      become: true
-      service:
-        name: postgresql
-        state: started
-        enabled: yes
-
     # We always recreate the DB from the last release dump. To do that, we have
     # to stop Tobira in case it's already running.
     - name: stop and disable tobira
@@ -138,10 +50,6 @@
 
     # TOBIRA
 
-    - name: create tobira users
-      become: true
-      user:
-        name: tobira
 
     - name: create application directory
       become: true
@@ -150,15 +58,6 @@
         state: directory
         owner: root
         group: root
-        mode: '0755'
-
-    - name: create logging directory
-      become: true
-      file:
-        path: /var/log/tobira
-        state: directory
-        owner: tobira
-        group: tobira
         mode: '0755'
 
     - name: create socket directory
@@ -299,72 +198,18 @@
 
     # NGINX
 
-    - name: deploy nginx configuration
+    - name: deploy nginx host configuration
       become: true
       template:
-        src: '{{ item.src }}'
-        dest: /etc/nginx/{{ item.dest }}
+        src: nginx-host.conf
+        dest: /etc/nginx/conf.d/tobira-{{ id }}.conf
         mode: '0644'
         owner: root
         group: root
-      loop:
-        - src: nginx.conf
-          dest: nginx.conf
-        - src: nginx-host.conf
-          dest: conf.d/tobira-{{ id }}.conf
       notify: reload nginx
 
-    - name: create ssl directory
-      become: true
-      file:
-        path: /etc/nginx/ssl
-        state: directory
-        owner: nginx
-        mode: '0755'
-
-    - name: initial configuration for certificates
-      become: true
-      copy:
-        src: ssl/{{ item.src }}
-        dest: /etc/nginx/ssl/{{ item.dest }}
-        owner: root
-        group: root
-        force: false
-        mode: '0640'
-      loop:
-        - src: certificate.pem
-          dest: '{{ inventory_hostname }}.crt'
-        - src: key.pem
-          dest: '{{ inventory_hostname }}.key'
-        - src: dhparam.pem
-          dest: dhparam.pem
-      notify: reload nginx
-
-    - name: configure firewall
-      become: true
-      firewalld:
-        service: '{{ item }}'
-        state: enabled
-        permanent: yes
-        immediate: yes
-      loop:
-        - http
-        - https
-
-    - name: start and enable nginx
-      become: true
-      systemd:
-        name: nginx
-        state: started
-        enabled: true
 
   handlers:
-    - name: restart postgresql
-      become: true
-      service:
-        name: postgresql
-        state: restarted
-
     - name: restart tobira
       become: true
       service:
@@ -380,9 +225,3 @@
       service:
         name: nginx
         state: reloaded
-
-    - name: restart meili
-      become: true
-      service:
-        name: meili
-        state: restarted

--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -10,7 +10,7 @@
   tasks:
     # We always recreate the DB from the last release dump. To do that, we have
     # to stop Tobira in case it's already running.
-    - name: stop and disable tobira
+    - name: stop tobira
       become: true
       systemd:
         name: '{{ item }}-{{ id }}'

--- a/.deployment/remove-deployment.yml
+++ b/.deployment/remove-deployment.yml
@@ -23,6 +23,7 @@
     - name: Clear search index
       become: true
       become_user: tobira
+      ignore_errors: true
       command:
         cmd: /opt/tobira/{{ id }}/tobira search-index clear --yes-absolutely-clear-index
         chdir: /opt/tobira/{{ id }}/

--- a/.deployment/setup-server.yml
+++ b/.deployment/setup-server.yml
@@ -1,0 +1,181 @@
+---
+
+- hosts: all
+
+  tasks:
+    - name: install dependencies
+      become: true
+      package:
+        state: present
+        name:
+          - postgresql-server
+          - postgresql-contrib
+          - python3
+          - python3-psycopg2
+          - nginx
+
+
+    # MeiliSearch
+
+    - name: create MeiliSearch directory
+      become: true
+      file:
+        path: /opt/meili
+        state: directory
+        mode: '0755'
+
+    - name: install MeiliSearch
+      become: true
+      get_url:
+        url: https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
+        dest: /opt/meili/meilisearch
+        mode: '0755'
+        checksum: sha256:d394626b43c71acba0516336016285a963046b5ccf6f2c5ea6d5ef17085a3b40
+      register: meili_changed
+
+    - name: install MeiliSearch service file
+      become: true
+      template:
+        src: meili.service
+        dest: /etc/systemd/system/meili.service
+        mode: '0644'
+        owner: root
+        group: root
+      register: meili_changed
+
+    - name: start and enable Meili
+      become: true
+      service:
+        name: meili
+        state: started
+        enabled: yes
+
+    - name: restart Meili
+      become: true
+      service:
+        name: meili
+        state: restarted
+        enabled: yes
+      when: meili_changed.changed
+
+
+    # DATABASE
+
+    - name: initialize database
+      become: true
+      command:
+        cmd: postgresql-setup --initdb
+        creates: /var/lib/pgsql/data/postgresql.conf
+
+    - name: set auth to scram-sha-256
+      become: true
+      lineinfile:
+        path: /var/lib/pgsql/data/postgresql.conf
+        regexp: '^password_encryption'
+        line: "password_encryption = 'scram-sha-256'"
+      notify: restart postgresql
+
+    - name: configure postgres access
+      become: true
+      copy:
+        src: pg_hba.conf
+        dest: /var/lib/pgsql/data/pg_hba.conf
+        owner: postgres
+        group: postgres
+        mode: '0644'
+      notify: restart postgresql
+
+    - name: start and enable database
+      become: true
+      service:
+        name: postgresql
+        state: started
+        enabled: yes
+
+
+    # Tobira
+
+    - name: create tobira users
+      become: true
+      user:
+        name: tobira
+
+    - name: create logging directory
+      become: true
+      file:
+        path: /var/log/tobira
+        state: directory
+        owner: tobira
+        group: tobira
+        mode: '0755'
+
+
+    # Nginx
+
+    - name: deploy nginx configuration
+      become: true
+      template:
+        src: nginx.conf
+        dest: /etc/nginx/nginx.conf
+        mode: '0644'
+        owner: root
+        group: root
+      notify: reload nginx
+
+    - name: create ssl directory
+      become: true
+      file:
+        path: /etc/nginx/ssl
+        state: directory
+        owner: nginx
+        mode: '0755'
+
+    - name: initial configuration for certificates
+      become: true
+      copy:
+        src: ssl/{{ item.src }}
+        dest: /etc/nginx/ssl/{{ item.dest }}
+        owner: root
+        group: root
+        force: false
+        mode: '0640'
+      loop:
+        - src: certificate.pem
+          dest: '{{ inventory_hostname }}.crt'
+        - src: key.pem
+          dest: '{{ inventory_hostname }}.key'
+        - src: dhparam.pem
+          dest: dhparam.pem
+      notify: reload nginx
+
+    - name: configure firewall
+      become: true
+      firewalld:
+        service: '{{ item }}'
+        state: enabled
+        permanent: yes
+        immediate: yes
+      loop:
+        - http
+        - https
+
+    - name: start and enable nginx
+      become: true
+      systemd:
+        name: nginx
+        state: started
+        enabled: true
+
+
+  handlers:
+    - name: restart postgresql
+      become: true
+      service:
+        name: postgresql
+        state: restarted
+
+    - name: reload nginx
+      become: true
+      service:
+        name: nginx
+        state: reloaded

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create release build
         run: ./x.sh build-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,14 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Restore backend cache
-      uses: Swatinem/rust-cache@v1.3.0
+      uses: Swatinem/rust-cache@v2
       with:
-        working-directory: backend
+        workspaces: backend
 
     # Frontend cache: only the NPM folder is cached, not the node_modules, as
     # recommended here: https://github.com/actions/cache/blob/main/examples.md#node---npm
     - name: Restore NPM cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,17 @@ env:
 jobs:
   main:
     runs-on: ubuntu-20.04
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: tobira
+          POSTGRES_PASSWORD: tobira
+          POSTGRES_DB: tobira
+        ports:
+          - 5432:5432
+        options: '--name tobira_pg'
+
     steps:
     - uses: actions/checkout@v2
 
@@ -87,6 +98,25 @@ jobs:
       run: ./tobira export-api-schema | diff -u --color=always - frontend/src/schema.graphql
     - name: Make sure `docs/docs/setup/config.toml` is up to date
       run: ./tobira write-config | diff -u --color=always - docs/docs/setup/config.toml
+
+
+    # Test DB migrations
+    - name: Download latest DB dump
+      run: curl --silent --output db-dump.xz https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz
+    - name: Decompress DB dump
+      run: xz -d db-dump.xz
+    # We need to use the same version as the DB, so we use 'docker exec'
+    - name: Restore DB dump
+      run: |
+        docker exec -i tobira_pg pg_restore \
+          --dbname postgresql://tobira:tobira@localhost/postgres \
+          --clean \
+          --create \
+          --if-exists \
+          < db-dump
+    - name: Run migrations
+      run: ./tobira db migrate --config util/dev-config/config.toml
+
 
     # Prepare the ID (used in the subdomain) for deployment. This has to be done
     # here because in the `deploy` workflow, we don't have access to the correct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
     # Archive files to be used in the `deploy` workflow
     - name: Archive deployment files as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-deployment-files
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,15 @@ jobs:
 
     # Figure out build mode
     - name: Determine build mode
-      id: build_mode
       run: |
         if [[ "$GITHUB_REPOSITORY" == "elan-ev/tobira" ]] && [ "$GITHUB_REF" == "refs/heads/master" ]; then
-          echo "::set-output name=cargo::--release"
-          echo "::set-output name=targetdir::target/release"
-          echo "::set-output name=webpack::production"
+          echo "ci_cargo_flags=--release" >> $GITHUB_ENV
+          echo "ci_targetdir=target/release" >> $GITHUB_ENV
+          echo "ci_webpack_flags=production" >> $GITHUB_ENV
         else
-          echo "::set-output name=cargo::--features=embed-in-debug"
-          echo "::set-output name=targetdir::target/debug"
-          echo "::set-output name=webpack::development"
+          echo "ci_cargo_flags=--features=embed-in-debug" >> $GITHUB_ENV
+          echo "ci_targetdir=target/debug" >> $GITHUB_ENV
+          echo "ci_webpack_flags=development" >> $GITHUB_ENV
         fi
 
     # The actual building and testing!
@@ -81,17 +80,17 @@ jobs:
       run: npx eslint --max-warnings 0 .
     - name: Build frontend
       working-directory: frontend
-      run: npx webpack --mode=${{ steps.build_mode.outputs.webpack }}
+      run: npx webpack --mode=${{ env.ci_webpack_flags }}
 
     - name: Build backend
       working-directory: backend
-      run: cargo build ${{ steps.build_mode.outputs.cargo }}
+      run: cargo build ${{ env.ci_cargo_flags }}
     - name: Test backend
       working-directory: backend
       run: cargo test
 
     - name: Move Tobira binary
-      run: mv backend/${{ steps.build_mode.outputs.targetdir }}/tobira tobira
+      run: mv backend/${{ env.ci_targetdir }}/tobira tobira
     - name: Compress Tobira binary
       run: objcopy --compress-debug-sections tobira
     - name: Make sure `schema.graphql` is up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         options: '--name tobira_pg'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore backend cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci
         working-directory: docs
       - name: Build documentation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         github.actor == 'lkiesow'
       ) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Unfortunately we cannot use `actions/download-artifact` here since that
     # only allows to download artifacts from the same run.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,17 +25,17 @@ jobs:
     # Unfortunately we cannot use `actions/download-artifact` here since that
     # only allows to download artifacts from the same run.
     - name: Download artifacts from build workflow
-      uses: actions/github-script@v3.1.0
+      uses: actions/github-script@v6
       with:
         script: |
-          const artifacts = await github.actions.listWorkflowRunArtifacts({
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: ${{ github.event.workflow_run.id }},
           });
           const deployFiles = artifacts.data.artifacts
               .filter(a => a.name == "test-deployment-files")[0];
-          const download = await github.actions.downloadArtifact({
+          const download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
               artifact_id: deployFiles.id,
@@ -46,7 +46,7 @@ jobs:
           fs.writeFileSync('${{github.workspace}}/artifacts.zip', Buffer.from(download.data));
 
           // The artifact is not needed anymore
-          github.actions.deleteArtifact({
+          github.rest.actions.deleteArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
               artifact_id: deployFiles.id,
@@ -98,7 +98,7 @@ jobs:
         deploy.yml
 
     - name: comment on PR
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -118,7 +118,7 @@ jobs:
               // upper limit. The worst that can happen is that this actions adds a second
               // comment.
               for (let page = 0; page < 20; page++) {
-                  const comments = await github.issues.listComments({
+                  const comments = await github.rest.issues.listComments({
                       issue_number,
                       owner: context.repo.owner,
                       repo: context.repo.repo,
@@ -138,7 +138,7 @@ jobs:
               }
 
               if (!commentedAlready) {
-                  await github.issues.createComment({
+                  await github.rest.issues.createComment({
                       issue_number,
                       owner: context.repo.owner,
                       repo: context.repo.repo,

--- a/.github/workflows/remove-deployment.yml
+++ b/.github/workflows/remove-deployment.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'elan-ev'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: prepare deploy key
       env:

--- a/.github/workflows/upload-db-dump.yml
+++ b/.github/workflows/upload-db-dump.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download Tobira binary
         run: curl --location --output tobira 'https://github.com/elan-ev/tobira/releases/download/${{github.ref_name}}/tobira-x86_64-unknown-linux-gnu'

--- a/.github/workflows/upload-db-dump.yml
+++ b/.github/workflows/upload-db-dump.yml
@@ -1,0 +1,79 @@
+on:
+  release:
+    types: [published]
+
+name: Create & upload DB dump
+
+jobs:
+  upload-db-dump:
+    name: Create & upload DB dump
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: tobira
+          POSTGRES_PASSWORD: tobira
+          POSTGRES_DB: tobira
+        ports:
+          - 5432:5432
+        options: '--name tobira_pg'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Tobira binary
+        run: curl --location --output tobira 'https://github.com/elan-ev/tobira/releases/download/${{github.ref_name}}/tobira-x86_64-unknown-linux-gnu'
+      - run: chmod +x tobira
+
+      # We adjust the dev config for simplicity here. We could also provide a
+      # full config here: either solution can get out of date.
+      - name: Adjust config for syncing
+        run: |
+          sed --in-place \
+            -e 's/host = "http:\/\/localhost:8081"/host = "https:\/\/oc.tobira.ethz.ch"/g' \
+            -e 's/password = "opencast"/password = "${{ secrets.TOBIRA_OPENCAST_ADMIN_PASSWORD }}"/g' \
+            -e 's/level = "trace"/level = "debug"/g' \
+            -e '/preferred_harvest_size/d' \
+            util/dev-config/config.toml
+
+      - name: Sync with Opencast
+        run: ./tobira sync run --config util/dev-config/config.toml
+      - name: Import realm tree
+        run: ./tobira import-realm-tree --config util/dev-config/config.toml .deployment/files/realms.yaml
+
+      # Here we specifically use the `pg_dump` binary from the docker container
+      # to use the oldest supported version of `pg_dump`. We don't let PG
+      # compress the output, as we will compress with xz below anyway and that
+      # compression works best when its input is uncompressed.
+      - name: Create DB dump
+        run: |
+          docker exec tobira_pg pg_dump \
+            --format custom \
+            --dbname postgresql://tobira:tobira@localhost/tobira \
+            --compress 0 \
+            --quote-all-identifiers \
+            > db-dump
+
+      - name: Compress DB dump
+        run: xz --best db-dump
+
+
+      # Upload
+      - name: Install s3cmd
+        run: |
+          sudo apt update
+          sudo apt install s3cmd --yes
+
+      - name: Setup s3cfg
+        run: echo "${{ secrets.S3_CONFIG }}" > ~/.s3cfg
+
+      # We upload it twice so that we have an archive of all dumps but also can
+      # easily access the latest dump. Finding out the latest dump URL in other
+      # ways is really tricky actually. And given that the dump is 2MB,
+      # this "waste" of storage and bandwidth is miniscule.
+      - name: Upload DB dump
+        run: |
+          s3cmd put db-dump.xz s3://tobira/db-dump-${{github.ref_name}}.xz
+          s3cmd put db-dump.xz s3://tobira/db-dump-latest.xz

--- a/util/scripts/db-load-dump.sh
+++ b/util/scripts/db-load-dump.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+basedir=$(dirname "$0")
+cd "$basedir"/../.. || exit 1
+
+if ! command -v xz &> /dev/null; then
+    >&2 echo "'xz' is not installed!"
+    exit 1
+fi
+if ! command -v docker-compose &> /dev/null; then
+    >&2 echo "'docker-compose' is not installed! (Also see './x.sh check-system')"
+    exit 1
+fi
+
+
+# Download dump
+TMP_DIR=$(mktemp -d)
+echo "Downloading DB dump"
+curl --output "$TMP_DIR/db-dump.xz" https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz
+xz -d "$TMP_DIR/db-dump.xz"
+
+# Prompt to notify that the current DB is deleted.
+echo
+echo
+echo "Will delete current DB in docker container and overwrite it with DB dump. Is that OK?"
+echo "To cancel, ctrl+c! To continue, press enter."
+read -r
+
+set -x
+docker-compose -f "$basedir/../containers/docker-compose.yml" \
+    exec -T tobira-dev-database \
+    pg_restore \
+    --dbname 'postgresql://tobira:tobira@localhost/postgres' \
+    --clean \
+    --create \
+    --if-exists \
+    < "$TMP_DIR/db-dump"

--- a/x.sh
+++ b/x.sh
@@ -27,6 +27,9 @@ if [[ $# -lt 1 ]]; then
     >&2 echo "  - ./x.sh containers [start|stop|run]"
     >&2 echo "        Manages all dev containers. To only start/stop some of them, use"
     >&2 echo "        docker-compose manually in 'util/containers'"
+    >&2 echo
+    >&2 echo "  - ./x.sh db load-dump"
+    >&2 echo "        Loads a public DB dump with lots of data."
     exit 1
 fi
 
@@ -63,6 +66,21 @@ containers() {
 
 }
 
+# DB operations
+db() {
+
+    case "$1" in
+        "load-dump")
+            "$basedir"/util/scripts/db-load-dump.sh
+            ;;
+        *)
+            >&2 echo "Incorrect argument for 'db' command!"
+            >&2 echo "Allowed: 'load-dump'. Example: './x.sh db load-dump'"
+            exit 1
+            ;;
+    esac
+
+}
 
 case "$1" in
     "check-system")
@@ -91,6 +109,9 @@ case "$1" in
         ;;
     "containers")
         containers "$2"
+        ;;
+    "db")
+        db "$2"
         ;;
     *)
         >&2 echo "Unknown command '$1'. Run this script without arguments for more information."


### PR DESCRIPTION
Closes #151

The main attraction of this PR is that we now automatically create DB dumps for each release, upload them to an S3 bucket and use those DB dumps in various places to our advantage: the CI script uses them to make sure DB migrations work, the deploy script uses them to speed things up, and there is a script for devs to quickly load a big test database without having to sync.

Some more details on that:
- With the `release: [published]` trigger, whenever a release is published, an action script downloads that binary, syncs with Opencast, imports the dummy realm tree. The the DB is dumped and the dump is uploaded to our S3 as `db-dump-vX.Y.xz` and `db-dump-latest.xz`. We upload it twice as this vastly simplifies the process of "getting the latest DB dump" that all other scripts need to perform. It's surprisingly tricky, especially due to timing.
- In our main CI script, the latest DB dump is loaded, and `tobira db migrate` is executed.
- In the deploy Ansible script the DB dump is loaded, then we still sync (but that's very fast now). And this removes the "insert dummy realms" step.

Apart from this main part, there are a bunch of commits that improve CI and deploy scripts. See commit message for more details.

I tested as much of this as I could (with a separate private repo). As by the nature of these GH action changes, things can still break. In particular, the "update action/scripts to v6" commit I did not test yet. My suggestion is: just review this PR, but don't try to test it yourself as that eats ton of time. And please schedule merging this PR with me so that I can push quick fixes to `master` if necessary.

Another note: as I described above, the DB dumps are created by starting with a fresh DB, syncing and inserting dummy realms. An alternative approach would be to continuously evolve on DB dump from v1.0 (or v1.3) and basically never do a big sync nor insert the dummy realms except that first time. I decided against that as (a) this makes it fairly hard to change our dummy realms (e.g. the text on the home page), and (b) we consider "resync" to be something that admins have to do from time to time, which would also be harder to do.

Oh I remembered another thing: the DB dump contains 15k entries in `search_index_queue`. Sounds bad and wasteful, but in the compressed dump it makes a tiny difference (10s of KB at most, don't quite remember). So to simplify scripts, I just left it in there.