### PR TITLE
Fix breadcrumbs and simplify realm SQL queries by using `resolved_name`

### DIFF
--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -1,7 +1,7 @@
 use juniper::{GraphQLInputObject, GraphQLObject};
 
 use crate::{
-    api::{Context, Id, err::{ApiResult, invalid_input}, model::realm::{REALM_JOINS, Realm}},
+    api::{Context, Id, err::{ApiResult, invalid_input}, model::realm::Realm},
     db::{types::Key, util::select},
     prelude::*,
 };
@@ -341,7 +341,7 @@ impl BlockValue {
                 returning realm, index\
             ) \
             select {selection} \
-            from realms {REALM_JOINS} \
+            from realms \
             where realms.id = (select realm from deleted)"
         );
         let result = db

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -11,7 +11,7 @@ use crate::{
         Context, Cursor, Id, Node, NodeValue,
         common::NotAllowed,
         err::{self, ApiResult, invalid_input},
-        model::{series::Series, realm::{Realm, REALM_JOINS}},
+        model::{series::Series, realm::Realm},
     },
     db::{
         types::{EventTrack, EventState, Key, ExtraMetadata, EventCaption},
@@ -171,7 +171,6 @@ impl AuthorizedEvent {
         let query = format!("\
             select {selection} \
             from realms \
-            {REALM_JOINS} \
             where exists ( \
                 select 1 as contains \
                 from blocks \

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -7,7 +7,7 @@ use crate::{
         err::ApiResult,
         Id,
         model::{
-            realm::{Realm, REALM_JOINS},
+            realm::Realm,
             event::{AuthorizedEvent, EventSortOrder}
         },
         Node,
@@ -127,7 +127,6 @@ impl Series {
         let query = format!("\
             select {selection} \
             from realms \
-            {REALM_JOINS} \
             where exists ( \
                 select 1 as contains \
                 from blocks \


### PR DESCRIPTION
When this whole "derive name from blocks" thing was introduced, all queries have gotten three extra joins. A useful SQL function was also added that allows us to just write `realms.resolved_name`. The comment on that function mentions that doing the join manually is faster than using the function. After testing this again, I cannot confirm. Even just querying all realms and selecting `resolved_name` runs within 90ms (including network!). There seems to be on problem and certainly no N+1 problem.

Using that instead of the joins simplifies many queries. But more importantly, our breadcrumbs are now correct. Before, the JOINs messed up the guaranteed order of `ancestors_of_realm`. Now it should be fixed.