### PR TITLE
Make events findable via opencastId

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,10 +1845,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reinda"
@@ -2373,6 +2399,7 @@ dependencies = [
  "procfs",
  "prometheus-client",
  "rand",
+ "regex",
  "reinda",
  "ring",
  "rustls",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -52,6 +52,7 @@ percent-encoding = "2.1.0"
 postgres-types = { version = "0.2.2", features = ["derive", "array-impls"] }
 prometheus-client = "0.18.0"
 rand = "0.8.4"
+regex = "1.7.1"
 reinda = "0.2"
 ring = "0.16"
 rustls = { version = "0.20", features = ["dangerous_configuration"] }


### PR DESCRIPTION
This adds a check to see if a search query is a valid uuid, and if so looks for a matching opencastId in the DB and returns the corresponding event. Works for upper- and lowercase queries.

Closes #544 