### PR TITLE
Replace "home" link title with aria-label

### DIFF
--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -35,7 +35,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
             <BreadcrumbsContainer>
                 <li>
                     <Link to="/" css={{ lineHeight: 1, padding: 2, ...FOCUS_STYLE_INSET }}>
-                        <FiHome title={t("home")} />
+                        <FiHome aria-label={t("home")} />
                     </Link>
                 </li>
                 {path.map((segment, i) => (
@@ -56,10 +56,8 @@ export const BreadcrumbsContainer: React.FC<React.PropsWithChildren> = ({ childr
         fontSize: 14,
         flexWrap: "wrap",
         whiteSpace: "nowrap",
-        "& svg": {
-            fontSize: 16,
-        },
-        "& > li": {
+        svg: { fontSize: 16 },
+        li: {
             display: "inline-flex",
             alignItems: "center",
         },


### PR DESCRIPTION
This replaces the `title` attribute of the link with an `aria-label`, as `title` won't be announced by many screen readers. It also adds a tooltip to the link, but I'm not sure if that is really necessary (I'm leaning towards no as it might be redundant and also a little distracting in this instance).

Closes #646 