### PR TITLE
Add remaining dashboard items to user menu

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -280,6 +280,8 @@ manage:
       Hier können Sie sehr einfach ein neues Video erstellen, indem Sie Ihr Mikrofon, Ihren Bildschirm
       und/oder Ihre Webcam aufzeichnen.
     my-videos-tile: Hier finden Sie alle Ihre Videos und können diese z.B. bearbeiten.
+    user-realm-tile: >
+      Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Element anordnen.
     manage-pages-tile-title: Seiten verwalten?
     manage-pages-tile-body: >
       Um Seiten zu bearbeiten, umzubenennen und zu löschen, navigieren Sie zu der gewünschten

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -102,7 +102,7 @@ user:
   login: Anmelden
   logout: Abmelden
   settings: Nutzereinstellungen
-  manage-content: Meine Inhalte
+  manage-content: Verwalten
   logged-in-as: Angemeldet als
 
 login-page:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -274,6 +274,8 @@ manage:
       Here you can easily create a new video by recording your microphone, screen and/or
       webcam.
     my-videos-tile: Here you can view and edit all your videos.
+    user-realm-tile: >
+      On your personal page, you can freely arrange videos, text, and other elements.
     manage-pages-tile-title: Manage pages?
     manage-pages-tile-body: >
       To rename, modify, and delete pages, navigate to the page in question. If you

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -99,7 +99,7 @@ user:
   login: Login
   logout: Log out
   settings: User settings
-  manage-content: My content
+  manage-content: Manage
   logged-in-as: Logged in as
 
 login-page:

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -2,8 +2,8 @@ import React, { KeyboardEvent, ReactNode, ReactElement } from "react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-    FiAlertTriangle, FiArrowLeft, FiCheck, FiUserCheck,
-    FiChevronDown, FiFolder, FiLogOut, FiUpload, FiLogIn,
+    FiAlertTriangle, FiArrowLeft, FiCheck, FiUserCheck, FiChevronDown,
+    FiFolder, FiLogOut, FiUpload, FiLogIn, FiFilm, FiVideo,
 } from "react-icons/fi";
 import { HiOutlineFire, HiOutlineTranslate } from "react-icons/hi";
 
@@ -20,6 +20,7 @@ import { REDIRECT_STORAGE_KEY } from "../../routes/Login";
 import { focusStyle } from "../../ui";
 import { ProtoButton } from "../../ui/Button";
 import { FloatingHandle, FloatingContainer, FloatingTrigger, Floating } from "../../ui/Floating";
+import { ExternalLink, ExternalLinkProps } from "../../relay/auth";
 
 
 /** User-related UI in the header. */
@@ -209,6 +210,22 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                     linkTo={`/@${user.username}`}
                     onClick={close}
                 >{t("realm.user-realm.your-page")}</MenuItem>}
+                {<MenuItem
+                    icon={<FiFilm />}
+                    borderBottom
+                    linkTo={"/~manage/videos"}
+                    onClick={close}
+                >{t("manage.my-videos.title")}</MenuItem>}
+                {user.canUseStudio && <MenuItem
+                    icon={<FiVideo />}
+                    borderBottom
+                    onClick={close}
+                    externalLinkProps={{
+                        service: "STUDIO",
+                        params: { "return.target": new URL(document.location.href) },
+                        fallback: "link",
+                    }}
+                >{t("manage.dashboard.studio-tile-title")}</MenuItem>}
                 {user.canUpload && <MenuItem
                     icon={<FiUpload />}
                     linkTo={"/~manage/upload"}
@@ -369,6 +386,7 @@ type MenuItemProps = {
     htmlLink?: boolean;
     borderBottom?: boolean;
     borderTop?: boolean;
+    externalLinkProps?: ExternalLinkProps;
     children: ReactNode;
 };
 
@@ -382,6 +400,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
     htmlLink = false,
     borderBottom = false,
     borderTop = false,
+    externalLinkProps,
 }) => {
     const inner = <>
         {icon ?? <svg />}
@@ -419,13 +438,35 @@ const MenuItem: React.FC<MenuItemProps> = ({
         }
     };
 
-    return linkTo
-        ? <li role="menuitem" {... { className }}>
+    let menuItem;
+    if (linkTo) {
+        menuItem = <li role="menuitem" {... { className }}>
             <Link to={linkTo} css={css} {...{ htmlLink, onClick, className }}>{inner}</Link>
-        </li>
-        : <li role="menuitem" tabIndex={0} css={css} {...{ onClick, className, onKeyDown }}>
-            {inner}
         </li>;
+    } else if (externalLinkProps) {
+        menuItem = <li role="menuitem">
+            <ExternalLink
+                {...externalLinkProps}
+                css={{
+                    backgroundColor: "transparent",
+                    border: "none",
+                    ...css,
+                    minWidth: "100%",
+                }}
+            >{inner}</ExternalLink>
+        </li>;
+    } else {
+        menuItem = (
+            <li
+                role="menuitem"
+                tabIndex={0}
+                css={css}
+                {...{ onClick, className, onKeyDown }}
+            >{inner}</li>
+        );
+    }
+
+    return menuItem;
 };
 
 

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -218,9 +218,15 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                     linkTo={"/~manage/videos"}
                     onClick={close}
                 >{t("manage.my-videos.title")}</MenuItem>}
