### PR TITLE
Add navigation elements to upload page

### DIFF
--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -211,7 +211,7 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                 >{t("realm.user-realm.your-page")}</MenuItem>}
                 {user.canUpload && <MenuItem
                     icon={<FiUpload />}
-                    linkTo={"/~upload"}
+                    linkTo={"/~manage/upload"}
                     onClick={close}
                 >{t("upload.title")}</MenuItem>}
             </>}

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -26,6 +26,8 @@ import { useRouter } from "../router";
 import { getJwt } from "../relay/auth";
 import { SeriesSelector } from "../ui/SearchableSelect";
 import { WithTooltip } from "../ui/Floating";
+import { Breadcrumbs } from "../ui/Breadcrumbs";
+import { ManageNav } from "./manage";
 
 
 export const UploadRoute = makeRoute(url => {
@@ -38,7 +40,7 @@ export const UploadRoute = makeRoute(url => {
         render: () => <RootLoader
             {...{ query, queryRef }}
             noindex
-            nav={() => []}
+            nav={() => <ManageNav active={UPLOAD_PATH} />}
             render={() => <Upload />}
         />,
         dispose: () => queryRef.dispose(),
@@ -68,6 +70,10 @@ const Upload: React.FC = () => {
             display: "flex",
             flexDirection: "column",
         }}>
+            <Breadcrumbs
+                path={[{ label: t("manage.management"), link: "/~manage" }]}
+                tail={t("upload.title")}
+            />
             <PageTitle title={t("upload.title")} />
             <div css={{ fontSize: 14, marginBottom: 16 }}>{t("upload.public-note")}</div>
             <UploadMain />
@@ -374,7 +380,7 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
             css={{
                 width: "100%",
                 height: "100%",
-                border: "3px dashed",
+                border: "2.5px dashed",
                 borderRadius: 10,
                 display: "flex",
                 padding: 8,

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -538,7 +538,7 @@ const UploadState: React.FC<{ state: NonFinishedUploadState }> = ({ state }) => 
             <div>
                 <LinkButton
                     kind="happy"
-                    to="/~upload"
+                    to="/~manage/upload"
                 >
                     {t("upload.reselect")}
                 </LinkButton>

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -40,7 +40,7 @@ export const ManageVideosRoute = makeRoute(url => {
         render: () => <RootLoader
             {...{ query, queryRef }}
             noindex
-            nav={() => <ManageNav key={1} active={PATH} />}
+            nav={() => <ManageNav active={PATH} />}
             render={data => !data.currentUser
                 ? <NotAuthorized />
                 : <ManageVideos vars={vars} connection={data.currentUser.myVideos} />
@@ -99,7 +99,7 @@ const ManageVideos: React.FC<Props> = ({ connection, vars }) => {
     } else {
         inner = <>
             <PageNavigation {...{ vars, connection }} />
-            <div css={{ flex: "1 0 0" }}>
+            <div css={{ flex: "1 0 0", margin: "16px 0" }}>
                 <EventTable events={connection.items} vars={vars} />
             </div>
             <PageNavigation {...{ vars, connection }} />
@@ -113,13 +113,12 @@ const ManageVideos: React.FC<Props> = ({ connection, vars }) => {
             display: "flex",
             flexDirection: "column",
             height: "100%",
-            gap: 16,
         }}>
             <Breadcrumbs
                 path={[{ label: t("manage.management"), link: "/~manage" }]}
                 tail={title}
             />
-            <PageTitle title={title} />
+            <PageTitle title={title} css={{ marginBottom: 32 }}/>
             {inner}
         </div>
     );

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -64,7 +64,7 @@ const Manage: React.FC = () => {
             gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
             gap: 24,
         }}>
-            {user.canUpload && <Link to="/~upload" css={gridTile}>
+            {user.canUpload && <Link to="/~manage/upload" css={gridTile}>
                 <FiUpload />
                 <h2>{t("upload.title")}</h2>
                 {t("manage.dashboard.upload-tile")}
@@ -123,7 +123,7 @@ const gridTile = css({
 });
 
 type ManageNavProps = {
-    active?: "/~manage" | "/~manage/videos" | "/~upload";
+    active?: "/~manage" | "/~manage/videos" | "/~manage/upload";
 };
 
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
@@ -133,7 +133,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         ["/~manage", t("manage.nav.dashboard"), <HiOutlineTemplate />],
         ["/~manage/videos", t("manage.nav.my-videos"), <FiFilm />],
-        ["/~upload", t("upload.title"), <FiUpload />],
+        ["/~manage/upload", t("upload.title"), <FiUpload />],
     ];
     /* eslint-enable react/jsx-key */
 

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -33,7 +33,7 @@ export const ManageRoute = makeRoute(url => {
         render: () => <RootLoader
             {...{ query, queryRef }}
             noindex
-            nav={() => <ManageNav key={1} active={PATH} />}
+            nav={() => <ManageNav active={PATH} />}
             render={() => <Manage />}
         />,
         dispose: () => queryRef.dispose(),
@@ -123,7 +123,7 @@ const gridTile = css({
 });
 
 type ManageNavProps = {
-    active?: "/~manage" | "/~manage/videos";
+    active?: "/~manage" | "/~manage/videos" | "/~upload";
 };
 
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
@@ -133,6 +133,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         ["/~manage", t("manage.nav.dashboard"), <HiOutlineTemplate />],
         ["/~manage/videos", t("manage.nav.my-videos"), <FiFilm />],
+        ["/~upload", t("upload.title"), <FiUpload />],
     ];
     /* eslint-enable react/jsx-key */
 

--- a/frontend/src/routes/paths.ts
+++ b/frontend/src/routes/paths.ts
@@ -1,4 +1,4 @@
 
 export const ABOUT_PATH = "/~tobira";
 export const LOGIN_PATH = "/~login";
-export const UPLOAD_PATH = "/~upload";
+export const UPLOAD_PATH = "/~manage/upload";

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -30,7 +30,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
     };
 
     return (
-        <nav aria-label="breadcrumbs" css={{ overflowX: "auto", marginBottom: 16 }}>
+        <nav aria-label="breadcrumbs" css={{ overflowX: "auto", marginBottom: 16, flexShrink: 0 }}>
             {path.length > 0 && (
                 <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
             )}


### PR DESCRIPTION
This adds an `upload video` item which links to the upload page to the `management` sidebox navigation, and adds that navigation element as well as breadcrumbs to the upload page.