### PR TITLE
Apply redesign of `~manage/realm/` pages

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -43,6 +43,11 @@ const CSS_RESETS = css({
 
         // A reset to a sensible value.
         lineHeight: 1.5,
+
+        // Accent color for generated UI control `<input>` elements
+        // where type="checkbox", "radio" or "range",
+        // as well as `<progress>` elements.
+        accentColor: "var(--accent-color)",
     },
 
     // This improves the readability of underlines in links.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -424,7 +424,7 @@ manage:
           heading: Layout
           videos-only: Nur Videos
           title-and-videos: Titel und Videos
-          description-and-videos: Bescheibung und Videos
+          description-and-videos: Beschreibung und Videos
           everything: Titel, Beschreibung und Videos
 
       event:

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -391,7 +391,7 @@ manage:
       view-page: Seite ansehen
 
       add: Hier einen neuen Block einfügen
-      add-popup-title: Hier einfügen
+      add-popup-title: Neu hinzufügen
       add-title: Titel
       add-text: Text
       add-series: Serie

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -380,7 +380,7 @@ manage:
       view-page: View page
 
       add: Insert a new block here
-      add-popup-title: Add here
+      add-popup-title: Add new
       add-title: Title
       add-text: Text
       add-series: Series

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -154,18 +154,21 @@ const AddChild: React.FC<Props> = ({ parent }) => {
                 css={{
                     margin: "32px 0",
                     "& > div": { marginBottom: 32 },
+                    "label + div": { display: "flex" },
+                    input: { height: 42, flexGrow: 1 },
                 }}
             >
                 <InputWithInfo info={t("manage.add-child.page-name-info")}>
                     <label htmlFor="name-field">{t("manage.realm.general.page-name")}</label>
-                    <Input
-                        id="name-field"
-                        css={{ width: 350, maxWidth: "100%" }}
-                        placeholder={t("manage.realm.general.page-name")}
-                        error={!!errors.name}
-                        autoFocus
-                        {...register("name", validations.name)}
-                    />
+                    <div>
+                        <Input
+                            id="name-field"
+                            placeholder={t("manage.realm.general.page-name")}
+                            error={!!errors.name}
+                            autoFocus
+                            {...register("name", validations.name)}
+                        />
+                    </div>
                     {boxError(errors.name?.message)}
                 </InputWithInfo>
 
@@ -211,6 +214,7 @@ const InputWithInfo: React.FC<InputWithInfoProps> = ({ info, children }) => (
         rowGap: 16,
         "@media (max-width: 1300px)": {
             flexDirection: "column",
+            div: { maxWidth: 500 },
         },
         "& code": {
             whiteSpace: "nowrap",
@@ -219,7 +223,7 @@ const InputWithInfo: React.FC<InputWithInfoProps> = ({ info, children }) => (
             padding: "2px 4px",
         },
     }}>
-        <div css={{ minWidth: "min(100%, 450px)" }}>{children}</div>
-        <Card kind="info" css={{ maxWidth: 600, minSize: 100, fontSize: 14 }}>{info}</Card>
+        <div css={{ width: "min(100%, 500px)" }}>{children}</div>
+        <Card kind="info" css={{ maxWidth: 500, fontSize: 14 }}>{info}</Card>
     </div>
 );

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -57,13 +57,13 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
     const { t, i18n } = useTranslation();
     const realm = useFragment(fragment, fragRef);
 
-    const intialSortOrder = realm.childOrder === "%future added value"
+    const initialSortOrder = realm.childOrder === "%future added value"
         // This is not optimal. The only useful thing we could do in the future
         // is to disable the whole form just to be save, whenever we encounter
         // a sort order we don't know.
         ? bug("unknown realm sort order")
         : realm.childOrder;
-    const [sortOrder, setSortOrder] = useState<SortOrder>(intialSortOrder);
+    const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder);
     const [children, setChildren] = useState(realm.children);
 
     // Swaps `index` with `index + 1`.
@@ -77,7 +77,7 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
     };
 
     // Check if anything has changed
