### PR TITLE
Apply hover styles also on keyboard focus

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -101,7 +101,7 @@ const GLOBAL_STYLE = css({
     a: {
         color: "var(--nav-color)",
         textDecoration: "none",
-        "&:hover": {
+        "&:hover, &:focus": {
             color: "var(--nav-color-darker)",
         },
     },

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -103,7 +103,7 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                     paddingRight: 12,
                     backgroundColor: "var(--grey92)",
                     border: "2px solid white",
-                    "&:hover": {
+                    "&:hover, &:focus": {
                         backgroundColor: "var(--grey86)",
                     },
                     "&:focus": {

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -84,7 +84,7 @@ const LoggedOut: React.FC<LoggedOutProps> = ({ menu }) => {
                     alignItems: "center",
                     backgroundColor: "var(--nav-color)",
                     color: "var(--nav-color-bw-contrast)",
-                    "&:hover": {
+                    "&:hover, &:focus": {
                         backgroundColor: "var(--nav-color-dark)",
                         color: "var(--nav-color-bw-contrast)",
                     },
@@ -333,7 +333,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
                 strokeWidth: "inherit",
             },
         },
-        "&:hover": {
+        "&:hover, &:focus": {
             backgroundColor: "var(--grey97)",
         },
         ...FOCUS_STYLE_INSET,

--- a/frontend/src/layout/header/ui.tsx
+++ b/frontend/src/layout/header/ui.tsx
@@ -39,7 +39,7 @@ export const ActionIcon: React.FC<ActionIconProps> = ({ title, onClick, children
                 cursor: "pointer",
                 fontSize: 28,
                 opacity: "0.75",
-                "&:hover": {
+                "&:hover, &:focus": {
                     opacity: "1",
                 },
                 [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: {

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -265,7 +265,7 @@ const Item: React.FC<ItemProps> = ({ link, children }) => (
                 margin: 16,
                 padding: 8,
                 gap: 16,
-                "&:hover": {
+                "&:hover, &:focus": {
                     backgroundColor: "var(--grey97)",
                 },
                 "& > *:first-child": {

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -193,7 +193,7 @@ const ChildList: React.FC<ChildListProps> = ({ disabled, children, swap }) => {
                             },
                             "&:not([disabled])": {
                                 cursor: "pointer",
-                                "&:hover": {
+                                "&:hover, &:focus": {
                                     backgroundColor: "var(--grey97)",
                                     color: "var(--accent-color)",
                                 },

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -76,7 +76,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    "&:hover": {
+                    "&:hover, &:focus": {
                         backgroundColor: "var(--accent-color-darker)",
                     },
                 }}
@@ -171,7 +171,7 @@ const AddItem: React.FC<AddItemProps> = ({ label, Icon, onClick, close }) => (
                 backgroundColor: "transparent",
                 cursor: "pointer",
                 border: "none",
-                "&:hover": {
+                "&:hover, &:focus": {
                     backgroundColor: "var(--grey97)",
                 },
             }}

--- a/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
@@ -64,7 +64,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
             title={t("manage.realm.content.remove")}
             css={{
                 color: "var(--danger-color)",
-                "&&:hover": {
+                "&&:hover, &&:focus": {
                     backgroundColor: "var(--danger-color)",
                     color: "var(--danger-color-bw-contrast)",
                 },

--- a/frontend/src/routes/manage/Realm/Content/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/util.tsx
@@ -18,7 +18,7 @@ export const Button: React.FC<ButtonProps> = props => (
             },
             "&:not([disabled])": {
                 cursor: "pointer",
-                "&:hover": {
+                "&:hover, &:focus": {
                     color: "var(--accent-color)",
                     backgroundColor: "var(--grey97)",
                 },

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -161,7 +161,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
     const header = (
         <div css={{ display: "flex", flexDirection: "column" }}>
             <Link to={videoLink} css={{
-                dislay: "block",
+                display: "block",
                 position: "relative",
                 width: "100%",
                 maxWidth: "calc(40vh * 16 / 9)",
@@ -175,10 +175,10 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
                     color: "white",
                     transform: "translate(-50%, -50%)",
                 },
-                "&:not(:hover) > svg": {
+                "&:not(:hover, :focus) > svg": {
                     display: "none",
                 },
-                "&:hover > div": {
+                "&:hover > div, &:focus > div": {
                     opacity: 0.7,
                 },
                 backgroundColor: "black",

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -175,7 +175,7 @@ const EventTable: React.FC<EventTableProps> = ({ events, vars }) => {
                 },
             },
             "& > tbody": {
-                "& > tr:hover": {
+                "& > tr:hover, tr:focus-within": {
                     backgroundColor: "var(--grey92)",
                 },
                 "& > tr:not(:first-child) > td": {
@@ -244,7 +244,7 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => 
                     marginLeft: 6,
                     fontSize: 22,
                 },
-                "&:hover": {
+                "&:hover, &:focus": {
                     color: "var(--accent-color)",
                 },
             }}
@@ -372,7 +372,7 @@ const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled }) => (
                 : {
                     color: "var(--grey40)",
                     cursor: "pointer",
-                    ":hover": {
+                    ":hover, :focus": {
                         color: "black",
                     },
                 },

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -100,7 +100,7 @@ const gridTile = css({
     fontSize: 14,
     color: "black",
     "&:is(button, a)": {
-        "&:hover": {
+        "&:hover, &:focus": {
             color: "black",
             borderColor: "var(--grey80)",
             boxShadow: "1px 1px 5px var(--grey92)",

--- a/frontend/src/ui/Button.tsx
+++ b/frontend/src/ui/Button.tsx
@@ -36,7 +36,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
         "normal": () => ({
             border: "1px solid var(--grey65)",
             color: "black",
-            "&:hover": {
+            "&:hover, &:focus": {
                 border: "1px solid var(--grey40)",
                 backgroundColor: "var(--grey92)",
             },
@@ -45,7 +45,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
         "danger": () => ({
             border: "1px solid var(--danger-color)",
             color: "var(--danger-color)",
-            "&:hover": {
+            "&:hover, &:focus": {
                 border: "1px solid var(--danger-color-darker)",
                 backgroundColor: "var(--danger-color)",
                 color: "var(--danger-color-bw-contrast)",
@@ -56,7 +56,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
             border: "1px solid var(--happy-color-dark)",
             color: "var(--happy-color-bw-contrast)",
             backgroundColor: "var(--happy-color)",
-            "&:hover": {
+            "&:hover, &:focus": {
                 border: "1px solid var(--happy-color-dark)",
                 backgroundColor: "var(--happy-color-darker)",
                 color: "var(--happy-color-bw-contrast)",

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -104,7 +104,7 @@ export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
             }),
         },
 
-        "&:hover": hoverActiveStyle,
+        "&:hover, &:focus": hoverActiveStyle,
         ...active && {
             color: "var(--nav-color-darker)",
             fontWeight: "bold",


### PR DESCRIPTION
This adds the `:focus` selector to almost all elements that feature a style that is being applied on hover events. This should improve the usability of keyboard-only navigation. Exceptions are elements that are not keyboard-focusable, like the "logged in as <username>" and upload date on video pages.

Closes #649