### PR TITLE
Fix setting a derived realm name for user root realms

### DIFF
--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -335,4 +335,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     18: "user-realms",
     19: "series-search-view",
     20: "fix-queue-triggers",
+    21: "fix-user-root-realm-name-block",
 ];

--- a/backend/src/db/migrations/21-fix-user-root-realm-name-block.sql
+++ b/backend/src/db/migrations/21-fix-user-root-realm-name-block.sql
@@ -1,0 +1,12 @@
+-- In '18-user-realms.sql', we mistakenly still defined the constraint in a way
+-- that forbids derived names for user root realms.
+
+alter table realms
+    -- Adjust the logic to work with user root realms.
+    drop constraint valid_name_source,
+    add constraint valid_name_source check (
+        -- The main root realm must not have a name
+        (id = 0 and name is null and name_from_block is null)
+        -- All other realms have either a plain or derived name.
+        or (id <> 0 and (name is null) != (name_from_block is null))
+    );


### PR DESCRIPTION
This was just a buggy DB constraint that wasn't updated.

Fixes #833