### PR TITLE
Fix building Tobira on macOS

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -49,7 +49,6 @@ paste = "1"
 pem = "1"
 percent-encoding = "2.1.0"
 postgres-types = { version = "0.2.2", features = ["derive", "array-impls"] }
-procfs = "0.14.1"
 prometheus-client = "0.18.0"
 rand = "0.8.4"
 reinda = "0.2"
@@ -70,6 +69,8 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_j
 tokio-postgres-rustls = "0.9"
 toml = "0.5"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "0.14.1"
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -179,6 +179,7 @@ struct MemInfo {
 impl MemInfo {
     /// Tries to gather memory info of the current process. If that fails,
     /// `None` is returned.
+    #[cfg(target_os = "linux")]
     fn gather() -> Option<Self> {
         let smaps = procfs::process::Process::myself().ok()?.smaps().ok()?;
 
@@ -199,6 +200,12 @@ impl MemInfo {
         }
 
         Some(out)
+    }
+
+    // On non-linux systems we don't gather any memory info.
+    #[cfg(not(target_os = "linux"))]
+    fn gather() -> Option<Self> {
+        None
     }
 }
 

--- a/util/scripts/check-system.sh
+++ b/util/scripts/check-system.sh
@@ -27,7 +27,7 @@ exit_code=0
 
 printf "▸ Rust installed? ('rustc' and 'cargo')"
 if has_command rustc && has_command cargo; then
-    rust_version=$(rustc -V | sed --quiet --regexp-extended 's/rustc ([.0-9]+) .+/\1/p')
+    rust_version=$(rustc -V | sed -E 's/rustc ([.0-9]+) .+/\1/p')
     if version_at_least "$rust_version" $MIN_RUST_VERSION; then
         print_yes
     else

--- a/util/scripts/on-backend-change.sh
+++ b/util/scripts/on-backend-change.sh
@@ -8,7 +8,7 @@ source "$basedir"/common-vars.sh
 # all browser sessions.
 reload_once_port_is_open() {
     while ! lsof -i:3080 > /dev/null; do
-        sleep 0.1s
+        sleep 0.1
     done
     $reload_command
 }


### PR DESCRIPTION
This enables building tobira on macOS by not gathering procfs memory info on non-linux systems.
It also fixes the `usage: sleep seconds` error - apparently, the `sleep` command doesn't work with quantifiers on macOS.