### PR TITLE
Use thumbnail as player preview image

### DIFF
--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -58,7 +58,7 @@ declare module "paella-core" {
         metadata: {
             duration: number;
             title?: string;
-            preview?: string;
+            preview?: string | null;
             // TODO: `related`
         };
 

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -19,10 +19,11 @@ type PaellaPlayerProps = {
     isLive: boolean;
     startTime: string | null;
     endTime: string | null;
+    previewImage: string | null;
 };
 
 const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
-    tracks, title, duration, isLive, captions, startTime, endTime,
+    tracks, title, duration, isLive, captions, startTime, endTime, previewImage,
 }) => {
     const { t } = useTranslation();
     const ref = useRef<HTMLDivElement>(null);
@@ -66,6 +67,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
                 metadata: {
                     title,
                     duration: fixedDuration,
+                    preview: previewImage,
                 },
                 streams: Object.entries(tracksByKind).map(([key, tracks]) => ({
                     content: key,
@@ -117,7 +119,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
             paellaSnapshot.unload();
             paella.current = undefined;
         };
-    }, [tracks, title, duration, isLive, captions, startTime, endTime, t]);
+    }, [tracks, title, duration, isLive, captions, startTime, endTime, previewImage, t]);
 
     return (
         <div

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -88,7 +88,11 @@ export const Player: React.FC<PlayerProps> = ({ event, onEventStateChange }) => 
                         ? { mode: "pending", startTime }
                         : { mode: "ended" },
                 }} />
-                : <LoadPaellaPlayer {...event} {...event.syncedData} />}
+                : <LoadPaellaPlayer
+                    {...event}
+                    {...event.syncedData}
+                    previewImage={event.syncedData.thumbnail}
+                />}
         </Suspense>
     );
 };


### PR DESCRIPTION
We talked about this and everyone said that this is better than just black (as before). However, it's not optimal as Tobira currently has only one image per event that is used for all purposes. There should be more images, larger ones for thumbnails, and bigger ones for the player preview. But we can still do that later.

Fixes #464 
(I will create a new issue then to deal with "use more better fitting images for different purposes")