### PR TITLE
Fix container size for portrait videos

### DIFF
--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -112,7 +112,9 @@ const delayTill = (date: Date): number => {
  * You probably want this one.
  */
 export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playerProps }) => {
-    const aspectRatio = getPlayerAspectRatio(event.syncedData.tracks);
+    // Sorting this makes sure the aspect ratio of this container will always
+    // be >= 1 to allow portrait videos to use the available vertical container space.
+    const aspectRatio = getPlayerAspectRatio(event.syncedData.tracks).slice().sort((a, b) => b - a);
 
     return (
         <div className={className} css={{


### PR DESCRIPTION
Previously, the `<InlinePlayer>` would always mirror the aspect ratio of the video itself, even when its height was greater that its width. This lead to portrait videos not using the available vertical space and instead be displayed too small. By swapping the values in these instances, we make sure that the container will always have a "landscape" orientation.

Closes #775 