### PR TITLE
Redirect from /~login when already logged in

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -106,8 +106,6 @@ user:
 login-page:
   user-id: Nutzerkennung
   password: Passwort
-  already-logged-in: Sie sind bereits als „{{name}}“ angemeldet.
-  go-to-homepage: Zur Startseite.
   bad-credentials: 'Anmeldung fehlgeschlagen: Falsche Anmeldedaten.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -103,8 +103,6 @@ user:
 login-page:
   user-id: User ID
   password: Password
-  already-logged-in: You are already logged in as “{{name}}”.
-  go-to-homepage: Go to homepage.
   bad-credentials: 'Login failed: invalid credentials.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
 

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -69,11 +69,8 @@ const LoggedOut: React.FC<LoggedOutProps> = ({ menu }) => {
             <Link
                 to={CONFIG.auth.loginLink ?? LOGIN_PATH}
                 onClick={() => {
-                    // If we are linking to our internal login page, store a
-                    // redirect link in session storage.
-                    if (!CONFIG.auth.loginLink) {
-                        window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, window.location.href);
-                    }
+                    // Store a redirect link in session storage.
+                    window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, window.location.href);
                 }}
                 htmlLink={!!CONFIG.auth.loginLink}
                 css={{

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -55,8 +55,6 @@ const Login: React.FC<Props> = ({ queryRef }) => {
 
     React.useEffect(() => {
         if (isLoggedIn) {
-            // This isn't working - 
-            // window.sessionStorage.getItem(REDIRECT_STORAGE_KEY) is always null.
             const redirectTo = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY) ?? "/";
             window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
             router.goto(redirectTo, true);

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -5,7 +5,7 @@ import type { PreloadedQuery } from "react-relay";
 
 import { Outer } from "../layout/Root";
 import { loadQuery } from "../relay";
-import { Link } from "../router";
+import { Link, useRouter } from "../router";
 import { LoginQuery } from "./__generated__/LoginQuery.graphql";
 import { Footer } from "../layout/Footer";
 import { Logo } from "../layout/header/Logo";
@@ -50,37 +50,46 @@ const Login: React.FC<Props> = ({ queryRef }) => {
     useNoindexTag();
     const { t } = useTranslation();
     const { currentUser } = usePreloadedQuery(query, queryRef);
+    const router = useRouter();
+    const isLoggedIn = currentUser !== null;
 
-    return <Outer>
-        <div css={{
-            height: "calc(1.7 * var(--header-height))",
-            maxHeight: "35vh",
-            padding: `${HEADER_BASE_PADDING}px 0`,
-            textAlign: "center",
-        }}><Logo /></div>
+    React.useEffect(() => {
+        if (isLoggedIn) {
+            // This isn't working - 
+            // window.sessionStorage.getItem(REDIRECT_STORAGE_KEY) is always null.
+            const redirectTo = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY) ?? "/";
+            window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+            router.goto(redirectTo, true);
+        }
+    });
 
-        <main css={{
-            margin: "0 auto",
-            padding: 16,
-            maxWidth: "100%",
-            flexGrow: 1,
-            display: "flex",
-            flexDirection: "column",
-        }}>
-            {currentUser !== null
-                ? <AlreadyLoggedIn displayName={currentUser.displayName} />
-                : <>
-                    <PageTitle title={t("user.login")} />
-                    <LoginBox />
-                    <div css={{ marginTop: 12, fontSize: 14, lineHeight: 1 }}>
-                        <BackButton />
-                    </div>
-                </>
-            }
-        </main>
+    return isLoggedIn
+        // Don't render anything when a redirect is triggered.
+        ? null
+        : <Outer>
+            <div css={{
+                height: "calc(1.7 * var(--header-height))",
+                maxHeight: "35vh",
+                padding: `${HEADER_BASE_PADDING}px 0`,
+                textAlign: "center",
+            }}><Logo /></div>
 
-        <Footer />
-    </Outer>;
+            <main css={{
+                margin: "0 auto",
+                padding: 16,
+                maxWidth: "100%",
+                flexGrow: 1,
+                display: "flex",
+                flexDirection: "column",
+            }}>
+                <PageTitle title={t("user.login")} />
+                <LoginBox />
+                <div css={{ marginTop: 12, fontSize: 14, lineHeight: 1 }}>
+                    <BackButton />
+                </div>
+            </main>
+            <Footer />
+        </Outer>;
 };
 
 const BackButton: React.FC = () => {
@@ -284,23 +293,4 @@ const Field: React.FC<FieldProps> = ({ isEmpty, children }) => {
             },
         }}>{children}</div>
     );
-};
-
-type AlreadyLoggedInProps = {
-    displayName: string;
-};
-
-/**
- * Shown if a logged-in user somehow ends up on the login page. We could also
- * automatically redirect, but that could always backfire. While this is not
- * optimal or particularly nice, it is surely functional.
- */
-const AlreadyLoggedIn: React.FC<AlreadyLoggedInProps> = ({ displayName }) => {
-    const { t } = useTranslation();
-
-    return <div>
-        {t("login-page.already-logged-in", { name: displayName })}
-        {" "}
-        <Link to="/">{t("login-page.go-to-homepage")}</Link>
-    </div>;
 };


### PR DESCRIPTION
This redirects an already logged in user from the login page to the homepage. Before, we would render a notice and a button component for manual redirection, which are now removed.

I don't think this could cause a redirect loop since this checks whether the user is already logged in or not. Also, I didn't find any instance where a user would be redirected to the login page. But maybe there are other ways a loop might occur that I am unaware of.

Ideally we would redirect to the page the user is coming from, like it is done when logging in. But the sessionStorage used for this is only set when the user clicks on the login button:
https://github.com/elan-ev/tobira/blob/a7588574a8764ac0bcea0cef62eae4d70ce0f841/frontend/src/layout/header/UserBox.tsx#L69-L77
This means that if a user would for any reason manually type in the `/~login` url or maybe use a bookmark pointing to that page while being on a Tobira page which isn't the homepage, they would always get redirected to the homepage (when already logged in or after logging in). 
Maybe we can somehow also store the previous page in these instances, but I'm not sure how.

Also, I am not sure if the redirect as implemented here is being done in the correct spot, but as that seems to be the only place we can check if a user is already logged in, I wouldn't know where else it could be done.

Finally, the `goto("/")` method without being wrapped in the useEffect() function would work, but throw two warnings that I couldn't really comprehend.