### PR TITLE
Add cancel button to video uploader and also cancel upload when leaving route

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -184,6 +184,7 @@ upload:
   starting: Starte Upload...
   finishing: Schließe Upload ab...
   waiting-for-metadata: Zum Fertigstellen bitte Videoinformationen speichern
+  cancel: Upload abbrechen
   still-uploading: >
     Video lädt hoch. Bitte schließen Sie diese Seite nicht, bevor der Upload beendet ist.
   time-estimate:
@@ -210,6 +211,7 @@ upload:
     opencast-server-error: Opencast-Server-Fehler (unerwartete Antwort).
     opencast-unreachable: 'Netzwerkfehler: Opencast kann nicht erreicht werden.'
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
+    upload-cancelled: Der Upload wurde abgebrochen.
 
 manage:
   management: Verwaltung

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -178,6 +178,7 @@ upload:
   drop-to-upload: Videodateien zum Hochladen per Drag-and-drop hinzufügen
   not-authorized: Sie haben nicht die Berechtigung, Videos hochzuladen.
   select-files: Dateien auswählen
+  reselect: Dateien erneut auswählen
   too-many-files: >
     Sie haben zu viele Dateien ausgewählt. Zurzeit werden nur einzelne Dateien unterstützt.
   not-a-file: Sie haben etwas in diesen Bereich gezogen, das keine Datei ist.
@@ -185,6 +186,7 @@ upload:
   finishing: Schließe Upload ab...
   waiting-for-metadata: Zum Fertigstellen bitte Videoinformationen speichern
   cancel: Upload abbrechen
+  upload-cancelled: Der Upload wurde abgebrochen.
   still-uploading: >
     Video lädt hoch. Bitte schließen Sie diese Seite nicht, bevor der Upload beendet ist.
   time-estimate:
@@ -211,7 +213,6 @@ upload:
     opencast-server-error: Opencast-Server-Fehler (unerwartete Antwort).
     opencast-unreachable: 'Netzwerkfehler: Opencast kann nicht erreicht werden.'
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
-    upload-cancelled: Der Upload wurde abgebrochen.
 
 manage:
   management: Verwaltung

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -179,6 +179,7 @@ upload:
   starting: Starting...
   finishing: Finishing up...
   waiting-for-metadata: Please save video information to finish the upload
+  cancel: Cancel upload
   still-uploading: >
     Video is still uploading. Please do not close this page before the upload is finished.
   time-estimate:
@@ -204,6 +205,7 @@ upload:
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
+    upload-cancelled: The upload was cancelled.
 
 manage:
   management: Management

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -174,12 +174,14 @@ upload:
   drop-to-upload: Drag and drop video files to upload
   not-authorized: You do not have the permission to upload videos.
   select-files: Select files
+  reselect: Reselect files
   too-many-files: You selected too many files. Currently, only a single file is supported.
   not-a-file: You dropped something that's not a file.
   starting: Starting...
   finishing: Finishing up...
   waiting-for-metadata: Please save video information to finish the upload
   cancel: Cancel upload
+  upload-cancelled: The upload was cancelled.
   still-uploading: >
     Video is still uploading. Please do not close this page before the upload is finished.
   time-estimate:
@@ -205,7 +207,6 @@ upload:
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
-    upload-cancelled: The upload was cancelled.
 
 manage:
   management: Management

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -115,7 +115,8 @@ const UploadMain: React.FC<CancelProps> = ({ controller }) => {
 
     const progressHistory = useRef<ProgressHistory>([]);
 
-    useNavBlocker(() => !!uploadState.current && uploadState.current.state !== "done");
+    useNavBlocker(() => !!uploadState.current
+        && !["done", "cancelled"].includes(uploadState.current.state));
 
     // Get user info
     const user = useUser();

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -514,7 +514,7 @@ const UploadState: React.FC<{ state: NonFinishedUploadState } & CancelProps> = (
                     onClick={() => {
                         if (setFiles) {
                             setFiles(null);
-                        } 
+                        }
                     }}>
                     {t("upload.reselect")}
                 </Button>
@@ -822,7 +822,7 @@ const uploadTracks = async (
                 controller.current = new AbortController();
                 cancelUpload(mediaPackage, setUploadState);
             });
