### PR TITLE
Fix `CopyableInput` and header button color in Safari

### DIFF
--- a/frontend/src/layout/header/ui.tsx
+++ b/frontend/src/layout/header/ui.tsx
@@ -13,6 +13,7 @@ export const ButtonContainer: React.FC<{ children: ReactNode }> = ({ children })
         display: "flex",
         position: "relative",
         alignItems: "center",
+        button: { color: COLORS.foreground },
         gap: 8,
         [`@media (max-width: ${BREAKPOINT_SMALL}px)`]: { gap: 4 },
     }}>

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -110,7 +110,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
             height: multiline ? 95 : 34,
             maxWidth: "100%",
         }} {...rest}>
-            <div css={{ position: "absolute", top: 0, right: 0 }}>
+            <div css={{ position: "absolute", top: 0, right: 0, zIndex: 10 }}>
                 <WithTooltip tooltip={label}>
                     <Button
                         aria-label={label}

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -85,12 +85,11 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
     };
 
     const copyableInputId = useId();
-    const buttonSize = 34;
     const sharedStyle = {
         ...style(false),
         width: "100%",
         height: "100%",
-        padding: `4px ${buttonSize + 10}px 4px 10px`,
+        padding: "4px 50px 4px 10px",
     };
     const sharedProps = {
         disabled: true,
@@ -118,6 +117,8 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
                         kind="happy"
                         onClick={copy}
                         css={{
+                            paddingLeft: 10,
+                            paddingRight: 10,
                             borderRadius: 4,
                             borderTopLeftRadius: 0,
                             height: 34,


### PR DESCRIPTION
See commits.