### PR TITLE
Change default font of copyable input

### DIFF
--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -84,7 +84,7 @@ const DirectLink: React.FC<Props> = ({ event }) => {
             <CopyableInput
                 label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
                 value={url.href}
-                css={{ width: "100%", fontFamily: "monospace", fontSize: 14 }}
+                css={{ width: "100%", fontSize: 14 }}
             />
         </div>
     );

--- a/frontend/src/routes/manage/Video/TechnicalDetails.tsx
+++ b/frontend/src/routes/manage/Video/TechnicalDetails.tsx
@@ -71,7 +71,7 @@ const OpencastId: React.FC<Props> = ({ event }) => {
         <CopyableInput
             label={t("manage.my-videos.technical-details.copy-oc-id-to-clipboard")}
             value={event.opencastId}
-            css={{ width: 400, fontFamily: "monospace", fontSize: 14 }}
+            css={{ width: 400, fontSize: 14 }}
         />
     </section>;
 };

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -87,6 +87,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
     const copyableInputId = useId();
     const sharedStyle = {
         ...style(false),
+        fontFamily: "monospace",
         width: "100%",
         height: "100%",
         padding: "4px 50px 4px 10px",
@@ -111,7 +112,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
             maxWidth: "100%",
         }} {...rest}>
             <div css={{ position: "absolute", top: 0, right: 0, zIndex: 10 }}>
-                <WithTooltip tooltip={label}>
+                <WithTooltip tooltip={label} css={{ fontFamily: "var(--main-font), sans-serif" }}>
                     <Button
                         aria-label={label}
                         kind="happy"


### PR DESCRIPTION
Changes font to monospace, but uses the regular font for the tooltip of the input.
Closes #880 