### PR TITLE
Improve `dummy-blocks` for better test data

### DIFF
--- a/.deployment/files/realms.yaml
+++ b/.deployment/files/realms.yaml
@@ -20,14 +20,19 @@ blocks:
   - series:
       series: { by_uuid: 94ecfeed-aa7d-4a5c-912b-58b5891543f4 }
       show_title: true
-      show_description: false
+      show_description: true
   - series:
-      series: { by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b }
+      series: { by_uuid: 8a430c59-7e04-4e4b-b532-b2fcad8de8d4 }
       show_title: true
       show_description: false
+  - title: Opencast Summit 2021
+  - text: |
+      The virtual Opencast Summit 2021, which took place in April of that year.
+      Of course, there have been Opencast summits every year after this one, but
+      you have to look for recordings of those elsewhere, sorry!
   - series:
       series: { by_uuid: ec912549-5bac-4f97-b72a-ace807047aca }
-      show_title: true
+      show_title: false
       show_description: false
 children:
   - path: 'campus'
@@ -5047,6 +5052,13 @@ children:
   - { path: 'documents', name: 'Support' }
   - path: 'live'
     name: 'Live'
+    blocks:
+      - text: |
+          Here are some never ending live streams!
+      - series:
+          series: { by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b }
+          show_title: true
+          show_description: false
     children:
       - path: 'events'
         name: 'Events'

--- a/.deployment/files/realms.yaml
+++ b/.deployment/files/realms.yaml
@@ -18,11 +18,17 @@ blocks:
       deployment. This is not a real website of the ETHZ!
 
   - series:
-      by_uuid: 94ecfeed-aa7d-4a5c-912b-58b5891543f4
+      series: { by_uuid: 94ecfeed-aa7d-4a5c-912b-58b5891543f4 }
+      show_title: true
+      show_description: false
   - series:
-      by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b
+      series: { by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b }
+      show_title: true
+      show_description: false
   - series:
-      by_uuid: ec912549-5bac-4f97-b72a-ace807047aca
+      series: { by_uuid: ec912549-5bac-4f97-b72a-ace807047aca }
+      show_title: true
+      show_description: false
 children:
   - path: 'campus'
     name: 'Campus'

--- a/backend/src/cmd/import_realm_tree.rs
+++ b/backend/src/cmd/import_realm_tree.rs
@@ -69,6 +69,7 @@ pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
     let conn = db.get().await?;
 
     if args.dummy_blocks {
+        info!("Generating dummy blocks...");
         add_dummy_blocks(&mut root, &**conn).await?;
     }
     
