### PR TITLE
Make uploader show error when selecting non-video or -audio files

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -192,6 +192,7 @@ upload:
   too-many-files: >
     Sie haben zu viele Dateien ausgewählt. Zurzeit werden nur einzelne Dateien unterstützt.
   not-a-file: Sie haben etwas in diesen Bereich gezogen, das keine Datei ist.
+  not-video-or-audio: Nur Video- und Audiodateien können hochgeladen werden.
   starting: Starte Upload...
   finishing: Schließe Upload ab...
   waiting-for-metadata: Zum Fertigstellen bitte Videoinformationen speichern

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -186,6 +186,7 @@ upload:
   reselect: Reselect files
   too-many-files: You selected too many files. Currently, only a single file is supported.
   not-a-file: You dropped something that's not a file.
+  not-video-or-audio: Only video and audio can be uploaded.
   starting: Starting...
   finishing: Finishing up...
   waiting-for-metadata: Please save video information to finish the upload

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -327,6 +327,9 @@ const UploadErrorBox: React.FC<{ error: unknown }> = ({ error }) => {
 // ===== Sub-components
 // ==============================================================================================
 
+const isValidForUpload = (file: File): boolean =>
+    file.type.startsWith("video/") || file.type.startsWith("audio/");
+
 type FileSelectProps = {
     onSelect: (files: FileList) => void;
 };
@@ -340,6 +343,18 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
     const [dragCounter, setDragCounter] = useState(0);
     const isDragging = dragCounter > 0;
 
+    const onSelectRaw = (files: FileList) => {
+        if (files.length === 0) {
+            setError(t("upload.not-a-file"));
+        } else if (files.length > 1) {
+            setError(t("upload.too-many-files"));
+        } else if (!Array.from(files).every(isValidForUpload)) {
+            setError(t("upload.not-video-or-audio"));
+        } else {
+            onSelect(files);
+        }
+    };
+
     return (
         <div
             onDragEnter={e => {
@@ -349,14 +364,7 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
             onDragOver={e => e.preventDefault()}
             onDragLeave={() => setDragCounter(old => old - 1)}
             onDrop={e => {
-                const files = e.dataTransfer.files;
-                if (files.length === 0) {
-                    setError(t("upload.not-a-file"));
-                } else if (files.length > 1) {
-                    setError(t("upload.too-many-files"));
-                } else {
-                    onSelect(e.dataTransfer.files);
-                }
+                onSelectRaw(e.dataTransfer.files);
                 setDragCounter(0);
                 e.preventDefault();
             }}
@@ -410,7 +418,7 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
                     ref={fileInput}
                     onChange={e => {
                         if (e.target.files) {
-                            onSelect(e.target.files);
+                            onSelectRaw(e.target.files);
                         }
                     }}
                     type="file"


### PR DESCRIPTION
Fixes #682

This could technically make some things that worked before fail now. Either because Opencast can deal with some files that have a non `video/` or `audio/` mime type. Or because the browser doesn't correctly infer the MIME type. MDN says that browser don't read the file but judge purely from the file name extension. And that for rare or ambiguous extensions, it might return an empty MIME  type. I think this should be fine, but I'm not entirely sure and have no idea. How I would find out more :/