### PR TITLE
Fix `remove-deployment` action

### DIFF
--- a/.github/workflows/remove-deployment.yml
+++ b/.github/workflows/remove-deployment.yml
@@ -39,7 +39,10 @@ jobs:
     - name: Delete GitHub deployment status
       uses: bobheadxi/deployments@v1.4.0
       with:
-        step: delete-env
+        # We would like to `delete-env` instead, but this requires additional
+        # permissions for the GITHUB_TOKEN. Fixing that seems to be fairly
+        # involved, unfortunately.
+        step: deactivate-env
         token: ${{ secrets.GITHUB_TOKEN }}
         env: test-deployment-${{ env.DEPLOY_ID }}
 


### PR DESCRIPTION
I broke this in #687: to actually delete an environment, a token with the "repo" scope is required as described in [1]. This could be done via a personal access token, but only via the classic ones. And there one has to give access to the "repo" scope for all repos. Which I'm not comfortable doing. There are other ways, but I think none are easy. Also check [2].

I tried using the `permissions:` key in the yaml file, but I don't think this works as there is no entry about environments which one could give access to.

[1]: https://docs.github.com/en/rest/deployments/environments#delete-an-environment
[2]: https://github.com/marketplace/actions/delete-deployment-environment#how-to-obtain-the-proper-token