### PR TITLE
Fix `import-realm-tree` command

### DIFF
--- a/backend/src/cmd/import_realm_tree.rs
+++ b/backend/src/cmd/import_realm_tree.rs
@@ -35,6 +35,7 @@ struct Realm {
     name_from_block: Option<u32>,
 
     #[serde(default)]
+    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     blocks: Vec<Block>,
 
     #[serde(default)]


### PR DESCRIPTION
This broke due to the `serde_yaml` update to 0.9. That release changed how enums are represented in YAML, preferring the appropriate `!Tag` syntax. This is an improvement, but we don't want to change our huge test-data file, so we opt-in using the old behavior.

This also fixes the "upload DB dump" GitHub action