### PR TITLE
Close QR-modal on outside click

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -27,7 +27,6 @@ import {
     useForceRerender,
     translatedConfig,
     match,
-    useOnOutsideClick,
     currentRef,
 } from "../util";
 import { unreachable } from "../util/err";
@@ -545,7 +544,6 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const isDark = useColorScheme().scheme === "dark";
     const ref = useRef(null);
     const qrModalRef = useRef<ModalHandle>(null);
-    useOnOutsideClick(ref, () => !qrModalRef.current?.isOpen?.() && setState("closed"));
 
     const isActive = (label: State) => label === state;
 
@@ -696,6 +694,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             arrowSize={12}
             ariaRole="dialog"
             open={state !== "closed"}
+            onClose={() => setState("closed")}
             viewPortMargin={12}
         >
             <FloatingTrigger>

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -622,9 +622,11 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             <HiOutlineQrCode />
             {t("video.share.show-qr-code")}
         </Button>
-        <Modal ref={qrModalRef}
+        <Modal
+            ref={qrModalRef}
             title={t("video.share.title", { title: label })}
             css={{ minWidth: "max-content" }}
+            closeOnOutsideClick
         >
             <div css={{ display: "flex", justifyContent: "center" }}>
                 <QRCodeCanvas

--- a/frontend/src/ui/Floating.tsx
+++ b/frontend/src/ui/Floating.tsx
@@ -94,6 +94,13 @@ type FloatingContainerProps = React.PropsWithChildren<{
      */
     ariaRole?: NonNullable<Parameters<typeof useRole>[1]>["role"];
 
+    /**
+     * Function that is called when the floating element is closed (e.g. via
+     * pressing escape, clicking outside of it, ...). This is mainly useful if
+     * you pass `open` and do the state management yourself.
+     */
+    onClose?: () => void;
+
     className?: string;
     // TODO: inline block?
 } & (
@@ -131,6 +138,7 @@ export const FloatingContainer = React.forwardRef<FloatingHandle, FloatingContai
         borderRadius = 4,
         viewPortMargin = 8,
         ariaRole = "tooltip",
+        onClose = () => {},
         className,
         ...rest
     }, ref) => {
@@ -155,7 +163,14 @@ export const FloatingContainer = React.forwardRef<FloatingHandle, FloatingContai
             context: floatContext,
         } = useFloating({
             open: actualOpen,
-            ...!("open" in rest) && { onOpenChange: setOpen },
+            onOpenChange: open => {
+                if (!("open" in rest)) {
+                    setOpen(open);
+                }
+                if (!open) {
+                    onClose();
+                }
+            },
             placement: idealPlacement,
             whileElementsMounted: autoUpdate,
             middleware: [

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -26,6 +26,7 @@ type ModalProps = {
     title: string;
     closable?: boolean;
     className?: string;
+    closeOnOutsideClick?: boolean;
 };
 
 export type ModalHandle = {
@@ -39,6 +40,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     closable = true,
     children,
     className,
+    closeOnOutsideClick = false,
 }, ref) => {
     const { t } = useTranslation();
     const [isOpen, setOpen] = useState(false);
@@ -61,26 +63,26 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     }, [closable]);
 
     return ReactDOM.createPortal(
-        isOpen && <div
-            {...(closable && { onClick: e => {
-                if (e.target === e.currentTarget) {
-                    setOpen(false);
-                }
-            } })}
-            css={{
-                position: "fixed",
-                top: 0,
-                bottom: 0,
-                left: 0,
-                right: 0,
-                backgroundColor: "rgba(0, 0, 0, 0.8)",
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                zIndex: 10001,
-            }}
-        >
-            <FocusTrap>
+        isOpen && <FocusTrap>
+            <div
+                {...(closable && closeOnOutsideClick && { onClick: e => {
+                    if (e.target === e.currentTarget) {
+                        setOpen(false);
+                    }
+                } })}
+                css={{
+                    position: "fixed",
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    backgroundColor: "rgba(0, 0, 0, 0.8)",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    zIndex: 10001,
+                }}
+            >
                 <div {...{ className }} css={{
                     backgroundColor: COLORS.background,
                     borderRadius: 4,
@@ -112,8 +114,8 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                     </div>
                     <div css={{ padding: 16 }}>{children}</div>
                 </div>
-            </FocusTrap>
-        </div>,
+            </div>
+        </FocusTrap>,
         document.body,
     );
 });


### PR DESCRIPTION
This closes the modal when clicked outside, but keeps the share menu open.
Closes #879 