-    const anyChange = intialSortOrder !== sortOrder
+    const anyChange = initialSortOrder !== sortOrder
         || children.some((c, i) => c.id !== realm.children[i].id);
 
     const [commitError, setCommitError] = useState<JSX.Element | null>(null);
@@ -105,12 +105,12 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
 
     const SortOrderOption: React.FC<SortOrderOptionProps> = ({ label, order }) => (
         <div css={{ margin: 6 }}>
-            <label>
+            <label css={{ display: "flex" }}>
                 <input
                     type="radio"
                     checked={order === sortOrder}
                     onChange={() => setSortOrder(order)}
-                    css={{ marginRight: 16 }}
+                    css={{ alignSelf: "center", marginRight: 14, height: 16, width: 16 }}
                 />
                 {label}
             </label>
@@ -140,7 +140,13 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
             </ChildList>
 
             <div css={{ display: "flex", alignItems: "center" }}>
-                <Button onClick={save} disabled={!anyChange}>{t("save")}</Button>
+                <Button
+                    onClick={save}
+                    disabled={!anyChange}
+                    css={{ borderRadius: 8, padding: "8px 16px" }}
+                >
+                    {t("save")}
+                </Button>
                 {isInFlight && <Spinner size={20} css={{ marginLeft: 16 }} />}
             </div>
             {boxError(commitError)}
@@ -157,7 +163,6 @@ type ChildListProps = {
 
 const ChildList: React.FC<ChildListProps> = ({ disabled, children, swap }) => (
     <ol css={{
-        marginLeft: 32,
         maxWidth: 900,
         padding: 0,
         ...disabled && {
@@ -190,14 +195,15 @@ const ChildEntry: React.FC<ChildEntryProps> = ({ index, swap, realmName, numChil
             display: "flex",
             alignItems: "center",
             border: "1px solid var(--grey80)",
-            margin: 4,
+            margin: "4px 0",
             borderRadius: 4,
         }}>
             <div css={{
                 display: "flex",
                 flexDirection: "column",
                 marginRight: 16,
-                fontSize: 20,
+                fontSize: 18,
+                borderRight: "1px solid var(--grey80)",
                 "& > div": {
                     "&:first-child > button": {
                         borderBottom: "1px solid var(--grey80)",
@@ -211,8 +217,7 @@ const ChildEntry: React.FC<ChildEntryProps> = ({ index, swap, realmName, numChil
                     border: "none",
                     display: "flex",
                     alignItems: "center",
-                    borderRight: "1px solid var(--grey80)",
-                    padding: "4px 16px",
+                    padding: "5px 12px",
                     backgroundColor: "inherit",
                     "&:disabled": {
                         color: "transparent",
@@ -223,7 +228,7 @@ const ChildEntry: React.FC<ChildEntryProps> = ({ index, swap, realmName, numChil
                             backgroundColor: "var(--grey97)",
                             color: "var(--accent-color)",
                         },
-                        ...focusStyle({}),
+                        ...focusStyle({ offset: -1.5 }),
                     },
                 },
             }}>

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -140,13 +140,7 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
             </ChildList>
 
             <div css={{ display: "flex", alignItems: "center" }}>
-                <Button
-                    onClick={save}
-                    disabled={!anyChange}
-                    css={{ borderRadius: 8, padding: "8px 16px" }}
-                >
-                    {t("save")}
-                </Button>
+                <Button onClick={save} disabled={!anyChange}>{t("save")}</Button>
                 {isInFlight && <Spinner size={20} css={{ marginLeft: 16 }} />}
             </div>
             {boxError(commitError)}

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -65,7 +65,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
         <FloatingContainer
             ref={floatingRef}
             trigger="click"
-            placement="top"
+            placement="right"
             borderRadius={8}
             ariaRole="menu"
             distance={6}
@@ -73,7 +73,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
         >
             <FloatingTrigger>
                 <div>
-                    <WithTooltip tooltip={t("manage.realm.content.add")} placement="bottom">
+                    <WithTooltip tooltip={t("manage.realm.content.add")} placement="top">
                         <ProtoButton aria-label={t("manage.realm.content.add")} css={{
                             width: BUTTON_SIZE,
                             height: BUTTON_SIZE,
@@ -100,6 +100,8 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                 borderWidth={0}
                 shadowBlur={12}
                 shadowColor="rgba(0, 0, 0, 30%)"
+                customArrowPosition={12.5}
+                alignWithTrigger="top"
                 css={{
                     backgroundColor: "white",
                     width: 200,

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -65,7 +65,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
         <FloatingContainer
             ref={floatingRef}
             trigger="click"
-            placement="right"
+            placement="top"
             borderRadius={8}
             ariaRole="menu"
             distance={6}
@@ -73,7 +73,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
         >
             <FloatingTrigger>
                 <div>
-                    <WithTooltip tooltip={t("manage.realm.content.add")} placement="top">
+                    <WithTooltip tooltip={t("manage.realm.content.add")} placement="right">
                         <ProtoButton aria-label={t("manage.realm.content.add")} css={{
                             width: BUTTON_SIZE,
                             height: BUTTON_SIZE,
@@ -100,8 +100,6 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                 borderWidth={0}
                 shadowBlur={12}
                 shadowColor="rgba(0, 0, 0, 30%)"
-                customArrowPosition={12.5}
-                alignWithTrigger="top"
                 css={{
                     backgroundColor: "white",
                     width: 200,

--- a/frontend/src/routes/manage/Realm/Content/Block.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Block.tsx
@@ -108,7 +108,7 @@ export const EditBlock: React.FC<Props> = ({
             alignSelf: "stretch",
             border: "1px solid var(--grey80)",
             borderRadius: 4,
-            padding: 8,
+            padding: 12,
             ...editMode && {
                 boxShadow: "0 2px 8px rgba(0, 0, 0, 20%)",
             },

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Title.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Title.tsx
@@ -59,7 +59,7 @@ export const EditTitleBlock: React.FC<EditTitleBlockProps> = ({ block: blockRef 
         <h3><Input
             placeholder={t("manage.realm.content.title.content")}
             defaultValue={content}
-            css={{ display: "block" }}
+            css={{ display: "block", width: "100%" }}
             {...form.register("content")}
         /></h3>
     </EditModeForm>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -98,7 +98,12 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
 
         <Heading>{t("manage.realm.content.titled.title")}</Heading>
         <label>
-            <input type="checkbox" defaultChecked={showTitle} {...form.register("showTitle")} />
+            <input
+                type="checkbox"
+                defaultChecked={showTitle}
+                {...form.register("showTitle")}
+                css={{ marginRight: 6 }}
+            />
             {t("manage.realm.content.titled.show-title")}
         </label>
     </EditModeForm>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -149,9 +149,10 @@ const EditModeButtons: React.FC<EditModeButtonsProps> = ({ onCancel }) => {
     const { formState: { isDirty } } = useFormContext();
 
     return <div css={{
-        marginTop: 24,
+        marginTop: 12,
         display: "flex",
-        justifyContent: "space-between",
+        justifyContent: "flex-end",
+        gap: 12,
     }}>
         <Button
             kind="danger"

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 
 
 export const Heading: React.FC<{ children: ReactNode }> = ({ children }) => <h3 css={{
-    marginTop: 12,
+    ":not(:first-of-type)": { marginTop: 12 },
     marginBottom: 8,
     fontSize: 18,
 }}>

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
@@ -31,7 +31,6 @@ export const NiceRadio: React.FC<NiceRadioProps> = ({ children, breakpoint }) =>
                 border: "1px solid var(--grey65)",
                 padding: "6px 12px",
                 cursor: "pointer",
-                height: "100%",
                 backgroundColor: "white",
             },
             "& > input:checked + div": {
@@ -40,8 +39,14 @@ export const NiceRadio: React.FC<NiceRadioProps> = ({ children, breakpoint }) =>
                 outlineOffset: -2,
                 position: "relative", // Needed so that the outline is over sibling divs
             },
+            // The attribute selector increases specificity
+            ":focus-within div[role='button']": {
+                backgroundColor: "var(--grey86)",
+                outline: "3px solid var(--accent-color)",
+            },
             "& > input": {
-                display: "none",
+                position: "absolute",
+                opacity: 0, // Needed for the radio input to work for keyboard-only users
             },
             [`@media (max-width: ${breakpoint}px)`]: {
                 "&:first-child > div": {
@@ -77,7 +82,7 @@ export const NiceRadioOption = React.forwardRef<HTMLInputElement, NiceRadioOptio
     ({ children, ...rest }, ref) => (
         <label>
             <input type="radio" ref={ref} {...rest} />
-            <div>{children}</div>
+            <div role="button">{children}</div>
         </label>
     ),
 );

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -50,7 +50,7 @@ export const EditButtons: React.FC<Props> = ({
         onError?.(error, "manage.realm.content.moving-failed");
     };
 
-    return <ButtonGroup css={{ marginTop: -8 }}>
+    return <ButtonGroup>
         <MoveButtons {...{ realm, index, onCommit, onCompleted }} onError={onMoveError} />
         <WithTooltip tooltip={t("manage.realm.content.edit")}>
             <Button aria-label={t("manage.realm.content.edit")} onClick={onEdit}>
@@ -75,7 +75,8 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = props => (
         borderTopLeftRadius: 0,
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
-        marginRight: -8,
+        marginTop: -12,
+        marginRight: -12,
     }} {...props} />
 );
 

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -143,8 +143,8 @@ const ManageContent: React.FC<Props> = ({ data }) => {
             } />
 
             <LinkButton to={path}>
-                <FiEye />
                 {t("manage.realm.content.view-page")}
+                <FiEye />
             </LinkButton>
 
             <div css={{

--- a/frontend/src/routes/manage/Realm/General.tsx
+++ b/frontend/src/routes/manage/Realm/General.tsx
@@ -180,6 +180,7 @@ export const NameForm: React.FC<NameFormProps> = ({ realm }) => {
                             cursor: "pointer",
                             "& > input[type=radio]": {
                                 width: 16,
+                                height: 16,
                                 margin: 0,
                             },
                         },

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -12,7 +12,7 @@ import { ChildOrder } from "./ChildOrder";
 import { General } from "./General";
 import { DangerZone } from "./DangerZone";
 import { LinkButton } from "../../../ui/Button";
-import { FiArrowRightCircle, FiPlus } from "react-icons/fi";
+import { FiArrowRightCircle, FiPlusCircle } from "react-icons/fi";
 import { Card } from "../../../ui/Card";
 import { Nav } from "../../../layout/Navigation";
 import { CenteredContent } from "../../../ui";
@@ -92,6 +92,12 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
         : t("manage.realm.heading", { realm: realm.name });
 
     const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
+    const buttonStyle = {
+        backgroundColor: "transparent",
+        padding: "8px 16px",
+        borderRadius: 8,
+        gap: 9,
+    };
 
     return (
         <RealmSettingsContainer css={{ maxWidth: 900 }}>
@@ -104,13 +110,16 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
                 flexWrap: "wrap",
                 gap: 16,
             }}>
-                <LinkButton to={realm.path}>
-                    <FiArrowRightCircle />
+                <LinkButton to={realm.path} css={buttonStyle}>
                     {t("manage.realm.view-page")}
+                    <FiArrowRightCircle />
                 </LinkButton>
-                <LinkButton to={`/~manage/realm/add-child?parent=${pathToQuery(realm.path)}`}>
-                    <FiPlus />
+                <LinkButton
+                    to={`/~manage/realm/add-child?parent=${pathToQuery(realm.path)}`}
+                    css={buttonStyle}
+                >
                     {t("realm.add-sub-page")}
+                    <FiPlusCircle />
                 </LinkButton>
             </div>
             <section><General fragRef={realm} /></section>

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -92,12 +92,6 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
         : t("manage.realm.heading", { realm: realm.name });
 
     const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
-    const buttonStyle = {
-        backgroundColor: "transparent",
-        padding: "8px 16px",
-        borderRadius: 8,
-        gap: 9,
-    };
 
     return (
         <RealmSettingsContainer css={{ maxWidth: 900 }}>
@@ -110,14 +104,11 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
                 flexWrap: "wrap",
                 gap: 16,
             }}>
-                <LinkButton to={realm.path} css={buttonStyle}>
+                <LinkButton to={realm.path}>
                     {t("manage.realm.view-page")}
                     <FiArrowRightCircle />
                 </LinkButton>
-                <LinkButton
-                    to={`/~manage/realm/add-child?parent=${pathToQuery(realm.path)}`}
-                    css={buttonStyle}
-                >
+                <LinkButton to={`/~manage/realm/add-child?parent=${pathToQuery(realm.path)}`}>
                     {t("realm.add-sub-page")}
                     <FiPlusCircle />
                 </LinkButton>

--- a/frontend/src/ui/Button.tsx
+++ b/frontend/src/ui/Button.tsx
@@ -95,10 +95,10 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
     });
 
     return {
-        borderRadius: 4,
+        borderRadius: 8,
         display: "inline-flex",
         alignItems: "center",
-        padding: "4px 10px",
+        padding: "7px 14px",
         gap: 12,
         whiteSpace: "nowrap",
         backgroundColor: "var(--grey97)",

--- a/frontend/src/ui/Button.tsx
+++ b/frontend/src/ui/Button.tsx
@@ -67,6 +67,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
                 border: "1px solid var(--grey40)",
                 backgroundColor: "var(--grey92)",
             },
+            ...focusStyle({ offset: -1 }),
         }),
 
         "danger": () => ({
@@ -77,6 +78,7 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
                 backgroundColor: "var(--danger-color)",
                 color: "var(--danger-color-bw-contrast)",
             },
+            ...focusStyle({ offset: 1 }),
         }),
 
         "happy": () => ({
@@ -110,7 +112,6 @@ const css = (kind: Kind, extraCss: Interpolation<Theme> = {}): Interpolation<The
         },
         "&:not([disabled])": {
             cursor: "pointer",
-            ...focusStyle({}),
             ...notDisabledStyle,
         },
         ...extraCss as Record<string, unknown>,

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -112,6 +112,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
                         kind="happy"
                         onClick={copy}
                         css={{
+                            borderRadius: 4,
                             borderTopLeftRadius: 0,
                             height: 34,
                             ...multiline

--- a/frontend/src/ui/PathSegmentInput.tsx
+++ b/frontend/src/ui/PathSegmentInput.tsx
@@ -21,18 +21,14 @@ export const PathSegmentInput = React.forwardRef<HTMLInputElement, Props>(
             gap: 8,
             backgroundColor: "var(--grey97)",
         }}>
-            <span css={{ paddingLeft: 8 }}>{base + (base.endsWith("/") ? "" : "/")}</span>
+            <span css={{ paddingLeft: 8, overflow: "auto" }}>
+                {base.split("/").join("\u200b/") + (base.endsWith("/") ? "" : "/")}
+            </span>
             <Input
                 css={{ margin: -1, width: 160 }}
                 spellCheck={false}
                 autoCapitalize="none"
-                // TODO: I have no idea why, but this cast is necessary.
-                // Otherwise TS complaints about type mismatch. By `ref` is
-                // exactly the same type as what the `ref` attributes of
-                // `Input` expects. Even taking the exact type of the error
-                // messages "cannot be assigned to $ty" and saying `ref={ref as $ty}`
-                // here does NOT fix it. Super weird.
-                ref={ref as any}
+                ref={ref}
                 {...rest}
             />
             {spinner && <Spinner size={20} css={{ position: "absolute", right: 6 }}/>}


### PR DESCRIPTION
Like the other redesigned pages/components, this is still missing the updated color scheme (the details of which we have yet to discuss).

Some notes regarding the "edit page content" design in particular:
- I noticed (admittedly a little late in the process) that the current design of the `addButtons` menu already seems to be applying some aspects of the suggested design. While I changed the placement of that menu in this PR, I do realize that the current placement might be a deliberate divergence from the suggestion.
- While this adds keyboard usability to the radio buttons of the `addSeries` modal, the screen-reader accessibility of that component is still lacking important information. I spent some time trying and not quite succeeding to fix that but ultimately decided that this should rather be done in a seperate PR (cross-browser screen-reader testing can be quite time consuming).