-            
+
             xhr.open("POST", url);
             xhr.setRequestHeader("Authorization", `Bearer ${jwt}`);
 

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -57,12 +57,6 @@ type Metadata = {
 
 const Upload: React.FC = () => {
     const { t } = useTranslation();
-    const router = useRouter();
-    const abortController = useRef(new AbortController());
-
-    router.listenAtNav(() => {
-        abortController.current.abort();
-    });
 
     return (
         <div css={{
@@ -73,7 +67,7 @@ const Upload: React.FC = () => {
         }}>
             <PageTitle title={t("upload.title")} />
             <div css={{ fontSize: 14, marginBottom: 16 }}>{t("upload.public-note")}</div>
-            <UploadMain abortController={abortController} />
+            <UploadMain />
         </div>
     );
 };
@@ -102,18 +96,24 @@ const CancelButton: React.FC<CancelProps> = ({ abortController }) => {
     );
 };
 
-const UploadMain: React.FC<CancelProps> = ({ abortController }) => {
+const UploadMain: React.FC = () => {
     // TODO: on first mount, send an `ocRequest` to `info/me.json` and make sure
     // that connection works. That way we can show an error very early, before
     // the user selected a file.
 
     const { t } = useTranslation();
+    const router = useRouter();
 
     const [files, setFiles] = useState<FileList | null>(null);
     const [uploadState, setUploadState] = useRefState<UploadState | null>(null);
     const [metadata, setMetadata] = useRefState<Metadata | null>(null);
 
     const progressHistory = useRef<ProgressHistory>([]);
+    const abortController = useRef(new AbortController());
+
+    router.listenAtNav(() => {
+        abortController.current.abort();
+    });
 
     useNavBlocker(() => !!uploadState.current
         && !["done", "cancelled"].includes(uploadState.current.state));

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -860,11 +860,16 @@ const cancelUpload = async (
     mediaPackage: string,
     setUploadState: (state: UploadState) => void,
 ) => {
-    setUploadState({ state: "cancelled" });
+    try {
+        setUploadState({ state: "cancelled" });
 
-    const body = new FormData();
-    body.append("mediaPackage", mediaPackage);
-    await ocRequest("/ingest/discardMediaPackage", { method: "post", body: body });
+        const body = new FormData();
+        body.append("mediaPackage", mediaPackage);
+        await ocRequest("/ingest/discardMediaPackage", { method: "post", body: body });
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Error cancelling: ", error);
+    }
 };
 
 /** Ingest the given metadata and finishes the ingest process */


### PR DESCRIPTION
This adds an `abortController` to the uploader, which can be called by pressing a `cancel` button when a video is being uploaded. It is also called when a user leaves or reloads the upload route. The controller then aborts the current `XMLHTTPRequest` and rejects the promise it was being called from.

Closes: #354 
<img width="400" alt="Bildschirmfoto 2022-12-13 um 18 05 24" src="https://user-images.githubusercontent.com/94838646/207397920-a0a0a766-88ae-48cb-abcf-fe12e8597deb.png">
<img width="400" alt="Bildschirmfoto 2022-12-13 um 17 45 41" src="https://user-images.githubusercontent.com/94838646/207393789-f3813151-de00-4417-9655-599e8a6e8cca.png">

~~Some notes:~~
  ~~- **this is still missing a way to cleanup the state on the opencast side**~~
  ~~- when an upload is cancelled, this will throw an error by rejecting the respective promise. It then informs the user that their upload was cancelled, similar to the other error messages that can occur for uploads, but without the added "Failed to upload video" message (see second screenshot)~~
  ~~- maybe there should be an additional button which links back to or rather rerenders the `select files` dialog, or perhaps it should even automatically do that. Right now, you would need to take a detour via the homepage to upload another file, as clicking the `upload video` option from the user dropdown menu just shows the same error message~~
  ~~- it might be a little confusing or irritating for the user to still see the `video title` and `description` input fields below the error message (I believe this and the previous point should also apply for other error messages)~~

**Update:**
I have added the ` POST /discardMediaPackage` call to clean up the state on Opencast's side and added a `cancelled` upload state. I also removed the metadata input fields when that state is shown.
I'm sure there are still some things to discuss, like the functionality of the `reselect files` button and overall styling of the `cancelled state` and also some code stuff (there might be too much nesting going on in a few places).
