### PR TITLE
Add and apply `focusStyle` function

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -104,6 +104,7 @@ const GLOBAL_STYLE = css({
         "&:hover, &:focus": {
             color: "var(--nav-color-darker)",
         },
+        ":focus-visible": { outline: "2.5px solid var(--accent-color)" },
     },
     hr: {
         border: "none",

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -6,7 +6,7 @@ import type { NavigationData$key } from "./__generated__/NavigationData.graphql"
 import { useTranslation } from "react-i18next";
 import {
     ellipsisOverflowCss,
-    FOCUS_STYLE_INSET,
+    focusStyle,
     LinkList,
     LinkWithIcon,
     SIDE_BOX_BORDER_RADIUS,
@@ -63,7 +63,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                     color: "var(--grey40)",
                     padding: "10px 14px",
                     borderRadius: `${SIDE_BOX_BORDER_RADIUS}px ${SIDE_BOX_BORDER_RADIUS}px 0 0`,
-                    ...FOCUS_STYLE_INSET,
+                    ...focusStyle({ inset: true }),
                 }}
             >
                 {/* Show arrow and hide chevron in burger menu */}

--- a/frontend/src/layout/header/Logo.tsx
+++ b/frontend/src/layout/header/Logo.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import CONFIG from "../../config";
 import { BREAKPOINT_SMALL } from "../../GlobalStyle";
 import { Link } from "../../router";
+import { focusStyle } from "../../ui";
 import { translatedConfig } from "../../util";
 import { HEADER_BASE_PADDING } from "./ui";
 
@@ -40,9 +41,8 @@ export const Logo: React.FC = () => {
                 flex: "0 1 auto",
                 margin: `-${HEADER_BASE_PADDING}px 0`,
                 borderRadius: 4,
-                outlineOffset: -2,
-                ":hover": { outline: "2px solid var(--grey80)" },
-                ":focus": { outline: "2px solid var(--accent-color)" },
+                ":hover": { outlineOffset: -2, outline: "2px solid var(--grey80)" },
+                ...focusStyle({ inset: true }),
                 "& > img": {
                     height: "100%",
                     width: "auto",

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { HiOutlineSearch } from "react-icons/hi";
 import { useRouter } from "../../router";
 import { isSearchActive } from "../../routes/Search";
+import { focusStyle } from "../../ui";
 import { Spinner } from "../../ui/Spinner";
 import { currentRef } from "../../util";
 
@@ -107,8 +108,13 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                             height,
                             paddingLeft: 42,
                             paddingRight: 12,
-                            ":hover": { outline: "2px solid var(--grey80)" },
-                            ":focus": { outline: "2px solid var(--accent-color)" },
+                            ":hover": {
+                                borderColor: "var(--grey80)",
+                                outline: "2.5px solid var(--grey80)",
+                                outlineOffset: -1,
+                            },
+                            ":focus-visible": { borderColor: "var(--accent-color)" },
+                            ...focusStyle({ offset: -1 }),
                             "&::placeholder": {
                                 color: "var(--grey40)",
                                 opacity: 1,

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -17,7 +17,7 @@ import CONFIG from "../../config";
 import { Spinner } from "../../ui/Spinner";
 import { LOGIN_PATH } from "../../routes/paths";
 import { REDIRECT_STORAGE_KEY } from "../../routes/Login";
-import { FOCUS_STYLE_INSET } from "../../ui";
+import { focusStyle } from "../../ui";
 import { ProtoButton } from "../../ui/Button";
 import { FloatingHandle, FloatingContainer, FloatingTrigger, Floating } from "../../ui/Floating";
 
@@ -75,14 +75,12 @@ const LoggedOut: React.FC = () => {
                     borderRadius: 8,
                     padding: "7px 14px",
                     backgroundColor: "var(--nav-color)",
-                    outlineOffset: 1,
                     svg: { fontSize: 20 },
                     ":hover, :focus": {
                         backgroundColor: "var(--nav-color-dark)",
                         color: "var(--nav-color-bw-contrast)",
                     },
-                    ":hover": { outline: "2px solid var(--grey80)" },
-                    ":focus": { outline: "2px solid var(--accent-color)" },
+                    ...focusStyle({ offset: 1 }),
                 },
                 /* Show only the icon on mobile devices. */
                 [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
@@ -118,8 +116,13 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
                 borderRadius: 8,
                 padding: "8px 10px 8px 16px",
                 cursor: "pointer",
-                ":hover": { outline: "2px solid var(--grey80)" },
-                ":focus": { outline: "2px solid var(--accent-color)" },
+                ":hover": {
+                    borderColor: "var(--grey80)",
+                    outline: "2.5px solid var(--grey80)",
+                    outlineOffset: -1,
+                },
+                ":focus-visible": { borderColor: "var(--accent-color)" },
+                ...focusStyle({ offset: -1 }),
                 [`@media (max-width: ${BREAKPOINT_MEDIUM}px)`]: {
                     display: "none",
                 },
@@ -301,17 +304,14 @@ const ReturnButton: React.FC<ReturnButtonProps> = ({ onClick, children }) => (
             display: "none",
         },
     }}>
-        <div onClick={onClick} tabIndex={0} css={{
+        <ProtoButton onClick={onClick} tabIndex={0} css={{
             display: "flex",
             alignItems: "center",
             cursor: "pointer",
             padding: "24px 12px",
             opacity: 0.75,
             ":hover, :focus": { opacity: 1 },
-            ":focus": {
-                outline: "2px solid var(--accent-color)",
-                outlineOffset: -2,
-            },
+            ...focusStyle({ inset: true }),
             "> svg": {
                 maxHeight: 23,
                 fontSize: 23,
@@ -320,7 +320,7 @@ const ReturnButton: React.FC<ReturnButtonProps> = ({ onClick, children }) => (
             },
         }}>
             <FiArrowLeft />
-        </div>
+        </ProtoButton>
         <span css={{
             whiteSpace: "nowrap",
             textOverflow: "ellipsis",
@@ -402,8 +402,8 @@ const MenuItem: React.FC<MenuItemProps> = ({
             strokeWidth: 2,
             "& > path": { strokeWidth: "inherit" },
         },
-        "&:hover, &:focus": { backgroundColor: "var(--grey97)" },
-        ...FOCUS_STYLE_INSET,
+        ":hover, :focus": { backgroundColor: "var(--grey97)" },
+        ...focusStyle({ inset: true }),
     } as const;
 
 

--- a/frontend/src/layout/header/ui.tsx
+++ b/frontend/src/layout/header/ui.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 
 import { BREAKPOINT_SMALL } from "../../GlobalStyle";
+import { focusStyle } from "../../ui";
 import { useTitle } from "../../util";
 
 
@@ -36,7 +37,7 @@ export const ICON_STYLE = {
     opacity: "0.75",
     ":hover, :focus": { opacity: 1 },
     ":hover": { outline: "2px solid var(--grey80)" },
-    ":focus": { outline: "2px solid var(--accent-color)" },
+    ...focusStyle({}),
     [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: { fontSize: 24 },
 };
 

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -308,9 +308,8 @@ const Field: React.FC<FieldProps> = ({ isEmpty, children }) => {
                     ...isEmpty && raisedStyle,
                 },
                 "& > input": {
-                    outline: "none",
-                    boxShadow: "0 0 0 1px var(--accent-color)",
                     borderColor: "var(--accent-color)",
+                    outline: "1px solid var(--accent-color)",
                 },
             },
         }}>{children}</div>

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -15,7 +15,7 @@ import { boxError } from "../../../ui/error";
 import { displayCommitError } from "./util";
 import { sortRealms } from "../../util";
 import { WithTooltip } from "../../../ui/Floating";
-
+import { focusStyle } from "../../../ui";
 
 
 const fragment = graphql`
@@ -223,6 +223,7 @@ const ChildEntry: React.FC<ChildEntryProps> = ({ index, swap, realmName, numChil
                             backgroundColor: "var(--grey97)",
                             color: "var(--accent-color)",
                         },
+                        ...focusStyle({}),
                     },
                 },
             }}>

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -15,6 +15,7 @@ import {
     WithTooltip,
 } from "../../../../ui/Floating";
 import { ProtoButton } from "../../../../ui/Button";
+import { focusStyle } from "../../../../ui";
 
 
 type Props = {
@@ -86,6 +87,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                             "&:hover, &:focus": {
                                 backgroundColor: "var(--accent-color-darker)",
                             },
+                            ...focusStyle({ offset: 1 }),
                         }}>
                             <FiPlus />
                         </ProtoButton>
@@ -185,10 +187,7 @@ const AddItem: React.FC<AddItemProps> = ({ label, Icon, onClick, close }) => (
                 "&:hover, &:focus": {
                     backgroundColor: "var(--grey97)",
                 },
-                "&:focus-visible": {
-                    outline: "2px solid var(--accent-color)",
-                    outlineOffset: -2,
-                },
+                ...focusStyle({ inset: true }),
             }}
         >
             {<Icon css={{ color: "var(--accent-color)", fontSize: 18 }}/>}

--- a/frontend/src/routes/manage/Realm/Content/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/util.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { focusStyle } from "../../../../ui";
 
 
 type ButtonProps = React.ComponentProps<"button">;
@@ -24,6 +25,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
                     color: "var(--accent-color)",
                     backgroundColor: "var(--grey97)",
                 },
+                ...focusStyle({}),
             },
         }}
         {...props}

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -27,7 +27,7 @@ import {
 } from "react-icons/fi";
 import { keyframes } from "@emotion/react";
 import { Description, SmallDescription } from "../metadata";
-import { ellipsisOverflowCss } from "..";
+import { ellipsisOverflowCss, focusStyle } from "..";
 import {
     Floating, FloatingContainer, FloatingHandle, FloatingTrigger,
 } from "../Floating";
@@ -303,12 +303,9 @@ const FloatingBaseMenu = React.forwardRef<FloatingHandle, FloatingBaseMenuProps>
                     height: 31,
                     padding: "0 8px",
                     whiteSpace: "nowrap",
-                    ":hover, :focus": {
-                        backgroundColor: "var(--grey92)",
-                    },
-                    ":focus-visible": {
-                        outline: "2px solid var(--accent-color)",
-                    },
+                    ":hover, :focus": { backgroundColor: "var(--grey92)" },
+                    ":focus-visible": { borderColor: "var(--accent-color)" },
+                    ...focusStyle({ offset: -1 }),
                 }}>
                     {triggerContent}
                     <FiChevronDown css={{ fontSize: 20 }} />
@@ -486,10 +483,7 @@ const MenuItem: React.FC<MenuItemProps> = ({ Icon, label, onClick, close, disabl
                     ":hover, :focus": {
                         backgroundColor: "var(--grey92)",
                     },
-                    ":focus-visible": {
-                        outline: "2px solid var(--accent-color)",
-                        outlineOffset: -2,
-                    },
+                    ...focusStyle({ inset: true }),
                     "&[disabled]": {
                         fontWeight: "bold",
                         color: "var(--grey20)",
@@ -550,9 +544,7 @@ const SliderView: React.FC<{ children: ReactNode }> = ({ children }) => {
         ":hover, :focus": {
             backgroundColor: "var(--grey40)",
         },
-        ":focus-visible": {
-            outline: "2px solid var(--accent-color)",
-        },
+        ...focusStyle({}),
     } as const;
 
     return <div css={{ position: "relative" }}>
@@ -624,9 +616,7 @@ const UpcomingEventsGrid: React.FC<React.PropsWithChildren> = ({ children }) => 
                     borderRadius: 4,
                     color: "black",
                 },
-                ":focus-visible": {
-                    outline: "2px solid var(--accent-color)",
-                },
+                ...focusStyle({}),
             },
             ":is([open]) summary": {
                 borderBottom: "1px solid var(--grey80)",
@@ -765,10 +755,7 @@ const GridTile: React.FC<GridTypeProps> = ({ event, basePath, active }) => {
                     transitionDuration: TRANSITION_IN_DURATION,
                 },
             },
-            "&:focus-visible": {
-                outline: "none",
-                boxShadow: "0 0 0 2px var(--accent-color)",
-            },
+            ...focusStyle({}),
         },
         // ListView styles:
         ...isList && {

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { BreadcrumbList, WithContext } from "schema-dts";
 
 import { Link } from "../router";
-import { FOCUS_STYLE_INSET } from ".";
+import { focusStyle } from ".";
 
 
 export type Props = {
@@ -36,7 +36,11 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
             )}
             <BreadcrumbsContainer>
                 <li>
-                    <Link to="/" css={{ lineHeight: 1, padding: 2, ...FOCUS_STYLE_INSET }}>
+                    <Link to="/" css={{
+                        lineHeight: 1,
+                        padding: 2,
+                        ...focusStyle({ inset: true }),
+                    }}>
                         <FiHome aria-label={t("home")} />
                     </Link>
                 </li>
@@ -88,7 +92,7 @@ const Segment: React.FC<SegmentProps> = ({ target, children }) => (
         <BreadcrumbSeparator />
         {target === undefined
             ? <div css={TEXT_STYLE}>{children}</div>
-            : <Link css={[TEXT_STYLE, FOCUS_STYLE_INSET]} to={target}>{children}</Link>}
+            : <Link css={[TEXT_STYLE, focusStyle({ inset: true })]} to={target}>{children}</Link>}
     </li>
 );
 

--- a/frontend/src/ui/Button.tsx
+++ b/frontend/src/ui/Button.tsx
@@ -1,5 +1,6 @@
 import { Interpolation, Theme } from "@emotion/react";
 import React from "react";
+import { focusStyle } from ".";
 
 import { Link } from "../router";
 import { match } from "../util";
@@ -87,6 +88,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
                 backgroundColor: "var(--happy-color-darker)",
                 color: "var(--happy-color-bw-contrast)",
             },
+            ...focusStyle({ offset: 1 }),
         }),
     });
 
@@ -106,12 +108,9 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
             border: "1px solid var(--grey80)",
             color: "var(--grey65)",
         },
-        "&:focus-visible": {
-            boxShadow: "0 0 0 3px var(--grey65)",
-            outline: "none",
-        },
         "&:not([disabled])": {
             cursor: "pointer",
+            ...focusStyle({}),
             ...notDisabledStyle,
         },
         ...extraCss as Record<string, unknown>,

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiCheck, FiCopy } from "react-icons/fi";
+import { focusStyle } from ".";
 import { Button } from "./Button";
 import { WithTooltip } from "./Floating";
 
@@ -8,11 +9,8 @@ import { WithTooltip } from "./Floating";
 const style = (error: boolean) => ({
     borderRadius: 4,
     border: `1px solid ${error ? "var(--danger-color)" : "var(--grey80)"}`,
-    "&:focus": {
-        outline: "none",
-        boxShadow: "0 0 0 1px var(--accent-color)",
-        borderColor: "var(--accent-color)",
-    },
+    ":focus-visible": { borderColor: "var(--accent-color)" },
+    ...focusStyle({ offset: -1 }),
 });
 
 export type InputProps = React.ComponentPropsWithoutRef<"input"> & {

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -27,13 +27,11 @@ export const LinkList: React.FC<LinkListProps> = ({ items, ...rest }) => (
             listStyle: "none",
             margin: 0,
             padding: 0,
-            "& a": { ...FOCUS_STYLE_INSET },
+            "& a": { ...focusStyle({ inset: true }) },
             "& > li": {
                 backgroundColor: "var(--grey95)",
                 borderBottom: "2px solid white",
-                "&:last-of-type": {
-                    borderBottom: "none",
-                },
+                "&:last-of-type": { borderBottom: "none" },
                 "& > *": {
                     display: "flex",
                     padding: "10px 16px",
@@ -126,12 +124,22 @@ export const Title: React.FC<TitleProps> = ({ title, className }) => (
     <h2 className={className} css={{ margin: "16px 0" }}>{title}</h2>
 );
 
-export const FOCUS_STYLE_INSET = {
+
+/**
+ * Applies focus outline with a default width of 2.5px to elements.
+ * This should always be used instead of a custom focus property to ensure
+ * consistency throughout the design.
+ * If `({ inset: true })` is declared, the focus will be on the inside
+ * of the focused element with a negative offset equal to the outline's width.
+ * Otherwise is also possible to declare an additional offset (usually 1) for
+ * elements with a similar color to the outline to make it stand out more.
+ */
+export const focusStyle = ({ width = 2.5, inset = false, offset = 0 }) => ({
     "&:focus-visible": {
-        outline: "none",
-        boxShadow: "inset 0 0 0 2px var(--accent-color)",
+        outline: `${width}px solid var(--accent-color)`,
+        outlineOffset: `${inset ? -width : offset}px`,
     },
-} as const;
+} as const);
 
 /** Returns CSS that makes text longer than `lines` lines to be truncated with `...`. */
 export const ellipsisOverflowCss = (lines: number): Record<string, any> => ({


### PR DESCRIPTION
This adds and where possible utilizes a function to apply a default, but somewhat customizable focus outline to elements. This function should be used in place of a manual `:focus` declaration to ensure a uniform focus style that is easily maintainable to Tobira.

Important note:
As noted in #724, Safari does not apply a border radius to outlines. This means, that in Safari, the focus outlines will always be rectangular. But I think this is reasonable enough (see my justification for this below).

I replaced the previously used `box-shadow` with an outline for two reasons:
- `box-shadow` in combination with `outline: none` _can_ be problematic with high contrast modes that use [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors), which forces `box-shadow: none` (for instance Windows high contrast mode). This could be fixed by using sth like `outline: 1px solid transparent` but:
- `outline` is more flexible than `box-shadow`, mainly by allowing to set a specific offset. While `box-shadow` has the `inset` keyword to show it inside the focused element, it does not allow for an outside offset without using multiple shadows.

Closes: #654 