### PR TITLE
Remove disabled buttons from accessibility tree

### DIFF
--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -357,6 +357,8 @@ type PageLinkProps = {
 const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled }) => (
     <Link
         to={varsToLink(vars)}
+        tabIndex={disabled ? -1 : 0}
+        aria-hidden={disabled}
         css={{
             background: "none",
             border: "none",


### PR DESCRIPTION
This removes the disabled buttons in `My videos` from tab order and screen reader exposition, so they can't be focused or activated anymore.
Reading around a bit, it seems that having disabled buttons at all might not be the most accessible solution, but I think in this case it still makes sense. Another option would be to hide the buttons completely when disabled.

Closes #642