### PR TITLE
Fix some typos in translation and docs

### DIFF
--- a/docs/docs/dev/data.md
+++ b/docs/docs/dev/data.md
@@ -10,7 +10,7 @@ The `tobira db` subcommand (usually via `cargo run -- db`) contains a number of 
 Run `db --help` to find out more.
 
 Whenever you change existing DB migrations, Tobira won't start.
-You can fix that by either purging the DB and rerunning all migrations, but that obviously also deletes your all data.
+You can fix that by either purging the DB and rerunning all migrations, but that obviously also deletes all your data.
 You can do that with `cargo run -- db reset`.
 Another option for when the migration change doesn't actually change anything in the DB (e.g. a comment change), is to use `cargo run -- db unsafe-overwrite-migrations`.
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -366,7 +366,7 @@ manage:
           heading: Video
           none: Kein Video ausgewählt
           invalid: Bitte ein Video auswählen
-          no-read-acccess-to-current: >
+          no-read-access-to-current: >
             Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.
 
       titled:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -28,7 +28,7 @@ welcome:
   title: Welcome to Tobira!
   body: >
     It looks like your main page is still empty! To add content to this page
-    or add other pages, first log in with an account that has moderator priviliges.
+    or add other pages, first log in with an account that has moderator privileges.
     Afterwards, you can use the buttons on the left to modify the pages of this
     video portal.
 
@@ -196,7 +196,7 @@ upload:
     save: Save and finish
   errors:
     failed-to-upload: Failed to upload video.
-    unknown: Unknown error occured during video upload.
+    unknown: Unknown error occurred during video upload.
     field-required: This field is required (cannot be empty)
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
@@ -355,7 +355,7 @@ manage:
           heading: Event
           none: No event selected
           invalid: Please select an event
-          no-read-acccess-to-current: >
+          no-read-access-to-current: >
             You do not have read access to the video that is currently referenced here.
 
       titled:
@@ -383,7 +383,7 @@ manage:
       You can change the page name at any time.
     path-segment-info: >
       The path segment appears in the URL/link to the new page. Try keeping
-      it rather short and don't repeat information already contained in preceeding
+      it rather short and don't repeat information already contained in preceding
       path segments. Changing the path segment later should be avoided.
       <br />
       Path segments must not contain whitespace nor <code>{{illegalChars}}</code>

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -83,7 +83,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
             <Card kind="error">{t("manage.realm.content.event.event.invalid")}</Card>
         </div>}
         {event?.__typename === "NotAllowed" && <Card kind="error" css={{ margin: "8px 0" }}>
-            {t("manage.realm.content.event.event.no-read-acccess-to-current")}
+            {t("manage.realm.content.event.event.no-read-access-to-current")}
         </Card>}
         <Controller
             defaultValue={currentEvent?.id}


### PR DESCRIPTION
This fixes a few typos ~~I found~~ vscode found in the translation file, as well as one in the docs (at least I believe this is a typo).