### PR TITLE
Add additional CI check to make sure files follow basic hygiene rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ env:
   RUSTFLAGS: --deny warnings
 
 jobs:
+  check_basic_hygiene:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: LukasKalbertodt/check-basic-style@v0.1
+      with:
+        files: |
+          **/!(*svg|*.md|*.sql|*.json)
+
   main:
     runs-on: ubuntu-20.04
     services:


### PR DESCRIPTION
I noticed that we don't have a check in place for "trailing newline per file" for example. Some other stuff is already checked by eslint, but this doesn't hurt.