### PR TITLE
Fix tooltips not opening on mobile

### DIFF
--- a/frontend/src/ui/Floating.tsx
+++ b/frontend/src/ui/Floating.tsx
@@ -234,7 +234,7 @@ export const FloatingTrigger: React.FC<FloatingTriggerProps> = ({ children }) =>
         "data-floating-state": context.open ? "open" : "closed",
         ...context.getReferenceProps({
             ref: context.refs.reference,
-            onClick: () => context.setOpen?.(false),
+            onClick: () => context.open && context.setOpen?.(false),
             ...children.props,
         }),
     });


### PR DESCRIPTION
Partially addresses #835
As tooltips on mobile are triggered via a click and we also close tooltips on click, this needs to check if the tooltip is actually open before it gets closed.

This still isn't perfect as if a user wants to open a tooltip again after closing it, they first need to click outside the trigger before it can be opened again. But I also think that's pretty much default behaviour.