### PR TITLE
Fix edit form of series blocks

### DIFF
--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -88,6 +88,7 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
     const form = useFormContext<SeriesFormData>();
     const { formState: { errors }, control } = form;
     const { field: seriesField } = useController({
+        defaultValue: series?.id,
         name: "series",
         control,
         rules: { required: true },


### PR DESCRIPTION
Previously, this wouldn't allow editing a series without selecting it again. Turns out, the controller was simply missing a default value.

Fixes #763