### PR TITLE
Add series selection to uploader (and start maintaining a series search index)

### DIFF
--- a/backend/src/api/id.rs
+++ b/backend/src/api/id.rs
@@ -85,6 +85,7 @@ define_kinds![
     event = b"ev",
     search_realm = b"rs",
     search_event = b"es",
+    search_series = b"ss",
 ];
 
 

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -265,16 +265,11 @@ fn looks_like_opencast_uuid(query: &str) -> bool {
 #[graphql(Context = Context)]
 pub(crate) enum EventSearchOutcome {
     SearchUnavailable(SearchUnavailable),
-    EmptyQuery(EmptyQuery),
     Results(SearchResults<search::Event>),
 }
 
 pub(crate) async fn all_events(user_query: &str, context: &Context) -> ApiResult<EventSearchOutcome> {
     context.require_moderator()?;
-
-    if user_query.is_empty() {
-        return Ok(EventSearchOutcome::EmptyQuery(EmptyQuery));
-    }
 
     let mut filter = String::new();
     let mut event_query = event_search_query(user_query, &mut filter, context);

--- a/backend/src/api/model/search/series.rs
+++ b/backend/src/api/model/search/series.rs
@@ -1,0 +1,34 @@
+use crate::{
+    api::{Context, Node, Id, NodeValue},
+    search,
+};
+
+
+impl Node for search::Series {
+    fn id(&self) -> Id {
+        Id::search_series(self.id.0)
+    }
+}
+
+#[juniper::graphql_object(Context = Context, impl = NodeValue, name = "SearchSeries")]
+impl search::Series {
+    fn id(&self) -> Id {
+        Node::id(self)
+    }
+
+    fn opencast_id(&self) -> &str {
+        &self.opencast_id
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn host_realms(&self) -> &[search::Realm] {
+        &self.host_realms
+    }
+}

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -12,7 +12,7 @@ use super::{
         realm::Realm,
         event::{AuthorizedEvent, Event},
         series::Series,
-        search::{self, SearchOutcome, EventSearchOutcome},
+        search::{self, SearchOutcome, EventSearchOutcome, SeriesSearchOutcome},
     },
     jwt::{JwtService, jwt},
 };
@@ -103,5 +103,16 @@ impl Query {
     /// moderator rights.
     async fn search_all_events(query: String, context: &Context) -> ApiResult<EventSearchOutcome> {
         search::all_events(&query, context).await
+    }
+
+    /// Searches through all series (including non-listed ones). If
+    /// `writable_only` is true, only series that the user can write are
+    /// returned. If it's false, moderator rights are required.
+    async fn search_all_series(
+        query: String,
+        writable_only: bool,
+        context: &Context,
+    ) -> ApiResult<SeriesSearchOutcome> {
+        search::all_series(&query, writable_only, context).await
     }
 }

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -14,12 +14,14 @@ mod general;
 mod theme;
 mod translated_string;
 mod opencast;
+mod upload;
 
 pub(crate) use self::{
     color::{Color, Hsl},
     translated_string::TranslatedString,
     theme::ThemeConfig,
     opencast::OpencastConfig,
+    upload::UploadConfig,
 };
 
 
@@ -80,6 +82,9 @@ pub(crate) struct Config {
 
     #[config(nested)]
     pub(crate) theme: ThemeConfig,
+
+    #[config(nested)]
+    pub(crate) upload: UploadConfig,
 }
 
 impl Config {

--- a/backend/src/config/upload.rs
+++ b/backend/src/config/upload.rs
@@ -1,0 +1,8 @@
+
+
+#[derive(Debug, confique::Config)]
+pub(crate) struct UploadConfig {
+    /// Whether specifying a series is required when uploading.
+    #[config(default = false)]
+    pub require_series: bool,
+}

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -333,4 +333,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     15: "fix-event-constraints",
     16: "master-track",
     17: "improve-ancestor-function-estimate",
+    18: "series-search-view",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -333,4 +333,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     16: "master-track",
     17: "improve-ancestor-function-estimate",
     18: "series-search-view",
+    19: "fix-queue-triggers",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -332,4 +332,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     14: "event-captions",
     15: "fix-event-constraints",
     16: "master-track",
+    17: "improve-ancestor-function-estimate",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -1,8 +1,7 @@
 use chrono::{DateTime, Utc, offset::TimeZone};
-use deadpool_postgres::Transaction;
 use once_cell::sync::Lazy;
 use std::{collections::BTreeMap, time::Duration, num::NonZeroU64};
-use tokio_postgres::{IsolationLevel, error::SqlState};
+use tokio_postgres::{IsolationLevel, Transaction, error::SqlState, Client};
 
 use crate::{prelude::*, db::util::select};
 use super::Db;
@@ -30,9 +29,9 @@ impl MigrationPlan {
     /// DB is in a state that we cannot fix, `Err` is returned. Does not modify
     /// the DB.
     pub(crate) async fn build(tx: &Transaction<'_>) -> Result<Self> {
-        if !super::query::does_table_exist(&**tx, "__db_migrations").await? {
+        if !super::query::does_table_exist(&*tx, "__db_migrations").await? {
             // Check if there are any other tables in the database, which would be fishy.
-            let tables = super::query::all_table_names(&**tx).await?;
+            let tables = super::query::all_table_names(&*tx).await?;
             if !tables.is_empty() {
                 bail!(
                     "migration table '__db_migrations' does not exist, but some other \
@@ -171,7 +170,7 @@ async fn create_meta_table_if_missing(tx: &Transaction<'_>) -> Result<()> {
 ///
 /// If anything unexpected is noticed, an error is returned to notify the user
 /// they have to manually deal with it.
-pub async fn migrate(db: &mut Db) -> Result<()> {
+pub async fn migrate(db: &mut Client) -> Result<()> {
     // The whole migration process is wrapped in one serializable transaction.
     // This guarantees that only one Tobira node ever does the migrations. As
     // this only happens during startup, the potential slow down from such a

--- a/backend/src/db/migrations/17-improve-ancestor-function-estimate.sql
+++ b/backend/src/db/migrations/17-improve-ancestor-function-estimate.sql
@@ -1,0 +1,5 @@
+-- This function is used a lot and PostgreSQL estimates it to return 1000 rows
+-- each time. Which is wildly incorrect. Of course this varies, but on the big
+-- test data set it's 4.26 on average. Fixing this estimation improves the
+-- query plan for a few big queries.
+alter function ancestors_of_realm(realm_id bigint) rows 4;

--- a/backend/src/db/migrations/18-series-search-view.sql
+++ b/backend/src/db/migrations/18-series-search-view.sql
@@ -6,6 +6,11 @@ create view search_series as
         series.id, series.state, series.opencast_id,
         series.read_roles, series.write_roles,
         series.title, series.description,
+        (select count(*) > 0
+            from blocks
+            inner join events on events.id = blocks.video
+            where events.series = series.id
+        ) as listed_via_events,
         coalesce(
             array_agg((
                 -- Using a nested query here improves the overall performance

--- a/backend/src/db/migrations/18-series-search-view.sql
+++ b/backend/src/db/migrations/18-series-search-view.sql
@@ -1,0 +1,133 @@
+-- All of this is the preparation to store series in the search index.
+
+-- Add view for series data that we put into the search index.
+create view search_series as
+    select
+        series.id, series.state, series.opencast_id,
+        series.read_roles, series.write_roles,
+        series.title, series.description,
+        coalesce(
+            array_agg((
+                -- Using a nested query here improves the overall performance
+                -- for the main use case: 'where id = any(...)'. If we would
+                -- use a join instead, the runtime would be the same with or
+                -- without the 'where id' (roughly 300ms on my machine).
+                select row(search_realms.id, name, full_path, ancestor_names)::search_realms
+                from search_realms
+                where search_realms.id = blocks.realm
+            )),
+            '{}'
+        ) as host_realms
+    from series
+    left join blocks on type = 'series' and blocks.series = series.id
+    group by series.id;
+
+
+-- Next we need to change the 'kind' of things we can insert into the queue to
+-- add 'series'.
+alter type search_index_item_kind rename to search_index_item_kind_old;
+create type search_index_item_kind as enum ('realm', 'event', 'series');
+alter table search_index_queue
+    alter column kind type search_index_item_kind using kind::text::search_index_item_kind;
+drop type search_index_item_kind_old;
+
+
+-- Add all triggers needed to automatically queue series whenever necessary.
+create function queue_series_for_reindex_on_block_change(block blocks)
+   returns void
+   language sql
+as $$
+    with listed_series as (select id from series where id = block.series)
+    insert into search_index_queue (item_id, kind)
+    select id, 'series' from listed_series
+    on conflict do nothing;
+$$;
+
+create function queue_series_on_blocks_change()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_series_for_reindex_on_block_change(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_series_for_reindex_on_block_change(new);
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_series_on_blocks_change
+after insert or delete or update of series
+on blocks
+for each row
+execute procedure queue_series_on_blocks_change();
+
+
+-- On some realm changes, some series have to be queued.
+create function queue_series_on_realm_change()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    -- All series listed on the changed realm are queued.
+    insert into search_index_queue (item_id, kind)
+    select blocks.series, 'series'
+    from blocks
+    where type = 'series' and (blocks.realm = old.id or blocks.realm = new.id)
+    on conflict do nothing;
+
+    -- If the name of this realm has changed, we also need to queue all series
+    -- included in child realms.
+    if tg_op = 'UPDATE' and (
+        old.name is distinct from new.name or
+        old.name_from_block is distinct from new.name_from_block
+    ) then
+        -- We don't need to queue the series in the realm itself as that already
+        -- happened above, hence the '/%'.
+        insert into search_index_queue (item_id, kind)
+        select blocks.series, 'series'
+        from blocks
+        inner join realms on realms.id = blocks.realm
+        where blocks.type = 'series' and full_path like new.full_path || '/%'
+        on conflict do nothing;
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_series_on_realm_change
+after update of id, parent, full_path, name, name_from_block
+on realms
+for each row
+execute procedure queue_series_on_realm_change();
+
+
+-- And of course, if the series itself is changed, it has to be queued
+create function queue_series_for_reindex(series series) returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    values (series.id, 'series')
+    on conflict do nothing
+$$;
+
+create function queue_touched_series_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_series_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_series_for_reindex(new);
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_touched_series_for_reindex
+after insert or delete or update
+on series
+for each row
+execute procedure queue_touched_series_for_reindex();

--- a/backend/src/db/migrations/19-fix-queue-triggers.sql
+++ b/backend/src/db/migrations/19-fix-queue-triggers.sql
@@ -1,0 +1,163 @@
+-- This migration does two things:
+-- * it fixes several bugs in '10-search-index-queue'
+-- * it adds triggers that were missing/omitted in `18-series-search-view`
+--
+-- Both things are done in this one migration because this saves us some code
+-- and results in fewer total triggers.
+
+
+-- Previously this trigger was installed with `update of id, full_path, ...`.
+-- Unfortunately, it is not triggered when `full_path` is changed via our
+-- trigger mechanism. If we just omit the columns, it works. So here we replace
+-- the trigger. But we also replace the function as we forgot one case
+-- (see below).
+drop trigger queue_touched_realm_for_reindex on realms;
+drop function queue_touched_realm_for_reindex;
+
+-- Returns all series and events that are hosted by the given realm. They are
+-- returned in the form that can be directly inserted into
+-- `search_index_queue`.
+create or replace function hosted_series_and_events(realm_id bigint)
+    returns table (id bigint, kind search_index_item_kind)
+    language 'sql'
+as $$
+    with
+        the_blocks as (
+            select *
+            from blocks
+            where blocks.realm = realm_id
+        ),
+        the_events as (
+            select events.id, 'event'::search_index_item_kind
+            from the_blocks
+            inner join events on (
+                type = 'series' and the_blocks.series = events.series
+                or type = 'video' and the_blocks.video = events.id
+            )
+        ),
+        the_series as (
+            select series.id, 'series'::search_index_item_kind
+            from the_blocks
+            inner join series on type = 'series' and the_blocks.series = series.id
+        )
+    select * from the_events union all select * from the_series
+$$;
+
+create function queue_touched_realm_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_realm_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_realm_for_reindex(new);
+    end if;
+
+    if tg_op = 'UPDATE' then
+        -- Events and series have to be queued as well. This was forgotten in
+        -- the '10-search-index-queue' migration. Events were only queued on
+        -- name change, but not if the path has changed.
+        if old.full_path is distinct from new.full_path then
+            insert into search_index_queue (item_id, kind)
+            select * from hosted_series_and_events(new.id) -- assuming ID doesnt change
+            on conflict do nothing;
+        end if;
+
+        -- If the name of this realm has changed, we also need to queue all child
+        -- realms as their 'ancestor_names' have changed.
+        if (
+            old.name is distinct from new.name or
+            old.name_from_block is distinct from new.name_from_block
+        ) then
+            insert into search_index_queue (item_id, kind)
+            select id, 'realm'
+            from realms
+            where full_path like new.full_path || '/%'
+            on conflict do nothing;
+
+            -- We also need to queue all events and series that are included on
+            -- any of those sub realms as they store their host realms. This
+            -- time, we include the realm itself (note the '%' instead of '/%'
+            -- above).
+            insert into search_index_queue (item_id, kind)
+            select h.*
+            from realms, hosted_series_and_events(realms.id) as h
+            where full_path like new.full_path || '%'
+            on conflict do nothing;
+        end if;
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_touched_realm_for_reindex
+after insert or delete or update -- no "of" columns here
+on realms
+for each row
+execute procedure queue_touched_realm_for_reindex();
+
+
+-- If a video block is changed, previously only the specific video was queued.
+-- But we said that a series and all its videos build one unit of being listed
+-- or unlisted. When any video of a series is mounted or unmounted, the listed
+-- status of potentially the whole unit changes.
+--
+-- Also, now series are queued.
+create or replace function queue_block_for_reindex(block blocks)
+   returns void
+   language sql
+as $$
+    with
+        -- The series that's involved: either via series block directly or the
+        -- one of the video (which could be null).
+        the_series(id) as (
+            select series from events where id = block.video and series is not null
+            union all select block.series where block.series is not null
+        ),
+        listed_events as (
+            select id from events where id = block.video
+            union all select events.id
+                from the_series
+                inner join events on events.series = the_series.id
+        ),
+        new_entries(id, kind) as (
+            select id, 'series'::search_index_item_kind from the_series
+            union all select id, 'event'::search_index_item_kind from listed_events
+        )
+    insert into search_index_queue (item_id, kind)
+    select id, kind from new_entries
+    on conflict do nothing;
+$$;
+
+
+-- This previously only queued the videos (and with the above change, series)
+-- related to the changed block. However, if the block was a name source for
+-- the realm, then we need to queue more realms.
+create or replace function queue_blocks_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_block_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_block_for_reindex(new);
+    end if;
+
+    -- If a realm was using this block as name source, we need to queue it and
+    -- all its descendents. (We assume the block ID is never updated to
+    -- simplify this code.)
+    if tg_op = 'UPDATE' and exists(select from realms where name_from_block = new.id) then
+        insert into search_index_queue (item_id, kind)
+        select realms.id, 'realm'
+        from realms
+        where full_path like (select full_path from realms where name_from_block = new.id) || '%'
+        on conflict do nothing;
+    end if;
+
+    return null;
+end;
+$$;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -25,6 +25,9 @@ mod tx;
 pub(crate) mod types;
 pub(crate) mod util;
 
+#[cfg(test)]
+mod tests;
+
 pub(crate) use self::{
     tx::Transaction,
     migrations::{migrate, MigrationPlan},

--- a/backend/src/db/tests/mod.rs
+++ b/backend/src/db/tests/mod.rs
@@ -1,0 +1,17 @@
+use crate::{prelude::*, db::types::Key};
+use super::DbConfig;
+use self::util::TestDb;
+
+mod util;
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn root_realm_exists() -> Result<()> {
+    let db = TestDb::with_migrations().await?;
+    let row = db.query_one("select * from realms", &[]).await?;
+    assert_eq!(row.get::<_, Key>("id"), Key(0));
+    assert_eq!(row.get::<_, String>("path_segment"), "");
+    assert_eq!(row.get::<_, String>("full_path"), "");
+
+    Ok(())
+}

--- a/backend/src/db/tests/mod.rs
+++ b/backend/src/db/tests/mod.rs
@@ -1,14 +1,10 @@
-use crate::{prelude::*, db::types::Key, search::IndexItemKind};
+use crate::{prelude::*, db::types::Key};
 use super::DbConfig;
 use self::util::TestDb;
 
 mod util;
+mod search_queue;
 
-macro_rules! set {
-    ($($e:expr),* $(,)?) => {
-        std::collections::HashSet::from([$($e),*])
-    };
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn root_realm_exists() -> Result<()> {
@@ -17,149 +13,6 @@ async fn root_realm_exists() -> Result<()> {
     assert_eq!(row.get::<_, Key>("id"), Key(0));
     assert_eq!(row.get::<_, String>("path_segment"), "");
     assert_eq!(row.get::<_, String>("full_path"), "");
-
-    Ok(())
-}
-
-// Makes sure realms are correctly inserted into the search queue.
-#[tokio::test(flavor = "multi_thread")]
-async fn realm_search_queue_triggers() -> Result<()> {
-    let db = TestDb::with_migrations().await?;
-
-    // Insert some realms and always make sure they are also in the queue. In
-    // the end we will have this realm tree:
-    //
-    // - animals
-    //   - dog
-    //   - cat
-    //     - momo
-    // - people
-    let animals = db.add_realm("animals", Key(0), "animals").await?;
-    let people = db.add_realm("people", Key(0), "people").await?;
-    let cat = db.add_realm("cat", animals, "cat").await?;
-    assert_eq!(db.search_queue().await?, set![
-        (animals, IndexItemKind::Realm),
-        (people, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-    ]);
-
-    // Make sure that parent realms are not queued when adding child realms.
-    db.clear_search_queue().await?;
-    let dog = db.add_realm("dog", animals, "dog").await?;
-    let momo = db.add_realm("momo", cat, "momo").await?;
-    assert_eq!(db.search_queue().await?, set![
-        (dog, IndexItemKind::Realm),
-        (momo, IndexItemKind::Realm),
-    ]);
-
-    // Make sure the parent is not queued when the child name changes.
-    db.clear_search_queue().await?;
-    db.execute("update realms set name = 'Momomo' where id = $1", &[&momo]).await?;
-    assert_eq!(db.search_queue().await?, set![(momo, IndexItemKind::Realm)]);
-
-    // Make sure the child realms are queued when a parent name is modified.
-    db.clear_search_queue().await?;
-    db.execute("update realms set name = 'Tiere' where id = $1", &[&animals]).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (animals, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (dog, IndexItemKind::Realm),
-        (momo, IndexItemKind::Realm),
-    ]);
-
-
-    // Create an event and a block for it. It will queue the event but not the
-    // realm.
-    db.clear_search_queue().await?;
-    let event = db.add_event("foo", 123, "foo").await?;
-    let video_block = db.query_one(
-        "insert into blocks (realm, index, type, video, show_title)
-            values ($1, 0, 'video', $2, true)
-            returning id",
-        &[&cat, &event],
-    ).await?.get::<_, Key>(0);
-    assert_eq!(db.search_queue().await?, set![(event, IndexItemKind::Event)]);
-
-    // Make sure if the name of the video is changed without being used as a
-    // name source block, it won't queue the realms.
-    db.clear_search_queue().await?;
-    db.execute("update events set title = 'bar' where id = $1", &[&event]).await?;
-    assert_eq!(db.search_queue().await?, set![(event, IndexItemKind::Event)]);
-
-    // Make sure when we set the realm to derive its name from the video block, it is queued.
-    db.clear_search_queue().await?;
-    db.execute(
-        "update realms set name = null, name_from_block = $1 where id = $2",
-        &[&video_block, &cat],
-    ).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (momo, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (event, IndexItemKind::Event),
-    ]);
-
-    // Make sure if the event's title is changed, the affected realms are queued too.
-    db.clear_search_queue().await?;
-    db.execute("update events set title = 'banana' where id = $1", &[&event]).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (momo, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (event, IndexItemKind::Event),
-    ]);
-
-
-    // Add series and corresponding block.
-    db.clear_search_queue().await?;
-    let series = db.add_series("green", "green").await?;
-    let series_block = db.query_one(
-        "insert into blocks (realm, index, type, series, show_title, videolist_order)
-            values ($1, 1, 'series', $2, true, 'new_to_old')
-            returning id",
-        &[&cat, &series],
-    ).await?.get::<_, Key>(0);
-    assert_eq!(db.search_queue().await?, set![(series, IndexItemKind::Series)]);
-
-    // Make sure if the name of the series is changed without being used as a
-    // name source block, it won't queue the realms.
-    db.clear_search_queue().await?;
-    db.execute("update series set title = 'blue' where id = $1", &[&series]).await?;
-    assert_eq!(db.search_queue().await?, set![(series, IndexItemKind::Series)]);
-
-    // Make sure when we set the realm to derive its name from the series block,
-    // it is queued. The series and event included are queued as well.
-    db.clear_search_queue().await?;
-    db.execute(
-        "update realms set name_from_block = $1 where id = $2",
-        &[&series_block, &cat],
-    ).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (momo, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (series, IndexItemKind::Series),
-        (event, IndexItemKind::Event),
-    ]);
-
-    // Make sure if the series' title is changed, everything is queued as above.
-    db.clear_search_queue().await?;
-    db.execute("update series set title = 'kiwi' where id = $1", &[&series]).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (momo, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (series, IndexItemKind::Series),
-        (event, IndexItemKind::Event),
-    ]);
-
-
-    // Finally, if a realm is deleted, it and all its deleted children need to
-    // be queued.
-    db.clear_search_queue().await?;
-    db.execute("delete from realms where id = $1", &[&cat]).await?;
-    assert_eq!(db.search_queue().await?, set![
-        (momo, IndexItemKind::Realm),
-        (cat, IndexItemKind::Realm),
-        (series, IndexItemKind::Series),
-        (event, IndexItemKind::Event),
-    ]);
 
     Ok(())
 }

--- a/backend/src/db/tests/mod.rs
+++ b/backend/src/db/tests/mod.rs
@@ -1,9 +1,14 @@
-use crate::{prelude::*, db::types::Key};
+use crate::{prelude::*, db::types::Key, search::IndexItemKind};
 use super::DbConfig;
 use self::util::TestDb;
 
 mod util;
 
+macro_rules! set {
+    ($($e:expr),* $(,)?) => {
+        std::collections::HashSet::from([$($e),*])
+    };
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn root_realm_exists() -> Result<()> {
@@ -12,6 +17,149 @@ async fn root_realm_exists() -> Result<()> {
     assert_eq!(row.get::<_, Key>("id"), Key(0));
     assert_eq!(row.get::<_, String>("path_segment"), "");
     assert_eq!(row.get::<_, String>("full_path"), "");
+
+    Ok(())
+}
+
+// Makes sure realms are correctly inserted into the search queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn realm_search_queue_triggers() -> Result<()> {
+    let db = TestDb::with_migrations().await?;
+
+    // Insert some realms and always make sure they are also in the queue. In
+    // the end we will have this realm tree:
+    //
+    // - animals
+    //   - dog
+    //   - cat
+    //     - momo
+    // - people
+    let animals = db.add_realm("animals", Key(0), "animals").await?;
+    let people = db.add_realm("people", Key(0), "people").await?;
+    let cat = db.add_realm("cat", animals, "cat").await?;
+    assert_eq!(db.search_queue().await?, set![
+        (animals, IndexItemKind::Realm),
+        (people, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+    ]);
+
+    // Make sure that parent realms are not queued when adding child realms.
+    db.clear_search_queue().await?;
+    let dog = db.add_realm("dog", animals, "dog").await?;
+    let momo = db.add_realm("momo", cat, "momo").await?;
+    assert_eq!(db.search_queue().await?, set![
+        (dog, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // Make sure the parent is not queued when the child name changes.
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'Momomo' where id = $1", &[&momo]).await?;
+    assert_eq!(db.search_queue().await?, set![(momo, IndexItemKind::Realm)]);
+
+    // Make sure the child realms are queued when a parent name is modified.
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'Tiere' where id = $1", &[&animals]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (animals, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+
+    // Create an event and a block for it. It will queue the event but not the
+    // realm.
+    db.clear_search_queue().await?;
+    let event = db.add_event("foo", 123, "foo").await?;
+    let video_block = db.query_one(
+        "insert into blocks (realm, index, type, video, show_title)
+            values ($1, 0, 'video', $2, true)
+            returning id",
+        &[&cat, &event],
+    ).await?.get::<_, Key>(0);
+    assert_eq!(db.search_queue().await?, set![(event, IndexItemKind::Event)]);
+
+    // Make sure if the name of the video is changed without being used as a
+    // name source block, it won't queue the realms.
+    db.clear_search_queue().await?;
+    db.execute("update events set title = 'bar' where id = $1", &[&event]).await?;
+    assert_eq!(db.search_queue().await?, set![(event, IndexItemKind::Event)]);
+
+    // Make sure when we set the realm to derive its name from the video block, it is queued.
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name = null, name_from_block = $1 where id = $2",
+        &[&video_block, &cat],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (event, IndexItemKind::Event),
+    ]);
+
+    // Make sure if the event's title is changed, the affected realms are queued too.
+    db.clear_search_queue().await?;
+    db.execute("update events set title = 'banana' where id = $1", &[&event]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (event, IndexItemKind::Event),
+    ]);
+
+
+    // Add series and corresponding block.
+    db.clear_search_queue().await?;
+    let series = db.add_series("green", "green").await?;
+    let series_block = db.query_one(
+        "insert into blocks (realm, index, type, series, show_title, videolist_order)
+            values ($1, 1, 'series', $2, true, 'new_to_old')
+            returning id",
+        &[&cat, &series],
+    ).await?.get::<_, Key>(0);
+    assert_eq!(db.search_queue().await?, set![(series, IndexItemKind::Series)]);
+
+    // Make sure if the name of the series is changed without being used as a
+    // name source block, it won't queue the realms.
+    db.clear_search_queue().await?;
+    db.execute("update series set title = 'blue' where id = $1", &[&series]).await?;
+    assert_eq!(db.search_queue().await?, set![(series, IndexItemKind::Series)]);
+
+    // Make sure when we set the realm to derive its name from the series block,
+    // it is queued. The series and event included are queued as well.
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name_from_block = $1 where id = $2",
+        &[&series_block, &cat],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series, IndexItemKind::Series),
+        (event, IndexItemKind::Event),
+    ]);
+
+    // Make sure if the series' title is changed, everything is queued as above.
+    db.clear_search_queue().await?;
+    db.execute("update series set title = 'kiwi' where id = $1", &[&series]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series, IndexItemKind::Series),
+        (event, IndexItemKind::Event),
+    ]);
+
+
+    // Finally, if a realm is deleted, it and all its deleted children need to
+    // be queued.
+    db.clear_search_queue().await?;
+    db.execute("delete from realms where id = $1", &[&cat]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series, IndexItemKind::Series),
+        (event, IndexItemKind::Event),
+    ]);
 
     Ok(())
 }

--- a/backend/src/db/tests/search_queue.rs
+++ b/backend/src/db/tests/search_queue.rs
@@ -1,0 +1,495 @@
+use crate::{prelude::*, db::types::Key, search::IndexItemKind};
+use super::util::TestDb;
+
+
+macro_rules! set {
+    ($($e:expr),* $(,)?) => {
+        std::collections::HashSet::from([$($e),*])
+    };
+}
+
+
+struct Setup {
+    animals: Key,
+    dog: Key,
+    cat: Key,
+    momo: Key,
+    people: Key,
+    video_free: Key,
+    video_a: Key,
+    video_b: Key,
+    series_a: Key,
+    series_empty: Key,
+}
+
+/// Create a test DB with a few test objects in it. The search queue is cleared
+/// by this function. The following realm tree is created:
+///
+/// ```text
+/// - animals
+///   - dog
+///   - cat
+///     - momo
+/// - people
+/// ```
+async fn setup() -> Result<(TestDb, Setup)> {
+    let db = TestDb::with_migrations().await?;
+
+    let animals = db.add_realm("animals", Key(0), "animals").await?;
+    let people = db.add_realm("people", Key(0), "people").await?;
+    let cat = db.add_realm("cat", animals, "cat").await?;
+    let dog = db.add_realm("dog", animals, "dog").await?;
+    let momo = db.add_realm("momo", cat, "momo").await?;
+
+    let series_a = db.add_series("Empty", "series-empty").await?;
+    let series_empty = db.add_series("Non empty", "series-non-empty").await?;
+    let video_free = db.add_event("Lonely", 123, "lonely-123", None).await?;
+    let video_a = db.add_event("Video A", 60, "video-a", Some(series_a)).await?;
+    let video_b = db.add_event("Video B", 80, "video-b", Some(series_a)).await?;
+
+    db.clear_search_queue().await?;
+    Ok((db, Setup {
+        animals, people, cat, dog, momo, video_free, video_a, video_b, series_a, series_empty,
+    }))
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_realm_add() -> Result<()> {
+    let (db, Setup { cat, .. }) = setup().await?;
+    let lili = db.add_realm("Lili", cat, "lili").await?;
+    assert_eq!(db.search_queue().await?, set![(lili, IndexItemKind::Realm)]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_realm_change() -> Result<()> {
+    let (db, Setup {
+        cat, animals, people, momo, dog, video_free, video_a, video_b, series_a, series_empty, ..
+    }) = setup().await?;
+
+    // Mount series and videos into some realms.
+    db.add_video_block(animals, video_free, 0).await?;
+    let cat_series_block = db.add_series_block(cat, series_a, 0).await?;
+    db.add_series_block(people, series_empty, 0).await?;
+    db.add_series_block(dog, series_empty, 0).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        (series_empty, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (video_free, IndexItemKind::Event),
+    ]);
+
+
+    // Change name of leaf realm without blocks.
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'different' where id = $1", &[&momo]).await?;
+    assert_eq!(db.search_queue().await?, set![(momo, IndexItemKind::Realm)]);
+
+    // Change name of realm with series block.
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'different' where id = $1", &[&cat]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    // Change name of realm with block and children with blocks
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'different' where id = $1", &[&animals]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (animals, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),      // bc mounted in cat
+        (series_empty, IndexItemKind::Series),  // bc mounted in dog
+        (video_a, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_b, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_free, IndexItemKind::Event),     // bc mounted in animals
+    ]);
+
+    // Change name of `people`.
+    db.clear_search_queue().await?;
+    db.execute("update realms set name = 'different' where id = $1", &[&people]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (people, IndexItemKind::Realm),
+        (series_empty, IndexItemKind::Series),
+    ]);
+
+
+    // Change to `name_from_block`
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name = null, name_from_block = $2 where id = $1",
+        &[&cat, &cat_series_block],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    // Change `name_from_block`
+    let second_block = db.add_video_block(cat, video_a, 1).await?;
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name_from_block = $2 where id = $1",
+        &[&cat, &second_block],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+
+    // Change path (via `path_segment`, but that triggers `full_path` being changes as well).
+    // Change name of leaf realm without blocks.
+    db.clear_search_queue().await?;
+    db.execute("update realms set path_segment = 'different' where id = $1", &[&momo]).await?;
+    assert_eq!(db.search_queue().await?, set![(momo, IndexItemKind::Realm)]);
+
+    // Change name of realm with series block.
+    db.clear_search_queue().await?;
+    db.execute("update realms set path_segment = 'different' where id = $1", &[&cat]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    // Change name of realm with block and children with blocks
+    db.clear_search_queue().await?;
+    db.execute("update realms set path_segment = 'different' where id = $1", &[&animals]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (momo, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (animals, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
+        (series_a, IndexItemKind::Series),      // bc mounted in cat
+        (series_empty, IndexItemKind::Series),  // bc mounted in dog
+        (video_a, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_b, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_free, IndexItemKind::Event),     // bc mounted in animals
+    ]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_realm_remove() -> Result<()> {
+    let (db, Setup { cat, momo, people, .. }) = setup().await?;
+    db.execute("delete from realms where id = $1", &[&people]).await?;
+    assert_eq!(db.search_queue().await?, set![(people, IndexItemKind::Realm)]);
+
+    db.clear_search_queue().await?;
+    db.execute("delete from realms where id = $1", &[&cat]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_event_add() -> Result<()> {
+    let (db, Setup { .. }) = setup().await?;
+    let event = db.add_event("Foo", 124, "foo", None).await?;
+    assert_eq!(db.search_queue().await?, set![(event, IndexItemKind::Event)]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_event_change() -> Result<()> {
+    let (db, Setup { video_a, animals, cat, dog, momo, .. }) = setup().await?;
+
+    // Change title without being inside a block.
+    db.execute("update events set title = 'different' where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+
+    // Change title while not a name source.
+    let block = db.add_video_block(animals, video_a, 0).await?;
+    db.clear_search_queue().await?;
+    db.execute("update events set title = 'different2' where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+
+    // Change title while a name source.
+    db.execute(
+        "update realms set name = null, name_from_block = $1 where id = $2",
+        &[&block, &animals],
+    ).await?;
+    db.clear_search_queue().await?;
+    db.execute("update events set title = 'bonanza' where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (animals, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // Changing the series just queues the video.
+    db.clear_search_queue().await?;
+    db.execute("update events set series = null where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+
+    // As does changing other fields.
+    db.clear_search_queue().await?;
+    db.execute("update events set duration = 987 where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_event_remove() -> Result<()> {
+    let (db, Setup { video_a, .. }) = setup().await?;
+    db.execute("delete from events where id = $1", &[&video_a]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_series_add() -> Result<()> {
+    let (db, Setup { .. }) = setup().await?;
+    let series = db.add_series("foo", "foo").await?;
+    assert_eq!(db.search_queue().await?, set![(series, IndexItemKind::Series)]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_series_change() -> Result<()> {
+    let (db, Setup { series_a, video_a, video_b, animals, cat, dog, momo, .. }) = setup().await?;
+
+    // Change title without being inside a block.
+    db.execute("update series set title = 'different' where id = $1", &[&series_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    // Change title while not a name source.
+    let block = db.add_series_block(animals, series_a, 0).await?;
+    db.clear_search_queue().await?;
+    db.execute("update series set title = 'different2' where id = $1", &[&series_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    // Change title while a name source.
+    db.execute(
+        "update realms set name = null, name_from_block = $1 where id = $2",
+        &[&block, &animals],
+    ).await?;
+    db.clear_search_queue().await?;
+    db.execute("update series set title = 'bonanza' where id = $1", &[&series_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (animals, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // As does changing other fields.
+    db.clear_search_queue().await?;
+    db.execute("update series set description = 'henlo' where id = $1", &[&series_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        // The videos don't have to be queued, but they currently are and it doesn't really hurt.
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_series_remove() -> Result<()> {
+    let (db, Setup { series_a, series_empty, video_a, video_b, .. }) = setup().await?;
+    db.execute("delete from series where id = $1", &[&series_empty]).await?;
+    assert_eq!(db.search_queue().await?, set![(series_empty, IndexItemKind::Series)]);
+
+    db.clear_search_queue().await?;
+    db.execute("delete from series where id = $1", &[&series_a]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_a, IndexItemKind::Series),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+    ]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_video_block_add_modify_delete() -> Result<()> {
+    let (db, Setup { cat, series_a, video_a, video_b, video_free, momo, .. }) = setup().await?;
+
+    // Add a video block -> the series and all its videos are now listed.
+    let block = db.add_video_block(cat, video_a, 0).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    // Change `video` field: listed status changes.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set video = $1 where id = $2", &[&video_free, &block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (video_free, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    // When the block is used as name source, and the title of the event is
+    // updated, the realms are queued.
+    db.execute(
+        "update realms set name = null, name_from_block = $1 where id = $2",
+        &[&block, &cat],
+    ).await?;
+    db.clear_search_queue().await?;
+    db.execute("update events set title = 'different' where id = $1", &[&video_free]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_free, IndexItemKind::Event),
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // Changing the video of the block also queues the realms as the name is retrieved from it.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set video = $1 where id = $2", &[&video_a, &block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (video_free, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+
+    // Changing display settings of the block won't queue anything.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set show_title = false where id = $1", &[&block]).await?;
+    assert_eq!(db.search_queue().await?, set![]);
+
+    // Stop using it as name source.
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name = 'peter', name_from_block = null where id = $1",
+        &[&cat],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // Delete block
+    db.clear_search_queue().await?;
+    db.execute("delete from blocks where id = $1", &[&block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn on_series_block_add_modify_delete() -> Result<()> {
+    let (db, Setup { cat, series_a, series_empty, video_a, video_b, momo, .. }) = setup().await?;
+
+    // Add a series block -> the series and all its videos are now listed.
+    let block = db.add_series_block(cat, series_a, 0).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    // Change `series` field: listed status changes.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set series = $1 where id = $2", &[&series_empty, &block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+        (series_empty, IndexItemKind::Series),
+    ]);
+
+    // When the block is used as name source, and the title of the series is
+    // updated, the realms are queued.
+    db.execute(
+        "update realms set name = null, name_from_block = $1 where id = $2",
+        &[&block, &cat],
+    ).await?;
+    db.clear_search_queue().await?;
+    db.execute("update series set title = 'different' where id = $1", &[&series_empty]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (series_empty, IndexItemKind::Series),
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+    // Changing the video of the block also queues the realms as the name is retrieved from it.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set series = $1 where id = $2", &[&series_a, &block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+        (series_empty, IndexItemKind::Series),
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+    ]);
+
+
+    // Changing display settings of the block won't queue anything.
+    db.clear_search_queue().await?;
+    db.execute("update blocks set show_title = false where id = $1", &[&block]).await?;
+    assert_eq!(db.search_queue().await?, set![]);
+
+    // Stop using it as name source.
+    db.clear_search_queue().await?;
+    db.execute(
+        "update realms set name = 'peter', name_from_block = null where id = $1",
+        &[&cat],
+    ).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (cat, IndexItemKind::Realm),
+        (momo, IndexItemKind::Realm),
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    // Delete block
+    db.clear_search_queue().await?;
+    db.execute("delete from blocks where id = $1", &[&block]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a, IndexItemKind::Event),
+        (video_b, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
+
+    Ok(())
+}

--- a/backend/src/db/tests/util.rs
+++ b/backend/src/db/tests/util.rs
@@ -1,0 +1,94 @@
+use std::ops::Deref;
+use secrecy::ExposeSecret;
+use tokio_postgres::{Client, NoTls};
+
+use crate::prelude::*;
+use super::DbConfig;
+
+
+async fn conn(config: &super::DbConfig) -> Result<Client> {
+    let (client, connection) = tokio_postgres::config::Config::new()
+        .user(&config.user)
+        .password(config.password.expose_secret())
+        .dbname(&config.database)
+        .host(&config.host)
+        .port(config.port)
+        .application_name("Tobira DB tests")
+        .connect(NoTls)
+        .await
+        .context("could not connect to DB in test")?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            panic!("PG connection error: {e}");
+        }
+        println!("done with connection");
+    });
+
+    Ok(client)
+}
+
+/// A temporary DB used for a single unit test. Is removed on drop.
+///
+/// Be sure to use the multi threaded Tokio runtime or else `drop` will hang
+/// indefinitely!
+pub(super) struct TestDb {
+    client: Option<Client>,
+    controller: Client,
+    db_name: String,
+}
+
+impl TestDb {
+    /// Creates a new temporary database with connection data from the dev config.
+    pub(super) async fn new() -> Result<Self> {
+        let config = crate::Config::load_from("../util/dev-config/config.toml")
+            .context("failed to load config")?;
+
+        // Create connection to original database and create a new temporary one.
+        let controller = conn(&config.db).await?;
+        let db_name = format!("tobira_test_{}", rand::random::<u64>());
+        controller.execute(&format!("create database {db_name}"), &[]).await
+            .context("failed to create temporary test DB")?;
+
+        // Connect to temporary database
+        let client = conn(&DbConfig { database: db_name.clone(), ..config.db }).await?;
+
+        Ok(Self {
+            controller,
+            client: Some(client),
+            db_name
+        })
+    }
+
+    pub(super) async fn with_migrations() -> Result<Self> {
+        let mut out = Self::new().await?;
+        crate::db::migrate(out.client.as_mut().unwrap()).await
+            .context("failed to run migrations on test DB")?;
+
+        Ok(out)
+    }
+}
+
+impl Deref for TestDb {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        self.client.as_ref().unwrap()
+    }
+}
+
+impl Drop for TestDb {
+    fn drop(&mut self) {
+        // Since there is no "async drop" in Rust yet, this is a bit annoying.
+        // First we need to drop the client to close all connections to the
+        // temporary database. Then we drop the database within `block_on`.
+        //
+        // This code requires the multi threaded Tokio runtime! :(
+        drop(self.client.take());
+        futures::executor::block_on(async move {
+            self.controller.execute(&format!("drop database {}", self.db_name), &[])
+                .await
+                .expect("failed to drop temporary test DB");
+        });
+    }
+}

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -90,6 +90,9 @@ impl Assets {
             "loginPageNote": config.auth.login_page.note,
             "preAuthExternalLinks": config.auth.pre_auth_external_links,
         }).to_string());
+        variables.insert("upload".into(), json!({
+            "requireSeries": config.upload.require_series,
+        }).to_string());
 
         // Note the mismatch between presentation and sync node;
         // these might not be the same forever!

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -182,6 +182,8 @@ async fn status(meili: &Client) -> Result<()> {
     // Individual indexes
     index_status("event", &meili.event_index, meili.config.event_index_name()).await?;
     println!();
+    index_status("series", &meili.series_index, meili.config.series_index_name()).await?;
+    println!();
     index_status("realm", &meili.realm_index, meili.config.realm_index_name()).await?;
     println!();
 

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -163,7 +163,7 @@ impl Client {
 
 // ===== Abstracting over search items ============================================================
 
-#[derive(Debug, Clone, Copy, FromSql, ToSql, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, FromSql, ToSql, PartialEq, Eq, Hash)]
 #[postgres(name = "search_index_item_kind")]
 pub(crate) enum IndexItemKind {
     #[postgres(name = "realm")]

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod cmd;
 mod event;
 mod meta;
 mod realm;
+mod series;
 pub(crate) mod writer;
 mod update;
 mod util;
@@ -30,13 +31,14 @@ pub(crate) use self::{
     event::Event,
     meta::IndexState,
     realm::Realm,
+    series::Series,
     update::{update_index, update_index_daemon},
 };
 
 
 /// The version of search index schema. Increase whenever there is a change that
 /// requires an index rebuild.
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
 
 
 // ===== Configuration ============================================================================
@@ -84,6 +86,10 @@ impl MeiliConfig {
         format!("{}{}", self.index_prefix, "events")
     }
 
+    fn series_index_name(&self) -> String {
+        format!("{}{}", self.index_prefix, "series")
+    }
+
     fn realm_index_name(&self) -> String {
         format!("{}{}", self.index_prefix, "realms")
     }
@@ -102,6 +108,7 @@ pub(crate) struct Client {
     pub(crate) client: MeiliClient,
     pub(crate) meta_index: Index,
     pub(crate) event_index: Index,
+    pub(crate) series_index: Index,
     pub(crate) realm_index: Index,
 }
 
@@ -120,9 +127,10 @@ impl Client {
         // actually exist!).
         let meta_index = client.index(&config.meta_index_name());
         let event_index = client.index(&config.event_index_name());
+        let series_index = client.index(&config.series_index_name());
         let realm_index = client.index(&config.realm_index_name());
 
-        Self { client, config, meta_index, event_index, realm_index }
+        Self { client, config, meta_index, event_index, series_index, realm_index }
     }
 
     /// Checks the connection to Meilisearch by accessing the `/health` endpoint.
@@ -162,6 +170,8 @@ pub(crate) enum IndexItemKind {
     Realm,
     #[postgres(name = "event")]
     Event,
+    #[postgres(name = "series")]
+    Series,
 }
 
 impl IndexItemKind {
@@ -169,6 +179,7 @@ impl IndexItemKind {
         match self {
             IndexItemKind::Realm => "realms",
             IndexItemKind::Event => "events",
+            IndexItemKind::Series => "series",
         }
     }
 }
@@ -255,6 +266,9 @@ pub(crate) async fn prepare_indexes(meili: &MeiliWriter<'_>) -> Result<()> {
     let event_index = create_index(&meili.client, &meili.config.event_index_name()).await?;
     event::prepare_index(&event_index).await?;
 
+    let series_index = create_index(&meili.client, &meili.config.series_index_name()).await?;
+    series::prepare_index(&series_index).await?;
+
     let realm_index = create_index(&meili.client, &meili.config.realm_index_name()).await?;
     realm::prepare_index(&realm_index).await?;
 
@@ -315,6 +329,7 @@ pub(crate) async fn clear(meili: &MeiliWriter<'_>) -> Result<()> {
 
     ignore_missing_index(meili.meta_index.clone().delete().await)?;
     ignore_missing_index(meili.event_index.clone().delete().await)?;
+    ignore_missing_index(meili.series_index.clone().delete().await)?;
     ignore_missing_index(meili.realm_index.clone().delete().await)?;
 
     info!("Deleted search indexes");
@@ -347,6 +362,7 @@ pub(crate) async fn index_all_data(
 
     let before = Instant::now();
     rebuild_index!("events", Event, meili.event_index);
+    rebuild_index!("series", Series, meili.series_index);
     rebuild_index!("realms", Realm, meili.realm_index);
     info!("Sent all data to Meili in {:.1?}", before.elapsed());
 

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -1,0 +1,86 @@
+use meilisearch_sdk::indexes::Index;
+use serde::{Serialize, Deserialize};
+use tokio_postgres::GenericClient;
+
+use crate::{
+    prelude::*,
+    db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
+};
+
+use super::{realm::Realm, SearchId, IndexItem, IndexItemKind, util};
+
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Series {
+    pub(crate) id: SearchId,
+    pub(crate) opencast_id: String,
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+
+    // See `search::Event::*_roles` for notes that also apply here.
+    pub(crate) read_roles: Vec<String>,
+    pub(crate) write_roles: Vec<String>,
+
+    // The `listed` field is always `!host_realms.is_empty()`, but we need to
+    // store it explicitly to filter for this condition in Meili.
+    pub(crate) listed: bool,
+    pub(crate) host_realms: Vec<Realm>,
+}
+
+impl IndexItem for Series {
+    const KIND: IndexItemKind = IndexItemKind::Series;
+    fn id(&self) -> SearchId {
+        self.id
+    }
+}
+
+impl_from_db!(
+    Series,
+    select: {
+        search_series.{id, opencast_id, title, description, read_roles, write_roles, host_realms},
+    },
+    |row| {
+        let host_realms = row.host_realms::<Vec<Realm>>();
+        Self {
+            id: row.id(),
+            opencast_id: row.opencast_id(),
+            title: row.title(),
+            description: row.description(),
+            read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
+            write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
+            listed: !host_realms.is_empty(),
+            host_realms,
+        }
+    }
+);
+
+impl Series {
+    pub(crate) async fn load_by_ids(db: &impl GenericClient, ids: &[Key]) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from search_series \
+            where id = any($1) and state <> 'waiting'");
+        let rows = db.query_raw(&query, dbargs![&ids]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load series from DB")
+    }
+
+    pub(crate) async fn load_all(db: &impl GenericClient) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from search_series where state <> 'waiting'");
+        let rows = db.query_raw(&query, dbargs![]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load series from DB")
+    }
+}
+
+pub(super) async fn prepare_index(index: &Index) -> Result<()> {
+    util::lazy_set_special_attributes(
+        index,
+        "series",
+        &["title", "description"],
+        &["listed", "read_roles", "write_roles"],
+    ).await
+}

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -38,7 +38,10 @@ impl IndexItem for Series {
 impl_from_db!(
     Series,
     select: {
-        search_series.{id, opencast_id, title, description, read_roles, write_roles, host_realms},
+        search_series.{
+            id, opencast_id, title, description, read_roles, write_roles,
+            listed_via_events, host_realms,
+        },
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
@@ -49,7 +52,7 @@ impl_from_db!(
             description: row.description(),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
-            listed: !host_realms.is_empty(),
+            listed: !host_realms.is_empty() || row.listed_via_events(),
             host_realms,
         }
     }

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -463,3 +463,10 @@
 #
 # Default value: "#27ae60"
 #happy = "#27ae60"
+
+
+[upload]
+# Whether specifying a series is required when uploading.
+#
+# Default value: false
+#require_series = false

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -29,6 +29,7 @@ type Config = {
     metadataLabels: Record<string, Record<string, MetadataLabel>>;
     logo: LogoConfig;
     plyr: PlyrConfig;
+    upload: UploadConfig;
 };
 
 type FooterLink = "about" | "graphiql" | {
@@ -72,6 +73,10 @@ type VersionInfo = {
     buildDateUtc: string;
     gitCommitHash: string;
     gitWasDirty: boolean;
+};
+
+type UploadConfig = {
+    requireSeries: boolean;
 };
 
 type MetadataLabel = "builtin:license" | "builtin:source" | TranslatedString;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -216,6 +216,9 @@ upload:
     description: Beschreibung
     required: Pflichtfeld
     save: Speichern und fertigstellen
+    note-writable-series: >
+      Sie können Videos nur in Serien hochladen, auf die Sie Schreibzugriff haben.
+      Andere Serien sind daher hier nicht auswählbar.
   errors:
     failed-to-upload: Hochladen fehlgeschlagen.
     unknown: Während des Dateiuploads ist ein unbekannter Fehler aufgetreten.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -210,8 +210,8 @@ upload:
     required: required
     save: Save and finish
     note-writable-series: >
-      Videos can only uploaded into series for which you have write-access.
-      Other series are therefore not listed selectable here.
+      Videos can only be uploaded into series for which you have write-access.
+      Other series are therefore not listed as selectable here.
   errors:
     failed-to-upload: Failed to upload video.
     unknown: Unknown error occurred during video upload.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -209,6 +209,9 @@ upload:
     description: Description
     required: required
     save: Save and finish
+    note-writable-series: >
+      Videos can only uploaded into series for which you have write-access.
+      Other series are therefore not listed selectable here.
   errors:
     failed-to-upload: Failed to upload video.
     unknown: Unknown error occurred during video upload.

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -12,6 +12,7 @@
       {
         "version": {{: var:version :}},
         "auth": {{: var:auth :}},
+        "upload": {{: var:upload :}},
         "siteTitle": {{: var:site-title :}},
         "footerLinks": {{: var:footer-links :}},
         "metadataLabels": {{: var:metadata-labels :}},

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -635,7 +635,13 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled }) => {
     const { register, handleSubmit, control, formState: { errors } } = useForm<Metadata>({
         mode: "onChange",
     });
-    const { field: seriesField } = useController({ name: "series", control });
+    const { field: seriesField } = useController({
+        name: "series",
+        control,
+        rules: {
+            required: CONFIG.upload.requireSeries ? t("upload.errors.field-required") : false,
+        },
+    });
 
     const onSubmit = handleSubmit(data => onSave(data));
 
@@ -673,6 +679,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled }) => {
                     onChange={data => seriesField.onChange(data?.opencastId)}
                     onBlur={seriesField.onBlur}
                 />
+                {boxError(errors.series?.message)}
             </InputContainer>
 
             {/* Submit button */}

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
 import { keyframes } from "@emotion/react";
 import { useController, useForm } from "react-hook-form";
-import { FiCheckCircle, FiUpload } from "react-icons/fi";
+import { FiCheckCircle, FiInfo, FiUpload } from "react-icons/fi";
 
 import { RootLoader } from "../layout/Root";
 import { loadQuery } from "../relay";
@@ -25,6 +25,7 @@ import { PageTitle } from "../layout/header/ui";
 import { useRouter } from "../router";
 import { getJwt } from "../relay/auth";
 import { SeriesSelector } from "../ui/SearchableSelect";
+import { WithTooltip } from "../ui/Floating";
 
 
 export const UploadRoute = makeRoute(url => {
@@ -199,7 +200,7 @@ const UploadMain: React.FC = () => {
                 margin: "0 auto",
             }}>
                 <UploadState state={uploadState.current} />
-                <div css={{ overflowY: "auto" }}>
+                <div>
                     {/* TODO: Show something after saving metadata.
                         - Just saying "saved" is kind of misleading because the data is only local.
                         - Maybe just show the form, but disable all inputs?
@@ -672,7 +673,21 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled }) => {
 
             {/* Series */}
             <InputContainer>
-                <label htmlFor="series-field">{t("series.series")}</label>
+                <label htmlFor="series-field">
+                    {t("series.series")}
+                    <WithTooltip
+                        tooltip={t("upload.metadata.note-writable-series")}
+                        tooltipCss={{ width: 400 }}
+                        css={{
+                            display: "inline-block",
+                            verticalAlign: "middle",
+                            fontWeight: "normal",
+                            marginLeft: 8,
+                        }}
+                    >
+                        <span><FiInfo tabIndex={0} /></span>
+                    </WithTooltip>
+                </label>
                 <SeriesSelector
                     writableOnly
                     menuPlacement="top"

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -646,9 +646,11 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled }) => {
 
     const onSubmit = handleSubmit(data => onSave(data));
 
-    // TODO: it might be too easy to accidentally submit the form with enter
+    // We only allow submitting the form on clicking the button below so that
+    // pressing 'enter' inside inputs doesn't lead to submit the form too
+    // early.
     return (
-        <Form noValidate onSubmit={onSubmit} css={{ margin: "32px 2px" }}>
+        <Form noValidate onSubmit={e => e.preventDefault()} css={{ margin: "32px 2px" }}>
             {/* Title */}
             <InputContainer>
                 <TitleLabel htmlFor="title-field" />
@@ -698,7 +700,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled }) => {
             </InputContainer>
 
             {/* Submit button */}
-            <Button kind="happy" type="submit" disabled={disabled}>
+            <Button kind="happy" disabled={disabled} onClick={onSubmit}>
                 {t("upload.metadata.save")}
             </Button>
         </Form>

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -118,7 +118,7 @@ type Series {
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!
 }
 
-union EventSearchOutcome = SearchUnavailable | EmptyQuery | EventSearchResults
+union EventSearchOutcome = SearchUnavailable | EventSearchResults
 
 input NewVideoBlock {
   event: ID!

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -208,8 +208,8 @@ interface Node {
   id: ID!
 }
 
-input UpdateTextBlock {
-  content: String
+type SeriesSearchResults {
+  items: [SearchSeries!]!
 }
 
 type Track {
@@ -222,6 +222,10 @@ type Track {
 
 type SearchResults {
   items: [Node!]!
+}
+
+input UpdateTextBlock {
+  content: String
 }
 
 type Realm implements Node {
@@ -292,6 +296,8 @@ type Realm implements Node {
   """
   references(id: ID!): Boolean!
 }
+
+union SeriesSearchOutcome = SearchUnavailable | SeriesSearchResults
 
 "Exactly one of `plain` or `block` has to be non-null."
 input UpdatedRealmName {
@@ -421,6 +427,12 @@ type Query {
     moderator rights.
   """
   searchAllEvents(query: String!): EventSearchOutcome!
+  """
+    Searches through all series (including non-listed ones). If
+    `writable_only` is true, only series that the user can write are
+    returned. If it's false, moderator rights are required.
+  """
+  searchAllSeries(query: String!, writableOnly: Boolean!): SeriesSearchOutcome!
 }
 
 interface RealmNameSourceBlock {
@@ -481,6 +493,14 @@ input NewSeriesBlock {
   showTitle: Boolean!
   showMetadata: Boolean!
   order: VideoListOrder!
+}
+
+type SearchSeries implements Node {
+  id: ID!
+  opencastId: String!
+  title: String!
+  description: String
+  hostRealms: [SearchRealm!]!
 }
 
 type User {

--- a/frontend/src/ui/Floating.tsx
+++ b/frontend/src/ui/Floating.tsx
@@ -1,3 +1,4 @@
+import { Interpolation } from "@emotion/react";
 import {
     arrow,
     autoUpdate,
@@ -17,6 +18,7 @@ import {
 } from "@floating-ui/react";
 import React, { ReactNode, ReactElement, useRef, useState, useImperativeHandle } from "react";
 import { mergeRefs } from "react-merge-refs";
+import { Theme } from "react-select";
 
 import { bug, unreachable } from "../util/err";
 
@@ -373,10 +375,11 @@ export const Floating = React.forwardRef<HTMLDivElement, FloatingProps>(
 type WithTooltipProps = {
     children: ReactElement;
     tooltip: ReactNode;
+    tooltipCss?: Interpolation<Theme>;
 } & Partial<Omit<FloatingContainerProps, "trigger">>;
 
 export const WithTooltip = React.forwardRef<FloatingHandle, WithTooltipProps>(
-    ({ children, tooltip, ...props }, ref) => (
+    ({ children, tooltip, tooltipCss, ...props }, ref) => (
         <FloatingContainer
             ref={ref}
             {...props}
@@ -386,6 +389,8 @@ export const WithTooltip = React.forwardRef<FloatingHandle, WithTooltipProps>(
             <Floating css={{
                 color: "var(--grey20)",
                 fontSize: 14,
+                maxWidth: "100%",
+                ...tooltipCss as Record<string, unknown>,
             }}>{tooltip}</Floating>
             <FloatingTrigger>{children}</FloatingTrigger>
         </FloatingContainer>

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -44,6 +44,7 @@ export const SearchableSelect = <T, >({
                 padding: 0,
             }),
             option: (_baseStyles, state) => ({
+                cursor: "default",
                 padding: "6px 10px",
                 "&:hover, &:focus": {
                     backgroundColor: "var(--grey95)",

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -30,6 +30,26 @@ export const SearchableSelect = <T, >({
         loadOptions={loadOptions}
         formatOptionLabel={(option: T) => format(option, t)}
         cacheOptions
+        // Without this, it thinks all entries are selected if any one is.
+        isOptionSelected={() => false}
+        styles={{
+            menuList: baseStyles => ({
+                ...baseStyles,
+                padding: 0,
+            }),
+            option: (_baseStyles, state) => ({
+                padding: "6px 10px",
+                "&:hover, &:focus": {
+                    backgroundColor: "var(--grey95)",
+                },
+                ...state.isSelected && {
+                    borderLeft: "4px solid var(--accent-color)",
+                },
+                ...(state.isFocused || state.isSelected) && {
+                    backgroundColor: "var(--grey95)",
+                },
+            }),
+        }}
         isClearable
         defaultOptions
         theme={theme}

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -31,6 +31,7 @@ export const SearchableSelect = <T, >({
         formatOptionLabel={(option: T) => format(option, t)}
         cacheOptions
         isClearable
+        defaultOptions
         theme={theme}
         loadingMessage={() => t("loading")}
         noOptionsMessage={noOptionsMessage ?? (() => t("general.form.select.no-options"))}

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -1,7 +1,13 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { TFunction, useTranslation } from "react-i18next";
 import { Theme } from "react-select";
 import AsyncSelect from "react-select/async";
+import { fetchQuery, graphql } from "react-relay";
+
+import { environment } from "../relay";
+import { Card } from "./Card";
+import { SmallDescription } from "./metadata";
+import { SearchableSelectSeriesQuery } from "./__generated__/SearchableSelectSeriesQuery.graphql";
 
 
 type DerivedProps<T> = Omit<Parameters<typeof AsyncSelect<T>>[0],
@@ -72,3 +78,76 @@ const theme = (theme: Theme) => ({
         primary25: "hsla(var(--accent-hue), var(--accent-sat), var(--accent-lightness), 0.25)",
     },
 });
+
+
+
+type SeriesSelectorProps = DerivedProps<SeriesOption> & {
+    onChange?: (series: SeriesOption | null) => void;
+    onBlur?: () => void;
+    defaultValue?: SeriesOption;
+    writableOnly: boolean;
+};
+
+type SeriesOption = {
+    readonly id: string;
+    readonly opencastId: string;
+    readonly title: string;
+    readonly description: string | null;
+};
+
+export const SeriesSelector: React.FC<SeriesSelectorProps> = ({
+    writableOnly, onBlur, onChange, defaultValue, ...rest
+}) => {
+    const { t } = useTranslation();
+    const [error, setError] = useState(false);
+
+    const query = graphql`
+        query SearchableSelectSeriesQuery($q: String!, $writableOnly: Boolean!) {
+            series: searchAllSeries(query: $q, writableOnly: $writableOnly) {
+                ... on SeriesSearchResults {
+                    items { id opencastId title description }
+                }
+            }
+        }
+    `;
+
+    const load = (input: string, callback: (options: readonly SeriesOption[]) => void) => {
+        fetchQuery<SearchableSelectSeriesQuery>(environment, query, { q: input, writableOnly })
+            .subscribe({
+                next: ({ series }) => {
+                    if (series.items === undefined) {
+                        setError(true);
+                        return;
+                    }
+
+                    callback(series.items.map(item => ({
+                        ...item,
+                        // Series returned by the search API have a different ID
+                        // prefix than other series. And the mutation expects an ID
+                        // starting with `ev`.
+                        id: item.id.replace(/^ss/, "sr"),
+                    })));
+                },
+                start: () => {},
+            });
+    };
+
+    return <>
+        {error && <Card kind="error" css={{ marginBottom: 8 }}>{t("search.unavailable")}</Card>}
+        <SearchableSelect
+            loadOptions={load}
+            format={formatSeriesOption}
+            onChange={onChange}
+            isDisabled={error}
+            {...{ onBlur, defaultValue }}
+            {...rest}
+        />
+    </>;
+};
+
+const formatSeriesOption = (series: SeriesOption, _: TFunction) => (
+    <div>
+        <div>{series.title}</div>
+        <SmallDescription css={{ margin: 0 }} lines={1} text={series.description} />
+    </div>
+);

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -141,7 +141,13 @@ export const FOCUS_STYLE_INSET = {
 export const ellipsisOverflowCss = (lines: number): Record<string, any> => ({
     overflow: "hidden",
     textOverflow: "ellipsis",
-    display: "-webkit-box",
-    WebkitBoxOrient: "vertical",
-    WebkitLineClamp: lines,
+    ...lines === 1
+        ? {
+            whiteSpace: "nowrap",
+        }
+        : {
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: lines,
+        },
 });

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -25,13 +25,18 @@ export const InputContainer: React.FC<{ children: ReactNode }> = ({ children }) 
 type SmallDescriptionProps = {
     text: string | null;
     lines?: number;
+    className?: string;
 };
 
 /**
  * An event's or series' description in at most `lines` lines. The text is not
  * transformed at all, but emitted as is.
  */
-export const SmallDescription: React.FC<SmallDescriptionProps> = ({ text, lines = 2 }) => {
+export const SmallDescription: React.FC<SmallDescriptionProps> = ({
+    text,
+    className,
+    lines = 2,
+}) => {
     const { t } = useTranslation();
     const sharedStyle = {
         fontSize: 13,
@@ -39,13 +44,13 @@ export const SmallDescription: React.FC<SmallDescriptionProps> = ({ text, lines 
     };
 
     if (text === null) {
-        return <div css={{
+        return <div {...{ className }} css={{
             ...sharedStyle,
             color: "var(--grey65)",
             fontStyle: "italic",
         }}>{t("manage.my-videos.no-description")}</div>;
     } else {
-        return <div css={{
+        return <div {...{ className }} css={{
             ...sharedStyle,
             color: "var(--grey40)",
             maxWidth: 800,


### PR DESCRIPTION
Fixes #675 

This PR:
- Adds the `search_series` DB view (which is used to populate the search index).
- Installs the appropriate triggers to make sure series are added to the `search_index_queue` when necessary.
- Adds a search index for series and populates it correctly.
- Uses that search index to make a `SearchableSelect` work with series.
- Uses that `SearchableSelect` to add a series selection to the uploader.

Additionally, I added tests to make sure all those triggers work as expected. Those tests revealed that, in fact, those triggers didn't work as expected. So another migration was added to fix those bugs. See commit messages for more information. Probably review commit by commit. (Though the last two commits change previous code, be aware.)

As series are now indexed, we could make the main search now also return series. I would wait with that though until Meili allows multi-index search. 

I noticed that in our test data, there aren't many series that have non-empty `write_roles`. So even Sabine can upload in just 2 series right now. But this "requires write permission to series" is the only sane condition we can use, and it was specified like that in #675.