### PR TITLE
Update `bobheadxi/deployments` to v1.4 to properly delete old GH envs

### DIFF
--- a/.github/workflows/remove-deployment.yml
+++ b/.github/workflows/remove-deployment.yml
@@ -37,7 +37,7 @@ jobs:
       if: github.event_name != 'delete'
 
     - name: Delete GitHub deployment status
-      uses: bobheadxi/deployments@v1.3.0
+      uses: bobheadxi/deployments@v1.4.0
       with:
         step: delete-env
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For each test deployment a GitHub "environment" is created. The previous version of this action had a bug that meant those were not actually deleted in step `delete-env`. With this new version they are.

Also see: https://github.com/bobheadxi/deployments/pull/134