### PR TITLE
Reduce noisiness of harvest logging

### DIFF
--- a/backend/src/prelude.rs
+++ b/backend/src/prelude.rs
@@ -2,7 +2,7 @@
 //! commonly used symbols are easily available.
 
 pub(crate) use anyhow::{anyhow, bail, Context as _, Result};
-pub(crate) use log::{error, warn, info, debug, trace};
+pub(crate) use log::{error, warn, info, debug, trace, log};
 pub(crate) use futures::{FutureExt as _, TryStreamExt as _};
 pub(crate) use tap::Pipe;
 

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -86,7 +86,7 @@ impl OcClient {
         );
         let (uri, req) = self.build_req(&pq);
 
-        debug!("Sending harvest request (since = {:?}): GET {}", since, uri);
+        trace!("Sending harvest request (since = {:?}): GET {}", since, uri);
 
         let response = tokio::time::timeout(Duration::from_secs(60), self.http_client.request(req))
             .await
@@ -94,11 +94,13 @@ impl OcClient {
             .with_context(|| format!("Harvest request failed (to '{uri}')"))?;
 
         let (out, body_len) = Self::deserialize_response::<HarvestResponse>(response, &uri).await?;
-        debug!(
-            "Received {} KiB ({} items) from the harvest API (in {:.2?})",
+        log!(
+            if out.items.len() > 0 { log::Level::Debug } else { log::Level::Trace },
+            "Received {} KiB ({} items) from the harvest API (in {:.2?}, since = {:?})",
             body_len / 1024,
             out.items.len(),
             before.elapsed(),
+            since,
         );
 
         Ok(out)

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -39,6 +39,12 @@ pub(crate) async fn run(
 
     let preferred_amount = config.sync.preferred_harvest_size.into();
 
+    if daemon {
+        info!("Starting harvesting daemon");
+    } else {
+        info!("Starting to harvest all data that's available now");
+    }
+
     loop {
         let sync_status = SyncStatus::fetch(&**db).await
             .context("failed to fetch sync status from DB")?;
@@ -104,7 +110,7 @@ pub(crate) async fn run(
             }
         } else {
             if daemon {
-                debug!(
+                trace!(
                     "Harvested all available data: waiting {:?} before starting next harvest",
                     config.sync.poll_period,
                 );
@@ -254,7 +260,7 @@ async fn store_in_db(
     }
 
     if upserted_events == 0 && upserted_series == 0 && removed_events == 0 && removed_series == 0 {
-        info!("Harvest outcome: nothing changed!");
+        trace!("Harvest outcome: nothing changed!");
     } else {
         info!(
             "Harvest outcome: upserted {} events, upserted {} series, \


### PR DESCRIPTION
Now there are only `trace` level logs emitted when nothing new happens, which should notably reduce log sizes.