### PR TITLE
Add error context to opening log file

### DIFF
--- a/backend/src/logger.rs
+++ b/backend/src/logger.rs
@@ -47,7 +47,13 @@ pub(crate) fn init(config: &LogConfig, args: &Args) -> Result<()> {
     };
 
     let file = config.file.as_ref()
-        .map(|path| OpenOptions::new().append(true).create(true).open(path))
+        .map(|path| {
+            OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(path)
+                .with_context(|| format!("failed to open/create log file '{}'", path.display()))
+        })
         .transpose()?
         .map(Mutex::new);
 


### PR DESCRIPTION
See #639. Before, Tobira would only print "permission denied" which is not helpful.

Fixes #640