### PR TITLE
Improve contrast between some texts and their backgrounds

### DIFF
--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -268,7 +268,7 @@ const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
                 }}>{event.title}</div>
             </h3>
             <div css={{
-                color: "var(--grey40)",
+                color: "var(--grey20)",
                 fontSize: 14,
                 display: "flex",
                 flexWrap: "wrap",


### PR DESCRIPTION
These are two mini-fixes to address some of the contrast errors found by the WAVE browser plugin.
I also tested most if not all tobira pages using tab navigation and voice over.
The `AddButtons` are not focusable using tab, but that appears to be fixed with #636.

The only other issues I noted so far is on video pages: Starting videos works fine using the keyboard, but once the control elements disappear, they seem to also lose focus, which makes it impossible to refocus them with the tab button. But I suppose this is rather a problem with the embedded player than tobira.
Also, the `play button` appears to be missing a description and is simply read as `button`, or `taste` in german.