### PR TITLE
Prevent overflow of git hash on small screens

### DIFF
--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -59,7 +59,10 @@ const About: React.FC = () => {
             <br />
             {"Git info: "}
             <a href={`https://github.com/elan-ev/tobira/commit/${version.gitCommitHash}`}>
-                <code css={{ fontSize: 14 }}>{version.gitCommitHash}</code>
+                <code css={{
+                    fontSize: 14,
+                    overflowWrap: "anywhere",
+                }}>{version.gitCommitHash}</code>
             </a>
             {version.gitWasDirty && ", dirty"}
             <br />


### PR DESCRIPTION
Previously, the "Git info" on the "About tobira" page would overflow when the screenwidth is below  ~`350px` (not a very common screen size but this doesn't hurt the larger ones either).
This wraps the line instead.