### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.deployment/
+.dockerignore
+.git/
+.github/
+.gitignore
+backend/.cargo/config.toml
+backend/target/
+docs/
+frontend/build/
+frontend/node_modules/
+frontend/tsconfig.tsbuildinfo
+LICENSE
+README.md
+util/
+x.sh

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -17,7 +17,9 @@ pub(crate) fn build_time_utc() -> &'static str {
 
 /// Returns the commit hash this was build from.
 pub(crate) fn git_commit_hash() -> &'static str {
-    build_info::GIT_COMMIT_HASH.expect("missing git version info")
+    build_info::GIT_COMMIT_HASH
+        .or(option_env!("GIT_COMMIT_HASH"))
+        .expect("missing git version info")
 }
 
 /// Returns whether the git working directory was dirty when this was built.

--- a/util/containers/Dockerfile
+++ b/util/containers/Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1.4
+
+ARG NODE_VERSION
+ARG RUST_VERSION
+
+
+FROM --platform=${BUILDPLATFORM} docker.io/node:${NODE_VERSION}-alpine AS frontend-build
+
+WORKDIR /build
+COPY frontend/package.json frontend/package-lock.json /build/
+RUN npm i
+
+COPY frontend .
+RUN npm ci
+RUN npx relay-compiler
+RUN npx webpack --mode=production
+
+
+FROM docker.io/rust:${RUST_VERSION}-alpine AS backend-build
+
+ENV CFLAGS    "-fdebug-prefix-map=/root/.cargo/registry/src/github.com-1ecc6299db9ec823/=__dep__"
+ENV RUSTFLAGS "--remap-path-prefix=/build/backend=<src> --remap-path-prefix=/root/.cargo/registry/src/github.com-1ecc6299db9ec823/=<dep>"
+
+WORKDIR /build/backend
+
+RUN apk add --no-cache \
+  make \
+  musl-dev \
+  perl
+
+ARG RUST_TARGET
+RUN rustup target add "${RUST_TARGET}"
+
+COPY backend/Cargo.toml backend/Cargo.lock /build/backend/
+COPY <<EOF /build/backend/src/main.rs
+fn main() {}
+EOF
+RUN cargo build --target "${RUST_TARGET}" --release
+
+COPY --from=frontend-build /build/build /build/frontend/build
+COPY backend .
+ARG GIT_COMMIT_HASH
+RUN cargo build --target "${RUST_TARGET}" --release
+RUN cp "target/${RUST_TARGET}/release/tobira" .
+RUN objcopy --compress-debug-sections tobira
+
+
+FROM docker.io/rust:${RUST_VERSION}-alpine AS rootfs
+RUN mkdir /rootfs \
+ && apk add -p /rootfs --no-cache --initdb \
+ && cp -R /etc/apk/repositories /etc/apk/keys /rootfs/etc/apk/ \
+ && apk add -p /rootfs --no-cache \
+      alpine-baselayout-data \
+      ca-certificates-bundle \
+      musl \
+ && rm -rf \
+      /rootfs/etc/apk \
+      /rootfs/lib/apk \
+      /rootfs/var/cache/apk
+COPY --from=backend-build /build/backend/tobira /rootfs/tobira
+RUN mkdir -p /rootfs/etc/tobira/ \
+ && /rootfs/tobira write-config /rootfs/etc/tobira/config.toml \
+ && sed -i '/\[http\]/,/^#address =.*$/ s/^#address =.*$/address = "0.0.0.0"/' /rootfs/etc/tobira/config.toml
+
+
+FROM scratch AS final
+ARG BUILT_TIME_UTC \
+    GIT_COMMIT_HASH \
+    VERSION
+
+LABEL maintainer="The Opencast project" \
+      org.opencontainers.image.created="${BUILT_TIME_UTC}" \
+      org.opencontainers.image.authors="The Opencast project" \
+      org.opencontainers.image.url="quay.io/opencast/tobira" \
+      org.opencontainers.image.documentation="https://elan-ev.github.io/tobira/" \
+      org.opencontainers.image.source="https://github.com/elan-ev/tobira" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${GIT_COMMIT_HASH}" \
+      org.opencontainers.image.vendor="ELAN e.V." \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="Tobira" \
+      org.opencontainers.image.description="Video portal for Opencast"
+
+COPY --from=rootfs /rootfs /
+EXPOSE 3080
+ENTRYPOINT [ "/tobira" ]

--- a/util/containers/README.md
+++ b/util/containers/README.md
@@ -1,6 +1,13 @@
-# Tobira development containers
+# Containers for Tobira development & production use
 
-A short overview over containers (see the compose file for more information):
+## Dockerfile for production use
+
+The `Dockerfile` is for building a container that can be used to deploy Tobira in production.
+
+
+## Development containers
+
+Most files in this directory are for setting up development environment.
 
 There is a container for a PostgreSQL DB and a container for MeiliSearch.
 These are straight forward.

--- a/util/scripts/build-container-image.sh
+++ b/util/scripts/build-container-image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+basedir=$(dirname "$0")
+cd "$basedir"/../..
+
+NODE_VERSION=19.3
+RUST_VERSION=1.66
+
+CONTAINER_PLATFORM="${CONTAINER_PLATFORM:-linux/amd64}"
+RUST_TARGET="${RUST_TARGET:-x86_64-unknown-linux-musl}"
+
+BUILT_TIME_UTC="$(date -u +"%Y-%m-%dT%TZ")"
+GIT_COMMIT_HASH="$(git rev-parse --short HEAD || echo "unknown")"
+VERSION="$(sed -n -E 's/^version = "([^"]+)"$/\1/p' backend/Cargo.toml)"
+
+docker buildx build \
+  --platform "${CONTAINER_PLATFORM}" \
+  --build-arg "NODE_VERSION=${NODE_VERSION}" \
+  --build-arg "RUST_VERSION=${RUST_VERSION}" \
+  --build-arg "RUST_TARGET=${RUST_TARGET}" \
+  --build-arg "BUILT_TIME_UTC=${BUILT_TIME_UTC}" \
+  --build-arg "GIT_COMMIT_HASH=${GIT_COMMIT_HASH}" \
+  --build-arg "VERSION=${VERSION}" \
+  -f "util/containers/Dockerfile" \
+  -t "quay.io/opencast/tobira:latest" \
+  -t "quay.io/opencast/tobira:${VERSION}" \
+  .

--- a/x.sh
+++ b/x.sh
@@ -24,6 +24,9 @@ if [[ $# -lt 1 ]]; then
     >&2 echo "  - ./x.sh build-release"
     >&2 echo "        Creates a clean production build that can be deployed."
     >&2 echo
+    >&2 echo "  - ./x.sh build-container-image"
+    >&2 echo "        Creates a production container image that can be deployed."
+    >&2 echo
     >&2 echo "  - ./x.sh containers [start|stop|run]"
     >&2 echo "        Manages all dev containers. To only start/stop some of them, use"
     >&2 echo "        docker-compose manually in 'util/containers'"
@@ -106,6 +109,9 @@ case "$1" in
             exit 1
         fi
         "$basedir"/util/scripts/build-release.sh
+        ;;
+    "build-container-image")
+        "$basedir"/util/scripts/build-container-image.sh
         ;;
     "containers")
         containers "$2"


### PR DESCRIPTION
This adds a Dockerfile for building Tobira container images. The `x.sh` script was extended with a new `build-container-image` target for doing so as the Dockerfile requires multiple arguments to be passed in.

This partially addresses #624.