### PR TITLE
Add `--color` flag to configure color choice and default to 'auto'

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bunt"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192bac6c13e04373feb683e4438cbc156e6bbe432f614a9d6247445108fc5551"
+checksum = "36684a2de5a8a9049e1da69e4019fb6313087327ecd1e416a3850e5158d3b922"
 dependencies = [
  "bunt-macros",
  "termcolor",
@@ -2250,6 +2250,7 @@ name = "tobira"
 version = "1.4.0"
 dependencies = [
  "anyhow",
+ "atty",
  "base64",
  "bincode",
  "bstr",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,10 +18,11 @@ embed-in-debug = ["reinda/debug-is-prod"]
 
 [dependencies]
 anyhow = "1"
+atty = "0.2.14"
 base64 = "0.13"
 bincode = "1.3.3"
 bstr = "0.2.17"
-bunt = "0.2.4"
+bunt = "0.2.7"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 clap = { version = "3.1.18", features = ["derive"] }

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -5,7 +5,8 @@
 use anyhow::Result;
 
 use crate::{
-    args, load_config_and_init_logger,
+    load_config_and_init_logger,
+    args::{self, Args},
     config::Config,
     db::{self, MigrationPlan},
     prelude::*,
@@ -13,8 +14,8 @@ use crate::{
 };
 
 
-pub(crate) async fn run(shared: &args::Shared) -> Result<()> {
-    let config = load_config_and_init_logger(shared)
+pub(crate) async fn run(shared: &args::Shared, args: &Args) -> Result<()> {
+    let config = load_config_and_init_logger(shared, args)
         .context("failed to load config: cannot proceed with `check` command")?;
 
 

--- a/backend/src/logger.rs
+++ b/backend/src/logger.rs
@@ -4,9 +4,9 @@ use std::{
     path::PathBuf,
     sync::Mutex,
 };
-use termcolor::{ColorChoice, NoColor, StandardStream, WriteColor};
+use termcolor::{NoColor, StandardStream, WriteColor};
 
-use crate::prelude::*;
+use crate::{prelude::*, args::Args};
 
 
 #[derive(Debug, confique::Config)]
@@ -40,10 +40,9 @@ struct Logger {
 }
 
 /// Installs our own logger globally. Must only be called once!
-pub(crate) fn init(config: &LogConfig) -> Result<()> {
+pub(crate) fn init(config: &LogConfig, args: &Args) -> Result<()> {
     let stdout = match config.stdout {
-        // TODO: we might want to pass color choice via args
-        true => Some(Mutex::new(StandardStream::stdout(ColorChoice::Always))),
+        true => Some(Mutex::new(StandardStream::stdout(args.stdout_color()))),
         false => None,
     };
 
@@ -76,7 +75,7 @@ impl Log for Logger {
         }
 
         if let Some(stdout) = &self.stdout {
-            // We ignore a poisened mutex. The stdout handle doesn't contain
+            // We ignore a poisoned mutex. The stdout handle doesn't contain
             // any "state" that other threads could have tainted. The worst
             // that could happen is slightly weird formatting.
             //


### PR DESCRIPTION
This also detects whether stdout/stderr is a terminal (or piped to a  file) and does not emit colors in the latter case. This is very useful for various situations. In 'auto' mode it also respects the `NO_COLOR=1` env var.

Fixes #604