### PR TITLE
JWT expiry during upload should no longer be a problem under normal circumstances

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -29,7 +29,7 @@ trusted_external_key = "tobira"
 
 [auth.jwt]
 signing_algorithm = "ES256"
-# This is currently not created by scripts, but is expected to be generated there manually.
+# This is currently not created by scripts, but is expected to be generated on site manually.
 secret_key = "/opt/tobira/secret-jwt-key.pem"
 expiration_time = "10min"
 

--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -31,7 +31,6 @@ trusted_external_key = "tobira"
 signing_algorithm = "ES256"
 # This is currently not created by scripts, but is expected to be generated on site manually.
 secret_key = "/opt/tobira/secret-jwt-key.pem"
-expiration_time = "10min"
 
 [log]
 file = "/var/log/tobira/{{ id }}.log"

--- a/docs/docs/setup/jwt.md
+++ b/docs/docs/setup/jwt.md
@@ -22,7 +22,6 @@ For Tobira, you only need to configure some values in `auth.jwt`, for example:
 [auth.jwt]
 signing_algorithm = "ES256"
 secret_key = "jwt-key.pem"
-expiration_time = "3min"
 ```
 
 The secret key has to be a key matching the algorithm.
@@ -39,11 +38,10 @@ Here, the `sec1.pem` is encoded as SEC1 instead of PKCS#8. The second command co
 **Important**: the expiration time for the JWT should be chosen to be fairly short to reduce the security risk posed by a stolen JWT.
 Tobira generates a new JWT right before every request it sends to Opencast.
 So you should only need to account for network delay and clock skew.
-
-*However*, due to a stupid set of circumstances, currently, the JWT has to live as long as the video upload takes.
-So, potentially very long in case of large videos or slow connections.
-This is a bug, or at the very least a terrible UX that needs fixing.
-We're on it!
+The default of 30 seconds should be fine for most installations,
+but you can try to be more conservative if you want.
+We strongly recommend against going higher, though. If you need that for some reason,
+you should probably rather try to mitigate the underlying problem.
 
 
 ## Setup Opencast

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -205,10 +205,7 @@ upload:
     field-required: Dieses Feld darf nicht leer sein
     opencast-server-error: Opencast-Server-Fehler (unerwartete Antwort).
     opencast-unreachable: 'Netzwerkfehler: Opencast kann nicht erreicht werden.'
-    jwt-expired: >
-      Interner Fremdauthentifizierungsfehler: Aufgrund Ihrer Internetverbindung wurde das Video zu langsam
-      hochgeladen. Zurzeit kann diese Anwendung damit nicht umgehen. Wir arbeiten bereits daran,
-      dieses Problem zu lösen. Bitte entschuldigen Sie diese Unannehmlichkeit.
+    jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
 
 manage:
   management: Verwaltung

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -199,10 +199,7 @@ upload:
     field-required: This field is required (cannot be empty)
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
-    jwt-expired: >
-      Internal cross-authentication error: due to your internet connection, the video was uploaded too slowly.
-      Currently, this application cannot deal with those cases. We are aware of this problem and
-      working on it! We are sorry for causing any inconvenience.
+    jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
 
 manage:
   management: Management

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -262,11 +262,9 @@ const UploadErrorBox: React.FC<{ error: unknown }> = ({ error }) => {
             potentiallyInternetProblem: false,
         };
     } else if (error instanceof JwtInvalid) {
-        // TODO: make it so that this error should not occur. And once that is
-        // done, change `probablyOurFault` to `true`.
         info = {
-            causes: new Set([t("upload.errors.jwt-expired")]),
-            probablyOurFault: false, // Well...
+            causes: new Set([t("upload.errors.jwt-invalid")]),
+            probablyOurFault: true,
             potentiallyInternetProblem: false,
         };
     } else {
@@ -638,7 +636,7 @@ export class OcNetworkError extends Error {
     }
 }
 
-/** The JWT sent to Opencast was rejected. Likely because it expired */
+/** The JWT sent to Opencast was rejected. */
 export class JwtInvalid extends Error {
     public constructor() {
         super();


### PR DESCRIPTION
In fact, it never was. See also https://github.com/opencast/opencast/issues/3245#issuecomment-1316803267. You just need to configure the reverse proxy in front of Opencast properly. Following the [Opencast installation guide](https://docs.opencast.org/develop/admin/#configuration/https/nginx/#minimal-set-up) is sufficient.