### PR TITLE
Adjust some borders of user menu items

### DIFF
--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -236,6 +236,7 @@ const FloatingMenu: React.FC<FloatingMenuProps> = ({ close, type }) => {
                 >{t("upload.title")}</MenuItem>}
                 {user.canUseStudio && <MenuItem
                     icon={<FiVideo />}
+                    borderBottom
                     indent
                     onClick={close}
                     externalLinkProps={{
@@ -587,7 +588,6 @@ const Logout: React.FC = () => {
                 "pending": () => <Spinner />,
                 "error": () => <FiAlertTriangle />,
             })}
-            borderTop
             css={{
                 color: COLORS.danger0,
             }}


### PR DESCRIPTION
Previously there were some doubled borders when certain items are not shown, e.g. when the current user doens't have the authorization to upload or record videos.