### PR TITLE
Alternative for a more precise indication of live event starting times

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -128,6 +128,7 @@ video:
     label: unverarbeitet
   thumbnail-for: Vorschaubild für „{{video}}“
   live: Live
+  live-since: Live seit
   upcoming: Anstehend
   ended: Beendet
   license: Lizenz

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -135,7 +135,8 @@ video:
   source: Quelle
   stream-ended: Dieser Stream ist beendet.
   stream-not-started-yet: Dieser Stream hat noch nicht begonnen.
-  starts-in: 'Startet <1></1>'
+  started: Gestartet {{duration}}
+  starts-in: Startet {{duration}}
   embed:
     button: Einbetten
     title: Video einbetten

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -24,6 +24,21 @@ general:
     select:
       no-options: Keine Optionen
       select-option: Option auswählen...
+  time:
+    second: '{{count}} Sekunde'
+    second_other: '{{count}} Sekunden'
+    minute: '{{count}} Minute'
+    minute_other: '{{count}} Minuten'
+    hour: '{{count}} Stunde'
+    hour_other: '{{count}} Stunden'
+    day: '{{count}} Tag'
+    day_other: '{{count}} Tagen'
+    week: '{{count}} Woche'
+    week_other: '{{count}} Wochen'
+    month: '{{count}} Monat'
+    month_other: '{{count}} Monaten'
+    year: '{{count}} Jahr'
+    year_other: '{{count}} Jahren'
 
 
 welcome:
@@ -128,15 +143,14 @@ video:
     label: unverarbeitet
   thumbnail-for: Vorschaubild für „{{video}}“
   live: Live
-  live-since: Live seit
+  live-in: 'Live in $t(general.time.{{timeUnit}}, {"count": {{duration}} })'
+  live-for: 'Live seit $t(general.time.{{timeUnit}}, {"count": {{duration}} })'
   upcoming: Anstehend
   ended: Beendet
   license: Lizenz
   source: Quelle
   stream-ended: Dieser Stream ist beendet.
   stream-not-started-yet: Dieser Stream hat noch nicht begonnen.
-  started: Gestartet {{duration}}
-  starts-in: Startet {{duration}}
   embed:
     button: Einbetten
     title: Video einbetten

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -125,6 +125,7 @@ video:
     label: unprocessed
   thumbnail-for: Thumbnail for “{{video}}”
   live: Live
+  live-since: Live for
   upcoming: Upcoming
   ended: Ended
   license: License

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -23,6 +23,21 @@ general:
     select:
       no-options: No options
       select-option: Select option...
+  time:
+    second: '{{count}} second'
+    second_other: '{{count}} seconds'
+    minute: '{{count}} minute'
+    minute_other: '{{count}} minutes'
+    hour: '{{count}} hour'
+    hour_other: '{{count}} hours'
+    day: '{{count}} day'
+    day_other: '{{count}} days'
+    week: '{{count}} week'
+    week_other: '{{count}} weeks'
+    month: '{{count}} month'
+    month_other: '{{count}} months'
+    year: '{{count}} year'
+    year_other: '{{count}} years'
 
 welcome:
   title: Welcome to Tobira!
@@ -125,14 +140,14 @@ video:
     label: unprocessed
   thumbnail-for: Thumbnail for “{{video}}”
   live: Live
+  live-in: 'Live in $t(general.time.{{timeUnit}}, {"count": {{duration}} })'
+  live-for: 'Live for $t(general.time.{{timeUnit}}, {"count": {{duration}} })'
   upcoming: Upcoming
   ended: Ended
   license: License
   source: Source
   stream-ended: This stream has ended.
   stream-not-started-yet: This stream has not started yet.
-  started: Started {{duration}}
-  starts-in: Starts {{duration}}
   embed:
     button: Embed
     title: Embed video

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -125,14 +125,14 @@ video:
     label: unprocessed
   thumbnail-for: Thumbnail for “{{video}}”
   live: Live
-  live-since: Live for
   upcoming: Upcoming
   ended: Ended
   license: License
   source: Source
   stream-ended: This stream has ended.
   stream-not-started-yet: This stream has not started yet.
-  starts-in: 'Starts <1></1>'
+  started: Started {{duration}}
+  starts-in: Starts {{duration}}
   embed:
     button: Embed
     title: Embed video

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -219,6 +219,7 @@ type GridTypeProps = {
 
 const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
     const TRANSITION_DURATION = "0.3s";
+    const date = event.isLive ? String(event.syncedData?.startTime) : event.created;
 
     const inner = <>
         <div css={{ borderRadius: 8 }}>
@@ -293,7 +294,7 @@ const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
                     // TODO: maybe find something better than `join`
                 }}>{event.creators.join(", ")}</span>}
                 {/* `new Date` is well defined for our ISO Date strings */}
-                <RelativeDate date={new Date(event.created)} isLive={event.isLive} />
+                <RelativeDate date={new Date(date)} isLive={event.isLive} />
             </div>
         </div>
     </>;

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -293,7 +293,7 @@ const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
                     // TODO: maybe find something better than `join`
                 }}>{event.creators.join(", ")}</span>}
                 {/* `new Date` is well defined for our ISO Date strings */}
-                <RelativeDate date={new Date(event.created)} />
+                <RelativeDate date={new Date(event.created)} isLive={event.isLive} />
             </div>
         </div>
     </>;

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, Suspense, useEffect } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { FiClock } from "react-icons/fi";
 import { HiOutlineStatusOffline } from "react-icons/hi";
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
@@ -244,10 +244,8 @@ const LiveEventPlaceholder: React.FC<LiveEventPlaceholderProps> = props => {
                 backgroundColor: "black",
                 borderRadius: 4,
                 padding: "8px 16px",
-            }}>
-                <Trans i18nKey={"video.starts-in"}>
-                    Starts <RelativeDate date={props.startTime} />
-                </Trans>
+            }}>                
+                <RelativeDate date={props.startTime} isLive />
             </div>
         )}
     </PlayerPlaceholder>;

--- a/frontend/src/ui/time.tsx
+++ b/frontend/src/ui/time.tsx
@@ -9,7 +9,7 @@ type RelativeDateProps = {
 
 /** 
  * Formats a date as something relative like "3 days ago" 
- * or "Started 3 days ago" in case of live events.
+ * or "Live in/for 3 days" in case of live events.
  */
 export const RelativeDate: React.FC<RelativeDateProps> = ({ date, isLive }) => {
     const { i18n } = useTranslation();
@@ -54,9 +54,9 @@ export const RelativeDate: React.FC<RelativeDateProps> = ({ date, isLive }) => {
             timeAndUnit = [secsAgo / YEAR, "year"];
         }
         const [time, unit] = timeAndUnit;
-        const prefix = time < 0 ? "video.starts-in" : "video.started";
+        const prefix = time < 0 ? "video.live-in" : "video.live-for";
         return isLive
-            ? t(prefix, { duration: intl.format(Math.round(-time), unit) })
+            ? t(prefix, { duration: Math.round(Math.abs(time)), timeUnit: unit })
             : intl.format(Math.round(-time), unit);
     })();
 


### PR DESCRIPTION
This is an alternative to #614, which uses different wording ("Live in...", "Live for..."), nested translations for these and a bunch of individual translations for the corresponding time units. I wasn't sure which wording fits best, so I decided to open this as a draft PR for potential review.

Closes #508