### PR TITLE
Add user realms (a page tree for each user)

### DIFF
--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -100,6 +100,7 @@ pub(crate) struct Realm {
     full_path: String,
     index: i32,
     child_order: RealmOrder,
+    owner_display_name: Option<String>,
 }
 
 impl_from_db!(
@@ -107,7 +108,7 @@ impl_from_db!(
     select: {
         realms.{
             id, parent, name, name_from_block, path_segment, full_path, index,
-            child_order, resolved_name
+            child_order, resolved_name, owner_display_name,
         },
     },
     |row| {
@@ -121,6 +122,7 @@ impl_from_db!(
             full_path: row.full_path(),
             index: row.index(),
             child_order: row.child_order(),
+            owner_display_name: row.owner_display_name(),
         }
     }
 );
@@ -142,6 +144,7 @@ impl Realm {
             full_path: String::new(),
             index: 0,
             child_order: mapping.child_order.of(&row),
+            owner_display_name: None,
         })
     }
 
@@ -297,6 +300,13 @@ impl Realm {
     /// `/@`.
     fn path(&self) -> &str {
         if self.key.0 == 0 { "/" } else { &self.full_path }
+    }
+
+    /// This is only returns a value for root user realms, in which case it is
+    /// the display name of the user who owns this realm. For all other realms,
+    /// `null` is returned.
+    fn owner_display_name(&self) -> Option<&str> {
+        self.owner_display_name.as_deref()
     }
 
     /// Returns the immediate parent of this realm.

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -215,7 +215,7 @@ impl Realm {
         }
     }
 
