### PR TITLE
Add playwright e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,6 @@ jobs:
     - name: Lint frontend
       working-directory: frontend
       run: npx eslint --max-warnings 0 .
-    - name: Install Playwright browsers
-      working-directory: frontend
-      run: npx playwright install --with-deps
     - name: Build frontend
       working-directory: frontend
       run: npx webpack --mode=${{ env.ci_webpack_flags }}
@@ -130,12 +127,18 @@ jobs:
 
     - name: Rebuild search index
       working-directory: backend
-      run: echo yes | cargo run -- search-index update
+      run: cargo run -- search-index update
 
+    - name: Install Playwright browsers
+      working-directory: frontend
+      run: npx playwright install --with-deps
     - name: Run playwright tests
       working-directory: frontend
       run: npx playwright test
     - name: Upload test results
+      # A test might need a retry to succeed or run longer than expected.
+      # In these cases the results should also be saved, since they might
+      # indicate what went wrong. Hence `always()` instead of on `failure()`.
       if: always()
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Lint frontend
       working-directory: frontend
       run: npx eslint --max-warnings 0 .
+    - name: Install Playwright browsers
+      working-directory: frontend
+      run: npx playwright install --with-deps
     - name: Build frontend
       working-directory: frontend
       run: npx webpack --mode=${{ env.ci_webpack_flags }}
@@ -116,6 +119,29 @@ jobs:
     - name: Run migrations
       run: ./tobira db migrate --config util/dev-config/config.toml
 
+    # UI tests
+    - name: Start docker containers
+      working-directory: util/containers
+      run: |
+        docker-compose -f docker-compose.yml up -d \
+          tobira-auth-proxy \
+          tobira-login-handler \
+          tobira-meilisearch
+
+    - name: Rebuild search index
+      working-directory: backend
+      run: echo yes | cargo run -- search-index update
+
+    - name: Run playwright tests
+      working-directory: frontend
+      run: npx playwright test
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: playwright-report
+        path: frontend/playwright-report/
+        retention-days: 7
 
     # Prepare the ID (used in the subdomain) for deployment. This has to be done
     # here because in the `deploy` workflow, we don't have access to the correct

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -70,8 +70,9 @@ module.exports = {
     ],
 
     ignorePatterns: [
-        "node_modules",
         "/build",
+        "node_modules",
+        "playwright-report",
         "/src/**/__generated__",
         "!.*",
     ],

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,3 +3,6 @@
 /src/**/__generated__/
 /tsconfig.tsbuildinfo
 /.eslintcache
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,7 @@
       "devDependencies": {
         "@emotion/babel-plugin": "^11.11.0",
         "@opencast/eslint-config-ts-react": "^0.1.0",
-        "@playwright/test": "^1.33.0",
+        "@playwright/test": "^1.35.1",
         "@types/react": "^18.2.6",
         "@types/react-beforeunload": "^2.1.1",
         "@types/react-dom": "^18.2.4",
@@ -2099,19 +2099,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
-      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+      "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.33.0"
+        "playwright-core": "1.35.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -7332,15 +7332,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
-      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/prelude-ls": {
@@ -10597,14 +10597,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
-      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+      "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.33.0"
+        "playwright-core": "1.35.1"
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -14264,9 +14264,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
-      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
       "dev": true
     },
     "prelude-ls": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
       "devDependencies": {
         "@emotion/babel-plugin": "^11.11.0",
         "@opencast/eslint-config-ts-react": "^0.1.0",
+        "@playwright/test": "^1.33.0",
         "@types/react": "^18.2.6",
         "@types/react-beforeunload": "^2.1.1",
         "@types/react-dom": "^18.2.4",
@@ -2095,6 +2096,25 @@
         "eslint": ">= 8",
         "eslint-plugin-react": ">= 7",
         "eslint-plugin-react-hooks": ">= 4"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.33.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -7311,6 +7331,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10562,6 +10594,17 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^5.59.9"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.33.0"
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -14219,6 +14262,12 @@
           }
         }
       }
+    },
+    "playwright-core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@emotion/babel-plugin": "^11.11.0",
     "@opencast/eslint-config-ts-react": "^0.1.0",
-    "@playwright/test": "^1.33.0",
+    "@playwright/test": "^1.35.1",
     "@types/react": "^18.2.6",
     "@types/react-beforeunload": "^2.1.1",
     "@types/react-dom": "^18.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@emotion/babel-plugin": "^11.11.0",
     "@opencast/eslint-config-ts-react": "^0.1.0",
+    "@playwright/test": "^1.33.0",
     "@types/react": "^18.2.6",
     "@types/react-beforeunload": "^2.1.1",
     "@types/react-dom": "^18.2.4",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,35 +1,20 @@
 import { defineConfig, devices } from "@playwright/test";
 
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
     testDir: "./tests",
-    workers: 1,
+    workers: process.env.CI ? 1 : undefined,
     retries: 1,
-    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: "html",
-    expect: { timeout: 10 * 1000 },
-    /**
-     * Shared settings for all the projects below.
-     * See https://playwright.dev/docs/api/class-testoptions.
-     */
-    use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: process.env.CI ? "http://localhost:3090" : "http://localhost:8030",
-        headless: true,
-        screenshot: "only-on-failure",
-        locale: "en",
+    expect: { timeout: 20 * 1000 },
 
-        /**
-         * Collect trace when retrying the failed test.
-         * See https://playwright.dev/docs/trace-viewer
-         */
+    use: {
+        baseURL: "http://localhost:3090",
+        headless: true,
+        locale: "en",
         trace: "retain-on-failure",
     },
 
