### PR TITLE
Fix `db clear` by not dropping automatically created array types

### DIFF
--- a/backend/src/db/cmd.rs
+++ b/backend/src/db/cmd.rs
@@ -159,10 +159,13 @@ async fn clear(db: &mut Db, config: &Config, yes: bool) -> Result<()> {
     let sql = "SELECT sequence_name FROM information_schema.sequences";
     let sequences = query_strings(&tx, sql).await.context("failed to query all sequences")?;
 
+    // With `typsubscript = 0` we make sure to not query automatically-created
+    // array types. Attempting to destroy those will fail.
     let sql = "\
         select typname \
         from pg_type \
-        where typnamespace = current_schema()::regnamespace";
+        where typnamespace = current_schema()::regnamespace \
+        and typsubscript = 0";
     let types = query_strings(&tx, sql).await.context("failed to query all types")?;
 
     // Tables


### PR DESCRIPTION
For each type that we create, postgres adds an additional "array" type of that type. Trying to drop that array type fails with:

    ERROR: cannot drop type block_type[] because type block_type requires it
    HINT: You can drop type block_type instead.

Deleting the base type also gets rid of the array type. The filter added in this commit seems to do the trick and should work generally. Related: https://www.postgresql.org/docs/current/catalog-pg-type.html

Note that this error occurs only occasionally, depending on what order the type names are returned from our query. In all my tests, the base types were ordered before the array types, hiding the problem. On a production instance, they were ordered differently, that's how I noticed this bug.