### PR TITLE
Add focus trap to popup modals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "babel-plugin-relay": "^14.1.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^10.2.4",
+        "focus-trap-react": "^10.1.1",
         "graphql": "^16.5.0",
         "hls.js": "^1.2.0",
         "i18next": "^22.4.9",
@@ -4888,6 +4889,28 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/focus-trap": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.0.tgz",
+      "integrity": "sha512-yI7FwUqU4TVb+7t6PaQ3spT/42r/KLEi8mtdGoQo2li/kFzmu9URmalTvw7xCCJtSOyhBxscvEAmvjeN9iHARg==",
+      "dependencies": {
+        "tabbable": "^6.1.1"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.1.1.tgz",
+      "integrity": "sha512-OtLeSIQPKFzMzbLHkGtfZYwGLMhTRHd3CDhfyd0DDx8tvXzlgpseClDiuiKoiIHZtdjsbXTfTmUuuLKaxrwSyQ==",
+      "dependencies": {
+        "focus-trap": "^7.4.0",
+        "tabbable": "^6.1.1"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.8.1",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -8121,9 +8144,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
-      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
     },
     "node_modules/tapable": {
       "version": "1.1.3",
@@ -12386,6 +12409,23 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "focus-trap": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.0.tgz",
+      "integrity": "sha512-yI7FwUqU4TVb+7t6PaQ3spT/42r/KLEi8mtdGoQo2li/kFzmu9URmalTvw7xCCJtSOyhBxscvEAmvjeN9iHARg==",
+      "requires": {
+        "tabbable": "^6.1.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.1.1.tgz",
+      "integrity": "sha512-OtLeSIQPKFzMzbLHkGtfZYwGLMhTRHd3CDhfyd0DDx8tvXzlgpseClDiuiKoiIHZtdjsbXTfTmUuuLKaxrwSyQ==",
+      "requires": {
+        "focus-trap": "^7.4.0",
+        "tabbable": "^6.1.1"
+      }
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -14590,9 +14630,9 @@
       }
     },
     "tabbable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
-      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-relay": "^14.1.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^10.2.4",
+    "focus-trap-react": "^10.1.1",
     "graphql": "^16.5.0",
     "hls.js": "^1.2.0",
     "i18next": "^22.4.9",

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -379,6 +379,7 @@ manage:
         button: Diese Seite und <strong>{{numSubPages}}</strong> Unterseiten löschen
         button-single: Seite löschen
         cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
+        confirm: Seite löschen?
         failed: Löschung fehlgeschlagen.
         warning: >
           Wenn Sie diese Seite löschen, werden automatisch alle direkten und
@@ -401,6 +402,7 @@ manage:
       move-up: Block nach oben verschieben
       edit: Block bearbeiten
       remove: Block entfernen
+      confirm: Block entfernen?
 
       cannot-remove-block: Block nicht entfernbar
       cannot-remove-name-source-block: >
@@ -441,6 +443,7 @@ manage:
 
       save: Speichern
       cancel: Verwerfen
+      confirm-cancel: Änderungen verwerfen?
 
       cancel-warning: Ihre Änderungen wurden noch nicht gespeichert!
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -2,6 +2,7 @@ language-name: Deutsch
 language: Sprache
 loading: Lade...
 close: Schließen
+cancel: Abbrechen
 save: Speichern
 back: Zurück
 home: Startseite
@@ -379,7 +380,7 @@ manage:
         button: Diese Seite und <strong>{{numSubPages}}</strong> Unterseiten löschen
         button-single: Seite löschen
         cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
-        confirm: Seite löschen?
+        confirm-removal: Seite löschen?
         failed: Löschung fehlgeschlagen.
         warning: >
           Wenn Sie diese Seite löschen, werden automatisch alle direkten und
@@ -402,7 +403,7 @@ manage:
       move-up: Block nach oben verschieben
       edit: Block bearbeiten
       remove: Block entfernen
-      confirm: Block entfernen?
+      confirm-removal: Block entfernen?
 
       cannot-remove-block: Block nicht entfernbar
       cannot-remove-name-source-block: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -368,6 +368,7 @@ manage:
         button: Delete this page and <strong>{{numSubPages}}</strong> sub-pages
         button-single: Delete page
         cannot-be-undone: This action <strong>cannot</strong> be undone!
+        confirm: Delete page?
         failed: Deleting the page failed.
         warning: >
           Deleting this page will also automatically delete all direct and
@@ -390,6 +391,7 @@ manage:
       move-up: Move block up
       edit: Edit block
       remove: Remove block
+      confirm: Remove block?
 
       cannot-remove-block: Cannot remove block
       cannot-remove-name-source-block: >
@@ -430,6 +432,7 @@ manage:
 
       save: Save
       cancel: Discard
+      confirm-cancel: Discard changes?
 
       cancel-warning: Your changes have not yet been saved!
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -2,6 +2,7 @@ language-name: English
 language: Language
 loading: Loading...
 close: Close
+cancel: Cancel
 save: Save
 back: Back
 home: Home
@@ -368,7 +369,7 @@ manage:
         button: Delete this page and <strong>{{numSubPages}}</strong> sub-pages
         button-single: Delete page
         cannot-be-undone: This action <strong>cannot</strong> be undone!
-        confirm: Delete page?
+        confirm-removal: Delete page?
         failed: Deleting the page failed.
         warning: >
           Deleting this page will also automatically delete all direct and
@@ -391,7 +392,7 @@ manage:
       move-up: Move block up
       edit: Edit block
       remove: Remove block
-      confirm: Remove block?
+      confirm-removal: Remove block?
 
       cannot-remove-block: Cannot remove block
       cannot-remove-name-source-block: >

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -175,6 +175,7 @@ const EditModeButtons: React.FC<EditModeButtonsProps> = ({ onCancel }) => {
             {t("manage.realm.content.save")}
         </Button>
         <ConfirmationModal
+            title={t("manage.realm.content.confirm-cancel")}
             buttonContent={t("manage.realm.content.cancel")}
             onSubmit={onCancel}
             ref={modalRef}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -13,6 +13,7 @@ import { EditTitleBlock } from "./Title";
 import { EditTextBlock } from "./Text";
 import { EditSeriesBlock } from "./Series";
 import { EditVideoBlock } from "./Video";
+import FocusTrap from "focus-trap-react";
 
 
 type EditModeProps = {
@@ -129,10 +130,12 @@ export const EditModeForm = <FormData extends object, ApiData extends object>(
 
 
     return <FormProvider<FormData> {...form}>
-        <form onSubmit={onSubmit}>
-            {children}
-            <EditModeButtons onCancel={onCancel} />
-        </form>
+        <FocusTrap>
+            <form onSubmit={onSubmit}>
+                {children}
+                <EditModeButtons onCancel={onCancel} />
+            </form>
+        </FocusTrap>
     </FormProvider>;
 };
 

--- a/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
@@ -87,7 +87,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
             {t("manage.realm.content.cannot-remove-name-source-block")}
         </Modal>
         <ConfirmationModal
-            title={t("manage.realm.content.confirm")}
+            title={t("manage.realm.content.confirm-removal")}
             buttonContent={t("manage.realm.content.remove")}
             onSubmit={remove}
             ref={modalRef}

--- a/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
@@ -87,6 +87,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
             {t("manage.realm.content.cannot-remove-name-source-block")}
         </Modal>
         <ConfirmationModal
+            title={t("manage.realm.content.confirm")}
             buttonContent={t("manage.realm.content.remove")}
             onSubmit={remove}
             ref={modalRef}

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -222,7 +222,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
             </Button>
         </div>
         <ConfirmationModal
-            title={t("manage.realm.danger-zone.delete.confirm")}
+            title={t("manage.realm.danger-zone.delete.confirm-removal")}
             {...{ buttonContent }}
             onSubmit={remove}
             ref={modalRef}

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -222,6 +222,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
             </Button>
         </div>
         <ConfirmationModal
+            title={t("manage.realm.danger-zone.delete.confirm")}
             {...{ buttonContent }}
             onSubmit={remove}
             ref={modalRef}

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -11,12 +11,14 @@ import {
 import ReactDOM from "react-dom";
 import { FiX } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
+import FocusTrap from "focus-trap-react";
 
-import { Button } from "./Button";
+import { Button, ProtoButton } from "./Button";
 import { Spinner } from "./Spinner";
 import { boxError } from "./error";
 import { bug } from "../util/err";
 import { currentRef } from "../util";
+import { focusStyle } from ".";
 
 
 type ModalProps = {
@@ -71,27 +73,36 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                 zIndex: 2000,
             }}
         >
-            <div css={{
-                backgroundColor: "white",
-                borderRadius: 4,
-                width: 400,
-                maxWidth: "100%",
-                margin: 16,
-            }}>
+            <FocusTrap>
                 <div css={{
-                    padding: "12px 16px",
-                    borderBottom: "1px solid var(--grey80)",
-                    display: "flex",
-                    alignItems: "center",
+                    backgroundColor: "white",
+                    borderRadius: 4,
+                    width: 400,
+                    maxWidth: "100%",
+                    margin: 16,
                 }}>
-                    <h2 css={{ flex: "1" }}>{title}</h2>
-                    {closable && <div
-                        onClick={() => setOpen(false)}
-                        css={{ fontSize: 32, cursor: "pointer", display: "inline-flex" }}
-                    ><FiX /></div>}
+                    <div css={{
+                        padding: "12px 16px",
+                        borderBottom: "1px solid var(--grey80)",
+                        display: "flex",
+                        alignItems: "center",
+                    }}>
+                        <h2 css={{ flex: 1 }}>{title}</h2>
+                        {closable && <ProtoButton
+                            tabIndex={0}
+                            onClick={() => setOpen(false)}
+                            css={{
+                                fontSize: 32,
+                                cursor: "pointer",
+                                display: "inline-flex",
+                                borderRadius: 4,
+                                ...focusStyle({}),
+                            }}
+                        ><FiX /></ProtoButton>}
+                    </div>
+                    <div css={{ padding: 16 }}>{children}</div>
                 </div>
-                <div css={{ padding: 16 }}>{children}</div>
-            </div>
+            </FocusTrap>
         </div>,
         document.body,
     );

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -36,6 +36,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     closable = true,
     children,
 }, ref) => {
+    const { t } = useTranslation();
     const [isOpen, setOpen] = useState(false);
 
     useImperativeHandle(ref, () => ({
@@ -77,8 +78,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                 <div css={{
                     backgroundColor: "white",
                     borderRadius: 4,
-                    width: 400,
-                    maxWidth: "100%",
+                    minWidth: "clamp(300px, 90%, 400px)",
                     margin: 16,
                 }}>
                     <div css={{
@@ -89,6 +89,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                     }}>
                         <h2 css={{ flex: 1 }}>{title}</h2>
                         {closable && <ProtoButton
+                            aria-label={t("close")}
                             tabIndex={0}
                             onClick={() => setOpen(false)}
                             css={{
@@ -163,10 +164,24 @@ export const ConfirmationModal
 
             return <Modal title={title} closable={!inFlight} ref={modalRef}>
                 {children}
-                <form onSubmit={onSubmitWrapper} css={{ marginTop: 32, textAlign: "center" }}>
-                    <Button disabled={inFlight} type="submit" kind="danger">
-                        {buttonContent}
-                    </Button>
+                <form onSubmit={onSubmitWrapper} css={{ marginTop: 32 }}>
+                    <div css={{
+                        display: "flex",
+                        gap: 12,
+                        justifyContent: "center",
+                        flexWrap: "wrap",
+                    }}>
+                        <Button disabled={inFlight} onClick={
+                            () => currentRef(modalRef).close?.()
+                        }>
+                            {t("cancel")}
+                        </Button>
+                        <Button disabled={inFlight} type="submit" kind="danger" css={{
+                            whiteSpace: "normal",
+                        }}>
+                            {buttonContent}
+                        </Button>
+                    </div>
                     {inFlight && <div css={{ marginTop: 16 }}><Spinner size={20} /></div>}
                 </form>
                 {boxError(error)}


### PR DESCRIPTION
This adds and utilizes the [`focus-trap-react`](https://www.npmjs.com/package/focus-trap-react) library to easily trap focus within popup modals like the add- and remove-block and remove-page modals.

We could try to implement this ourselves but I think using a library for this is reasonable. The one added here is actively maintained and quite easy to use, though there are also some alternatives around that I haven't tested.

Closes #648 