### PR TITLE
Use shared ESLint config

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,176 +1,74 @@
 "use strict";
 
-const noUnusedVarsOptions = {
-    args: "all",
-    varsIgnorePattern: "^_",
-    argsIgnorePattern: "^_",
-    caughtErrors: "all",
-    caughtErrorsIgnorePattern: "^_",
-    ignoreRestSiblings: true,
-};
-const noUnusedExpressionsOptions = {
-    allowTernary: true,
-    enforceForJSX: true,
-};
-const braceStyle = ["warn", "1tbs", { allowSingleLine: true }];
-const quoteOptions = ["double", { avoidEscape: true }];
-
-// eslint quote-props: "warn", "consistent-as-needed"
 module.exports = {
-    parserOptions: {
-        ecmaVersion: 11,
-    },
-    extends: [
-        "eslint:recommended",
-        "plugin:react-hooks/recommended",
-    ],
+    extends: ["@opencast/eslint-config-ts-react"],
     rules: {
-        // `== null` is actually a useful check for `null` and `undefined` at the same time
-        "eqeqeq": ["error", "always", { null: "ignore" }],
-        "no-void": ["error", { allowAsStatement: true }],
+        // Tobira's frontend uses an indentation of 4 to match the backend. In
+        // Rust, four spaces is the one style used by basically every code
+        // base.
+        "indent": ["warn", 4, { SwitchCase: 1 }],
 
-        // Style lints should only `"warn"`
+        // Making this stricter
+        "max-len": ["warn", { code: 100 }],
+
+
+        // ----- Additional rules  -------------------------------------------
+
+        // Newlines/linebreaks
         "array-bracket-newline": ["warn", "consistent"],
-        "array-bracket-spacing": "warn",
         "array-element-newline": ["warn", "consistent"],
-        "arrow-body-style": "warn",
-        "arrow-parens": ["warn", "as-needed"],
-        "block-spacing": "warn",
-        "brace-style": braceStyle,
-        "camelcase": ["warn", {
-            allow: ["\\$key$"],
-            ignoreImports: true,
-        }],
+        "function-call-argument-newline": ["warn", "consistent"],
+        "function-paren-newline": ["warn", "consistent"],
+        "object-property-newline": ["warn", { allowAllPropertiesOnSameLine: true }],
+        "operator-linebreak": ["warn", "before"],
+
+        // Comments
         "capitalized-comments": ["warn", "always", {
             ignoreInlineComments: true,
             ignoreConsecutiveComments: true,
         }],
-        "comma-dangle": ["warn", "always-multiline"],
-        "comma-spacing": "warn",
-        "comma-style": "warn",
-        "computed-property-spacing": "warn",
-        "curly": "warn",
+        "multiline-comment-style": ["warn", "separate-lines"],
+
+        // Other style stuff
+        "rest-spread-spacing": "warn",
         "dot-location": ["warn", "property"],
         "dot-notation": "warn",
-        "func-call-spacing": "warn",
-        "function-call-argument-newline": ["warn", "consistent"],
-        "function-paren-newline": ["warn", "consistent"],
-        "implicit-arrow-linebreak": "warn",
-        "indent": ["warn", 4, { SwitchCase: 1 }],
-        "key-spacing": "warn",
-        "keyword-spacing": "warn",
-        "lines-between-class-members": "warn",
-        "max-len": ["warn", { code: 100 }],
         "max-statements-per-line": "warn",
-        "multiline-comment-style": ["warn", "separate-lines"],
-        "no-mixed-spaces-and-tabs": "warn",
-        "no-multi-spaces": "warn",
         "no-multiple-empty-lines": ["warn", { max: 5 }],
-        "no-tabs": "warn",
-        "no-unused-vars": ["warn", noUnusedVarsOptions],
-        "no-unused-expressions": ["warn", noUnusedExpressionsOptions],
-        "object-curly-spacing": ["warn", "always"],
-        "object-property-newline": ["warn", {
-            allowAllPropertiesOnSameLine: true,
-        }],
+        "arrow-body-style": "warn",
         "one-var": ["warn", "never"],
-        "operator-linebreak": ["warn", "before"],
-        "padding-line-between-statements": "warn",
-        "quotes": ["warn", ...quoteOptions],
-        "rest-spread-spacing": "warn",
-        "semi": "warn",
-        "semi-spacing": "warn",
-        "space-before-function-paren": ["warn", {
-            "anonymous": "always",
-            "named": "never",
-            "asyncArrow": "always",
+
+
+        // Semantic
+        "eqeqeq": ["error", "always", {
+            // `== null` is actually a useful check for `null` and `undefined`
+            // at the same time
+            null: "ignore",
         }],
-        "space-in-parens": "warn",
-        "space-infix-ops": "warn",
-        "space-unary-ops": "warn",
-        "spaced-comment": "warn",
+        "no-void": ["error", { allowAsStatement: true }],
         "no-console": "warn",
-        "no-trailing-spaces": "warn",
+
+        "@typescript-eslint/explicit-member-accessibility": "warn",
+        "@typescript-eslint/member-delimiter-style": "warn",
     },
-    overrides: [{
-        files: ["./*"],
-        env: {
-            node: true,
-        },
-    }, {
-        files: ["./webpack.config.ts"],
-        parser: "@typescript-eslint/parser",
-        extends: ["plugin:@typescript-eslint/recommended"],
-    }, {
-        files: ["src/**/*.ts{,x}"],
-        parser: "@typescript-eslint/parser",
-        parserOptions: {
-            tsconfigRootDir: __dirname,
-            project: "./tsconfig.json",
-        },
-        extends: [
-            "plugin:@typescript-eslint/recommended",
-            "plugin:react/recommended",
-        ],
-        rules: {
-            // Turn off some intrusive rules
-            "implicit-arrow-linebreak": "off",
-            "react/display-name": "off",
-            "react/prop-types": "off",
-            "react/react-in-jsx-scope": "off",
-            "@typescript-eslint/no-empty-function": "off",
-            "@typescript-eslint/no-explicit-any": "off",
 
-            // Turn off base rules overridden by `@typescript-eslint` rules
-            "indent": "off",
-            "lines-between-class-members": "off",
-            "no-unused-vars": "off",
-            "no-unused-expressions": "off",
-            "semi": "off",
-            "no-extra-semi": "off",
-
-            "@typescript-eslint/no-unused-vars": ["warn", noUnusedVarsOptions],
-            "@typescript-eslint/no-unused-expressions": ["warn", noUnusedExpressionsOptions],
-
-            // Make style issues warnings
-            "react/jsx-curly-spacing": ["warn", { children: true }],
-            "@typescript-eslint/brace-style": braceStyle,
-            "@typescript-eslint/comma-spacing": "warn",
-            "@typescript-eslint/explicit-member-accessibility": "warn",
-            "@typescript-eslint/indent": [
-                "warn",
-                4,
-                {
-                    "ignoredNodes": [
-                        "TSUnionType",
-                        "TSTypeAliasDeclaration *",
-                    ],
-                },
-            ],
-            "@typescript-eslint/member-delimiter-style": "warn",
-            "@typescript-eslint/naming-convention": ["warn", {
-                selector: "variable",
-                types: ["function"],
-                format: ["PascalCase", "camelCase"],
-            }],
-            "@typescript-eslint/object-curly-spacing": ["warn", "always"],
-            "@typescript-eslint/quotes": ["warn", ...quoteOptions],
-            "@typescript-eslint/semi": "warn",
-            "@typescript-eslint/no-extra-semi": "warn",
-            "@typescript-eslint/space-before-function-paren": ["warn", {
-                "anonymous": "always",
-                "named": "never",
-                "asyncArrow": "always",
-            }],
-
-            "react/no-unknown-property": ["error", { ignore: ["css"] }],
-        },
-        settings: {
-            react: {
-                version: "detect",
+    overrides: [
+        // Config files can make use of Node stuff.
+        {
+            files: ["./*"],
+            env: {
+                node: true,
             },
         },
-    }],
+        // This TS file is not part of the project.
+        {
+            files: ["./webpack.config.ts"],
+            parserOptions: {
+                project: false,
+            },
+        },
+    ],
+
     ignorePatterns: [
         "node_modules",
         "/build",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
       },
       "devDependencies": {
         "@emotion/babel-plugin": "^11.11.0",
+        "@opencast/eslint-config-ts-react": "^0.1.0",
         "@types/react": "^18.2.6",
         "@types/react-beforeunload": "^2.1.1",
         "@types/react-dom": "^18.2.4",
@@ -2081,6 +2082,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opencast/eslint-config-ts-react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@opencast/eslint-config-ts-react/-/eslint-config-ts-react-0.1.0.tgz",
+      "integrity": "sha512-+GTSxMUZQvT13Noe1+4X3s0hHc9cNxMAXWNYqlDGQ2tO7ygvk1+w7a/HhpRGeDeQxk7EahCn36Z/2stKGVlnPw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^5.59.9"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": ">= 5",
+        "eslint": ">= 8",
+        "eslint-plugin-react": ">= 7",
+        "eslint-plugin-react-hooks": ">= 4"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -2616,14 +2632,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.5.tgz",
-      "integrity": "sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
+      "integrity": "sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
+        "@typescript-eslint/scope-manager": "5.59.11",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/typescript-estree": "5.59.11",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2641,6 +2657,113 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
+      "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
+      "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
+      "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/visitor-keys": "5.59.11",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
+      "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.11",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.59.5",
@@ -10432,6 +10555,15 @@
         "fastq": "^1.6.0"
       }
     },
+    "@opencast/eslint-config-ts-react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@opencast/eslint-config-ts-react/-/eslint-config-ts-react-0.1.0.tgz",
+      "integrity": "sha512-+GTSxMUZQvT13Noe1+4X3s0hHc9cNxMAXWNYqlDGQ2tO7ygvk1+w7a/HhpRGeDeQxk7EahCn36Z/2stKGVlnPw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^5.59.9"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -10810,15 +10942,82 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.5.tgz",
-      "integrity": "sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==",
+      "version": "5.59.11",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.11.tgz",
+      "integrity": "sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
+        "@typescript-eslint/scope-manager": "5.59.11",
+        "@typescript-eslint/types": "5.59.11",
+        "@typescript-eslint/typescript-estree": "5.59.11",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.59.11",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz",
+          "integrity": "sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.59.11",
+            "@typescript-eslint/visitor-keys": "5.59.11"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.59.11",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.11.tgz",
+          "integrity": "sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.59.11",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz",
+          "integrity": "sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.59.11",
+            "@typescript-eslint/visitor-keys": "5.59.11",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.59.11",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz",
+          "integrity": "sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.59.11",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.11.0",
+    "@opencast/eslint-config-ts-react": "^0.1.0",
     "@types/react": "^18.2.6",
     "@types/react-beforeunload": "^2.1.1",
     "@types/react-dom": "^18.2.4",

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,5 +1,5 @@
 declare module "*.yaml" {
-    const value: any;
+    const value: unknown;
     export default value;
 }
 

--- a/frontend/src/rauta.tsx
+++ b/frontend/src/rauta.tsx
@@ -94,7 +94,7 @@ export type RouterLib = {
 };
 
 /** Helper class: a list of listeners */
-class Listeners<F extends (...args: any) => any> {
+class Listeners<F extends (...args: unknown[]) => unknown> {
     private list: { listener: F }[] = [];
 
     /** Pass through the iterable protocol to the inner list */
@@ -174,7 +174,7 @@ export interface RouterControl {
 
 export const makeRouter = <C extends Config, >(config: C): RouterLib => {
     // Helper to log debug messages if `config.debug` is true.
-    const debugLog = (...args: any[]) => {
+    const debugLog = (...args: unknown[]) => {
         if (config.debug) {
             // eslint-disable-next-line no-console
             console.debug("[rauta] ", ...args);

--- a/frontend/src/rauta.tsx
+++ b/frontend/src/rauta.tsx
@@ -257,7 +257,7 @@ export const makeRouter = <C extends Config, >(config: C): RouterLib => {
                 // When navigating to new routes, the scroll position always
                 // starts as 0 (i.e. the very top).
                 context.setActiveRoute({ route: newRoute, initialScroll: 0 });
-                replaceEntry ? replace(href) : push(href);
+                (replaceEntry ? replace : push)(href);
 
                 debugLog(`Setting active route for '${href}' (index ${currentIndex}) `
                     + "to: ", newRoute);

--- a/frontend/src/relay/errors.ts
+++ b/frontend/src/relay/errors.ts
@@ -68,9 +68,11 @@ export class APIError extends Error {
         this.response = response;
         this.errors = this.response.errors.map(e => ({
             message: e.message,
+            /* eslint-disable @typescript-eslint/no-explicit-any */
             path: (e as any).path,
             kind: (e as any).extensions.kind,
             key: (e as any).extensions.key,
+            /* eslint-enable @typescript-eslint/no-explicit-any */
         }));
         this.message = (() => {
             let out = "";

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -83,7 +83,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = props => (
 // For use in block mutations that might have an effect on the realm name.
 // Only used to be included in queries in order to update the store
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-graphql`
+const _frag = graphql`
     fragment EditBlockUpdateRealmNameData on Block {
         realm {
             name,

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -3,6 +3,7 @@ import { match } from "../util";
 import { BREAKPOINT as NAV_BREAKPOINT } from "../layout/Navigation";
 import { ReactNode } from "react";
 import { COLORS } from "../color";
+import { CSSObject } from "@emotion/react";
 
 
 export const SIDE_BOX_BORDER_RADIUS = 8;
@@ -144,7 +145,7 @@ export const focusStyle = ({ width = 2.5, inset = false, offset = 0 }) => ({
 } as const);
 
 /** Returns CSS that makes text longer than `lines` lines to be truncated with `...`. */
-export const ellipsisOverflowCss = (lines: number): Record<string, any> => ({
+export const ellipsisOverflowCss = (lines: number): CSSObject => ({
     overflow: "hidden",
     textOverflow: "ellipsis",
     ...lines === 1

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -164,7 +164,7 @@ export const currentRef = <T>(ref: React.RefObject<T>): T => (
 
 
 // Some utilities to handle the different lifecycle stages of events and series
-type OpencastEntity = { syncedData: any };
+type OpencastEntity = { syncedData: unknown };
 export type SyncedOpencastEntity<T extends OpencastEntity> = T & {
     syncedData: NonNullable<T["syncedData"]>;
 };


### PR DESCRIPTION
We noticed a lot of ESLint duplication (and maybe even worse: differences) between our three very similar-tech-stack projects Editor, Studio and Tobira. So we pulled out most of the config into a separate package. 

This required minimal changes in Tobira, as we already had a pretty strict config.