### PR TITLE
Use searchable series select in series block edit UI

### DIFF
--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -49,15 +49,6 @@ impl_from_db!(
 );
 
 impl Series {
-    pub(crate) async fn load_all(context: &Context) -> ApiResult<Vec<Self>> {
-        let selection = Self::select();
-        let query = format!("select {selection} from series order by title");
-        context.db(context.require_moderator()?)
-            .query_mapped(&query, dbargs![], |row| Self::from_row_start(&row))
-            .await?
-            .pipe(Ok)
-    }
-
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> ApiResult<Option<Self>> {
         if let Some(key) = id.key_for(Id::SERIES_KIND) {
             Self::load_by_key(key, context).await

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -64,11 +64,6 @@ impl Query {
         Series::load_by_id(id, context).await
     }
 
-    /// Returns a list of all series.
-    async fn all_series(context: &Context) -> ApiResult<Vec<Series>> {
-        Series::load_all(context).await
-    }
-
     /// Returns the current user.
     fn current_user(context: &Context) -> Option<&User> {
         match &context.auth {
@@ -105,9 +100,12 @@ impl Query {
         search::all_events(&query, context).await
     }
 
-    /// Searches through all series (including non-listed ones). If
-    /// `writable_only` is true, only series that the user can write are
-    /// returned. If it's false, moderator rights are required.
+    /// Searches through all series. If `writable_only` is true, only series
+    /// that the user has write access to are searched (but including
+    /// non-listed ones). If it's false, it depends: if the user is moderator,
+    /// all series are searched (including non-listed ones). If the user is not
+    /// moderator, series that are listed or the user has write access to are
+    /// searched.
     async fn search_all_series(
         query: String,
         writable_only: bool,

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -1,12 +1,10 @@
-import React, { useContext } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
-import { useFormContext, UseFormReturn } from "react-hook-form";
+import { useController, useFormContext, UseFormReturn } from "react-hook-form";
 
-import { isSynced, match } from "../../../../../../util";
+import { match } from "../../../../../../util";
 import { Card } from "../../../../../../ui/Card";
-import { Select } from "../../../../../../ui/Input";
-import { ContentManageQueryContext } from "../..";
 import { EditModeForm } from ".";
 import { Heading, NiceRadio, NiceRadioOption } from "./util";
 import type {
@@ -14,15 +12,13 @@ import type {
     SeriesEditModeBlockData$key,
 } from "./__generated__/SeriesEditModeBlockData.graphql";
 import {
-    SeriesEditModeSeriesData$key,
-} from "./__generated__/SeriesEditModeSeriesData.graphql";
-import {
     SeriesEditSaveMutation,
 } from "./__generated__/SeriesEditSaveMutation.graphql";
 import {
     SeriesEditCreateMutation,
 } from "./__generated__/SeriesEditCreateMutation.graphql";
 import { BREAKPOINT_MEDIUM } from "../../../../../../GlobalStyle";
+import { SeriesSelector } from "../../../../../../ui/SearchableSelect";
 
 
 type SeriesFormData = {
@@ -38,24 +34,11 @@ type EditSeriesBlockProps = {
 };
 
 export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRef }) => {
-
-    const { allSeries } = useFragment(graphql`
-        fragment SeriesEditModeSeriesData on Query {
-            allSeries {
-                id
-                title
-                syncedData {
-                    # only queried to see wether syncedData is null
-                    description
-                }
-            }
-        }
-    `, useContext(ContentManageQueryContext) as SeriesEditModeSeriesData$key);
-
     const { series, showTitle, showMetadata, order } = useFragment(graphql`
         fragment SeriesEditModeBlockData on SeriesBlock {
             series {
                 id
+                opencastId
                 title
                 syncedData {
                     # only queried to see wether syncedData is null
@@ -103,31 +86,26 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
     const { t } = useTranslation();
 
     const form = useFormContext<SeriesFormData>();
-    const { formState: { errors } } = form;
+    const { formState: { errors }, control } = form;
+    const { field: seriesField } = useController({
+        name: "series",
+        control,
+        rules: { required: true },
+    });
 
     return <EditModeForm create={create} save={save} map={mapFormData}>
         <Heading>{t("manage.realm.content.series.series.heading")}</Heading>
         {"series" in errors && <div css={{ margin: "8px 0" }}>
             <Card kind="error">{t("manage.realm.content.series.series.invalid")}</Card>
         </div>}
-        <Select
-            css={{ maxWidth: "100%" }}
-            error={"series" in errors}
-            defaultValue={series?.id}
-            {...form.register("series", { required: true })}
-        >
-            <option value="" hidden>
-                {t("manage.realm.content.series.series.none")}
-            </option>
-            {series && series.syncedData === null && <option value={series.id} hidden>
-                {t("manage.realm.content.series.series.waiting")}
-            </option>}
-            {allSeries
-                .filter(isSynced)
-                .map(({ id, title }) => (
-                    <option key={id} value={id}>{title}</option>
-                ))}
-        </Select>
+        <SeriesSelector
+            defaultValue={series == null ? undefined : {
+                ...series,
+                description: series.syncedData?.description ?? null,
+            }}
+            onChange={data => seriesField.onChange(data?.id)}
+            onBlur={seriesField.onBlur}
+        />
 
         <Heading>{t("series.settings.order")}</Heading>
         <NiceRadio breakpoint={0}>

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -72,7 +72,6 @@ const query = graphql`
             ... NavigationData
             ... ContentManageRealmData
         }
-        ... SeriesEditModeSeriesData
     }
 `;
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -412,8 +412,6 @@ type Query {
   seriesByOpencastId(id: String!): Series
   "Returns a series by its ID."
   seriesById(id: ID!): Series
-  "Returns a list of all series."
-  allSeries: [Series!]!
   "Returns the current user."
   currentUser: User
   "Returns a new JWT that can be used to authenticate against Opencast for using the given service"
@@ -428,9 +426,12 @@ type Query {
   """
   searchAllEvents(query: String!): EventSearchOutcome!
   """
-    Searches through all series (including non-listed ones). If
-    `writable_only` is true, only series that the user can write are
-    returned. If it's false, moderator rights are required.
+    Searches through all series. If `writable_only` is true, only series
+    that the user has write access to are searched (but including
+    non-listed ones). If it's false, it depends: if the user is moderator,
+    all series are searched (including non-listed ones). If the user is not
+    moderator, series that are listed or the user has write access to are
+    searched.
   """
   searchAllSeries(query: String!, writableOnly: Boolean!): SeriesSearchOutcome!
 }

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -86,7 +86,7 @@ type SeriesSelectorProps = DerivedProps<SeriesOption> & {
     onChange?: (series: SeriesOption | null) => void;
     onBlur?: () => void;
     defaultValue?: SeriesOption;
-    writableOnly: boolean;
+    writableOnly?: boolean;
 };
 
 type SeriesOption = {
@@ -97,7 +97,7 @@ type SeriesOption = {
 };
 
 export const SeriesSelector: React.FC<SeriesSelectorProps> = ({
-    writableOnly, onBlur, onChange, defaultValue, ...rest
+    writableOnly = false, onBlur, onChange, defaultValue, ...rest
 }) => {
     const { t } = useTranslation();
     const [error, setError] = useState(false);


### PR DESCRIPTION
This replaces the previous bad UI that just listed all series in a single select. Series were added to the index some time ago.

Fixes #373 
Well, there are still some possible improvements listed there but I think it's fair to close it. The event part of this was done previously already.

This is required for user realms as in those, non-moderators need to be able to edit realm content, which is impossible with the `allSeries` API we had before.