-    fn require_write_access(&self, context: &Context) -> ApiResult<()> {
+    pub(crate) fn require_write_access(&self, context: &Context) -> ApiResult<()> {
         if !self.can_current_user_edit(context) {
             if let AuthContext::User(user) = &context.auth {
                 return Err(ApiError {

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -55,8 +55,8 @@ impl Realm {
         let db = &context.db;
 
         let res = db.query_one(
-            "insert into realms (parent, name, path_segment) \
-                values (null, $1, $2) \
+            "insert into realms (parent, name, path_segment, owner_display_name) \
+                values (null, $1, $2, $1) \
                 returning id",
             &[&user.display_name, &format!("@{}", user.username)],
         ).await;

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -11,15 +11,16 @@ use super::{Realm, RealmOrder};
 
 impl Realm {
     pub(crate) async fn add(realm: NewRealm, context: &Context) -> ApiResult<Realm> {
-        let db = context.db(context.require_moderator()?);
-
-        let parent_key = id_to_key(realm.parent, "`parent`")?;
+        let Some(parent) = Self::load_by_id(realm.parent, context).await? else {
+            return Err(invalid_input!("`parent` realm does not exist"));
+        };
+        parent.require_write_access(context)?;
+        let db = &context.db;
 
         // Check if the path is a reserved one.
-        let is_top_level_realm = parent_key.0 == 0;
         let path_is_reserved = context.config.general.reserved_paths()
             .any(|r| realm.path_segment == r);
-        if is_top_level_realm && path_is_reserved {
+        if parent.is_main_root() && path_is_reserved {
             return Err(invalid_input!(key = "realm.path-is-reserved", "path is reserved and cannot be used"));
         }
         // TODO: validate input
@@ -29,7 +30,7 @@ impl Realm {
                 "insert into realms (parent, name, path_segment) \
                     values ($1, $2, $3) \
                     returning id",
-                &[&parent_key, &realm.name, &realm.path_segment],
+                &[&parent.key, &realm.name, &realm.path_segment],
             )
             .await?
             .get(0);
@@ -49,10 +50,13 @@ impl Realm {
         // frontend error or the DB has changed since the user opened the
         // page. TODO: The latter case we should communicate to the user somehow.
 
-        let db = context.db(context.require_moderator()?);
-
-        // Verify and convert arguments.
-        let parent_key = id_to_key(parent, "`parent`")?;
+        let Some(parent) = Self::load_by_id(parent, context).await? else {
+            // TODO: this is likely caused by a realm being removed while a user
+            // is on the settings page. Maybe we want to give a hint.
+            return Err(invalid_input!("`parent` realm does not exist (for `setChildOrder`)"));
+        };
+        parent.require_write_access(context)?;
+        let db = &context.db;
 
         if let Some(child_indices) = child_indices {
             if child_order != RealmOrder::ByIndex {
@@ -81,7 +85,7 @@ impl Realm {
 
             // Retrieve the current children of the given realm
             let current_children: Vec<(_, i32)> = db
-                .query_raw("select id, index from realms where parent = $1", [parent_key])
+                .query_raw("select id, index from realms where parent = $1", [parent.key])
                 .await?
                 .map_ok(|row| (row.get(0), row.get(1)))
                 .try_collect()
@@ -96,9 +100,9 @@ impl Realm {
             for (key, _) in &current_children {
                 if !child_indices.contains_key(key) {
                     return Err(invalid_input!(
-                        "child {} of realm {} is missing in children given to `setChildOrder`",
+                        "child {} of realm '{}' is missing in children given to `setChildOrder`",
                         Id::realm(*key),
-                        parent,
+                        parent.full_path,
                     ));
                 }
             }
@@ -117,7 +121,7 @@ impl Realm {
             db
                 .execute(
                     "update realms set index = default where parent = $1",
-                    &[&parent_key],
+                    &[&parent.key],
                 )
                 .await?;
         }
@@ -125,25 +129,22 @@ impl Realm {
         // Write the order to DB
         db.execute(
             "update realms set child_order = $1 where id = $2",
-            &[&child_order, &parent_key],
+            &[&child_order, &parent.key],
         ).await?;
-        debug!("Set 'child_order' of realm {} to {:?}", parent, child_order);
+        debug!("Set 'child_order' of realm '{}' to {:?}", parent.full_path, child_order);
 
 
-        // Load the updated realm. If the realm does not exist, we either
-        // noticed the error above or the above queries did not change
-        // anything.
-        Realm::load_by_key(parent_key, &context)
-            .await
-            .and_then(|realm| realm.ok_or_else(|| {
-                // TODO: tell user the realm was removed
-                invalid_input!("`parent` realm does not exist (for `setChildOrder`)")
-            }))
+        // Load the updated realm. We already know it exists, so we can unwrap.
+        Realm::load_by_key(parent.key, &context).await.map(Option::unwrap)
     }
 
     pub(crate) async fn rename(id: Id, name: UpdatedRealmName, context: &Context) -> ApiResult<Realm> {
-        let db = context.db(context.require_moderator()?);
-        let key = id_to_key(id, "`id`")?;
+        let Some(realm) = Self::load_by_id(id, context).await? else {
+            return Err(invalid_input!("`id` does not refer to an existing realm"));
+        };
+        realm.require_write_access(context)?;
+
+        let db = &context.db;
         if name.plain.is_some() == name.block.is_some() {
             return Err(invalid_input!("exactly one of name.block and name.plain has to be set"));
         }
@@ -152,27 +153,29 @@ impl Realm {
                 .ok_or_else(|| invalid_input!("name.block does not refer to a block")))
             .transpose()?;
 
+        // TODO: the DB will already check that the block has a fitting type and
+        // that it belongs to the realm, but those errors should result in
+        // an "invalid input" error.
         let stmt = "
             update realms set \
                 name = $2, \
                 name_from_block = $3 \
                 where id = $1
             ";
-        let affected_rows = db.execute(stmt, &[&key, &name.plain, &block]).await?;
+        db.execute(stmt, &[&realm.key, &name.plain, &block]).await?;
 
-        if affected_rows != 1 {
-            return Err(invalid_input!("`id` does not refer to an existing realm"));
-        }
-
-        Self::load_by_key(key, context).await.map(Option::unwrap)
+        Self::load_by_key(realm.key, context).await.map(Option::unwrap)
     }
 
     pub(crate) async fn update(id: Id, set: UpdateRealm, context: &Context) -> ApiResult<Realm> {
         // TODO: validate input
 
-        let db = context.db(context.require_moderator()?);
+        let Some(realm) = Self::load_by_id(id, context).await? else {
+            return Err(invalid_input!("`id` does not refer to an existing realm"));
+        };
+        realm.require_write_access(context)?;
+        let db = &context.db;
 
-        let key = id_to_key(id, "`id`")?;
         let parent_key = set.parent.map(|parent| id_to_key(parent, "`parent`")).transpose()?;
 
         // We have to make sure the path is not changed to a reserved one.
@@ -188,7 +191,7 @@ impl Realm {
                     // check the DB whether this realm is a top-level one.
                     None => {
                         let real_parent = db
-                            .query_one("select parent from realms where id = $1", &[&key])
+                            .query_one("select parent from realms where id = $1", &[&realm.key])
                             .await?
                             .get::<_, Key>(0);
 
@@ -200,40 +203,37 @@ impl Realm {
             }
         }
 
-        let affected_rows = db
+        db
             .execute(
                 "update realms set \
                     parent = coalesce($2, parent), \
                     path_segment = coalesce($3, path_segment) \
                     where id = $1",
-                &[&key, &parent_key, &set.path_segment],
+                &[&realm.key, &parent_key, &set.path_segment],
             )
             .await?;
 
-        if affected_rows != 1 {
-            return Err(invalid_input!("`id` does not refer to an existing realm"));
-        }
-
-        Self::load_by_key(key, context).await.map(Option::unwrap)
+        // Load realm with new data.
+        Self::load_by_key(realm.key, context).await.map(Option::unwrap)
     }
 
     pub(crate) async fn remove(id: Id, context: &Context) -> ApiResult<RemovedRealm> {
-        let db = context.db(context.require_moderator()?);
+        let Some(realm) = Self::load_by_id(id, context).await? else {
+            return Err(invalid_input!("`id` does not refer to an existing realm"));
+        };
+        realm.require_write_access(context)?;
+        let db = &context.db;
 
-        let key = id_to_key(id, "`id`")?;
-        if key.0 == 0 {
+        if realm.is_main_root() {
             return Err(invalid_input!("Cannot remove the root realm"));
         }
 
-        let realm = Self::load_by_key(key, context).await?
-            .ok_or_else(|| invalid_input!("`id` does not refer to an existing realm"))?;
+        db.execute("delete from realms where id = $1", &[&realm.key]).await?;
 
-        db.execute("delete from realms where id = $1", &[&key]).await?;
-
-        // We checked above that `realm` is not the root realm, so we can unwrap.
-        let parent = Self::load_by_key(realm.parent_key.expect("missing parent"), context)
-            .await?
-            .expect("realm has no parent");
+        let parent = match realm.parent_key {
+            Some(parent) => Self::load_by_key(parent, context).await?,
+            None => None,
+        };
 
         Ok(RemovedRealm { parent })
     }
@@ -289,5 +289,5 @@ pub(crate) struct RealmSpecifier {
 #[derive(juniper::GraphQLObject)]
 #[graphql(Context = Context)]
 pub(crate) struct RemovedRealm {
-    parent: Realm,
+    parent: Option<Realm>,
 }

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -176,6 +176,10 @@ impl Realm {
         realm.require_write_access(context)?;
         let db = &context.db;
 
+        if realm.is_user_root() {
+            return Err(invalid_input!("cannot move or change path segment of user root realm"));
+        }
+
         let parent_key = set.parent.map(|parent| id_to_key(parent, "`parent`")).transpose()?;
 
         // We have to make sure the path is not changed to a reserved one.

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -146,6 +146,7 @@ pub(crate) async fn perform(
         let mut query = context.search.realm_index.search();
         query.with_query(user_query);
         query.with_limit(10);
+        query.with_filter("is_user_realm = false");
         query.with_show_matches_position(true);
         query
     };

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -41,6 +41,10 @@ impl User {
         self.can_use_editor(&context.config.auth)
     }
 
+    fn can_create_user_realm(&self, context: &Context) -> bool {
+        self.can_create_user_realm(&context.config.auth)
+    }
+
     /// Returns all events that somehow "belong" to the user, i.e. that appear
     /// on the "my videos" page.
     ///

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -45,6 +45,11 @@ impl Mutation {
         Realm::add(realm, context).await
     }
 
+    /// Creates the current users realm. Errors if it already exists.
+    async fn create_my_user_realm(context: &Context) -> ApiResult<Realm> {
+        Realm::create_user_realm(context).await
+    }
+
     /// Sets the order of all children of a specific realm.
     ///
     /// `childIndices` must contain at least one element, i.e. do not call this

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -23,7 +23,7 @@ pub(crate) struct Query;
 
 #[graphql_object(Context = Context)]
 impl Query {
-    /// Returns the root realm.
+    /// Returns the main root realm.
     async fn root_realm(context: &Context) -> ApiResult<Realm> {
         Realm::root(context).await
     }
@@ -34,12 +34,13 @@ impl Query {
         Realm::load_by_id(id, context).await
     }
 
-    /// Returns the realm with the given path or `None` if the path does not
+    /// Returns the realm with the given path or `null` if the path does not
     /// refer to a realm.
     ///
     /// Paths with and without trailing slash are accepted and treated equally.
     /// The paths `""` and `"/"` refer to the root realm. All other paths have
-    /// to start with `"/"`.
+    /// to start with `"/"`. Paths starting with `"/@"` are considered user
+    /// root realms.
     async fn realm_by_path(path: String, context: &Context) -> ApiResult<Option<Realm>> {
         Realm::load_by_path(path, context).await
     }

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -97,8 +97,12 @@ impl Query {
 
     /// Searches through all events (including non-listed ones). Requires
     /// moderator rights.
-    async fn search_all_events(query: String, context: &Context) -> ApiResult<EventSearchOutcome> {
-        search::all_events(&query, context).await
+    async fn search_all_events(
+        query: String,
+        writable_only: bool,
+        context: &Context,
+    ) -> ApiResult<EventSearchOutcome> {
+        search::all_events(&query, writable_only, context).await
     }
 
     /// Searches through all series. If `writable_only` is true, only series

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -78,6 +78,10 @@ pub(crate) struct AuthConfig {
     #[config(default = "ROLE_TOBIRA_EDITOR")]
     pub(crate) editor_role: String,
 
+    /// If a user has this role, they are allowed to create their own "user realm".
+    #[config(default = "ROLE_USER")]
+    pub(crate) user_realm_role: String,
+
     /// Duration of a Tobira-managed login session.
     /// Note: This is only relevant if `auth.mode` is `login-proxy`.
     #[config(default = "30d", deserialize_with = crate::config::deserialize_duration)]
@@ -348,6 +352,10 @@ pub(crate) trait HasRoles {
 
     fn can_use_editor(&self, auth_config: &AuthConfig) -> bool {
         self.is_moderator(auth_config) || self.roles().contains(&auth_config.editor_role)
+    }
+
+    fn can_create_user_realm(&self, auth_config: &AuthConfig) -> bool {
+        self.roles().contains(&auth_config.user_realm_role)
     }
 
     /// Returns `true` if the user is a global Opencast administrator and can do

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -334,4 +334,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     17: "improve-ancestor-function-estimate",
     18: "series-search-view",
     19: "fix-queue-triggers",
+    20: "user-realms",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -332,7 +332,7 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     15: "fix-event-constraints",
     16: "master-track",
     17: "improve-ancestor-function-estimate",
-    18: "series-search-view",
-    19: "fix-queue-triggers",
-    20: "user-realms",
+    18: "user-realms",
+    19: "series-search-view",
+    20: "fix-queue-triggers",
 ];

--- a/backend/src/db/migrations/18-series-search-view.sql
+++ b/backend/src/db/migrations/18-series-search-view.sql
@@ -6,10 +6,11 @@ create view search_series as
         series.id, series.state, series.opencast_id,
         series.read_roles, series.write_roles,
         series.title, series.description,
-        (select count(*) > 0
+        exists (select
             from blocks
             inner join events on events.id = blocks.video
-            where events.series = series.id
+            inner join realms on realms.id = blocks.realm
+            where events.series = series.id and realms.full_path not like '/@%'
         ) as listed_via_events,
         coalesce(
             array_agg((

--- a/backend/src/db/migrations/18-user-realms.sql
+++ b/backend/src/db/migrations/18-user-realms.sql
@@ -77,3 +77,56 @@ begin
     return NEW;
 end;
 $$ language plpgsql;
+
+
+-- We add more fields to the realm search index to be able to filter by user
+-- realms, for example. This replaces the view definition from
+-- `11-search-views.sql`. There are two differences:
+--
+-- * We add `is_user_realm` and `is_root` columns.
+-- * We removed the joins and the `coalesce` call by just `resolved_name`. I
+--   found no difference in query performance for both, "query all" and `where
+--   id = any('{a few IDs}'). So this simplifies the view.
+create or replace view search_realms as
+    select
+        realms.id,
+        realms.resolved_name as name,
+        realms.full_path,
+        array(
+            select ancestors.resolved_name
+            from ancestors_of_realm(realms.id) ancestors
+            offset 1
+        ) as ancestor_names,
+        realms.full_path like '/@%' as is_user_realm,
+        realms.parent is null as is_root
+    from realms;
+
+-- Due to the change of `search_realms`, we need to adjust the other two search
+-- views as well, since the use `search_realms`: `row(...)::search_realms`. But
+-- the "..." is a manual selection of four columns, so this fails after adding
+-- two new columns to `search_realms`. The `search_series` view is changed in
+-- place in `19-series-search-view.sql` as that migration was not yet released.
+-- The `search_events` is recreated here (mostly copied from `11-search-views`).
+create or replace view search_events as
+    select
+        events.id, events.state,
+        events.series, series.title as series_title,
+        events.title, events.description, events.creators,
+        events.thumbnail, events.duration,
+        events.is_live, events.created, events.start_time, events.end_time,
+        events.read_roles, events.write_roles,
+        coalesce(
+            array_agg(
+                distinct
+                row(search_realms.*)::search_realms
+            ) filter(where search_realms.id is not null),
+            '{}'
+        ) as host_realms
+    from events
+    left join series on events.series = series.id
+    left join blocks on (
+        type = 'series' and blocks.series = events.series
+        or type = 'video' and blocks.video = events.id
+    )
+    left join search_realms on search_realms.id = blocks.realm
+    group by events.id, series.id;

--- a/backend/src/db/migrations/18-user-realms.sql
+++ b/backend/src/db/migrations/18-user-realms.sql
@@ -13,6 +13,14 @@
 alter table realms
     -- Constraint `root_no_path` is still fine.
 
+    -- We want to be able to show the name of the user that owns a user realm.
+    -- Since the root user realm can be renamed, we have to add a separate
+    -- column for that. It's only set for root user realms.
+    add column owner_display_name text,
+    add constraint owner_set check (
+        (parent is null and full_path ~ '^/@') = (owner_display_name is not null)
+    ),
+
     -- There can be more root realms now.
     drop constraint has_parent,
 

--- a/backend/src/db/migrations/19-series-search-view.sql
+++ b/backend/src/db/migrations/19-series-search-view.sql
@@ -18,7 +18,7 @@ create view search_series as
                 -- for the main use case: 'where id = any(...)'. If we would
                 -- use a join instead, the runtime would be the same with or
                 -- without the 'where id' (roughly 300ms on my machine).
-                select row(search_realms.id, name, full_path, ancestor_names)::search_realms
+                select row(search_realms.*)::search_realms
                 from search_realms
                 where search_realms.id = blocks.realm
             )) filter(where blocks.realm is not null),

--- a/backend/src/db/migrations/20-fix-queue-triggers.sql
+++ b/backend/src/db/migrations/20-fix-queue-triggers.sql
@@ -1,6 +1,6 @@
 -- This migration does two things:
 -- * it fixes several bugs in '10-search-index-queue'
--- * it adds triggers that were missing/omitted in `18-series-search-view`
+-- * it adds triggers that were missing/omitted in `19-series-search-view`
 --
 -- Both things are done in this one migration because this saves us some code
 -- and results in fewer total triggers.

--- a/backend/src/db/migrations/20-user-realms.sql
+++ b/backend/src/db/migrations/20-user-realms.sql
@@ -1,0 +1,79 @@
+-- This adjusts the `realm` table such that it can also accommodate user realms.
+-- This means that there is not only one realm tree, but a forest of realm
+-- trees. One public one (which root has id = 0) and potentially one per user.
+-- Most constraints are only slightly adjusted with code copied from
+-- `03-realms.sql`.
+--
+-- Some terms that are used:
+-- - A root realm is a realm with `parent = null`
+-- - "The root realm" or "main root realm" is the realm with id = 0 which is the
+--   root of the public realm tree.
+-- - A "user root realm" is a root realm with id <> 0.
+
+alter table realms
+    -- Constraint `root_no_path` is still fine.
+
+    -- There can be more root realms now.
+    drop constraint has_parent,
+
+    -- Adjust the logic to work with user root realms.
+    drop constraint valid_name_source,
+    add constraint valid_name_source check (
+        -- The main root realm must not have a name
+        (id = 0 and name is null and name_from_block is null)
+        -- User root realms must have a plain name set
+        or (id <> 0 and parent is null and name is not null and name_from_block is null)
+        -- All other realms have either a plain or derived name.
+        or (parent is not null and (name is null) != (name_from_block is null))
+    ),
+
+    -- All root realms (not just the id = 0 one) need to be exempt from the
+    -- normal path rules.
+    drop constraint valid_path,
+    add constraint valid_path check (
+        -- Main root realm
+        (id = 0 and path_segment = '')
+        -- For everything else, there are some general rules.
+        or (
+            id <> 0
+            -- Exclude control characters.
+            and path_segment !~ '[\u0000-\u001F\u007F-\u009F]'
+            -- Exclude some whitespace characters.
+            and path_segment !~ '[\u0020\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]'
+            -- Exclude characters that are disallowed in URL paths or that have
+            -- a semantic meaning there.
+            and path_segment !~ $$["<>[\\\]^`{|}#%/?]$$
+            -- Ensure at least two bytes (we want to reserve single ASCII char
+            -- segments for internal use).
+            and octet_length(path_segment) >= 2
+
+            -- For realms that are not user root realms (parent is null), there
+            -- are additional rules.
+            -- There are additional rules depending on whether its a user root realm.
+            and (
+                -- User root realm: has to start with '@'.
+                (parent is null and path_segment ~ '^@')
+                -- All other realms: Exclude reserved characters in leading position.
+                or (parent is not null and path_segment !~ $$^[-+~@_!$&;:.,=*'()]$$)
+            )
+        )
+    );
+
+-- We need to replace this trigger function which assumed `parent` to be non
+-- null for inserted realms.
+create or replace function set_full_realm_path() returns trigger as $$
+begin
+    if NEW.full_path is not null then
+        raise exception 'do not set the full path of a realm directly (for realm %)', NEW.id;
+    end if;
+
+    -- New root realms (user root realms) just get their path segment with
+    -- leading slash as path. Others concat with the parent's full path.
+    if NEW.parent is null then
+        NEW.full_path := '/' || NEW.path_segment;
+    else
+        NEW.full_path := (select full_path from realms where id = NEW.parent) || '/' || NEW.path_segment;
+    end if;
+    return NEW;
+end;
+$$ language plpgsql;

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -78,7 +78,7 @@ impl_from_db!(
             end_time: row.end_time(),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
-            listed: !host_realms.is_empty(),
+            listed: host_realms.iter().any(|realm| !realm.is_user_realm()),
             host_realms,
         }
     }

--- a/backend/src/search/realm.rs
+++ b/backend/src/search/realm.rs
@@ -15,6 +15,8 @@ pub(crate) struct Realm {
     pub(crate) id: SearchId,
     pub(crate) name: Option<String>,
     pub(crate) full_path: String,
+    pub(crate) is_user_realm: bool,
+    pub(crate) is_root: bool,
 
     /// Includes the names of all ancestors, excluding the root and this realm
     /// itself. It starts with a direct child of the root and ends with the
@@ -32,7 +34,7 @@ impl IndexItem for Realm {
 impl_from_db!(
     Realm,
     select: {
-        search_realms.{ id, name, full_path, ancestor_names },
+        search_realms.{ id, name, full_path, ancestor_names, is_root, is_user_realm },
     },
     |row| {
         Self {
@@ -40,6 +42,8 @@ impl_from_db!(
             name: row.name(),
             full_path: row.full_path(),
             ancestor_names: row.ancestor_names(),
+            is_root: row.is_root(),
+            is_user_realm: row.is_user_realm(),
         }
     }
 );
@@ -67,5 +71,10 @@ impl Realm {
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {
-    util::lazy_set_special_attributes(index, "realm", &["name"], &[]).await
+    util::lazy_set_special_attributes(
+        index,
+        "realm",
+        &["name"],
+        &["is_root", "is_user_realm"],
+    ).await
 }

--- a/backend/src/search/realm.rs
+++ b/backend/src/search/realm.rs
@@ -60,6 +60,10 @@ impl Realm {
         let rows = db.query_raw(&query, dbargs![]);
         collect_rows_mapped(rows, |row| Self::from_row_start(&row)).await.map_err(Into::into)
     }
+
+    pub(crate) fn is_user_realm(&self) -> bool {
+        self.full_path.starts_with("/@")
+    }
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -45,6 +45,8 @@ impl_from_db!(
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
+        let listed = host_realms.iter().any(|realm| !realm.is_user_realm())
+            || row.listed_via_events();
         Self {
             id: row.id(),
             opencast_id: row.opencast_id(),
@@ -52,7 +54,7 @@ impl_from_db!(
             description: row.description(),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
-            listed: !host_realms.is_empty() || row.listed_via_events(),
+            listed,
             host_realms,
         }
     }

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -198,6 +198,11 @@
 # Default value: "ROLE_TOBIRA_EDITOR"
 #editor_role = "ROLE_TOBIRA_EDITOR"
 
+# If a user has this role, they are allowed to create their own "user realm".
+#
+# Default value: "ROLE_USER"
+#user_realm_role = "ROLE_USER"
+
 # Duration of a Tobira-managed login session.
 # Note: This is only relevant if `auth.mode` is `login-proxy`.
 #

--- a/frontend/src/User.tsx
+++ b/frontend/src/User.tsx
@@ -23,6 +23,7 @@ export type User = {
     canUpload: boolean;
     canUseStudio: boolean;
     canUseEditor: boolean;
+    canCreateUserRealm: boolean;
 };
 
 export const isRealUser = (state: UserState): state is User => (
@@ -55,6 +56,7 @@ export const userDataFragment = graphql`
             canUpload
             canUseStudio
             canUseEditor
+            canCreateUserRealm
         }
     }
 `;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -194,6 +194,20 @@ realm:
     note-body: >
       Dies ist eine persönliche Nutzerseite, die allein von {{user}} gepflegt wird.
       Für alle Inhalte ist {{user}} verantwortlich.
+    create:
+      currently-none: Sie haben zurzeit keine persönliche Seite.
+      heading: Persönliche Seite erstellen
+      what-you-can-do: >
+        Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Element anordnen,
+        um so Inhalte besser präsentieren und teilen zu können.
+        Sie können sogar Unterseiten anlegen, um ihr Ihr eigenes kleines Videoportal zu erstellen.
+      available-at: 'Ihre Seite wird unter folgendem Link verfügbar sein:'
+      find-and-delete: >
+        Alle, die diesen Link oder Ihren Benutzernamen kennen, können Ihre Seite besuchen.
+        Darüberhinaus wird Ihre Seite jedoch nicht in der Suche oder im Hauptteil dieses
+        Videoportals auftauchen.
+        Sie können Ihre Seite später jederzeit wieder löschen.
+      button: Persönliche Seite erstellen
 
 search:
   input-label: Suche

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -464,6 +464,7 @@ api-remote-errors:
     not-a-moderator: Sie müssen Moderator sein, um diese Aktion auszuführen.
   realm:
     path-is-reserved: Dieser Pfad ist reserviert und kann nicht für Seiten genutzt werden.
+    path-collision: Eine Seite mit diesem Pfad existiert bereits.
     no-write-access: Sie haben nicht die Berechtigung, diese Seite zu bearbeiten.
     cannot-create-user-realm: Sie haben nicht die Berechtigung, eine persönliche Seite anzulegen.
     user-realm-already-exists: Ihre persönliche Seite existiert bereits.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -204,8 +204,7 @@ realm:
       available-at: 'Ihre Seite wird unter folgendem Link verfügbar sein:'
       find-and-delete: >
         Alle, die diesen Link oder Ihren Benutzernamen kennen, können Ihre Seite besuchen.
-        Darüberhinaus wird Ihre Seite jedoch nicht in der Suche oder im Hauptteil dieses
-        Videoportals auftauchen.
+        Ihre Seite wird jedoch nicht in der Hauptnavigation dieses Videoportals auftauchen.
         Sie können Ihre Seite später jederzeit wieder löschen.
       button: Persönliche Seite erstellen
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -200,7 +200,7 @@ realm:
       what-you-can-do: >
         Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Element anordnen,
         um so Inhalte besser präsentieren und teilen zu können.
-        Sie können sogar Unterseiten anlegen, um ihr Ihr eigenes kleines Videoportal zu erstellen.
+        Sie können sogar Unterseiten anlegen, um Ihr eigenes kleines Videoportal zu erstellen.
       available-at: 'Ihre Seite wird unter folgendem Link verfügbar sein:'
       find-and-delete: >
         Alle, die diesen Link oder Ihren Benutzernamen kennen, können Ihre Seite besuchen.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -189,6 +189,7 @@ realm:
   add-sub-page: Unterseite hinzufügen
   missing-name: Fehlender Name
   user-realm:
+    your-page: Persönliche Seite
     note-label: Nutzerseite
     note-body: >
       Dies ist eine persönliche Nutzerseite, die allein von {{user}} gepflegt wird.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -188,6 +188,11 @@ realm:
   edit-page-content: Seiteninhalt bearbeiten
   add-sub-page: Unterseite hinzufügen
   missing-name: Fehlender Name
+  user-realm:
+    note-label: Nutzerseite
+    note-body: >
+      Dies ist eine persönliche Nutzerseite, die allein von {{user}} gepflegt wird.
+      Für alle Inhalte ist {{user}} verantwortlich.
 
 search:
   input-label: Suche
@@ -346,6 +351,7 @@ manage:
         heading: Pfad ändern
         button: Pfadsegment ändern
         failed: Änderung des Pfades fehlgeschlagen.
+        cannot-userrealm: Der Pfad Ihrer persönlichen Seite kann nicht geändert werden.
         warning: >
           Wichtig: Wenn Sie den Pfad ändern, invalidieren Sie damit alle bisherigen
           Links zu dieser Seite, zu allen direkten und indirekten Unterseiten, und
@@ -457,6 +463,7 @@ api-remote-errors:
     not-a-moderator: Sie müssen Moderator sein, um diese Aktion auszuführen.
   realm:
     path-is-reserved: Dieser Pfad ist reserviert und kann nicht für Seiten genutzt werden.
+    no-write-access: Sie haben nicht die Berechtigung, diese Seite zu bearbeiten.
 
 embed:
   not-supported: Diese Seite kann nicht eingebettet werden

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -465,6 +465,12 @@ api-remote-errors:
   realm:
     path-is-reserved: Dieser Pfad ist reserviert und kann nicht für Seiten genutzt werden.
     no-write-access: Sie haben nicht die Berechtigung, diese Seite zu bearbeiten.
+    cannot-create-user-realm: Sie haben nicht die Berechtigung, eine persönliche Seite anzulegen.
+    user-realm-already-exists: Ihre persönliche Seite existiert bereits.
+    username-not-valid-as-path: >
+      Ihr Nutzername '{{username}}' enthält Zeichen, die nicht in Seitenpfaden erlaubt sind.
+      Daher können Sie sich keine persönliche Seite anlegen.
+      Kontaktieren Sie einen Systemadministrator für weitere Unterstützung.
 
 embed:
   not-supported: Diese Seite kann nicht eingebettet werden

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -190,6 +190,20 @@ realm:
     note-body: >
       This is a personal user page which is managed by {{user}}.
       They are responsible for all contents.
+    create:
+      currently-none: You don't currently have a personal page.
+      heading: Create your own page
+      what-you-can-do: >
+        On your personal page, you can freely arrange videos, text, and other elements.
+        This allows you to better present and share your content.
+        You can even create sub-pages to create your own small video-portal.
+      available-at: 'Your page will be available at:'
+      find-and-delete: >
+        Anyone who who has this link or knows your username can visit your page.
+        However, it will not appear anywhere in the search or main part of this video portal.
+        You can always delete your page later, should you change your mind.
+      button: Create your own page
+
 
 search:
   input-label: Search

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -185,6 +185,7 @@ realm:
   add-sub-page: Add sub-page
   missing-name: Missing name
   user-realm:
+    your-page: Your page
     note-label: User page
     note-body: >
       This is a personal user page which is managed by {{user}}.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -184,6 +184,11 @@ realm:
   edit-page-content: Edit page content
   add-sub-page: Add sub-page
   missing-name: Missing name
+  user-realm:
+    note-label: User page
+    note-body: >
+      This is a personal user page which is managed by {{user}}.
+      They are responsible for all contents.
 
 search:
   input-label: Search
@@ -335,6 +340,7 @@ manage:
         heading: Change path
         button: Change path segment
         failed: Changing the path failed.
+        cannot-userrealm: The path of your personal page cannot be changed.
         warning: >
           Important: Changing the path of this page invalidates all links to
           this page, to all direct or indirect sub-pages, and to all videos
@@ -445,6 +451,7 @@ api-remote-errors:
     not-a-moderator: You have to be a moderator to perform this action.
   realm:
     path-is-reserved: The chosen path is reserved and cannot be used for pages.
+    no-write-access: You are not allowed to modify this page.
 
 embed:
   not-supported: This page can't be embedded

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -453,6 +453,12 @@ api-remote-errors:
   realm:
     path-is-reserved: The chosen path is reserved and cannot be used for pages.
     no-write-access: You are not allowed to modify this page.
+    cannot-create-user-realm: You are not allowed to create your own page.
+    user-realm-already-exists: Your own page already exists.
+    username-not-valid-as-path: >
+      Your username '{{username}}' contains characters that are not allowed in page paths,
+      thus you cannot create your own page. Contact a system administrator for
+      further assistance.
 
 embed:
   not-supported: This page can't be embedded

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -452,6 +452,7 @@ api-remote-errors:
     not-a-moderator: You have to be a moderator to perform this action.
   realm:
     path-is-reserved: The chosen path is reserved and cannot be used for pages.
+    path-collision: A page with this path already exists.
     no-write-access: You are not allowed to modify this page.
     cannot-create-user-realm: You are not allowed to create your own page.
     user-realm-already-exists: Your own page already exists.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -199,8 +199,8 @@ realm:
         You can even create sub-pages to create your own small video-portal.
       available-at: 'Your page will be available at:'
       find-and-delete: >
-        Anyone who who has this link or knows your username can visit your page.
-        However, it will not appear anywhere in the search or main part of this video portal.
+        Anyone who has this link or knows your username can visit your page.
+        However, it will not appear anywhere in main navigation of this video portal.
         You can always delete your page later, should you change your mind.
       button: Create your own page
 

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -38,7 +38,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 name
                 childOrder
                 children { id name path }
-                parent { isRoot name path }
+                parent { isMainRoot name path }
             }
         `,
         fragRef,
@@ -69,7 +69,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 {/* Show arrow and hide chevron in burger menu */}
                 <FiCornerLeftUp css={{ display: "none" }}/>
                 <FiChevronLeft />
-                {realm.parent.isRoot ? t("home") : realm.parent.name ?? <MissingRealmName />}
+                {realm.parent.isMainRoot ? t("home") : realm.parent.name ?? <MissingRealmName />}
             </LinkWithIcon>
             <div css={{
                 padding: "8px 14px 8px 16px",

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -37,6 +37,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 id
                 name
                 childOrder
+                isUserRoot
                 children { id name path }
                 parent { isMainRoot name path }
             }
@@ -44,7 +45,14 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
         fragRef,
     );
 
-    const hasRealmParent = realm.parent !== null;
+    const parent = realm.isUserRoot
+        ? {
+            path: "/",
+            name: t("home"),
+            isMainRoot: true,
+        }
+        : realm.parent;
+    const hasRealmParent = parent !== null;
 
     // We expect all production instances to have more than the root realm. So
     // we print this information instead of an empty div to avoid confusion.
@@ -57,7 +65,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
     return <nav>
         {hasRealmParent && <>
             <LinkWithIcon
-                to={realm.parent.path}
+                to={parent.path}
                 iconPos="left"
                 css={{
                     color: "var(--grey40)",
@@ -69,7 +77,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 {/* Show arrow and hide chevron in burger menu */}
                 <FiCornerLeftUp css={{ display: "none" }}/>
                 <FiChevronLeft />
-                {realm.parent.isMainRoot ? t("home") : realm.parent.name ?? <MissingRealmName />}
+                {parent.isMainRoot ? t("home") : parent.name ?? <MissingRealmName />}
             </LinkWithIcon>
             <div css={{
                 padding: "8px 14px 8px 16px",

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -5,7 +5,7 @@ import {
     FiAlertTriangle, FiArrowLeft, FiCheck, FiUserCheck,
     FiChevronDown, FiFolder, FiLogOut, FiUpload, FiLogIn,
 } from "react-icons/fi";
-import { HiOutlineTranslate } from "react-icons/hi";
+import { HiOutlineFire, HiOutlineTranslate } from "react-icons/hi";
 
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { languages } from "../../i18n";
@@ -203,6 +203,12 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                     linkTo="/~manage"
                     onClick={close}
                 >{t("user.manage-content")}</MenuItem>
+                {user.canCreateUserRealm && <MenuItem
+                    icon={<HiOutlineFire />}
+                    borderBottom
+                    linkTo={`/@${user.username}`}
+                    onClick={close}
+                >{t("realm.user-realm.your-page")}</MenuItem>}
                 {user.canUpload && <MenuItem
                     icon={<FiUpload />}
                     linkTo={"/~upload"}

--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -67,6 +67,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                 && "canUpload" in user && typeof user.canUpload === "boolean"
                 && "canUseStudio" in user && typeof user.canUseStudio === "boolean"
                 && "canUseEditor" in user && typeof user.canUseEditor === "boolean"
+                && "canCreateUserRealm" in user && typeof user.canCreateUserRealm === "boolean"
             ) {
                 // `userData = user` unfortunately doesn't work here as the type
                 // of the `user` object is not sufficiently narrowed. Relevant
@@ -77,6 +78,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                     canUpload: user.canUpload,
                     canUseStudio: user.canUseStudio,
                     canUseEditor: user.canUseEditor,
+                    canCreateUserRealm: user.canCreateUserRealm,
                 };
             }
         }

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -62,17 +62,22 @@ export const checkPathSegment = (segment: string): PathSegmentValidity => {
 export const isValidPathSegment = (segment: string): boolean =>
     checkPathSegment(segment) === "valid";
 
+export const isValidRealmPath = (path: string[]): boolean => {
+    if (path.length === 1 && path[0] === "") {
+        return true;
+    }
+
+    return path.every((segment, i) => (
+        isValidPathSegment(segment)
+           || (i === 0 && segment.startsWith("@") && isValidPathSegment(segment.substring(1)))
+    ));
+};
+
 export const RealmRoute = makeRoute(url => {
     const urlPath = url.pathname.replace(/^\/|\/$/g, "");
     const pathSegments = urlPath.split("/").map(decodeURIComponent);
-    if (urlPath !== "") {
-        for (const [i, segment] of pathSegments.entries()) {
-            const isValid = isValidPathSegment(segment)
-                || (i === 0 && segment.startsWith("@") && isValidPathSegment(segment.substring(1)));
-            if (!isValid) {
-                return null;
-            }
-        }
+    if (!isValidRealmPath(pathSegments)) {
+        return null;
     }
 
     const realmPath = "/" + pathSegments.join("/");

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react";
 import { graphql, loadQuery } from "react-relay/hooks";
 import type { RealmQuery, RealmQuery$data } from "./__generated__/RealmQuery.graphql";
 import { useTranslation } from "react-i18next";
-import { FiEdit, FiPlusCircle, FiSettings, FiSunrise } from "react-icons/fi";
+import { FiEdit, FiInfo, FiPlusCircle, FiSettings, FiSunrise } from "react-icons/fi";
 
 import { environment as relayEnv } from "../relay";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
@@ -17,6 +17,7 @@ import { characterClass, useTitle, useTranslatedConfig } from "../util";
 import { makeRoute } from "../rauta";
 import { MissingRealmName } from "./util";
 import { realmBreadcrumbs } from "../util/realm";
+import { WithTooltip } from "../ui/Floating";
 
 
 // eslint-disable-next-line @typescript-eslint/quotes
@@ -102,6 +103,7 @@ const query = graphql`
             name
             path
             isMainRoot
+            isUserRealm
             children { id }
             blocks { id }
             canCurrentUserEdit
@@ -129,7 +131,10 @@ const RealmPage: React.FC<Props> = ({ realm }) => {
         {!realm.isMainRoot && (
             <Breadcrumbs path={breadcrumbs} tail={realm.name ?? <MissingRealmName />} />
         )}
-        {title && <h1>{title}</h1>}
+        {title && <div>
+            <h1 css={{ display: "inline-block" }}>{title}</h1>
+            {realm.isUserRealm && <UserRealmNote realm={realm} />}
+        </div>}
         {realm.blocks.length === 0 && realm.isMainRoot
             ? <WelcomeMessage />
             : <Blocks realm={realm} />}
@@ -160,6 +165,32 @@ const WelcomeMessage: React.FC = () => {
                 <p>{t("welcome.body")}</p>
             </div>
         </div>
+    );
+};
+
+const UserRealmNote: React.FC<Props> = ({ realm }) => {
+    const { t } = useTranslation();
+    const displayName = realm.ancestors.concat(realm)[0].name;
+
+    return (
+        <WithTooltip
+            tooltip={t("realm.user-realm.note-body", { user: displayName })}
+            placement="bottom"
+            tooltipCss={{ width: 400 }}
+            css={{ display: "inline-block", marginLeft: 12 }}
+        >
+            <div css={{
+                fontSize: 14,
+                lineHeight: 1,
+                color: "var(--grey40)",
+                display: "flex",
+                gap: 4,
+            }}>
+                <FiInfo />
+                {t("realm.user-realm.note-label")}
+            </div>
+        </WithTooltip>
+
     );
 };
 

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -111,10 +111,11 @@ const query = graphql`
             path
             isMainRoot
             isUserRealm
+            ownerDisplayName
             children { id }
             blocks { id }
             canCurrentUserEdit
-            ancestors { name path }
+            ancestors { name path ownerDisplayName }
             parent { id }
             ... BlocksData
             ... NavigationData
@@ -177,7 +178,7 @@ const WelcomeMessage: React.FC = () => {
 
 const UserRealmNote: React.FC<Props> = ({ realm }) => {
     const { t } = useTranslation();
-    const displayName = realm.ancestors.concat(realm)[0].name;
+    const displayName = realm.ancestors.concat(realm)[0].ownerDisplayName;
 
     return (
         <WithTooltip

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -12,7 +12,7 @@ import { WaitingPage } from "../ui/Waiting";
 import { getPlayerAspectRatio, InlinePlayer } from "../ui/player";
 import { SeriesBlockFromSeries } from "../ui/Blocks/Series";
 import { makeRoute, MatchedRoute } from "../rauta";
-import { isValidPathSegment } from "./Realm";
+import { isValidRealmPath } from "./Realm";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { PageTitle } from "../layout/header/ui";
 import {
@@ -75,10 +75,8 @@ export const VideoRoute = makeRoute(url => {
     }
 
     const realmPathParts = parts.slice(0, parts.length - 2);
-    for (const segment of realmPathParts) {
-        if (!isValidPathSegment(segment)) {
-            return null;
-        }
+    if (!isValidRealmPath(realmPathParts)) {
+        return null;
     }
 
     const query = graphql`

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -198,7 +198,7 @@ const realmFragment = graphql`
     fragment VideoPageRealmData on Realm {
         name
         path
-        isRoot
+        isMainRoot
         ancestors { name path }
     }
 `;
@@ -263,7 +263,7 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
         return <WaitingPage type="video" />;
     }
 
-    const breadcrumbs = realm.isRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
+    const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
 
     const { hasStarted, hasEnded } = getEventTimeInfo(event);
     const isCurrentlyLive = hasStarted === true && hasEnded === false;

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -74,7 +74,7 @@ const query = graphql`
         parent: realmByPath(path: $parent) {
             id
             name
-            isRoot
+            isMainRoot
             path
             canCurrentUserEdit
             ancestors { name path }
@@ -132,7 +132,9 @@ const AddChild: React.FC<Props> = ({ parent }) => {
     });
 
     const validations = realmValidations(t);
-    const breadcrumbs = parent.isRoot ? [] : realmBreadcrumbs(t, parent.ancestors.concat(parent));
+    const breadcrumbs = parent.isMainRoot
+        ? []
+        : realmBreadcrumbs(t, parent.ancestors.concat(parent));
 
     return (
         <RealmSettingsContainer>
@@ -140,7 +142,7 @@ const AddChild: React.FC<Props> = ({ parent }) => {
             <PageTitle title={t("manage.add-child.heading")} />
             <p>
                 {
-                    parent.isRoot
+                    parent.isMainRoot
                         ? t("manage.add-child.below-root")
                         : <Trans i18nKey="manage.add-child.below-this-parent">
                             {{ parent: parent.name }}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -116,7 +116,7 @@ const EventSelector: React.FC<EventSelectorProps> = ({ onChange, onBlur, default
 
     const query = graphql`
         query VideoEditModeSearchQuery($q: String!) {
-            events: searchAllEvents(query: $q) {
+            events: searchAllEvents(query: $q, writableOnly: false) {
                 ... on EventSearchResults {
                     items {
                         id

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 import { fetchQuery, graphql, useFragment, useMutation } from "react-relay";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
@@ -18,6 +18,7 @@ import { Creators, Thumbnail } from "../../../../../../ui/Video";
 import { environment } from "../../../../../../relay";
 import { VideoEditModeSearchQuery } from "./__generated__/VideoEditModeSearchQuery.graphql";
 import { MovingTruck } from "../../../../../../ui/Waiting";
+import { ErrorDisplay } from "../../../../../../util/err";
 
 
 type VideoFormData = {
@@ -111,7 +112,7 @@ type EventSelectorProps = {
 
 const EventSelector: React.FC<EventSelectorProps> = ({ onChange, onBlur, defaultValue }) => {
     const { t } = useTranslation();
-    const [error, setError] = useState(false);
+    const [error, setError] = useState<ReactNode>(null);
 
     const query = graphql`
         query VideoEditModeSearchQuery($q: String!) {
@@ -138,7 +139,7 @@ const EventSelector: React.FC<EventSelectorProps> = ({ onChange, onBlur, default
         fetchQuery<VideoEditModeSearchQuery>(environment, query, { q: input }).subscribe({
             next: ({ events }) => {
                 if (events.items === undefined) {
-                    setError(true);
+                    setError(t("search.unavailable"));
                     return;
                 }
 
@@ -153,16 +154,17 @@ const EventSelector: React.FC<EventSelectorProps> = ({ onChange, onBlur, default
                 })));
             },
             start: () => {},
+            error: (error: Error) => setError(<ErrorDisplay error={error} />),
         });
     };
 
     return <>
-        {error && <Card kind="error" css={{ marginBottom: 8 }}>{t("search.unavailable")}</Card>}
+        {error && <Card kind="error" css={{ marginBottom: 8 }}>{error}</Card>}
         <SearchableSelect
             loadOptions={loadEvents}
             format={formatOption}
             onChange={data => onChange(data?.id)}
-            isDisabled={error}
+            isDisabled={!!error}
             {...{ onBlur, defaultValue }}
         />
     </>;

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -90,7 +90,7 @@ const ManageContent: React.FC<Props> = ({ data }) => {
             fragment ContentManageRealmData on Realm {
                 name
                 path
-                isRoot
+                isMainRoot
                 ancestors { name path }
                 ... BlockRealmData
                 ... AddButtonsRealmData
@@ -102,7 +102,7 @@ const ManageContent: React.FC<Props> = ({ data }) => {
         `,
         data.realm as ContentManageRealmData$key,
     );
-    const { name, path, isRoot: realmIsRoot, blocks } = realm;
+    const { name, path, blocks } = realm;
 
 
     const [inFlight, setInFlight] = useState(false);
@@ -131,13 +131,13 @@ const ManageContent: React.FC<Props> = ({ data }) => {
     }, [hasUnsavedChanges, editedBlock]);
 
 
-    const breadcrumbs = realm.isRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
+    const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
 
     return <ContentManageQueryContext.Provider value={data}>
         <RealmSettingsContainer>
             <Breadcrumbs path={breadcrumbs} tail={<i>{t("realm.edit-page-content")}</i>} />
             <PageTitle title={
-                realmIsRoot
+                realm.isMainRoot
                     ? t("manage.realm.content.heading-root")
                     : t("manage.realm.content.heading", { realm: name })
             } />

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -191,6 +191,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
             variables: {
                 id: realm.id,
             },
+            updater: store => store.delete(realm.id),
             onCompleted: response => {
                 const typedResponse = response as DangerZoneRemoveRealmMutation$data;
                 router.goto(typedResponse.removeRealm.parent?.path ?? "/");

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -27,6 +27,7 @@ const fragment = graphql`
         id
         name
         isMainRoot
+        isUserRoot
         path
         numberOfDescendants
     }
@@ -105,6 +106,15 @@ const ChangePath: React.FC<InnerProps> = ({ realm }) => {
 
     const [commitError, setCommitError] = useState<JSX.Element | null>(null);
     const [commit, isInFlight] = useMutation(changePathMutation);
+
+    if (realm.isUserRoot) {
+        return <>
+            <h3>{t("manage.realm.danger-zone.change-path.heading")}</h3>
+            <p css={{ fontSize: 14 }}>
+                {t("manage.realm.danger-zone.change-path.cannot-userrealm")}
+            </p>
+        </>;
+    }
 
     const onSubmit = handleSubmit(data => {
         commit({

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -26,7 +26,7 @@ const fragment = graphql`
     fragment DangerZoneRealmData on Realm {
         id
         name
-        isRoot
+        isMainRoot
         path
         numberOfDescendants
     }
@@ -57,7 +57,7 @@ export const DangerZone: React.FC<Props> = ({ fragRef }) => {
 
     return <>
         <h2>{t("manage.realm.danger-zone.heading")}</h2>
-        {realm.isRoot
+        {realm.isMainRoot
             ? <p>{t("manage.realm.danger-zone.root-note")}</p>
             : (
                 <div css={{
@@ -183,7 +183,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
             },
             onCompleted: response => {
                 const typedResponse = response as DangerZoneRemoveRealmMutation$data;
-                router.goto(typedResponse.removeRealm.parent.path);
+                router.goto(typedResponse.removeRealm.parent?.path ?? "/");
             },
             onError: error => {
                 const failedAction = t("manage.realm.danger-zone.delete.failed");

--- a/frontend/src/routes/manage/Realm/General.tsx
+++ b/frontend/src/routes/manage/Realm/General.tsx
@@ -41,7 +41,7 @@ const fragment = graphql`
                 }
             }
         }
-        isRoot
+        isMainRoot
     }
 `;
 
@@ -66,7 +66,7 @@ export const General: React.FC<Props> = ({ fragRef }) => {
     const realm = useFragment(fragment, fragRef);
 
     // We do not allow changing the name of the root realm.
-    if (realm.isRoot) {
+    if (realm.isMainRoot) {
         return <p>{t("manage.realm.general.no-rename-root")}</p>;
     }
 

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -63,7 +63,7 @@ const query = graphql`
         ... UserData
         realm: realmByPath(path: $path) {
             name
-            isRoot
+            isMainRoot
             path
             canCurrentUserEdit
             numberOfDescendants
@@ -87,11 +87,11 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
         return <NotAuthorized />;
     }
 
-    const heading = realm.isRoot
+    const heading = realm.isMainRoot
         ? t("manage.realm.heading-root")
         : t("manage.realm.heading", { realm: realm.name });
 
-    const breadcrumbs = realm.isRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
+    const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
 
     return (
         <RealmSettingsContainer css={{ maxWidth: 900 }}>

--- a/frontend/src/routes/manage/Realm/util.tsx
+++ b/frontend/src/routes/manage/Realm/util.tsx
@@ -55,7 +55,7 @@ export const RealmSettingsContainer: React.FC<RealmSettingsContainerProps> = ({
 );
 
 /** Returns an element that displays the given mutation error as best as possible. */
-export const displayCommitError = (error: Error, failedAction: string): JSX.Element => {
+export const displayCommitError = (error: Error, failedAction?: string): JSX.Element => {
     // eslint-disable-next-line no-console
     console.error("Error when committing GraphQL mutation:", error);
     return <ErrorDisplay error={error} failedAction={failedAction} />;

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -154,7 +154,7 @@ const HostRealms: React.FC<Props> = ({ event }) => {
                 <p>{t("manage.my-videos.details.referencing-pages-explanation")}</p>
                 <ul>{event.hostRealms.map(realm => <li key={realm.id}>
                     <Link to={realm.path}>{
-                        realm.isRoot
+                        realm.isMainRoot
                             ? <i>{t("general.homepage")}</i>
                             : realm.name
                     }</Link>

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -93,7 +93,7 @@ const query = graphql`
                     opencastId
                     ...SeriesBlockSeriesData
                 }
-                hostRealms { id isRoot name path }
+                hostRealms { id isMainRoot name path }
             }
         }
     }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -432,7 +432,7 @@ type Query {
     Searches through all events (including non-listed ones). Requires
     moderator rights.
   """
-  searchAllEvents(query: String!): EventSearchOutcome!
+  searchAllEvents(query: String!, writableOnly: Boolean!): EventSearchOutcome!
   """
     Searches through all series. If `writable_only` is true, only series
     that the user has write access to are searched (but including

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -57,7 +57,7 @@ scalar Cursor
 union SearchOutcome = SearchUnavailable | EmptyQuery | SearchResults
 
 type RemovedRealm {
-  parent: Realm!
+  parent: Realm
 }
 
 type SearchEvent implements Node {
@@ -242,7 +242,12 @@ type Realm implements Node {
     root realm, non-null for all other realms.
   """
   nameSource: RealmNameSource
-  isRoot: Boolean!
+  "Returns `true` if this is the root of the public realm tree (with path = \"/\")."
+  isMainRoot: Boolean!
+  "Returns true if this is the root of a user realm tree."
+  isUserRoot: Boolean!
+  "Returns `true` if this realm is managed by a user (path starting with `/@`)."
+  isUserRealm: Boolean!
   index: Int!
   """
     Specifies how the children of this realm should be ordered (e.g. in the
@@ -251,13 +256,13 @@ type Realm implements Node {
   childOrder: RealmOrder!
   """
     Returns the trailing segment of this realm's path, without any instances of `/`.
-    Empty for the root realm.
+    Empty for the main root realm.
   """
   pathSegment: String!
   """
-    Returns the full path of this realm. `"/"` for the root realm. For
-    non-root realms, the path always starts with `/` and never has a
-    trailing `/`.
+    Returns the full path of this realm. `"/"` for the main root realm.
+    Otherwise it never has a trailing `/`. For user realms, starts with
+    `/@`.
   """
   path: String!
   "Returns the immediate parent of this realm."
@@ -388,7 +393,7 @@ type RemovedBlock {
 }
 
 type Query {
-  "Returns the root realm."
+  "Returns the main root realm."
   rootRealm: Realm!
   """
     Returns the realm with the specific ID or `None` if the ID does not
@@ -396,12 +401,13 @@ type Query {
   """
   realmById(id: ID!): Realm
   """
-    Returns the realm with the given path or `None` if the path does not
+    Returns the realm with the given path or `null` if the path does not
     refer to a realm.
 
     Paths with and without trailing slash are accepted and treated equally.
     The paths `""` and `"/"` refer to the root realm. All other paths have
-    to start with `"/"`.
+    to start with `"/"`. Paths starting with `"/@"` are considered user
+    root realms.
   """
   realmByPath(path: String!): Realm
   "Returns an event by its Opencast ID."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -313,6 +313,8 @@ input UpdatedRealmName {
 type Mutation {
   "Adds a new realm."
   addRealm(realm: NewRealm!): Realm!
+  "Creates the current users realm. Errors if it already exists."
+  createMyUserRealm: Realm!
   """
     Sets the order of all children of a specific realm.
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -522,6 +522,7 @@ type User {
   canUseStudio: Boolean!
   "`True` if the user has the permission to use Opencast Studio."
   canUseEditor: Boolean!
+  canCreateUserRealm: Boolean!
   """
     Returns all events that somehow "belong" to the user, i.e. that appear
     on the "my videos" page.

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -265,6 +265,12 @@ type Realm implements Node {
     `/@`.
   """
   path: String!
+  """
+    This is only returns a value for root user realms, in which case it is
+    the display name of the user who owns this realm. For all other realms,
+    `null` is returned.
+  """
+  ownerDisplayName: String
   "Returns the immediate parent of this realm."
   parent: Realm
   """

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -9,6 +9,7 @@ import { environment } from "../relay";
 import { Card } from "./Card";
 import { SmallDescription } from "./metadata";
 import { SearchableSelectSeriesQuery } from "./__generated__/SearchableSelectSeriesQuery.graphql";
+import { ErrorDisplay } from "../util/err";
 
 
 type DerivedProps<T> = Omit<Parameters<typeof AsyncSelect<T>>[0],
@@ -101,7 +102,7 @@ export const SeriesSelector: React.FC<SeriesSelectorProps> = ({
     writableOnly = false, onBlur, onChange, defaultValue, ...rest
 }) => {
     const { t } = useTranslation();
-    const [error, setError] = useState(false);
+    const [error, setError] = useState<ReactNode>(null);
 
     const query = graphql`
         query SearchableSelectSeriesQuery($q: String!, $writableOnly: Boolean!) {
@@ -118,7 +119,7 @@ export const SeriesSelector: React.FC<SeriesSelectorProps> = ({
             .subscribe({
                 next: ({ series }) => {
                     if (series.items === undefined) {
-                        setError(true);
+                        setError(t("search.unavailable"));
                         return;
                     }
 
@@ -131,16 +132,17 @@ export const SeriesSelector: React.FC<SeriesSelectorProps> = ({
                     })));
                 },
                 start: () => {},
+                error: (error: Error) => setError(<ErrorDisplay error={error} />),
             });
     };
 
     return <>
-        {error && <Card kind="error" css={{ marginBottom: 8 }}>{t("search.unavailable")}</Card>}
+        {error && <Card kind="error" css={{ marginBottom: 8 }}>{error}</Card>}
         <SearchableSelect
             loadOptions={load}
             format={formatSeriesOption}
             onChange={onChange}
-            isDisabled={error}
+            isDisabled={!!error}
             {...{ onBlur, defaultValue }}
             {...rest}
         />


### PR DESCRIPTION
Fixes #291 (and more :P)


This PR adds "user realms". Every user (that has a configurable role) can create its own page. They can then edit the contents of that page like a moderator can modify any other page. Users can also add sub pages, i.e. they can build their own realm tree. These pages won't be linked anywhere on the main part of the page and won't appear in the search. Instead, they have to be reached via a manually shared link. This makes sure that normal visitors, expecting a website of that university, don't get surprised. Further, each user realm contains a small note (hidden behind an icon) that explains that the content is user generated.

~~This is a **draft** as there are still some things that need to be done. I created the PR so that we already have a test deployment one can show. Still TODO:~~
- [x] Make realm content edit tools work for non-moderators
- [x] Remove user realms from search (currently they can be found)
- [x] Decide about and fix rename dialog in settings (for user root realms)
- [x] Potentially pull out user-realm-independent changes into their own PRs

This can be reviewed commit by commit.