### PR TITLE
Rerender the current route on every navigation

### DIFF
--- a/frontend/src/rauta.tsx
+++ b/frontend/src/rauta.tsx
@@ -454,7 +454,9 @@ export const makeRouter = <C extends Config, >(config: C): RouterLib => {
             }
         }, [context.activeRoute]);
 
-        return context.activeRoute.route.render();
+        return <React.Fragment key={currentIndex}>
+            {context.activeRoute.route.render()}
+        </React.Fragment>;
     };
 
     return {


### PR DESCRIPTION
Due to how React works, this previously only happened when you actually visited a new route. Visiting the same route would **not** rerender and thus also not reset any state.

This is unexpected for example when you click
the "upload video" button in the users menu while already uploading something.

Closes #681.