### PR TITLE
Stop discarding fully uploaded videos when navigating away from uploader

### DIFF
--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -114,7 +114,10 @@ const UploadMain: React.FC = () => {
     const abortController = useRef(new AbortController());
 
     router.listenAtNav(() => {
-        abortController.current.abort();
+        const state = uploadState.current?.state;
+        if (state && !["done", "cancelled", "error"].includes(state)) {
+            abortController.current.abort();
+        }
     });
 
     useNavBlocker(() => !!uploadState.current


### PR DESCRIPTION
This leads to those videos failing to get processed as the media package is partially deleted.