@@ -308,6 +309,7 @@ fn dummy_text(title: &str) -> String {
     let end_index = DUMMY_TEXT.char_indices().filter(|(_, c)| c == &'.').nth(num).unwrap().0;
     let text = &DUMMY_TEXT[..=end_index];
     
+    let num = num + 1; // 0-based to 1-based
     format!("\
         What you are seeing here is __{title}__, a collection of videos about potentially \
         very cool and interesting topics. \n\

--- a/backend/src/cmd/import_realm_tree.rs
+++ b/backend/src/cmd/import_realm_tree.rs
@@ -3,7 +3,8 @@
 
 use serde::Deserialize;
 use tokio_postgres::GenericClient;
-use std::{fs::File, future::Future, path::PathBuf, pin::Pin};
+use std::{fs::File, future::Future, path::PathBuf, pin::Pin, collections::HashMap};
+use rand::{thread_rng, Rng};
 
 use crate::{
     config::Config,
@@ -41,6 +42,7 @@ enum Block {
     Title(String),
     Text(String),
     Series(SeriesBlock),
+    Video(i64),
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -52,7 +54,7 @@ enum SeriesBlock {
 
 pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
     let file = File::open(&args.input_file)?;
-    let root: Realm = serde_yaml::from_reader(file)?;
+    let mut root: Realm = serde_yaml::from_reader(file)?;
     info!("Read YAML file");
 
     // Open DB connection, check consistency and migrate if necessary.
@@ -62,31 +64,161 @@ pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
         .context("failed to check/run DB migrations")?;
     let conn = db.get().await?;
 
-    let mut dummy_blocks = DummyBlocks::new(args.dummy_blocks, &**conn).await?;
-
+    if args.dummy_blocks {
+        add_dummy_blocks(&mut root, &**conn).await?;
+    }
+    
     info!("Starting to insert realms into the DB...");
-    insert_realm(&**conn, &root, 0, &mut dummy_blocks).await?;
+    insert_realm(&**conn, &root, 0).await?;
     info!("Done inserting realms");
 
     Ok(())
 }
+
+fn for_all_realms(realm: &mut Realm, mut f: impl FnMut(&mut Realm)) {
+    fn add_blocks(realm: &mut Realm, f: &mut impl FnMut(&mut Realm)) {
+        f(realm);
+
+        for child in &mut realm.children {
+            add_blocks(child, f);
+        }
+    }
+
+    add_blocks(realm, &mut f);
+}
+
+async fn add_dummy_blocks(root: &mut Realm, db: &impl GenericClient) -> Result<()> {
+    // Get relevant series fields.
+    let series_rows = db.query("select title, opencast_id from series", &[]).await?;
+    let mut series = <HashMap<_, Vec<_>>>::new();
+
+    // Store fields in hashmap and make a copy of that.
+    for row in series_rows {
+        let Some(title) = row.get::<_, Option<String>>("title") else {
+            continue;
+        };
+        let oc_id = row.get::<_, String>("opencast_id");
+
+        series.entry(title).or_default().push(oc_id);
+    }
+    let mut series_copy = series.clone();
+
+    // Get relevant event fields. `part_of` is used to match events to their series.
+    let event_rows = db.query("select id, part_of from events", &[]).await?;
+    let mut events = <HashMap<_, Vec<_>>>::new();
+
+    // Store fields in hashmap and make a copy.
+    for row in event_rows {
+        let id = row.get::<_, i64>("id");
+        let part_of = row.get::<_, Option<String>>("part_of");
+        events.entry(part_of).or_default().push(id);
+    }
+
+    // Recursive functions to populate realms and children realms:
+    // Insert text blocks
+    for_all_realms(root, |realm|
+        if !realm.blocks.iter().any(|block| matches!(block, Block::Text(_))) {
+            realm.blocks.push(Block::Text(dummy_text(&realm.name)));
+        }
+    );
+    
+    // Insert series blocks
+    for_all_realms(root, |realm|
+        if let Some(uuids) = series.get_mut(&realm.name) {
+            // We can `unwrap` here because in the lines below,
+            // we make sure that there are no empty vectors in the hashmap.
+            let series_uuid = uuids.pop().unwrap();
+            if uuids.is_empty() {
+                series.remove(&realm.name);
+            }
+            realm.blocks.push(Block::Series(SeriesBlock::ByUuid(series_uuid)));
+        }
+    );
+
+    // Insert remaining series
+    for_all_realms(root, |realm|
+        if !realm.blocks.iter().any(|block| matches!(block, Block::Series(_))) {
+            if let Some((title, uuids)) = series.iter_mut().next() {
+                let uuid = uuids.pop().unwrap();
+                let copy = title.clone();
+                if uuids.is_empty() {
+                    series.remove(&copy);
+                }
+                // Only insert series if it is not empty,
+                // i.e. `events` map contains a `part_of` key for that series.
+                if events.contains_key(&Some(uuid.clone())) {
+                    realm.blocks.push(Block::Series(SeriesBlock::ByUuid(uuid)));
+                }
+            }
+        }
+    );
+
+    // Insert video blocks
+    for_all_realms(root, |realm|
+        if let Some(uuids) = series_copy.get_mut(&realm.name) {
+            let series_uuid = uuids.pop().unwrap();
+            let copy = series_uuid.clone();
+            if uuids.is_empty() {
+                series_copy.remove(&realm.name);
+            }
+    
+            // Look for events that are `part_of` series with `series_uuid`
+            if let Some(event_ids) = events.get_mut(&Some(series_uuid)) {
+                // Insert a random number of these
+                let num = if event_ids.len() < 4 {
+                    thread_rng().gen_range(0..=event_ids.len())
+                } else {
+                    thread_rng().gen_range(0..4)
+                };
+                for event_id in event_ids.drain(..num) {
+                    realm.blocks.push(Block::Video(event_id));
+                }
+                if event_ids.is_empty() {
+                    events.remove(&Some(copy));
+                }
+            }
+        }
+    );
+
+    // Insert remaining videos
+    for_all_realms(root, |realm|
+        // See if realm already has at least one video block.
+        // If not: insert one that hasn't been inserted yet.
+        if !realm.blocks.iter().any(|block| matches!(block, Block::Video(_))) {
+            if !events.is_empty() {
+                // Get a random key.
+                let key = events.keys().next().unwrap().to_owned();
+                // Insert a random number of events with that key.
+                if let Some(event_ids) = events.get_mut(&key) {
+                    let num = if event_ids.len() < 4 {
+                        thread_rng().gen_range(0..=event_ids.len())
+                    } else {
+                        thread_rng().gen_range(0..4)
+                    };
+                    for event_id in event_ids.drain(..num) {
+                        realm.blocks.push(Block::Video(event_id));
+                    }
+                    if event_ids.is_empty() {
+                        events.remove(&key);
+                    }
+                }
+            }
+        }
+    );
+
+    Ok(())
+}
+
 
 // Recursive async functions have to be written manually, unfortunately.
 fn insert_realm<'a>(
     db: &'a impl GenericClient,
     realm: &'a Realm,
     id: i64,
-    dummy_blocks: &'a mut DummyBlocks,
 ) -> Pin<Box<dyn 'a + Future<Output = Result<()>>>> {
     Box::pin(async move {
         // Insert all blocks
-        let blocks = if realm.blocks.is_empty() {
-            dummy_blocks.next_blocks()
-        } else {
-            Box::new(realm.blocks.iter().cloned())
-        };
-
-        for (i, block) in blocks.enumerate() {
+        for (i, block) in realm.blocks.iter().enumerate() {
             block.insert(id, i, db).await?;
         }
 
@@ -98,55 +230,13 @@ fn insert_realm<'a>(
                 returning id";
             let row = db.query_one(query, &[&id, &child.name, &child.path]).await?;
             let child_id = row.get::<_, i64>(0);
-            insert_realm(db, child, child_id, dummy_blocks).await?;
+            insert_realm(db, child, child_id).await?;
         }
 
         Ok(())
     })
 }
 
-
-enum DummyBlocks {
-    Disabled,
-    Enabled {
-        series: Vec<String>,
-        idx: usize,
-    },
-}
-
-impl DummyBlocks {
-    async fn new(enable: bool, db: &impl GenericClient) -> Result<Self> {
-        if enable {
-            let series = db.query_raw("select opencast_id from series", dbargs![])
-                .await?
-                .map_ok(|row| row.get::<_, String>(0))
-                .try_collect()
-                .await?;
-
-            Ok(Self::Enabled {
-                series,
-                idx: 0,
-            })
-        } else {
-            Ok(Self::Disabled)
-        }
-    }
-
-    fn next_blocks(&mut self) -> Box<dyn Iterator<Item = Block>> {
-        match self {
-            Self::Disabled => Box::new(std::iter::empty()),
-            Self::Enabled { series, idx } => {
-                let uuid = series[*idx].clone();
-                *idx = (*idx + 1) % series.len();
-
-                Box::new([
-                    Block::Text(DUMMY_TEXT.into()),
-                    Block::Series(SeriesBlock::ByUuid(uuid)),
-                ].into_iter())
-            }
-        }
-    }
-}
 
 impl Block {
     async fn insert(&self, realm_id: i64, index: usize, db: &impl GenericClient) -> Result<()> {
@@ -164,6 +254,14 @@ impl Block {
                     values ($1, 'text', $2, $3)
                 ";
                 db.execute(query, &[&realm_id, &(index as i16), text]).await?;
+            }
+            Block::Video(event_id) => {
+                let query = "
+                    insert into blocks
+                    (realm, type, index, video)
+                    values ($1, 'video', $2, $3)
+                ";
+                db.execute(query, &[&realm_id, &(index as i16), &event_id]).await?;
             }
             Block::Series(series) => {
                 // Obtain the series ID
@@ -204,13 +302,46 @@ impl Block {
     }
 }
 
-const DUMMY_TEXT: &str = "\
-    The videos you see below have nothing to do with the name of this page. They \
-    have been randomly assigned.\n\
-    \n\
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
-    incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
-    exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute \
-    irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla \
-    pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia \
-    deserunt mollit anim id est laborum.";
+fn dummy_text(title: &str) -> String {
+    const DUMMY_TEXT: &str = "\
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
+        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud \
+        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute \
+        irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla \
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia \
+        deserunt mollit anim id est laborum. Et sint libero id porro libero quo accusamus \
+        saepe sed dolores inventore id ducimus iure sed consequatur modi. Eum atque tempore \
+        et voluptas corporis et tempora quia sed rerum earum eos quia voluptate. Cum ullam \
+        minima est nihil fugit quo nemo similique. Et omnis sequi hic aliquid ipsa eos \
+        deleniti harum id obcaecati deserunt et omnis architecto non eligendi necessitatibus \
+        sit similique ipsum.";
+    // Split `DUMMY_TEXT` into sentences. We could also split this into words
+    // and print a random amount of these, though the formatting would get a little
+    // more tricky with that. Or we could use a library to generate the lorem text.
+
+    // let sentences: Vec<_> = DUMMY_TEXT.split_inclusive(". ").collect();
+    // let num = thread_rng().gen_range(1..sentences.len());
+
+    let num_sentences = DUMMY_TEXT.chars().filter(|c| c == &'.').count();
+    let num = thread_rng().gen_range(1..num_sentences);
+    let end_index = DUMMY_TEXT.char_indices().filter(|(_, c)| c == &'.').nth(num).unwrap().0;
+    let text = &DUMMY_TEXT[..=end_index];
+
+    // // Build a string with a random number of lorem sentences.
+    // let mut text = String::new();
+    // for i in 1..=num {
+    //     text.push_str(sentences[i])
+    // }
+    // let text = sentences.iter().take(num).collect::<String>();
+    
+    format!("\
+        What you are seeing here is __{title}__, a collection of videos about potentially \
+        very cool and interesting topics. \n\
+        Note that the videos featured here might not have anything to do with the title \
+        of this page. \n\
+        Read on to learn more about this collection in no less than *{num}* sentences. \n\
+        \n\
+        {text}
+        ")
+}
+

--- a/util/dummy-realms.yaml
+++ b/util/dummy-realms.yaml
@@ -17,7 +17,9 @@ blocks:
       testing.
 
   - series:
-      by_title: Cats
+      series: { by_title: "Cats" }
+      show_title: true
+      show_description: false
 
 children:
   - path: campus
@@ -25,7 +27,9 @@ children:
     blocks:
       - text: Videos about life on the campus, the canteen and more.
       - series:
-          by_title: SciFi Chicken
+          series: { by_title: "SciFi Chicken" }
+          show_title: true
+          show_description: false
 
   - path: library
     name: Library


### PR DESCRIPTION
This is adds a couple of functions that insert various types of dummy blocks (series, text, title, video).

I'm sure there are a lot of things that can be improved upon, as I am still pretty new to rust. Some things might look weird to seasoned rust developers, so I left some comments trying to explain what the code is meant to do/what I think it does.

Closes #601 when eventually completed.