-    /* Configure projects for major browsers */
     projects: [
         {
             name: "chromium",
@@ -48,11 +33,9 @@ export default defineConfig({
         },
     ],
 
-    /* Run your local dev server before starting the tests */
     webServer: {
         command: "cargo run --manifest-path=../backend/Cargo.toml -- serve",
         url: "http://localhost:3090",
-        timeout: 120 * 1000,
         reuseExistingServer: true,
     },
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -41,20 +41,11 @@ export default defineConfig({
             use: { ...devices["Desktop Firefox"] },
         },
 
-        // {
-        //     name: "webkit",
-        //     use: { ...devices["Desktop Safari"] },
-        // },
-
-        /* Test against mobile viewports. */
-        // {
-        //   name: 'Mobile Chrome',
-        //   use: { ...devices['Pixel 5'] },
-        // },
-        // {
-        //   name: 'Mobile Safari',
-        //   use: { ...devices['iPhone 12'] },
-        // },
+        // Safari doesn't allow http logins, so we can't test everything there.
+        {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] },
+        },
     ],
 
     /* Run your local dev server before starting the tests */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,11 +6,10 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
     testDir: "./tests",
-    retries: 2,
     workers: 1,
+    retries: 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: "html",
-    timeout: 60 * 1000,
     expect: { timeout: 10 * 1000 },
     /**
      * Shared settings for all the projects below.
@@ -18,7 +17,7 @@ export default defineConfig({
      */
     use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: "http://localhost:8030/",
+        baseURL: process.env.CI ? "http://localhost:3090" : "http://localhost:8030",
         headless: true,
         screenshot: "only-on-failure",
         locale: "en",
@@ -28,7 +27,6 @@ export default defineConfig({
          * See https://playwright.dev/docs/trace-viewer
          */
         trace: "retain-on-failure",
-        video: "retain-on-failure",
     },
 
     /* Configure projects for major browsers */
@@ -60,9 +58,10 @@ export default defineConfig({
     ],
 
     /* Run your local dev server before starting the tests */
-    // webServer: {
-    //   command: 'npm run start',
-    //   url: 'http://127.0.0.1:3000',
-    //   reuseExistingServer: !process.env.CI,
-    // },
+    webServer: {
+        command: "cargo run --manifest-path=../backend/Cargo.toml -- serve",
+        url: "http://localhost:3090",
+        timeout: 120 * 1000,
+        reuseExistingServer: true,
+    },
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,68 @@
+import { defineConfig, devices } from "@playwright/test";
+
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+    testDir: "./tests",
+    retries: 2,
+    workers: 1,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: "html",
+    timeout: 60 * 1000,
+    expect: { timeout: 10 * 1000 },
+    /**
+     * Shared settings for all the projects below.
+     * See https://playwright.dev/docs/api/class-testoptions.
+     */
+    use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+        baseURL: "http://localhost:8030/",
+        headless: true,
+        screenshot: "only-on-failure",
+        locale: "en",
+
+        /**
+         * Collect trace when retrying the failed test.
+         * See https://playwright.dev/docs/trace-viewer
+         */
+        trace: "retain-on-failure",
+        video: "retain-on-failure",
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"], channel: "chrome" },
+        },
+
+        {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] },
+        },
+
+        // {
+        //     name: "webkit",
+        //     use: { ...devices["Desktop Safari"] },
+        // },
+
+        /* Test against mobile viewports. */
+        // {
+        //   name: 'Mobile Chrome',
+        //   use: { ...devices['Pixel 5'] },
+        // },
+        // {
+        //   name: 'Mobile Safari',
+        //   use: { ...devices['iPhone 12'] },
+        // },
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: {
+    //   command: 'npm run start',
+    //   url: 'http://127.0.0.1:3000',
+    //   reuseExistingServer: !process.env.CI,
+    // },
+});

