### PR TITLE
Avoid host networking

### DIFF
--- a/util/containers/docker-compose.yml
+++ b/util/containers/docker-compose.yml
@@ -5,14 +5,18 @@ services:
   # handler.
   tobira-auth-proxy:
     image: nginx
-    network_mode: "host"
+    ports:
+      - "3090:3090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./tobira-auth-proxy-nginx.conf:/etc/nginx/conf.d/default.conf
 
   # A simple webserver handling login requests with some dummy users.
   tobira-login-handler:
     image: python:3
-    network_mode: "host"
+    ports:
+      - "3091:3091"
     volumes:
       - ./login-handler.py:/usr/bin/login-handler.py
     command: python -u /usr/bin/login-handler.py
@@ -21,7 +25,10 @@ services:
   # (required for the Tobira uploader, for example).
   opencast-cors-proxy:
     image: nginx
-    network_mode: "host"
+    ports:
+      - "8081:8081"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./opencast-cors-proxy-nginx.conf:/etc/nginx/conf.d/default.conf
 

--- a/util/containers/opencast-cors-proxy-nginx.conf
+++ b/util/containers/opencast-cors-proxy-nginx.conf
@@ -21,6 +21,6 @@ server {
 
     location / {
         proxy_set_header Host $http_host;
-        proxy_pass http://localhost:8080;
+        proxy_pass http://host.docker.internal:8080;
     }
 }

--- a/util/containers/tobira-auth-proxy-nginx.conf
+++ b/util/containers/tobira-auth-proxy-nginx.conf
@@ -21,7 +21,7 @@ server {
         proxy_set_header x-tobira-user-display-name "";
         proxy_set_header x-tobira-user-roles "";
         proxy_set_header Host $http_host;
-        proxy_pass http://localhost:3080;
+        proxy_pass http://host.docker.internal:3080;
     }
 
     # Intercept requests to /~login
@@ -38,7 +38,7 @@ server {
         proxy_set_header x-tobira-user-display-name "";
         proxy_set_header x-tobira-user-roles "";
         proxy_set_header Host $http_host;
-        proxy_pass http://localhost:3080;
+        proxy_pass http://host.docker.internal:3080;
     }
 
     # We have a `POST /~login` request!
@@ -49,7 +49,7 @@ server {
     # way, nginx deals with forwarding the user data to Tobira to create a session.
     location = /~internal-login {
         internal;
-        proxy_pass http://localhost:3091;
+        proxy_pass http://host.docker.internal:3091;
     }
 
     # Our dummy login script said the user data is correct and we should tell
@@ -71,6 +71,6 @@ server {
         proxy_set_header content-length '';
         proxy_set_header content-type '';
         proxy_method POST;
-        proxy_pass 'http://localhost:3080/~session';
+        proxy_pass 'http://host.docker.internal:3080/~session';
     }
 }

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -4,6 +4,12 @@
 [general]
 site_title.en = "Tobira Videoportal"
 
+[http]
+# To make our Docker based development setup work, Tobira needs to listen
+# on every interface. This is an unfortunate side effect of us trying to avoid
+# host networking which is not supported on platforms other than Linux.
+address = "0.0.0.0"
+
 [db]
 password = "tobira"
 tls_mode = "off"


### PR DESCRIPTION
This removes the need for host networking in our Docker development setup. This is a good thing(TM) because Docker Desktop for Windows and macOS does not (and cannot) support that networking mode. It uses a "magic host" that Docker Desktop exposes. To make it work on Linux as well, we have to pull a little trick (basically emulating that magic host with a little less magic) which forces us to make Tobira listen on `0.0.0.0`. This is not nice(TM) but it should be fine in practice since our port (`3080`) is a rather obscure one.

For more context, see also #325.