### PR TITLE
Update MeiliSearch to v1.1

### DIFF
--- a/.deployment/setup-server.yml
+++ b/.deployment/setup-server.yml
@@ -28,11 +28,11 @@
     - name: install MeiliSearch
       become: true
       get_url:
-        url: https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64
+        url: https://github.com/meilisearch/meilisearch/releases/download/v1.1.1/meilisearch-linux-amd64
         dest: /opt/meili/meilisearch
         mode: '0755'
-        checksum: sha256:d394626b43c71acba0516336016285a963046b5ccf6f2c5ea6d5ef17085a3b40
-      register: meili_changed
+        checksum: sha256:dfc945fe521511af43dab0264193b154d639d91292e1899f553157836ec53acd
+      register: meili_updated
 
     - name: install MeiliSearch service file
       become: true
@@ -51,13 +51,20 @@
         state: started
         enabled: yes
 
+    - name: remove Meili indexes
+      become: true
+      file:
+        path: /opt/meili/data.ms
+        state: absent
+      when: meili_updated.changed
+
     - name: restart Meili
       become: true
       service:
         name: meili
         state: restarted
         enabled: yes
-      when: meili_changed.changed
+      when: meili_changed.changed or meili_updated.changed
 
 
     # DATABASE

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -411,6 +411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +661,9 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1424,20 +1436,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "meilisearch-sdk"
-version = "0.18.1"
+name = "meilisearch-index-setting-macro"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b26bc51d2f7c789fd75cb329b7ca7edba0f4c964892787f8f1103c50705756"
+checksum = "782a5c1a79ec476d9bdc8fd5eeeea0a6abd7b9968db716b44bf5b5fb563a3481"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "meilisearch-sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91918ad10dee774486b1af57fdf7e683a8eef674715ff35362cd3df03a97449b"
 dependencies = [
  "async-trait",
+ "either",
  "futures",
+ "futures-io",
  "isahc",
  "iso8601-duration",
  "js-sys",
  "jsonwebtoken",
  "log",
+ "meilisearch-index-setting-macro",
  "serde",
  "serde_json",
+ "thiserror",
  "time",
  "uuid",
  "wasm-bindgen",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,7 +42,7 @@ isahc = { version = "1", features = ["static-ssl"] }
 juniper = { version = "0.15.10", default-features = false, features = ["chrono", "schema-language"] }
 libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", features = ["serde", "std"] }
-meilisearch-sdk = "0.18.0"
+meilisearch-sdk = "0.23.0"
 mime_guess = { version = "2", default-features = false }
 once_cell = "1.5"
 p256 = { version = "0.13.2", features = ["jwk"] }

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -120,7 +120,7 @@ impl Client {
         // Create client (this does not connect to Meili).
         let client = MeiliClient::new(
             &config.host.to_string(),
-            config.key.expose_secret(),
+            Some(config.key.expose_secret()),
         );
 
         // Store some references to the indices (without checking whether they

--- a/docs/docs/setup/ansible-example.md
+++ b/docs/docs/setup/ansible-example.md
@@ -35,8 +35,8 @@ tobira_trusted_external_key: "{{ vault_tobira_trusted_external_key }}"
 
 tobira_release_url: "https://github.com/elan-ev/tobira/releases/download/v1.2/tobira-x86_64-unknown-linux-gnu"
 tobira_release_checksum: "sha256:c173c60bc35e8fa922324910a4968557903c9382a5d46d67cc99a15df262e245"
-meili_release_url: "https://github.com/meilisearch/meilisearch/releases/download/v0.28.1/meilisearch-linux-amd64"
-meili_release_checksum: "sha256:d394626b43c71acba0516336016285a963046b5ccf6f2c5ea6d5ef17085a3b40"
+meili_release_url: "https://github.com/meilisearch/meilisearch/releases/download/v1.1.1/meilisearch-linux-amd64"
+meili_release_checksum: "sha256:dfc945fe521511af43dab0264193b154d639d91292e1899f553157836ec53acd"
 ```
 
 ## Services
@@ -57,6 +57,7 @@ meili_release_checksum: "sha256:d394626b43c71acba0516336016285a963046b5ccf6f2c5e
     mode: '0755'
     checksum: '{{ meili_release_checksum }}'
   # TODO: this does not handle rebuilding the search index when doing a major meili update!
+  # In that case, delete `/opt/meili/data.ms` and restart the tobira worker.
   notify: restart meili
 
 - name: install MeiliSearch service file

--- a/docs/docs/setup/requirements.md
+++ b/docs/docs/setup/requirements.md
@@ -8,7 +8,7 @@ To run, Tobira requires:
 
 - A Unix system.
 - A **PostgreSQL** (≥10) database (see below for further requirements).
-- [**Meilisearch**](https://www.meilisearch.com/) (currently v0.28.1). For installation, see [Meili's docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html#step-1-setup-and-installation).
+- [**Meilisearch**](https://www.meilisearch.com/) (≥ v1.1). For installation, see [Meili's docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html#step-1-setup-and-installation).
 - An **Opencast** that satisfies certain condition. See below.
 
 

--- a/util/containers/docker-compose.yml
+++ b/util/containers/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   # A MeiliSearch for Tobira.
   tobira-meilisearch:
-    image: getmeili/meilisearch:v0.28.1
+    image: getmeili/meilisearch:v1.1
     restart: unless-stopped
     ports:
       - 127.0.0.1:7700:7700


### PR DESCRIPTION
Fixes #747 

This updates the dev container and the test deployment to MeiliSearch v1.1. Doing this update before Tobira 2.0 is a good idea as this bundles all the non-trivial update steps into one release. Updating to a 1.x version is also useful as Meili is forward compatible to other 1.x releases now. So system administrators can update Meili independently from Tobira, if they want to.

I chose 1.1 instead of 1.0 for no particular reason. We don't currently need features from 1.1 in Tobira and I don't see this changing. However, it doesn't hurt just demanding 1.1 since admins have to update anyway. So if we need an 1.1 feature in the future, we can just use it.

Luckily, the update was painless and I hardly needed to adjust anything. Everything still seems to work.