### PR TITLE
Add `--dummy-blocks` to `import-realm-tree` when creating DB dump

### DIFF
--- a/.github/workflows/upload-db-dump.yml
+++ b/.github/workflows/upload-db-dump.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Sync with Opencast
         run: ./tobira sync run --config util/dev-config/config.toml
       - name: Import realm tree
-        run: ./tobira import-realm-tree --config util/dev-config/config.toml .deployment/files/realms.yaml
+        run: |
+          ./tobira import-realm-tree \
+            --dummy-blocks \
+            --config util/dev-config/config.toml \
+            .deployment/files/realms.yaml
 
       # Here we specifically use the `pg_dump` binary from the docker container
       # to use the oldest supported version of `pg_dump`. We don't let PG


### PR DESCRIPTION
This was forgotten before, leading to all DB dumps (and thus also the test deployments) having only very very few blocks.