### PR TITLE
Fix "redirect after external login"

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -117,6 +117,7 @@ login-page:
   password: Passwort
   bad-credentials: 'Anmeldung fehlgeschlagen: Falsche Anmeldedaten.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
+  already-logged-in: Sie sind bereits angemeldet.
 
 video:
   video: Video

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -114,6 +114,7 @@ login-page:
   password: Password
   bad-credentials: 'Login failed: invalid credentials.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
+  already-logged-in: You are already logged in.
 
 video:
   video: Video

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,7 +3,29 @@ import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import "./i18n";
 import { matchInitialRoute } from "./router";
+import { REDIRECT_STORAGE_KEY } from "./routes/Login";
 
+
+// Potentially redirect to previous page after login.
+//
+// When clicking on the login button, the (then) current page is stored in
+// session storage. If the login button is configured to be a link to some
+// external page, the user is likely redirected to `/~login` from that external
+// login page. In that case, we want to redirect the user to the page they are
+// coming from.
+//
+// We previously had this logic in the `LoginPage` component and redirected in
+// an effect. But this is not the proper tool: we don't want to cause rendering
+// a component to trigger a redirect. In fact, that approach would break in
+// `StrictMode`.
+const redirectTo = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+if (window.location.pathname === "/~login" && redirectTo) {
+    const newUri = new URL(redirectTo, document.baseURI).href;
+    // eslint-disable-next-line no-console
+    console.debug(`Requested login page after login: redirecting to previous page ${newUri}`);
+    window.history.replaceState(null, "", newUri);
+    window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+}
 
 const initialRoute = matchInitialRoute();
 const root = document.createElement("div");

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -5,7 +5,7 @@ import type { PreloadedQuery } from "react-relay";
 
 import { Outer } from "../layout/Root";
 import { loadQuery } from "../relay";
-import { Link, useRouter } from "../router";
+import { Link } from "../router";
 import { LoginQuery } from "./__generated__/LoginQuery.graphql";
 import { Footer } from "../layout/Footer";
 import { PageTitle } from "../layout/header/ui";
@@ -55,21 +55,10 @@ const Login: React.FC<Props> = ({ queryRef }) => {
     useNoindexTag();
     const { t } = useTranslation();
     const { currentUser } = usePreloadedQuery(query, queryRef);
-    const router = useRouter();
     const isLoggedIn = currentUser !== null;
 
-    React.useEffect(() => {
-        if (isLoggedIn) {
-            const redirectTo = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY) ?? "/";
-            window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
-            router.goto(redirectTo, true);
-        }
-    });
-
-    return isLoggedIn
-        // Don't render anything when a redirect is triggered.
-        ? null
-        : <Outer>
+    return (
+        <Outer>
             <Header loginMode />
             <main css={{
                 padding: 16,
@@ -93,7 +82,9 @@ const Login: React.FC<Props> = ({ queryRef }) => {
                                 fontSize: 30,
                             },
                         }}/>
-                        <LoginBox />
+                        {isLoggedIn
+                            ? <Card kind="info">{t("login-page.already-logged-in")}</Card>
+                            : <LoginBox />}
                         <div css={{ marginTop: 12, fontSize: 14, lineHeight: 1 }}>
                             <BackButton />
                         </div>
@@ -101,7 +92,8 @@ const Login: React.FC<Props> = ({ queryRef }) => {
                 </div>
             </main>
             <Footer />
-        </Outer>;
+        </Outer>
+    );
 };
 
 const BackButton: React.FC = () => {


### PR DESCRIPTION
We want to redirect freshly-logged-in users to the page they were coming from. But the previous implementation didn't work. One easy fix was actually to add `[isLoggedIn]` as dependencies to the `useEffect` hook. The problem was that the effect was executed a second time after calling `router.goto` as `router = useRouter()` caused a rerender. And the second time, the session storage was already cleared and thus, `router.goto` was called again, but with `"/"`. Users would always be redirected to the homepage.

Again, this simple specification of `useEffect` dependencies fixed it in production. But with React's `StrictMode` it was still broken as the effect would be executed twice. React says that effects+cleanup should be a noop. So running effect, then cleanup, then effect should result in the exact same state of the world as only running effect once. One could fix it by having some boolean local variable, but that seemed hacky. After reading React docs again, I think triggering this redirect in an effect just seems like the wrong approach.

So I moved all that logic to the very start of `index.tsx`, before the initial route is matched. This works well, as users from external logins would always load that login page "normally" and not via internal router navigation. I'm not 100% happy with this as now the logic is even less localized to `Login.tsx`. But I guess its the best option?

Oh and now the login page renders a "you are already logged in" text in that case. It's not super pretty, but note that users should never be able to see it as there is no internal-router-link to `/~login` anywhere on the page if the user is logged in. The user can still type the path manually, but... oh well, then they see that note :shrug: Seems fine to me.

---

The way I tested this works is by removing/commenting-out the three redirect lines in `<LoginBox>`. Then one can login without any redirection taking place. Then you can just refresh the page (you are still on `/~login`) to test the new code. But I also asked Bern whether they want to test it on their test system, which would be helpful.