### PR TITLE
Drop PostgreSQL 10 support and fix user session query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:10
+        image: postgres:11
         env:
           POSTGRES_USER: tobira
           POSTGRES_PASSWORD: tobira
@@ -112,7 +112,7 @@ jobs:
           --clean \
           --create \
           --if-exists \
-          < db-dump
+          < db-dump || true
     - name: Run migrations
       run: ./tobira db migrate --config util/dev-config/config.toml
 

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -250,7 +250,7 @@ impl User {
         let query = format!(
             "select {selection} from user_sessions \
                 where id = $1 \
-                and extract(epoch from now() - created) < $2"
+                and extract(epoch from now() - created) < $2::double precision"
         );
         let row = match db.query_opt(&query, &[&session_id, &session_duration.as_secs_f64()]).await? {
             None => return Ok(None),

--- a/util/containers/docker-compose.yml
+++ b/util/containers/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   # A PostgreSQL database for Tobira.
   tobira-dev-database:
-    image: docker.io/library/postgres:10
+    image: docker.io/library/postgres:15
     restart: unless-stopped
     ports:
       - 127.0.0.1:5432:5432


### PR DESCRIPTION
Fixes #748 
Fixes #776 

See commit messages for further information.

What's still missing: update the test deployment server to PG10 and then creating all DB dumps with PG11. However, we currently have tons of open PRs and I don't want to upgrade PG on the test server now :D #784