### PR TITLE
Improve presentation order of upcoming and live events

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -149,6 +149,7 @@ series:
   deleted: Gelöschte Serie
   deleted-series-block: Die hier referenzierte Serie wurde gelöscht.
   no-events: Diese Serie enthält keine Videos oder Sie sind nicht berechtigt, diese zu sehen.
+  upcoming-live-streams: "Anstehende Livestreams ({{count}})"
   videos:
     heading: Videos
   not-ready:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -146,6 +146,7 @@ series:
   deleted: Deleted series
   deleted-series-block: The series referenced here was deleted.
   no-events: This series does not contain any events, or you might not be authorized to see them.
+  upcoming-live-streams: "Upcoming Live Streams ({{count}})"
   videos:
     heading: Videos
   not-ready:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -146,7 +146,7 @@ series:
   deleted: Deleted series
   deleted-series-block: The series referenced here was deleted.
   no-events: This series does not contain any events, or you might not be authorized to see them.
-  upcoming-live-streams: "Upcoming Live Streams ({{count}})"
+  upcoming-live-streams: "Upcoming live streams ({{count}})"
   videos:
     heading: Videos
   not-ready:

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -154,27 +154,22 @@ const ReadySeriesBlock: React.FC<ReadyProps> = ({
         upcomingEvents.sort((a, b) => timeMs(a) - timeMs(b));
     }
 
+    const eventsToTiles = (events: Event[]) => events.map(event =>
+        <GridTile
+            key={event.id}
+            active={event.id === activeEventId}
+            {...{ basePath, event }}
+        />);
+
     const eventsUI = events.length === 0
         ? t("series.no-events")
         : <>
             {upcomingEvents.length > 1
                 && <UpcomingEventsGrid>
-                    {upcomingEvents.map(
-                        event => <GridTile
-                            key={event.id}
-                            active={event.id === activeEventId}
-                            {...{ basePath, event }}
-                        />,
-                    )}
+                    {eventsToTiles(upcomingEvents)}
                 </UpcomingEventsGrid>}
             <VideoGrid>
-                {sortedEvents.map(
-                    event => <GridTile
-                        key={event.id}
-                        active={event.id === activeEventId}
-                        {...{ basePath, event }}
-                    />,
-                )}
+                {eventsToTiles(sortedEvents)}
             </VideoGrid>
         </>;
 

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -271,7 +271,7 @@ type GridTypeProps = {
 const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
     const TRANSITION_IN_DURATION = "0.15s";
     const TRANSITION_OUT_DURATION = "0.3s";
-    const date = event.isLive ? event.syncedData?.startTime ?? event.created : event.created;
+    const date = event.syncedData?.startTime ?? event.created;
 
     const inner = <>
         <div css={{ borderRadius: 8, position: "relative" }}>

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -12,7 +12,7 @@ import {
     SeriesBlockSeriesData$data,
     SeriesBlockSeriesData$key,
 } from "./__generated__/SeriesBlockSeriesData.graphql";
-import { isPastLiveEvent, isUpcomingEvent, Thumbnail } from "../Video";
+import { isPastLiveEvent, isUpcomingLiveEvent, Thumbnail } from "../Video";
 import { RelativeDate } from "../time";
 import { Card } from "../Card";
 import { FiPlay } from "react-icons/fi";
@@ -126,10 +126,10 @@ const ReadySeriesBlock: React.FC<ReadyProps> = ({
 
     const events = series.events.filter(event =>
         !isPastLiveEvent(event.syncedData?.endTime ?? null, event.isLive)
-        && !isUpcomingEvent(event.syncedData?.startTime ?? null));
+        && !isUpcomingLiveEvent(event.syncedData?.startTime ?? null, event.isLive));
 
-    const upcomingEvents = series.events.filter(event =>
-        isUpcomingEvent(event.syncedData?.startTime ?? null));
+    const upcomingLiveEvents = series.events.filter(event =>
+        isUpcomingLiveEvent(event.syncedData?.startTime ?? null, event.isLive));
 
     const timeMs = (event: Event) =>
         new Date(event.syncedData?.startTime ?? event.created).getTime();
@@ -148,10 +148,10 @@ const ReadySeriesBlock: React.FC<ReadyProps> = ({
     });
 
     // If there is only one upcoming event, it doesn't need an extra box or ordering.
-    if (upcomingEvents.length === 1) {
-        sortedEvents.unshift(upcomingEvents[0]);
+    if (upcomingLiveEvents.length === 1) {
+        sortedEvents.unshift(upcomingLiveEvents[0]);
     } else {
-        upcomingEvents.sort((a, b) => timeMs(a) - timeMs(b));
+        upcomingLiveEvents.sort((a, b) => timeMs(a) - timeMs(b));
     }
 
     const eventsToTiles = (events: Event[]) => events.map(event =>
@@ -164,9 +164,9 @@ const ReadySeriesBlock: React.FC<ReadyProps> = ({
     const eventsUI = events.length === 0
         ? t("series.no-events")
         : <>
-            {upcomingEvents.length > 1
+            {upcomingLiveEvents.length > 1
                 && <UpcomingEventsGrid>
-                    {eventsToTiles(upcomingEvents)}
+                    {eventsToTiles(upcomingLiveEvents)}
                 </UpcomingEventsGrid>}
             <VideoGrid>
                 {eventsToTiles(sortedEvents)}

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -234,27 +234,40 @@ const VideoGrid: React.FC<React.PropsWithChildren> = ({ children }) => (
 const UpcomingEventsGrid: React.FC<React.PropsWithChildren> = ({ children }) => {
     const { t } = useTranslation();
 
-    return <details css={{
-        backgroundColor: "var(--grey86)",
-        borderRadius: 4,
-        "> summary": {
-            color: "var(--grey20)",
-            cursor: "pointer",
-            fontSize: 14,
-            padding: "6px 12px",
-        },
-        "> hr": {
-            margin: "0 12px",
-        },
-    }}>
-        <summary>
-            {t("series.upcoming-live-streams", { count: Children.count(children) })}
-        </summary>
-        <hr />
-        <VideoGrid>
-            {children}
-        </VideoGrid>
-    </details>;
+    return (
+        <details css={{
+            backgroundColor: "var(--grey86)",
+            borderRadius: 4,
+            marginBottom: 8,
+            "> summary": {
+                color: "var(--grey20)",
+                cursor: "pointer",
+                fontSize: 14,
+                padding: "6px 12px",
+                "> span": {
+                    marginLeft: 4,
+                },
+                ":hover, :focus-visible": {
+                    backgroundColor: "var(--grey80)",
+                    borderRadius: 4,
+                    color: "black",
+                },
+            },
+            "> hr": {
+                margin: "0 12px",
+            },
+        }}>
+            <summary>
+                <span>
+                    {t("series.upcoming-live-streams", { count: Children.count(children) })}
+                </span>
+            </summary>
+            <hr />
+            <VideoGrid>
+                {children}
+            </VideoGrid>
+        </details>
+    );
 };
 
 type GridTypeProps = {

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -168,8 +168,8 @@ export const formatDuration = (totalMs: number): string => {
 export const isPastLiveEvent = (endTime: string | null, isLive: boolean): boolean =>
     isLive && endTime != null && new Date(endTime) < new Date();
 
-export const isUpcomingEvent = (startingTime: string | null): boolean =>
-    startingTime != null && new Date(startingTime) > new Date();
+export const isUpcomingLiveEvent = (startingTime: string | null, isLive: boolean): boolean =>
+    isLive && startingTime != null && new Date(startingTime) > new Date();
 
 const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
     const { t } = useTranslation();

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -168,6 +168,9 @@ export const formatDuration = (totalMs: number): string => {
 export const isPastLiveEvent = (endTime: string | null, isLive: boolean): boolean =>
     isLive && endTime != null && new Date(endTime) < new Date();
 
+export const isUpcomingEvent = (startingTime: string | null): boolean =>
+    startingTime != null && new Date(startingTime) > new Date();
+
 const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
     const { t } = useTranslation();
     const [loadError, setLoadError] = useState(false);


### PR DESCRIPTION
This adds a collapsible box to event blocks which hides upcoming events if there are more than one present. These events are ordered by their starting time so that the earliest upcoming event is shown first.
Presentation of the remaining events is also reorganzied so that live events are always shown before non-live events and all events are now ordered by their starting time instead of creation time.

Notes: 
- The presentation order of the upcoming events is not configurable as I figured that we would always want to show the soonest one first, but that would be a small add if desired.
- I initially wanted to add some animation as the pop up of the details/summary element is a little sudden, but that turned out to be a little more complicated with that element because it doesn't have a fixed height, and also isn't super neccessary and might also look weird with too many upcoming events.

Closes #586 

Edit: to test this, you need to either create some upcoming and live events or edit the status (`is_live` and `start_time`) of some events in the database.