### PR TITLE
Add screen reader support for language selection

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -1,5 +1,7 @@
 language-name: Deutsch
 language: Sprache
+language-selection: Sprachauswahl
+selected-language: 'Auswahl: Deutsch'
 loading: Lade...
 close: Schließen
 save: Speichern

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -1,5 +1,7 @@
 language-name: English
 language: Language
+language-selection: Language selection
+selected-language: 'Selection: English'
 loading: Loading...
 close: Close
 save: Save

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -282,15 +282,28 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
     );
 };
 
+// Use this for text elements that exist exclusively for screen reader purposes
+export const visuallyHidden = {
+    clipPath: "inset(50%)",
+    height: 1,
+    width: 1,
+    overflow: "hidden",
+    position: "absolute",
+    whiteSpace: "nowrap",
+} as const;
+
 
 export const LanguageSettings: React.FC = () => {
     const { t } = useTranslation();
 
-    return <WithFloatingMenu type="language">
-        <ActionIcon title={t("language")}>
-            <HiOutlineTranslate />
-        </ActionIcon>
-    </WithFloatingMenu>;
+    return <>
+        <div css={visuallyHidden} aria-live="polite">{t("selected-language")}</div>
+        <WithFloatingMenu type="language">
+            <ActionIcon title={t("language-selection")}>
+                <HiOutlineTranslate />
+            </ActionIcon>
+        </WithFloatingMenu>
+    </>;
 };
 
 
@@ -342,6 +355,8 @@ const LanguageMenu: React.FC<{ close: () => void }> = ({ close }) => {
     return <>
         {Object.keys(languages).map(lng => (
             <MenuItem
+                isLanguageItem
+                selected={isCurrentLanguage(lng)}
                 key={lng}
                 icon={isCurrentLanguage(lng) ? <FiCheck /> : undefined}
                 onClick={() => {
@@ -370,6 +385,8 @@ type MenuItemProps = {
     borderBottom?: boolean;
     borderTop?: boolean;
     children: ReactNode;
+    isLanguageItem?: boolean;
+    selected?: boolean;
 };
 
 /** A single item in the user menu. */
@@ -382,6 +399,8 @@ const MenuItem: React.FC<MenuItemProps> = ({
     htmlLink = false,
     borderBottom = false,
     borderTop = false,
+    isLanguageItem = false,
+    selected = false,
 }) => {
     const inner = <>
         {icon ?? <svg />}
@@ -419,11 +438,16 @@ const MenuItem: React.FC<MenuItemProps> = ({
         }
     };
 
+    const additionalProps = !isLanguageItem ? { role: "menuitem" } : {
+        role: "checkbox",
+        "aria-checked": selected,
+    };
+
     return linkTo
-        ? <li role="menuitem" {... { className }}>
+        ? <li {...additionalProps} {... { className }}>
             <Link to={linkTo} css={css} {...{ htmlLink, onClick, className }}>{inner}</Link>
         </li>
-        : <li role="menuitem" tabIndex={0} css={css} {...{ onClick, className, onKeyDown }}>
+        : <li {...additionalProps} tabIndex={0} css={css} {...{ onClick, className, onKeyDown }}>
             {inner}
         </li>;
 };


### PR DESCRIPTION
The language selection menu will now verbally indicate the selection status of the focused menuitem. When switching the language, the new selection will also be announced.

Unfortunately, the `aria-live` attribute used for the selection announcement is not yet supported by firefox (https://caniuse.com/?search=aria-live).
I have spent some time looking for an alternative, but couldn't find any so far. Hopefully, firefox will add support for this soon.

(somewhat, apart from firefox) fixes #657