### PR TITLE
Disable `spellcheck` and `autocapitalize` on username and path inputs

### DIFF
--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -199,6 +199,8 @@ const LoginBox: React.FC = () => {
                         <input
                             id="userid"
                             autoComplete="username email"
+                            spellCheck={false}
+                            autoCapitalize="none"
                             required
                             autoFocus
                             {...register("userid", validation)}

--- a/frontend/src/ui/PathSegmentInput.tsx
+++ b/frontend/src/ui/PathSegmentInput.tsx
@@ -24,6 +24,8 @@ export const PathSegmentInput = React.forwardRef<HTMLInputElement, Props>(
             <span css={{ paddingLeft: 8 }}>{base + (base.endsWith("/") ? "" : "/")}</span>
             <Input
                 css={{ margin: -1, width: 160 }}
+                spellCheck={false}
+                autoCapitalize="none"
                 // TODO: I have no idea why, but this cast is necessary.
                 // Otherwise TS complaints about type mismatch. By `ref` is
                 // exactly the same type as what the `ref` attributes of


### PR DESCRIPTION
The user ID is case sensitive and usually lowercase, so having a mobile keyboard autocapitalize it isn't helping. Spellcheck/auto-correct also makes no sense.
For the path input, one usually wants lower case only. Spell check for path input isn't that clear, but I think I'd prefer it off, too.