--- a/frontend/tests/blocks.spec.ts
+++ b/frontend/tests/blocks.spec.ts
@@ -3,7 +3,8 @@ import { Block, blocks, deleteRealm, insertBlock, login, realmSetup, realms } fr
 
 
 for (const realm of realms) {
-    test(`${realm} realm blocks`, async ({ page }) => {
+    test(`${realm} realm blocks`, async ({ page, browserName }) => {
+        test.skip(browserName === "webkit", "Skip safari because it doesn't allow http logins");
         await test.step("Setup", async () => {
             await login(page, "admin");
             await realmSetup(page, realm);

--- a/frontend/tests/blocks.spec.ts
+++ b/frontend/tests/blocks.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { Block, blocks, deleteRealm, insertBlock, login, realmSetup, realms } from "./common";
+import { Block, User, blocks, deleteRealm, insertBlock, login, realmSetup, realms } from "./common";
 
 
 for (const realm of realms) {
@@ -15,7 +15,8 @@ for (const realm of realms) {
                 await login(page, user.login);
             } else {
                 await login(page, "admin");
-            await realmSetup(page, realm);
+            }
+            await realmSetup(page, realm, user, realmIndex);
         });
 
         await test.step("Editing", async () => {
@@ -36,7 +37,7 @@ for (const realm of realms) {
                     await removeBlock(page);
                 }
 
-                await expect(page.locator("_react=EditBlock")).toHaveCount(0);
+                await expect(page.getByRole("button", { name: "Move block down" })).toHaveCount(0);
             });
         });
 
@@ -63,11 +64,11 @@ const editBlock = async (page: Page, block: Block, index: number) => {
 
     if (block === "Series") {
         await test.step("Series can be changed", async () => {
-            const input = page.locator("_react=SeriesSelector");
+            const input = editBlock.getByText("The best open cat videos");
             const query = "Mixed Test Series";
             await input.type("mixed test");
             await page.getByText(query).click();
-            await input.press("Enter");
+            await page.keyboard.press("Enter");
 
             await expect(page.getByRole("heading", { name: query })).toBeVisible();
         });
@@ -130,10 +131,10 @@ const editBlock = async (page: Page, block: Block, index: number) => {
     }
     if (block === "Video") {
         await test.step("Video can be changed", async () => {
-            const input = page.locator("_react=EventSelector");
+            const input = editBlock.getByText("Chicken");
             await input.type("belemmi");
             await page.getByText("Series: The best open cat videos").click();
-            await input.press("Enter");
+            await page.keyboard.press("Enter");
 
             await expect(page
                 .getByRole("heading", { name: "Video Of A Tabby Cat" })
@@ -163,6 +164,6 @@ const editBlock = async (page: Page, block: Block, index: number) => {
 
 const removeBlock = async (page: Page) => {
     const block = page.locator("_react=EditBlock").first();
-    await block.locator("_react=RemoveButton").click();
+    await block.getByRole("button", { name: "Remove block" }).click();
     await page.getByText("Remove block", { exact: true }).click();
 };

--- a/frontend/tests/blocks.spec.ts
+++ b/frontend/tests/blocks.spec.ts
@@ -5,8 +5,16 @@ import { Block, blocks, deleteRealm, insertBlock, login, realmSetup, realms } fr
 for (const realm of realms) {
     test(`${realm} realm blocks`, async ({ page, browserName }) => {
         test.skip(browserName === "webkit", "Skip safari because it doesn't allow http logins");
+        const user: User = browserName === "chromium"
+            ? { login: "morgan", displayName: "Morgan Yu" }
+            : { login: "jose", displayName: "José Carreño Quiñones" };
+        const realmIndex = browserName === "chromium" ? 0 : 1;
+
         await test.step("Setup", async () => {
-            await login(page, "admin");
+            if (realm === "User") {
+                await login(page, user.login);
+            } else {
+                await login(page, "admin");
             await realmSetup(page, realm);
         });
 

--- a/frontend/tests/blocks.spec.ts
+++ b/frontend/tests/blocks.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect, Page } from "@playwright/test";
+import { Block, blocks, deleteRealm, insertBlock, login, realmSetup, realms } from "./common";
+
+
+for (const realm of realms) {
+    test(`${realm} realm blocks`, async ({ page }) => {
+        await test.step("Setup", async () => {
+            await login(page, "admin");
+            await realmSetup(page, realm);
+        });
+
+        await test.step("Editing", async () => {
+            await test.step("Blocks can be added", async () => {
+                for (const block of blocks) {
+                    await insertBlock(page, block);
+                }
+            });
+
+            await test.step("Blocks can be edited", async () => {
+                for (const [index, block] of blocks.slice().reverse().entries()) {
+                    await editBlock(page, block, index);
+                }
+            });
+
+            await test.step("Blocks can be removed", async () => {
+                for (const _ of blocks) {
+                    await removeBlock(page);
+                }
+
+                await expect(page.locator("_react=EditBlock")).toHaveCount(0);
+            });
+        });
+
+        await test.step("Cleanup", async () => {
+            await deleteRealm(page);
+        });
+    });
+}
+
+
+const editBlock = async (page: Page, block: Block, index: number) => {
+    const saveButton = page.getByRole("button", { name: "Save" });
+    const editBlock = page.locator("_react=EditBlock").nth(index);
+    const editButton = editBlock.getByRole("button", { name: "Edit block" });
+
+    const editText = async (page: Page, text: string) => {
+        await editBlock.getByRole("textbox").fill(text);
+        await saveButton.click();
+
+        await expect(page.getByText(text)).toBeVisible();
+    };
+
+    await editButton.click();
+
+    if (block === "Series") {
+        await test.step("Series can be changed", async () => {
+            const input = page.locator("_react=SeriesSelector");
+            const query = "Mixed Test Series";
+            await input.type("mixed test");
+            await page.getByText(query).click();
+            await input.press("Enter");
+
+            await expect(page.getByRole("heading", { name: query })).toBeVisible();
+        });
+
+        await test.step("Video order can be changed", async () => {
+            await editButton.click();
+            await page.getByRole("button", { name: "Oldest first" }).click();
+            await saveButton.click();
+
+            await expect(page.getByRole("button", { name: "Choose video order" }))
+                .toHaveText("Oldest first");
+        });
+
+        await test.step("Layout options work as intended", async () => {
+            await test.step("Title and videos (initial)", async () => {
+                await expect(
+                    editBlock.getByRole("heading", { name: "Mixed Test Series" }),
+                ).toBeVisible();
+            });
+
+            await test.step("Videos only", async () => {
+                await editButton.click();
+                await page.getByRole("button", { name: "Videos only" }).click();
+                await saveButton.click();
+
+                await expect(
+                    editBlock.getByRole("heading", { name: "Mixed Test Series" }),
+                ).not.toBeVisible();
+            });
+
+            await test.step("Description and videos", async () => {
+                await editButton.click();
+                await page.getByRole("button", { name: "Description and videos" }).first().click();
+                await saveButton.click();
+
+                await expect(
+                    editBlock.getByRole("heading", { name: "Mixed Test Series" }),
+                ).not.toBeVisible();
+                await expect(
+                    editBlock.getByText("Some normal events, some scheduled ones and a live one."),
+                ).toBeVisible();
+            });
+
+            await test.step("Title, description and videos", async () => {
+                await editButton.click();
+                await page
+                    .getByRole("button", { name: "Title, Description and videos" })
+                    .first()
+                    .click();
+                await saveButton.click();
+
+                await expect(
+                    editBlock.getByRole("heading", { name: "Mixed Test Series" }),
+                ).toBeVisible();
+                await expect(
+                    editBlock.getByText("Some normal events, some scheduled ones and a live one."),
+                ).toBeVisible();
+            });
+        });
+    }
+    if (block === "Video") {
+        await test.step("Video can be changed", async () => {
+            const input = page.locator("_react=EventSelector");
+            await input.type("belemmi");
+            await page.getByText("Series: The best open cat videos").click();
+            await input.press("Enter");
+
+            await expect(page
+                .getByRole("heading", { name: "Video Of A Tabby Cat" })
+                .first())
+                .toBeVisible();
+        });
+
+        await test.step("Title can be hidden", async () => {
+            await editButton.click();
+            await page.getByText("Show title").click();
+            await saveButton.click();
+
+            await expect(editBlock.getByRole("heading")).toHaveCount(0);
+        });
+    }
+    if (block === "Text") {
+        await test.step("Text can be changed", async () => {
+            await editText(page, "The lazy dog jumps over the quick brown fox.");
+        });
+    }
+    if (block === "Title") {
+        await test.step("Title can be changed", async () => {
+            await editText(page, "Super unique title");
+        });
+    }
+};
+
+const removeBlock = async (page: Page) => {
+    const block = page.locator("_react=EditBlock").first();
+    await block.locator("_react=RemoveButton").click();
+    await page.getByText("Remove block", { exact: true }).click();
+};

--- a/frontend/tests/common.ts
+++ b/frontend/tests/common.ts
@@ -117,12 +117,13 @@ export type Block = typeof blocks[number];
 export const insertBlock = async (page: Page, block: Block) => {
     const addButton = page.locator("_react=AddButtons").first();
     const saveButton = page.getByRole("button", { name: "Save" });
+
     await addButton.click();
     await page.getByRole("button", { name: block }).first().click();
 
     if (block === "Title") {
         await test.step("Title block", async () => {
-            await page.getByPlaceholder("You can put your title here.").fill("Title");
+            await page.getByRole("textbox").nth(1).fill("Title");
             await saveButton.click();
 
             await expect(page.getByRole("heading", { name: "Title" })).toBeVisible();
@@ -131,9 +132,7 @@ export const insertBlock = async (page: Page, block: Block) => {
     if (block === "Text") {
         await test.step("Text block", async () => {
             const pangram = "The quick brown fox jumps over the lazy dog.";
-            await page
-                .getByPlaceholder("You can put your text content here. You can even use Markdown.")
-                .fill(pangram);
+            await page.getByRole("textbox").nth(1).fill(pangram);
             await saveButton.click();
 
             await expect(page.getByText(pangram)).toBeVisible();

--- a/frontend/tests/common.ts
+++ b/frontend/tests/common.ts
@@ -1,0 +1,166 @@
+import { Page, expect, test } from "@playwright/test";
+
+
+type User = "admin" | "björk" | "jose" | "morgan" | "sabine";
+
+export const login = async (page: Page, user: User) => {
+    await expect(async () => {
+        await navigateTo("~login", page);
+        await page.getByLabel("User ID").fill(user);
+        await page.getByLabel("Password").fill("tobira");
+        await page.getByRole("button", { name: "Login" }).click();
+        await page.waitForURL("/");
+    }).toPass({
+        intervals: [2000, 5000, 10000],
+        timeout: 30 * 1000,
+    });
+};
+
+
+export const navigateTo = async (path: string, page: Page) => {
+    await expect(async () => {
+        await page.goto(path);
+        await page.waitForURL(path);
+    }).toPass({
+        intervals: [2000, 5000, 10000],
+        timeout: 30 * 1000,
+    });
+};
+
+
+export const deleteRealm = async (page: Page) => {
+    const deleteButton = page.locator("button:has-text('Delete')");
+
+    await expect(async () => {
+        if (!await deleteButton.isVisible()) {
+            await page.getByRole("link", { name: "Page settings" }).click();
+            await expect(deleteButton).toBeVisible();
+        }
+
+        await deleteButton.click();
+        await expect(deleteButton.nth(1)).toBeVisible();
+
+        await Promise.all([
+            page.waitForResponse(response =>
+                response.url().includes("graphql")
+                && response.status() === 200),
+            deleteButton.nth(1).click(),
+        ]);
+    }).toPass();
+};
+
+
+export const realms = ["User", "Regular"] as const;
+export type Realm = typeof realms[number];
+
+export const realmSetup = async (page: Page, realm: Realm) => {
+    if (realm === "User") {
+        await navigateTo("@admin", page);
+        await page.waitForURL("@admin");
+    } else {
+        await navigateTo("/", page);
+    }
+
+    await test.step("Create test realms", async () => {
+        if (realm === "User") {
+            const createRealmButton = page
+                .locator("_react=CreateUserRealm")
+                .nth(1)
+                .getByRole("button");
+            if (!await createRealmButton.isVisible()) {
+                await expect(async () => {
+                    await deleteRealm(page);
+                    await page.waitForURL("/");
+                    await navigateTo("@admin", page);
+                    await expect(createRealmButton).toBeVisible();
+                }).toPass();
+            }
+            await createRealmButton.click();
+            await expect(page.getByText("Edit page “Administrator”")).toBeVisible();
+        }
+
+        if (realm === "Regular") {
+            await page.waitForSelector("nav");
+            for (const name of ["Chicken", "Funky Realm", "E2E Test Realm"]) {
+                const realmLink = page.locator("nav").getByRole("link", { name: name });
+                if (await realmLink.isVisible()) {
+                    await realmLink.click();
+                    await deleteRealm(page);
+                }
+            }
+
+            await addSubPage(page, "E2E Test Realm");
+            await expect(page.getByRole("link", { name: "E2E Test Realm" })).toBeVisible();
+            await page.waitForURL("~manage/realm/content?path=/e2e-test-realm");
+        }
+    });
+};
+
+
+export const addSubPage = async (page: Page, name: string) => {
+    await page.getByRole("link", { name: "Add sub-page" }).first().click();
+    await page.getByPlaceholder("Page name").fill(name);
+    await page.keyboard.press("Tab");
+    await page.keyboard.type(name.trim().toLowerCase().replace(/\s+/g, "-"));
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().includes("graphql")
+            && response.status() === 200),
+        page.getByRole("button", { name: "Create page" }).click(),
+    ]);
+};
+
+
+export const blocks = ["Series", "Video", "Text", "Title"] as const;
+export type Block = typeof blocks[number];
+
+export const insertBlock = async (page: Page, block: Block) => {
+    const addButton = page.locator("_react=AddButtons").first();
+    const saveButton = page.getByRole("button", { name: "Save" });
+    await addButton.click();
+    await page.getByRole("button", { name: block }).first().click();
+
+    if (block === "Title") {
+        await test.step("Title block", async () => {
+            await page.getByPlaceholder("You can put your title here.").fill("Title");
+            await saveButton.click();
+
+            await expect(page.getByRole("heading", { name: "Title" })).toBeVisible();
+        });
+    }
+    if (block === "Text") {
+        await test.step("Text block", async () => {
+            const pangram = "The quick brown fox jumps over the lazy dog.";
+            await page
+                .getByPlaceholder("You can put your text content here. You can even use Markdown.")
+                .fill(pangram);
+            await saveButton.click();
+
+            await expect(page.getByText(pangram)).toBeVisible();
+        });
+    }
+    if (block === "Series") {
+        await test.step("Series block", async () => {
+            const input = page.locator("_react=SeriesSelector");
+            const query = "The best open cat videos";
+
+            await input.type("cat videos");
+            await page.getByText("The best open cat videos").click();
+            await saveButton.click();
+
+            await expect(page.getByRole("heading", { name: query })).toBeVisible();
+        });
+    }
+    if (block === "Video") {
+        await test.step("Video block", async () => {
+            const input = page.locator("_react=EventSelector");
+            const query = "Chicken";
+
+            await input.type("chicken");
+            await page.getByText("Series: The best open cat videos").click();
+            await input.press("Enter");
+
+            await expect(page.getByRole("heading", { name: query }).first()).toBeVisible();
+        });
+    }
+};

--- a/frontend/tests/common.ts
+++ b/frontend/tests/common.ts
@@ -35,22 +35,20 @@ export const navigateTo = async (path: string, page: Page) => {
 export const deleteRealm = async (page: Page) => {
     const deleteButton = page.locator("button:has-text('Delete')");
 
-    await expect(async () => {
-        if (!await deleteButton.isVisible()) {
-            await page.getByRole("link", { name: "Page settings" }).click();
-            await expect(deleteButton).toBeVisible();
-        }
+    if (!await deleteButton.isVisible()) {
+        await page.getByRole("link", { name: "Page settings" }).click();
+        await expect(deleteButton).toBeVisible();
+    }
 
-        await deleteButton.click();
-        await expect(deleteButton.nth(1)).toBeVisible();
+    await deleteButton.click();
+    await expect(deleteButton.nth(1)).toBeVisible();
 
-        await Promise.all([
-            page.waitForResponse(response =>
-                response.url().includes("graphql")
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().includes("graphql")
                 && response.status() === 200),
-            deleteButton.nth(1).click(),
-        ]);
-    }).toPass();
+        deleteButton.nth(1).click(),
+    ]);
 };
 
 
@@ -67,10 +65,7 @@ export const realmSetup = async (page: Page, realm: Realm, user: User, index: nu
 
     await test.step("Create test realms", async () => {
         if (realm === "User") {
-            const createRealmButton = page
-                .locator("_react=CreateUserRealm")
-                .nth(1)
-                .getByRole("button");
+            const createRealmButton = page.getByRole("button", { name: "Create your own page" });
             if (!await createRealmButton.isVisible()) {
                 await expect(async () => {
                     await deleteRealm(page);
@@ -120,7 +115,7 @@ export const blocks = ["Series", "Video", "Text", "Title"] as const;
 export type Block = typeof blocks[number];
 
 export const insertBlock = async (page: Page, block: Block) => {
-    const addButton = page.locator("_react=AddButtons").first();
+    const addButton = page.getByRole("button", { name: "Insert a new block here" }).first();
     const saveButton = page.getByRole("button", { name: "Save" });
 
     await addButton.click();
@@ -145,7 +140,7 @@ export const insertBlock = async (page: Page, block: Block) => {
     }
     if (block === "Series") {
         await test.step("Series block", async () => {
-            const input = page.locator("_react=SeriesSelector");
+            const input = page.locator("div").filter({ hasText: "Select option..." }).nth(1);
             const query = "The best open cat videos";
 
             await input.type("cat videos");
@@ -157,12 +152,12 @@ export const insertBlock = async (page: Page, block: Block) => {
     }
     if (block === "Video") {
         await test.step("Video block", async () => {
-            const input = page.locator("_react=EventSelector");
+            const input = page.locator("div").filter({ hasText: "Select option..." }).nth(1);
             const query = "Chicken";
 
             await input.type("chicken");
             await page.getByText("Series: The best open cat videos").click();
-            await input.press("Enter");
+            await page.keyboard.press("Enter");
 
             await expect(page.getByRole("heading", { name: query }).first()).toBeVisible();
         });

--- a/frontend/tests/languageSelection.spec.ts
+++ b/frontend/tests/languageSelection.spec.ts
@@ -3,8 +3,6 @@ import { navigateTo } from "./common";
 
 test("Language selection", async ({ page }) => {
     const html = page.locator("html");
-    const languageMenu = page.locator("_react=WithFloatingMenu");
-    const trigger = languageMenu.locator("_react=FloatingTrigger");
     const english = page.getByRole("checkbox", { name: "English" });
     const german = page.getByRole("checkbox", { name: "Deutsch" });
 
@@ -12,8 +10,9 @@ test("Language selection", async ({ page }) => {
     await page.waitForSelector("nav");
 
     await test.step("Language button is present and opens menu", async () => {
-        await trigger.click();
-        await expect(languageMenu.locator("_react=FloatingMenu")).toBeVisible();
+        await page.getByRole("button", { name: "Language selection" }).click();
+        await expect(english).toBeVisible();
+        await expect(german).toBeVisible();
     });
 
     await test.step("Language can be changed", async () => {
@@ -22,16 +21,16 @@ test("Language selection", async ({ page }) => {
         await expect(english).toBeChecked();
         await expect(html).toHaveAttribute("lang", "en");
 
-        await test.step("To german", async () => {
+        await test.step("to german", async () => {
             await expect(german).toBeVisible();
             await german.dispatchEvent("click");
 
-            await trigger.click();
+            await page.getByRole("button", { name: "Sprachauswahl" }).click();
             await expect(german).toBeChecked();
             await expect(html).toHaveAttribute("lang", "de");
         });
 
-        await test.step("To english", async () => {
+        await test.step("to english", async () => {
             await english.dispatchEvent("click");
             await expect(html).toHaveAttribute("lang", "en");
         });

--- a/frontend/tests/languageSelection.spec.ts
+++ b/frontend/tests/languageSelection.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { navigateTo } from "./common";
+
+test("Language selection", async ({ page }) => {
+    const html = page.locator("html");
+    const languageMenu = page.locator("_react=WithFloatingMenu");
+    const trigger = languageMenu.locator("_react=FloatingTrigger");
+    const english = page.getByRole("checkbox", { name: "English" });
+    const german = page.getByRole("checkbox", { name: "Deutsch" });
+
+    await navigateTo("/", page);
+    await page.waitForSelector("nav");
+
+    await test.step("Language button is present and opens menu", async () => {
+        await trigger.click();
+        await expect(languageMenu.locator("_react=FloatingMenu")).toBeVisible();
+    });
+
+    await test.step("Language can be changed", async () => {
+        // The initial language for these tests is english if not
+        // explicitly specified otherwise in the configuration.
+        await expect(english).toBeChecked();
+        await expect(html).toHaveAttribute("lang", "en");
+
+        await test.step("To german", async () => {
+            await expect(german).toBeVisible();
+            await german.dispatchEvent("click");
+
+            await trigger.click();
+            await expect(german).toBeChecked();
+            await expect(html).toHaveAttribute("lang", "de");
+        });
+
+        await test.step("To english", async () => {
+            await english.dispatchEvent("click");
+            await expect(html).toHaveAttribute("lang", "en");
+        });
+    });
+});

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test";
+import { navigateTo } from "./common";
+
+test("Login", async ({ page, baseURL }) => {
+    await navigateTo("/", page);
+
+    await page.getByRole("link", { name: "Login" }).click();
+    await expect(page).toHaveURL("~login");
+
+    await page.getByLabel("User ID").fill("admin");
+    await page.getByLabel("Password").fill("tobira");
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(baseURL as string);
+    await expect(page.getByRole("button", { name: "Administrator" })).toBeVisible();
+});

--- a/frontend/tests/login.spec.ts
+++ b/frontend/tests/login.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "@playwright/test";
 import { navigateTo } from "./common";
 
-test("Login", async ({ page, baseURL }) => {
+test("Login", async ({ page, baseURL, browserName }) => {
+    test.skip(browserName === "webkit", "Skip safari because it doesn't allow http logins");
+
     await navigateTo("/", page);
 
     await page.getByRole("link", { name: "Login" }).click();

--- a/frontend/tests/realms.spec.ts
+++ b/frontend/tests/realms.spec.ts
@@ -11,7 +11,8 @@ import {
 
 
 for (const realm of realms) {
-    test(`${realm} realm editing`, async ({ page }) => {
+    test(`${realm} realm editing`, async ({ page, browserName }) => {
+        test.skip(browserName === "webkit", "Skip safari because it doesn't allow http logins");
         const settingsLink = page.getByRole("link", { name: "Page settings" });
         const saveButton = page.getByRole("button", { name: "Save" });
         const subPages = ["Alchemy", "Barnacles", "Cheese"];

--- a/frontend/tests/realms.spec.ts
+++ b/frontend/tests/realms.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+    addSubPage,
+    deleteRealm,
+    insertBlock,
+    login,
+    navigateTo,
+    realmSetup,
+    realms,
+} from "./common";
+
+
+for (const realm of realms) {
+    test(`${realm} realm editing`, async ({ page }) => {
+        const settingsLink = page.getByRole("link", { name: "Page settings" });
+        const saveButton = page.getByRole("button", { name: "Save" });
+        const subPages = ["Alchemy", "Barnacles", "Cheese"];
+        const nav = page.locator("nav").first().getByRole("listitem");
+
+        await test.step("Setup", async () => {
+            await login(page, "admin");
+            await realmSetup(page, realm);
+            await insertBlock(page, "Video");
+        });
+
+        await test.step("Sub-pages can be added", async () => {
+            const target = realm === "User" ? "@admin" : "e2e-test-realm";
+            for (const subPage of subPages) {
+                await expect(async () => {
+                    await navigateTo(target, page);
+                    await addSubPage(page, subPage);
+                    await page.waitForSelector(`h1:has-text("Edit page “${subPage}”")`);
+                }).toPass();
+            }
+
+            await navigateTo(target, page);
+            await expect(nav).toHaveText(subPages);
+        });
+
+        await test.step("Order of sub-pages can be changed", async () => {
+            await test.step("Sort alphabetically descending", async () => {
+                await settingsLink.click();
+                await page.getByText("Sort alphabetically descending").click();
+                await saveButton.nth(1).click();
+
+                await expect(nav).toHaveText(subPages.slice().reverse());
+            });
+
+            await test.step("Sort alphabetically ascending", async () => {
+                await page.getByText("Sort alphabetically ascending").click();
+                await saveButton.nth(1).click();
+
+                await expect(nav).toHaveText(subPages);
+            });
+
+            await test.step("Manually order", async () => {
+                const options = page.locator("ol").nth(1);
+                const buttons = [[1, 1], [2, 0], [2, 1], [3, 0]].map(([item, button]) =>
+                    options.locator(`li:nth-child(${item}) >> button`).nth(button));
+
+                await page.getByText("Manually order").click();
+                const preOrder = await Promise.all(
+                    [1, 2, 3].map(n => options.locator(`li:nth-child(${n})`).textContent()),
+                );
+                // Indexes should change from 0 1 2 => 1 2 0.
+                const postOrder = [1, 2, 0].map(n => preOrder[n] as string);
+
+                for (const index of [3, 1, 2, 0]) {
+                    await buttons[index].click();
+                }
+                await saveButton.nth(1).click();
+
+                await expect(nav).toHaveText(postOrder);
+            });
+        });
+
+        await test.step("Name can be changed", async () => {
+            await test.step("Derived name", async () => {
+                await page.locator("label:has-text('Derive name from video or series')").click();
+                await page.getByRole("combobox").selectOption("Video: Chicken");
+                await saveButton.first().click();
+
+                await expect(
+                    page.getByRole("heading", { name: "Settings of page “Chicken”" }),
+                ).toBeVisible();
+            });
+
+            await test.step("Custom name", async () => {
+                await page.locator("label:has-text('Name directly')").click();
+                await page.locator("#rename-field").fill("Funky realm");
+                await saveButton.first().click();
+
+                await expect(
+                    page.getByRole("heading", { name: "Settings of page “Funky realm”" }),
+                ).toBeVisible();
+
+                await page.locator("#rename-field").fill("E2E Test realm");
+                await saveButton.first().click();
+                await expect(page.getByRole("heading", { name: "E2E Test realm" })).toBeVisible();
+            });
+        });
+
+        if (realm === "Regular") {
+            await test.step("Path changing", async () => {
+                await test.step("Path can be changed", async () => {
+                    const pathInput = page.locator("input[name='pathSegment']");
+                    await pathInput.fill("chicken");
+                    await page.getByRole("button", { name: "Change path segment" }).click();
+
+                    await expect(page).toHaveURL("~manage/realm?path=/chicken");
+                });
+
+                await test.step("Links are updated", async () => {
+                    const links = [
+                        ["Go to page", "E2E Test Realm"],
+                        ["Page settings", "Settings of page “E2E Test Realm”"],
+                        ["Edit page content", "Edit page “E2E Test Realm”"],
+                        ["Add sub-page", "Add page"],
+                        ["Barnacles", "Barnacles"],
+                        ["E2E Test Realm", "E2E Test Realm"],
+                    ];
+
+                    const linkTest = async (page: Page, linkName: string, heading: string) => {
+                        await page.getByRole("link", { name: linkName }).first().click();
+                        await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+                    };
+
+                    for (const [name, heading] of links) {
+                        await linkTest(page, name, heading);
+                    }
+                });
+            });
+        }
+
+
+        await test.step("Page can be deleted", async () => {
+            await deleteRealm(page);
+
+            if (realm === "User") {
+                await navigateTo("@admin", page);
+                await expect(
+                    page.locator("_react=CreateUserRealm").nth(1).getByRole("button"),
+                ).toBeVisible();
+            } else {
+                await expect(page.getByRole("link", { name: "E2E Test realm" })).not.toBeVisible();
+            }
+        });
+    });
+}
+

--- a/frontend/tests/realms.spec.ts
+++ b/frontend/tests/realms.spec.ts
@@ -7,6 +7,7 @@ import {
     navigateTo,
     realmSetup,
     realms,
+    User,
 } from "./common";
 
 
@@ -150,7 +151,7 @@ for (const realm of realms) {
             if (realm === "User") {
                 await navigateTo(`@${user.login}`, page);
                 await expect(
-                    page.locator("_react=CreateUserRealm").nth(1).getByRole("button"),
+                    page.getByRole("button", { name: "Create your own page" }),
                 ).toBeVisible();
             } else {
                 await expect(

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { navigateTo } from "./common";
+
+
+test("Search", async ({ page }) => {
+    await navigateTo("/", page);
+    await page.waitForSelector("nav");
+    const searchField = page.locator("_react=SearchField").locator("input");
+
+    await test.step("Should be focusable by keyboard shortcut", async () => {
+        await page.keyboard.press("s");
+        await expect(searchField).toBeFocused();
+    });
+
+    await test.step("Should allow search queries to be executed", async () => {
+        const url = "~search?q=Video";
+        await searchField.fill("Video");
+
+        await expect(page).toHaveURL(url);
+    });
+
+    await test.step("Should show search results", async () => {
+        const results = page.locator("_react=SearchResults");
+        await expect(results).toBeVisible();
+        expect(await results.getByRole("link").count()).toBeGreaterThan(0);
+    });
+});

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -5,7 +5,7 @@ import { navigateTo } from "./common";
 test("Search", async ({ page }) => {
     await navigateTo("/", page);
     await page.waitForSelector("nav");
-    const searchField = page.locator("_react=SearchField").locator("input");
+    const searchField = page.getByPlaceholder("Search");
 
     await test.step("Should be focusable by keyboard shortcut", async () => {
         await page.keyboard.press("s");
@@ -20,7 +20,10 @@ test("Search", async ({ page }) => {
     });
 
     await test.step("Should show search results", async () => {
-        const results = page.locator("_react=SearchResults");
+        const results = page
+            .locator("div")
+            .filter({ has: page.getByText("Search results for “Video”") })
+            .nth(4);
         await expect(results).toBeVisible();
         expect(await results.getByRole("link").count()).toBeGreaterThan(0);
     });

--- a/frontend/tests/videoPage.spec.ts
+++ b/frontend/tests/videoPage.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import { navigateTo } from "./common";
+
+
+// Ideally this would get a semi-random event from the database that is
+// (1) part of a series and (2) we know is included as a video in tobira.
+// Though this also comes with the caveat that I don't know if there is a way to
+// match an event to it's path in tobira.
+
+test("Video page", async ({ page }) => {
+    const seriesBlock = page.locator("_react=SeriesBlockContainer");
+    const metadatumLocator = (datum: "duration" | "part of series") =>
+        page.locator("_react=Metadata").locator(`dd:right-of(dt:has-text("${datum}"))`).first();
+
+    await test.step("Setup", async () => {
+        await navigateTo("/", page);
+        await seriesBlock.getByRole("link").first().click();
+        await page.waitForSelector("nav");
+    });
+
+    await test.step("Video player", async () => {
+        const player = page.locator("_react=PaellaPlayer");
+
+        await test.step("Player is present", async () => {
+            await expect(player).toBeVisible();
+        });
+
+        await test.step("Video is playable", async () => {
+            await player.click();
+
+            await expect(page.locator(".progress-indicator-container")).toBeVisible();
+        });
+    });
+
+    await test.step("Share button", async () => {
+        const shareButton = page.locator("_react=ShareButton");
+
+        await test.step("Button is present", async () => {
+            await expect(shareButton).toBeVisible();
+        });
+
+        await test.step("Button opens share menu", async () => {
+            await shareButton.click();
+
+            await expect(
+                shareButton.getByRole("button").first(),
+            ).toHaveAttribute("aria-expanded", "true");
+        });
+    });
+
+    await test.step("Metadata fields are present", async () => {
+        // We can at least test the presence of "Duration" and "Part of series" values
+        // as those should always be shown for these tests.
+        await expect(metadatumLocator("part of series")).not.toBeEmpty();
+        await expect(metadatumLocator("duration")).not.toBeEmpty();
+    });
+
+    await test.step("Series block", async () => {
+        const series = await metadatumLocator("part of series").textContent();
+
+        await test.step("Block is present", async () => {
+            await expect(seriesBlock).toBeVisible();
+        });
+
+        await test.step("Block has the correct tile", async () => {
+            const blockTitle = page.getByRole("heading", { name: `More from “${series}”` });
+            await expect(seriesBlock.locator(blockTitle)).toBeVisible();
+        });
+
+        // Only do this step if block contains at least one other event.
+        const siblingEvent = seriesBlock.getByRole("link").first();
+        if (await siblingEvent.isVisible()) {
+            await test.step("Block contains sibling event tile", async () => {
+                await test.step("Tile links to event", async () => {
+                    const siblingId = await siblingEvent.getAttribute("href") as string;
+                    await siblingEvent.click();
+                    await expect(page).toHaveURL(siblingId);
+                });
+
+                await test.step("Event is part of the correct series", async () => {
+                    const siblingSeries = await metadatumLocator("part of series").textContent();
+                    expect(siblingSeries).toBe(series);
+                });
+            });
+        }
+    });
+});

--- a/frontend/tests/videoPage.spec.ts
+++ b/frontend/tests/videoPage.spec.ts
@@ -2,15 +2,10 @@ import { test, expect } from "@playwright/test";
 import { navigateTo } from "./common";
 
 
-// Ideally this would get a semi-random event from the database that is
-// (1) part of a series and (2) we know is included as a video in tobira.
-// Though this also comes with the caveat that I don't know if there is a way to
-// match an event to it's path in tobira.
-
 test("Video page", async ({ page }) => {
     const seriesBlock = page.locator("_react=SeriesBlockContainer");
     const metadatumLocator = (datum: "duration" | "part of series") =>
-        page.locator("_react=Metadata").locator(`dd:right-of(dt:has-text("${datum}"))`).first();
+        page.locator(`dd:right-of(dt:has-text("${datum}"))`).first();
 
     await test.step("Setup", async () => {
         await navigateTo("/", page);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,5 +18,5 @@
         "node_modules/@types"
     ]
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "playwright.config.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,5 +18,5 @@
         "node_modules/@types"
     ]
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
This adds the playwright framework for e2e UI tests as outlined in #855.

Several tests are already included but are still subject to change and improve. Unfortunately some of these can be flaky and are prone to getting stuck when loading and or navigating (in like 10% of all runs). I'm unsure if that is caused by poor test design or outside conditions. Right now the config allows for 2 retries to be extra sure everything passes, but in in my experience 1 retry should suffice. 
**Edit**: Actually, I haven't encountered any test failures in CI so I changed that back to 1 retry.

Especially the `realm` and `block` tests might still benefit from breaking them down into smaller chunks, but since so much of these tests depend on one another, I started by doing them in one swoop and in sequence.

I broke each test down into several steps and sub-steps using `test.step`, but there are definitely other ways of doing this. The benefit of using `test.step` is mainly for readability and sequentiality (is that even a word? google says it is 🤷)

Another thing to consider for these tests:
Right now they rely on certain events and series to be present _somewhere_ in Tobira, and at least one series block to be present on the "welcome page". I believe this is suboptimal since that data might change in the future (correct me if I'm wrong of course).