### PR TITLE
Limit allowed file formats for upload to audio/video

### DIFF
--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -425,6 +425,7 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
                         }
                     }}
                     type="file"
+                    accept="video/*, audio/*"
                     aria-hidden="true"
                     css={{ display: "none" }}
                 />


### PR DESCRIPTION
Previously we would only show an error message if another file type was selected for upload. With this, it becomes impossible to select any non audio/video file. The error message will still be shown for drag and drop.