### PR TITLE
Disable request buffering in our CORS proxy

### DIFF
--- a/util/containers/opencast-cors-proxy-nginx.conf
+++ b/util/containers/opencast-cors-proxy-nginx.conf
@@ -16,6 +16,8 @@ server {
 
     # Accept large ingests
     client_max_body_size 0;
+    # Upload directly to Opencast
+    proxy_request_buffering off;
 
     location / {
         proxy_set_header Host $http_host;


### PR DESCRIPTION
This stopped Opencast to validate the JWT of an upload request before receiving the full body (aka the video track). See also #370 and opencast/opencast#3245.