### PR TITLE
Fix audio-only playablility

### DIFF
--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -88,9 +88,9 @@ declare module "paella-core" {
         text?: string;
     }
 
-    // https://github.com/polimediaupv/paella-core/blob/main/doc/mp4-video-plugin.md
-    // https://github.com/polimediaupv/paella-core/blob/main/doc/hls-video-plugin.md
-    // https://github.com/polimediaupv/paella-core/blob/main/doc/hls-live-video-plugin.md
+    // https://github.com/polimediaupv/paella-core/blob/main/doc/mp4_video_plugin.md
+    // https://github.com/polimediaupv/paella-core/blob/main/doc/hls_video_plugin.md
+    // https://github.com/polimediaupv/paella-core/blob/main/doc/hls_live_video_plugin.md
     export interface Source {
         src: string;
         // Currently unused...

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -8,9 +8,6 @@ import { SPEEDS } from "./consts";
 import { useTranslation } from "react-i18next";
 
 
-// Paella currently can't handle audio tracks
-type VideoTrack = Track & { resolution: NonNullable<Track["resolution"]> };
-
 type PaellaPlayerProps = {
     title: string;
     duration: number;
@@ -40,9 +37,8 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
         // do that now and set the initialized instance to `ref.current.paella`.
         if (!paella.current) {
             // Video/event specific information we have to give to Paella.
-            const tracksByKind: Record<string, VideoTrack[]> = {};
-            const videoTracks = tracks.filter((t): t is VideoTrack => !!t.resolution);
-            for (const track of videoTracks) {
+            const tracksByKind: Record<string, Track[]> = {};
+            for (const track of tracks) {
                 const kind = track.flavor.split("/")[0];
                 if (!(kind in tracksByKind)) {
                     tracksByKind[kind] = [];
@@ -91,7 +87,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
             // at random.
             if (manifest.streams.length > 1 && !("presenter" in tracksByKind)) {
                 // eslint-disable-next-line no-console
-                console.warn("Picking first stream as main audio source. Tracks: ", videoTracks);
+                console.warn("Picking first stream as main audio source. Tracks: ", tracks);
                 manifest.streams[0].role = "mainAudio";
             }
 
@@ -275,9 +271,9 @@ const PAELLA_CONFIG = {
     },
 };
 
-const tracksToPaellaSources = (tracks: VideoTrack[], isLive: boolean): Stream["sources"] => {
-    const trackToSource = (t: VideoTrack): Source => {
-        const [w, h] = t.resolution;
+const tracksToPaellaSources = (tracks: Track[], isLive: boolean): Stream["sources"] => {
+    const trackToSource = (t: Track): Source => {
+        const [w, h] = t.resolution ?? [0, 0];
         return {
             src: t.uri,
             // TODO: what to do if `t.mimetype` is not mp4 or not specified?


### PR DESCRIPTION
This basically (sort of) reverts #506 since the handling of audio tracks appears to be working now.
There is also a paella plugin for audio-videos, but it doesn't appear to be necessary for this to work (https://github.com/polimediaupv/paella-core/blob/main/doc/audio_video_plugin.md, https://github.com/polimediaupv/paella-core/blob/main/doc/audio_canvas_plugin.md).
I'm also not certain if we should add some audio specific configuration for this in our `paella-core` and `paella` files, as it also works without.

One thing that is still not too pretty is the background of the audio-video, which is plain grey. It would be nice to show a more fitting preview image in the future (likely the one that is shown in series blocks, which would theoretically also be used as a video background, if I understand the docs correctly).

Fixes #795 