### PR TITLE
Add code to regularly send basic statistics to Opencast for adopter registration

### DIFF
--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -134,6 +134,19 @@ pub(crate) enum AuthMode {
     Opencast,
 }
 
+impl AuthMode {
+    /// Returns the string that has to be specified in the config file to select
+    /// this mode.
+    pub fn label(&self) -> &'static str {
+        match self {
+            AuthMode::None => "none",
+            AuthMode::FullAuthProxy => "full-auth-proxy",
+            AuthMode::LoginProxy => "login-proxy",
+            AuthMode::Opencast => "opencast",
+        }
+    }
+}
+
 /// Information about whether or not, and if so how
 /// someone or something talking to Tobira is authenticated
 #[derive(PartialEq, Eq)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -141,6 +141,7 @@ async fn start_worker(config: Config) -> Result<Never> {
     let mut search_conn = db.get().await?;
     let sync_conn = db.get().await?;
     let db_maintenance_conn = db.get().await?;
+    let stats_conn = db.get().await?;
     let auth_config = config.auth.clone();
 
     tokio::select! {
@@ -151,6 +152,7 @@ async fn start_worker(config: Config) -> Result<Never> {
             res.map(|()| unreachable!("sync task unexpectedly stopped"))
                 .context("error synchronizing with Opencast")
         }
+        never = sync::stats::run_daemon(stats_conn, &config) => { never }
         never = auth::db_maintenance(&db_maintenance_conn, &auth_config) => { never }
     }
 }

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -7,6 +7,7 @@ use crate::{config::Config, db::DbConnection, prelude::*};
 
 pub(crate) mod cmd;
 pub(crate) mod harvest;
+pub(crate) mod stats;
 mod client;
 mod status;
 

--- a/backend/src/sync/stats.rs
+++ b/backend/src/sync/stats.rs
@@ -66,9 +66,9 @@ struct ConfigStats {
     /// Value of `auth.mode`
     auth_mode: &'static str,
     /// Whether `auth.login_link` is set or not.
-    login_link_overwritten: bool,
+    login_link_overridden: bool,
     /// Whether `auth.logout_link` is set or not.
-    logout_link_overwritten: bool,
+    logout_link_overridden: bool,
     /// Value of `auth.pre_auth_external_links`.
     uses_pre_auth: bool,
     /// Whether `theme.logo.small` is set.
@@ -97,8 +97,8 @@ impl Stats {
             config: ConfigStats {
                 download_button_shown: config.general.show_download_button,
                 auth_mode: config.auth.mode.label(),
-                login_link_overwritten: config.auth.login_link.is_some(),
-                logout_link_overwritten: config.auth.logout_link.is_some(),
+                login_link_overridden: config.auth.login_link.is_some(),
+                logout_link_overridden: config.auth.logout_link.is_some(),
                 uses_pre_auth: config.auth.pre_auth_external_links,
                 has_narrow_logo: config.theme.logo.small.is_some(),
             },

--- a/backend/src/sync/stats.rs
+++ b/backend/src/sync/stats.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio_postgres::Row;
+
+use crate::{config::Config, db::DbConnection, prelude::*};
+
+use super::OcClient;
+
+
+/// How often Tobira sends statistics to Opencast.
+const SEND_PERIOD: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// Regularly sends statistical data to Opencast. If the Opencast admin agreed
+/// to sharing basic data as part of adopter registration, this data is sent to
+/// the Opencast server. Otherwise it is not used at all (and only stored in
+/// memory at the Opencast side).
+pub(crate) async fn run_daemon(db: DbConnection, config: &Config) -> ! {
+    // Let the other more important worker processes do stuff first. This is
+    // mainly to have less interleaved output in the log.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let client = OcClient::new(config);
+
+    loop {
+        if let Err(e) = send_stats(&client, &db, config).await {
+            warn!("Failed to send stats for adopter registration to Opencast: {e:?}");
+        }
+        tokio::time::sleep(SEND_PERIOD).await;
+    }
+}
+
+async fn send_stats(client: &OcClient, db: &DbConnection, config: &Config) -> Result<()> {
+    let stats = Stats::gather(db, config).await.context("failed to gather stats")?;
+    let json = serde_json::to_string(&stats).context("failed to serialize stats")?;
+    client.send_stats(json).await?;
+    debug!(
+        "Sent statistics to Opencast (only used for adopter registration, if opted-in). {:#?}",
+        stats,
+    );
+
+    Ok(())
+}
+
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Stats {
+    num_realms: u32,
+    num_blocks: u32,
+    version: VersionStats,
+    config: ConfigStats,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionStats {
+    identifier: String,
+    build_time_utc: &'static str,
+    git_commit_hash: &'static str,
+    git_was_dirty: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigStats {
+    /// Value of `general.show_download_button`.
+    download_button_shown: bool,
+    /// Value of `auth.mode`
+    auth_mode: &'static str,
+    /// Whether `auth.login_link` is set or not.
+    login_link_overwritten: bool,
+    /// Whether `auth.logout_link` is set or not.
+    logout_link_overwritten: bool,
+    /// Value of `auth.pre_auth_external_links`.
+    uses_pre_auth: bool,
+    /// Whether `theme.logo.small` is set.
+    has_narrow_logo: bool,
+}
+
+
+impl Stats {
+    async fn gather(db: &DbConnection, config: &Config) -> Result<Self> {
+        let get_count = |row: Row| -> u32 {
+            row.get::<_, i64>(0).try_into().expect("count does not fit u32")
+        };
+        let num_realms = get_count(db.query_one("select count(*) from realms", &[]).await?);
+        let num_blocks = get_count(db.query_one("select count(*) from blocks", &[]).await?);
+
+
+        Ok(Self {
+            num_realms,
+            num_blocks,
+            version: VersionStats {
+                identifier: crate::version::identifier(),
+                build_time_utc: crate::version::build_time_utc(),
+                git_commit_hash: crate::version::git_commit_hash(),
+                git_was_dirty: crate::version::git_was_dirty(),
+            },
+            config: ConfigStats {
+                download_button_shown: config.general.show_download_button,
+                auth_mode: config.auth.mode.label(),
+                login_link_overwritten: config.auth.login_link.is_some(),
+                logout_link_overwritten: config.auth.logout_link.is_some(),
+                uses_pre_auth: config.auth.pre_auth_external_links,
+                has_narrow_logo: config.theme.logo.small.is_some(),
+            },
+        })
+    }
+}

--- a/backend/src/sync/stats.rs
+++ b/backend/src/sync/stats.rs
@@ -44,7 +44,6 @@ async fn send_stats(client: &OcClient, db: &DbConnection, config: &Config) -> Re
 
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct Stats {
     num_realms: u32,
     num_blocks: u32,
@@ -53,7 +52,6 @@ struct Stats {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct VersionStats {
     identifier: String,
     build_time_utc: &'static str,
@@ -62,7 +60,6 @@ struct VersionStats {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct ConfigStats {
     /// Value of `general.show_download_button`.
     download_button_shown: bool,


### PR DESCRIPTION
Related Opencast PR: https://github.com/opencast/opencast/pull/5040

Still draft as there are open questions and this does not yet work with above PR.

I think the statistics sent here are very basic and don't contain any too sensitive data. And in any case, the data is only sent outside of ones installation if they agreed to sharing basic data as part of the adopter registration. Otherwise it's completely discarded/unused. And sending it from Tobira to Opencast is also no problem as that connection needs to be private anyway, as all Opencast data will go through it. So I don't see how anyone could have a privacy concern regarding this. See the structs at the bottom of `stats.rs` to see what exactly is sent.