+                {user.canUpload && <MenuItem
+                    icon={<FiUpload />}
+                    borderBottom
+                    indent
+                    linkTo={"/~manage/upload"}
+                    onClick={close}
+                >{t("upload.title")}</MenuItem>}
                 {user.canUseStudio && <MenuItem
                     icon={<FiVideo />}
-                    borderBottom
                     indent
                     onClick={close}
                     externalLinkProps={{
@@ -229,12 +235,6 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                         fallback: "link",
                     }}
                 >{t("manage.dashboard.studio-tile-title")}</MenuItem>}
-                {user.canUpload && <MenuItem
-                    icon={<FiUpload />}
-                    indent
-                    linkTo={"/~manage/upload"}
-                    onClick={close}
-                >{t("upload.title")}</MenuItem>}
             </>}
 
             {/* Logout button if the user is logged in */}

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -207,18 +207,21 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                 {user.canCreateUserRealm && <MenuItem
                     icon={<HiOutlineFire />}
                     borderBottom
+                    indent
                     linkTo={`/@${user.username}`}
                     onClick={close}
                 >{t("realm.user-realm.your-page")}</MenuItem>}
                 {<MenuItem
                     icon={<FiFilm />}
                     borderBottom
+                    indent
                     linkTo={"/~manage/videos"}
                     onClick={close}
                 >{t("manage.my-videos.title")}</MenuItem>}
                 {user.canUseStudio && <MenuItem
                     icon={<FiVideo />}
                     borderBottom
+                    indent
                     onClick={close}
                     externalLinkProps={{
                         service: "STUDIO",
@@ -228,6 +231,7 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                 >{t("manage.dashboard.studio-tile-title")}</MenuItem>}
                 {user.canUpload && <MenuItem
                     icon={<FiUpload />}
+                    indent
                     linkTo={"/~manage/upload"}
                     onClick={close}
                 >{t("upload.title")}</MenuItem>}
@@ -386,6 +390,7 @@ type MenuItemProps = {
     htmlLink?: boolean;
     borderBottom?: boolean;
     borderTop?: boolean;
+    indent?: boolean;
     externalLinkProps?: ExternalLinkProps;
     children: ReactNode;
 };
@@ -400,6 +405,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
     htmlLink = false,
     borderBottom = false,
     borderTop = false,
+    indent = false,
     externalLinkProps,
 }) => {
     const inner = <>
@@ -412,6 +418,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
         alignItems: "center",
         minWidth: 200,
         padding: 12,
+        ...indent && { paddingLeft: 30 },
         cursor: "pointer",
         whiteSpace: "nowrap",
         color: "black",

--- a/frontend/src/relay/auth.tsx
+++ b/frontend/src/relay/auth.tsx
@@ -18,7 +18,7 @@ const serviceUrl = (service: JwtLinkedService): URL => new URL(match(service, {
     STUDIO: () => CONFIG.opencast.studioUrl,
 }));
 
-type ExternalLinkProps = PropsWithChildren<{
+export type ExternalLinkProps = PropsWithChildren<{
     className?: string;
     fallback: "link" | "button";
 } & ({

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { FiFilm, FiUpload, FiVideo } from "react-icons/fi";
-import { HiOutlineTemplate } from "react-icons/hi";
+import { HiOutlineFire, HiOutlineTemplate } from "react-icons/hi";
 import { graphql } from "react-relay";
 
 import { RootLoader } from "../../layout/Root";
@@ -84,6 +84,11 @@ const Manage: React.FC = () => {
                 <h2>{t("manage.my-videos.title")}</h2>
                 {t("manage.dashboard.my-videos-tile")}
             </Link>
+            {user.canCreateUserRealm && <Link to={`/@${user.username}`} css={gridTile}>
+                <HiOutlineFire />
+                <h2>{t("realm.user-realm.your-page")}</h2>
+                {t("manage.dashboard.user-realm-tile")}
+            </Link>}
             <div css={gridTile}>
                 <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
                 {t("manage.dashboard.manage-pages-tile-body")}


### PR DESCRIPTION
This adds a link to the "My videos" page and an external link to "Record video" (with studio) to the user menu.

This took longer than I expected because I durdled around with making the `externalLink` component reusable as `MenuItem` for the user menu. Since we don't plan to add any more external links to that menu, that might seem kinda pointless. But I think it makes the menu and `menuItem` at least a little cleaner without having to pull out the shared css styles.

closes #751 