### PR TITLE
Improve "gallery view" of series block

### DIFF
--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -529,12 +529,20 @@ const Videos: React.FC<ViewProps> = ({ basePath, items }) => {
     });
 };
 
+const ITEM_MIN_SIZE = 240;
+const ITEM_MIN_SIZE_LARGE_SCREENS = 260;
+const ITEM_MAX_SIZE = 310;
+const ITEM_MAX_SIZE_SMALL_SCREENS = 360;
+
 const GalleryView: React.FC<ViewProps> = ({ basePath, items }) => (
     <div css={{
-        display: "flex",
-        flexWrap: "wrap",
-        [`@media (max-width: ${VIDEO_GRID_BREAKPOINT}px)`]: {
-            justifyContent: "center",
+        display: "grid",
+        gridTemplateColumns: `repeat(auto-fill, minmax(${ITEM_MIN_SIZE}px, 1fr))`,
+        marginTop: 6,
+        columnGap: 12,
+        rowGap: 28,
+        "@media (min-width: 1600px)": {
+            gridTemplateColumns: `repeat(auto-fill, minmax(${ITEM_MIN_SIZE_LARGE_SCREENS}px, 1fr))`,
         },
     }}>
         {items.map(({ event, active }) => (
@@ -542,11 +550,11 @@ const GalleryView: React.FC<ViewProps> = ({ basePath, items }) => (
                 key={event.id}
                 {...{ event, active, basePath }}
                 css={{
-                    margin: "8px 6px 28px 6px",
-                    width: 16 * 15,
+                    margin: "0 auto",
+                    width: "100%",
+                    maxWidth: ITEM_MAX_SIZE,
                     [`@media (max-width: ${VIDEO_GRID_BREAKPOINT}px)`]: {
-                        width: "100%",
-                        maxWidth: 360,
+                        maxWidth: ITEM_MAX_SIZE_SMALL_SCREENS,
                     },
                 }}
             />

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -1,7 +1,6 @@
 import React, {
-    Children, createContext,
     ReactElement, ReactNode,
-    useContext, useEffect, useRef, useState,
+    createContext, useContext, useEffect, useRef, useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
@@ -208,9 +207,11 @@ const ReadySeriesBlock: React.FC<ReadyProps> = ({
             {!eventsNotEmpty
                 ? t("series.no-events")
                 : <>
-                    {upcomingLiveEvents.length > 1 && <UpcomingEventsGrid>
-                        {renderEvents(upcomingLiveEvents)}
-                    </UpcomingEventsGrid>}
+                    {upcomingLiveEvents.length > 1 && (
+                        <UpcomingEventsGrid count={upcomingLiveEvents.length}>
+                            {renderEvents(upcomingLiveEvents)}
+                        </UpcomingEventsGrid>
+                    )}
                     {renderEvents(sortedEvents)}
                 </>
             }
@@ -677,7 +678,11 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items }) => {
 };
 
 
-const UpcomingEventsGrid: React.FC<React.PropsWithChildren> = ({ children }) => {
+type UpcomingEventsGridProps = React.PropsWithChildren<{
+    count: number;
+}>;
+
+const UpcomingEventsGrid: React.FC<UpcomingEventsGridProps> = ({ count, children }) => {
     const { t } = useTranslation();
 
     return (
@@ -707,7 +712,7 @@ const UpcomingEventsGrid: React.FC<React.PropsWithChildren> = ({ children }) => 
         }}>
             <summary>
                 <span>
-                    {t("series.upcoming-live-streams", { count: Children.count(children) })}
+                    {t("series.upcoming-live-streams", { count })}
                 </span>
             </summary>
             {children}


### PR DESCRIPTION
See the second commit message for the main attraction:

> Make "gallery view" of series block scale items to better fill screen 
> 
> This should look better on more screens. Before, there was some left-over space on the right if there wasn't enough space for a new video item. On some screens it looked really bad because a new item would almost fit.
> 
> With this, the items themselves scale a bit to fill the space. They do have a max width. When that's reached, the remaining space is distributed as margin left/right of the items.

The first commit refactors those components to make the second commit possible. The refactoring makes it so that all "view dependent" CSS code is actually contained in the respective `*View` component, not conditionally inside `Item`.

Regarding the main style change: I'm really interested in just feedback. The video items certainly grew in size on average. It's still smaller than on YouTube. I'm not sure if the max width is too overwhelming? I'm also not sure if distributing the left-over space to each item instead of all at the end is an improvement? I'm open to suggestions. Of course, this is something that can be fine-tweaked a lot to make certain screen sizes look better. 