### PR TITLE
Increase dashboad coherence

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -229,7 +229,7 @@ realm:
       currently-none: Sie haben zurzeit keine persönliche Seite.
       heading: Persönliche Seite erstellen
       what-you-can-do: >
-        Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Element anordnen,
+        Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Elemente anordnen,
         um so Inhalte besser präsentieren und teilen zu können.
         Sie können sogar Unterseiten anlegen, um Ihr eigenes kleines Videoportal zu erstellen.
       available-at: 'Ihre Seite wird unter folgendem Link verfügbar sein:'
@@ -294,22 +294,21 @@ upload:
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
 
 manage:
-  management: Verwaltung
   nav:
     dashboard: Übersicht
     my-videos: Meine Videos
 
   dashboard:
     title: Dashboard
-    upload-tile: Hier können Sie einfach Videos von Ihrem Computer hochladen.
+    upload-tile: Hier können Sie Videos von Ihrem Computer hochladen.
     studio-tile-title: Video aufnehmen
     studio-tile-body: >
-      Hier können Sie sehr einfach ein neues Video erstellen, indem Sie Ihr Mikrofon, Ihren Bildschirm
-      und/oder Ihre Webcam aufzeichnen.
-    my-videos-tile: Hier finden Sie alle Ihre Videos und können diese z.B. bearbeiten.
+      Erstellen Sie Videos, indem Sie Ihren Bildschirm, Ihre Webcam
+      und Ihr Mikrofonsignal aufzeichnen.
+    my-videos-tile: Hier finden Sie Ihre Videos und können diese verwalten und bearbeiten.
     user-realm-tile: >
-      Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Element anordnen.
-    manage-pages-tile-title: Seiten verwalten?
+      Auf ihren persönlichen Seiten können Sie Videos, Text und andere Elemente anordnen.
+    manage-pages-tile-title: Seiten verwalten
     manage-pages-tile-body: >
       Um Seiten zu bearbeiten, umzubenennen und zu löschen, navigieren Sie zu der gewünschten
       Seite. Solange Sie angemeldet sind und die benötigten Rechte haben, gibt es dort entsprechende

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -295,7 +295,7 @@ upload:
 
 manage:
   nav:
-    dashboard: Übersicht
+    dashboard: Dashboard
     my-videos: Meine Videos
 
   dashboard:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -287,22 +287,20 @@ upload:
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
 
 manage:
-  management: Management
   nav:
     dashboard: Dashboard
     my-videos: My videos
 
   dashboard:
-    title: Management Dashboard
+    title: Dashboard
     upload-tile: Here you can upload a new video from your computer.
     studio-tile-title: Record video
     studio-tile-body: >
-      Here you can easily create a new video by recording your microphone, screen and/or
-      webcam.
-    my-videos-tile: Here you can view and edit all your videos.
+      Create videos by recording your screen, webcam and microphone.
+    my-videos-tile: Here you can view and edit your videos.
     user-realm-tile: >
-      On your personal page, you can freely arrange videos, text, and other elements.
-    manage-pages-tile-title: Manage pages?
+      On your personal pages, you can freely arrange videos, text, and other elements.
+    manage-pages-tile-title: Manage pages
     manage-pages-tile-body: >
       To rename, modify, and delete pages, navigate to the page in question. If you
       are logged in and have the necessary permissions, page management buttons will appear.

--- a/frontend/src/layout/Burger.tsx
+++ b/frontend/src/layout/Burger.tsx
@@ -39,7 +39,7 @@ export const BurgerMenu: React.FC<BurgerMenuProps> = ({ hide, items }) => (
                 borderRadius: 4,
                 margin: 8,
                 borderBottom: "none",
-                "a, span": {
+                "a, span, button": {
                     padding: 16,
                     borderRadius: 4,
                 },

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -207,7 +207,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
             />,
             keepOpenAfterClick: true,
             children: t("manage.dashboard.studio-tile-title"),
-            css: indent,
+            css: { ...indent, width: "100%" },
         }] : [],
 
         // Logout button

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -4,7 +4,7 @@ import { graphql, loadQuery, useMutation } from "react-relay/hooks";
 import type { RealmQuery, RealmQuery$data } from "./__generated__/RealmQuery.graphql";
 import { useTranslation } from "react-i18next";
 import { FiEdit, FiInfo, FiPlusCircle, FiSettings, FiSunrise } from "react-icons/fi";
-import { WithTooltip } from "@opencast/appkit";
+import { WithTooltip, screenWidthAtMost } from "@opencast/appkit";
 
 import { environment as relayEnv } from "../relay";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
@@ -27,6 +27,8 @@ import { Spinner } from "../ui/Spinner";
 import { useRouter } from "../router";
 import { COLORS } from "../color";
 import { useMenu } from "../layout/MenuState";
+import { ManageNav } from "./manage";
+import { BREAKPOINT as NAV_BREAKPOINT } from "../layout/Navigation";
 
 
 // eslint-disable-next-line @typescript-eslint/quotes
@@ -91,7 +93,7 @@ export const RealmRoute = makeRoute(url => {
             {...{ query, queryRef }}
             nav={data => {
                 if (!data.realm) {
-                    return [];
+                    return <ManageNav active={realmPath as `/@${string}`} />;
                 }
 
                 const mainNav = <Nav key="nav" fragRef={data.realm} />;
@@ -253,10 +255,11 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
     return <>
         <Breadcrumbs path={[]} tail={<i>{t("realm.user-realm.create.heading")}</i>} />
         <div css={{
-            width: 500,
+            width: "80ch",
             maxWidth: "100%",
-            margin: "0 auto",
-            textAlign: "center",
+            [screenWidthAtMost(NAV_BREAKPOINT)]: {
+                textAlign: "center",
+            },
             "> h1, > p": {
                 textAlign: "left",
                 margin: "16px 0",
@@ -275,7 +278,7 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
             <h1>{t("realm.user-realm.create.heading")}</h1>
             <p>{t("realm.user-realm.create.what-you-can-do")}</p>
             <p>{t("realm.user-realm.create.available-at")}</p>
-            <code>{window.location.origin + realmPath}</code>
+            <code css={{ textAlign: "center" }}>{window.location.origin + realmPath}</code>
             <p>{t("realm.user-realm.create.find-and-delete")}</p>
             <Button kind="happy"css={{ marginTop: 32 }} onClick={onSubmit}>
                 {t("realm.user-realm.create.button")}

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -72,7 +72,7 @@ const Upload: React.FC = () => {
             flexDirection: "column",
         }}>
             <Breadcrumbs
-                path={[{ label: t("manage.management"), link: "/~manage" }]}
+                path={[{ label: t("user.manage-content"), link: "/~manage" }]}
                 tail={t("upload.title")}
             />
             <PageTitle title={t("upload.title")} />

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -29,7 +29,7 @@ const Page: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
 
     const breadcrumbs = [
-        { label: t("manage.management"), link: "/~manage" },
+        { label: t("user.manage-content"), link: "/~manage" },
         { label: t("manage.my-videos.title"), link: "/~manage/videos" },
     ];
 

--- a/frontend/src/routes/manage/Video/TechnicalDetails.tsx
+++ b/frontend/src/routes/manage/Video/TechnicalDetails.tsx
@@ -33,7 +33,7 @@ const Page: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
 
     const breadcrumbs = [
-        { label: t("manage.management"), link: "/~manage" },
+        { label: t("user.manage-content"), link: "/~manage" },
         { label: t("manage.my-videos.title"), link: "/~manage/videos" },
         { label: event.title, link: `/~manage/videos/${event.id.substring(2)}` },
     ];

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -117,7 +117,7 @@ const ManageVideos: React.FC<Props> = ({ connection, vars }) => {
             height: "100%",
         }}>
             <Breadcrumbs
-                path={[{ label: t("manage.management"), link: "/~manage" }]}
+                path={[{ label: t("user.manage-content"), link: "/~manage" }]}
                 tail={title}
             />
             <PageTitle title={title} css={{ marginBottom: 32 }}/>

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -17,7 +17,6 @@ import { ExternalLink } from "../../relay/auth";
 import {
     manageDashboardQuery as ManageDashboardQuery,
 } from "./__generated__/manageDashboardQuery.graphql";
-import { css } from "@emotion/react";
 import { COLORS } from "../../color";
 import { useMenu } from "../../layout/MenuState";
 

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { FiFilm, FiUpload, FiVideo } from "react-icons/fi";
+import { FiExternalLink, FiFilm, FiUpload, FiVideo } from "react-icons/fi";
 import { HiOutlineFire, HiOutlineTemplate } from "react-icons/hi";
 import { graphql } from "react-relay";
 import { useColorScheme } from "@opencast/appkit";
@@ -9,7 +9,7 @@ import { RootLoader } from "../../layout/Root";
 import { makeRoute } from "../../rauta";
 import { loadQuery } from "../../relay";
 import { Link } from "../../router";
-import { LinkList, LinkWithIcon, darkModeBoxShadow } from "../../ui";
+import { LinkList, LinkWithIcon, darkModeBoxShadow, linkWithIconStyle } from "../../ui";
 import { NotAuthorized } from "../../ui/error";
 import { isRealUser, useUser } from "../../User";
 import { Breadcrumbs } from "../../ui/Breadcrumbs";
@@ -126,28 +126,34 @@ const Manage: React.FC = () => {
                 {t("manage.dashboard.studio-tile-body")}
             </ExternalLink>}
         </div>
-        {/* <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
+        <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
             <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
             {t("manage.dashboard.manage-pages-tile-body")}
-        </div> */}
+        </div>
     </>;
 };
 
 
 type ManageNavProps = {
-    active?: "/~manage" | "/~manage/videos" | "/~manage/upload";
+    active?: "/~manage" | "/~manage/videos" | "/~manage/upload" | `/@${string}`;
 };
 
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const { t } = useTranslation();
     const user = useUser();
     const menu = useMenu();
+    const isDark = useColorScheme().scheme === "dark";
 
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         ["/~manage", t("manage.nav.dashboard"), <HiOutlineTemplate />],
         ["/~manage/videos", t("manage.nav.my-videos"), <FiFilm />],
     ];
+    if (isRealUser(user) && user.canCreateUserRealm) {
+        entries.splice(
+            1, 0, [`/@${user.username}`, t("realm.user-realm.my-page"), <HiOutlineFire />]
+        );
+    }
     if (isRealUser(user) && user.canUpload) {
         entries.push(["/~manage/upload", t("upload.title"), <FiUpload />]);
     }
@@ -165,6 +171,29 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
             {label}
         </LinkWithIcon>
     ));
+
+    if (isRealUser(user) && user.canUseStudio) {
+        items.push(
+            <ExternalLink
+                service="STUDIO"
+                params={{ "return.target": new URL(document.location.href) }}
+                fallback="link"
+                css={{
+                    backgroundColor: "inherit",
+                    border: "none",
+                    color: COLORS.primary0,
+                    cursor: "pointer",
+                    width: "100%",
+                    ...linkWithIconStyle(isDark, "left"),
+                    ":hover, :focus-visible": { color: isDark ? COLORS.primary2 : COLORS.primary1 },
+                }}
+            >
+                <FiVideo />
+                {t("manage.dashboard.studio-tile-title")}
+                <FiExternalLink size={18} css={{ marginLeft: 4 }}/>
+            </ExternalLink>
+        );
+    }
 
     return <LinkList items={items} />;
 };

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -8,8 +8,7 @@ import { useColorScheme } from "@opencast/appkit";
 import { RootLoader } from "../../layout/Root";
 import { makeRoute } from "../../rauta";
 import { loadQuery } from "../../relay";
-import { Link } from "../../router";
-import { LinkList, LinkWithIcon, darkModeBoxShadow, linkWithIconStyle } from "../../ui";
+import { LinkList, LinkWithIcon, linkWithIconStyle } from "../../ui";
 import { NotAuthorized } from "../../ui/error";
 import { isRealUser, useUser } from "../../User";
 import { Breadcrumbs } from "../../ui/Breadcrumbs";
@@ -50,82 +49,14 @@ const query = graphql`
 
 const Manage: React.FC = () => {
     const { t } = useTranslation();
-    const isDark = useColorScheme().scheme === "dark";
     const user = useUser();
     if (!isRealUser(user)) {
         return <NotAuthorized />;
     }
 
-    const gridTile = css({
-        borderRadius: 4,
-        border: `1px solid ${COLORS.neutral15}`,
-        backgroundColor: isDark ? COLORS.neutral10 : COLORS.neutral10,
-        padding: "8px 16px 16px 16px",
-        fontSize: 14,
-        color: COLORS.neutral90,
-        textAlign: "left",
-        textDecoration: "none",
-        "&:is(button, a)": {
-            "&:hover, &:focus": {
-                color: COLORS.neutral90,
-                borderColor: COLORS.neutral25,
-                ...!isDark && { boxShadow: `1px 1px 5px ${COLORS.neutral15}` },
-                cursor: "pointer",
-            },
-        },
-        position: "relative",
-        "& > svg:first-of-type": {
-            position: "absolute",
-            top: 8,
-            right: 8,
-            color: COLORS.primary0,
-            fontSize: 22,
-        },
-        "& > h2": {
-            fontSize: 18,
-            marginBottom: 16,
-        },
-        ...isDark && darkModeBoxShadow,
-    });
-
-    const studioReturnUrl = new URL(document.location.href);
     return <>
         <Breadcrumbs path={[]} tail={t("user.manage-content")} />
         <PageTitle title={t("manage.dashboard.title")} />
-        <div css={{
-            display: "grid",
-            width: 950,
-            maxWidth: "100%",
-            margin: "32px 0",
-            gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
-            gap: 24,
-        }}>
-            {user.canCreateUserRealm && <Link to={`/@${user.username}`} css={gridTile}>
-                <HiOutlineFire />
-                <h2>{t("realm.user-realm.my-page")}</h2>
-                {t("manage.dashboard.user-realm-tile")}
-            </Link>}
-            <Link to="/~manage/videos" css={gridTile}>
-                <FiFilm />
-                <h2>{t("manage.my-videos.title")}</h2>
-                {t("manage.dashboard.my-videos-tile")}
-            </Link>
-            {user.canUpload && <Link to="/~manage/upload" css={gridTile}>
-                <FiUpload />
-                <h2>{t("upload.title")}</h2>
-                {t("manage.dashboard.upload-tile")}
-            </Link>}
-            {user.canUseStudio && <ExternalLink
-                service={"STUDIO"}
-                params={{ "return.target": studioReturnUrl }}
-                fallback="link"
-                css={gridTile}
-            >
-                <FiVideo />
-                <h2>{t("manage.dashboard.studio-tile-title")}</h2>
-                {t("manage.dashboard.studio-tile-body")}
-            </ExternalLink>}
-        </div>
         <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
             <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
             {t("manage.dashboard.manage-pages-tile-body")}

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -90,7 +90,7 @@ const Manage: React.FC = () => {
 
     const studioReturnUrl = new URL(document.location.href);
     return <>
-        <Breadcrumbs path={[]} tail={t("manage.management")} />
+        <Breadcrumbs path={[]} tail={t("user.manage-content")} />
         <PageTitle title={t("manage.dashboard.title")} />
         <div css={{
             display: "grid",
@@ -126,10 +126,10 @@ const Manage: React.FC = () => {
                 {t("manage.dashboard.studio-tile-body")}
             </ExternalLink>}
         </div>
-        <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
+        {/* <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
             <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
             {t("manage.dashboard.manage-pages-tile-body")}
-        </div>
+        </div> */}
     </>;
 };
 

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -120,7 +120,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
             >
                 <FiVideo />
                 {t("manage.dashboard.studio-tile-title")}
-                <FiExternalLink size={18} css={{ marginLeft: 4 }}/>
+                <FiExternalLink size={18} css={{ marginLeft: 4 }} />
             </ExternalLink>
         );
     }

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -26,28 +26,31 @@ type LinkListProps = {
 };
 
 /** A box with light grey background containing a list of items */
-export const LinkList: React.FC<LinkListProps> = ({ items, ...rest }) => (
-    <ul
+export const LinkList: React.FC<LinkListProps> = ({ items, ...rest }) => {
+    const itemStyle = {
+        backgroundColor: COLORS.neutral10,
+        borderBottom: `2px solid ${COLORS.neutral05}`,
+        "&:last-of-type": { borderBottom: "none" },
+        "& > a, & > span, & > form > button": {
+            display: "flex",
+            padding: "10px 16px",
+        },
+    };
+
+    return <ul
         css={{
             listStyle: "none",
             margin: 0,
             padding: 0,
-            "& a": {
+            "& a, & form button": {
                 ...focusStyle({ inset: true }),
                 ...useColorScheme().scheme === "dark" && { color: COLORS.primary1 },
             },
-            "& > li": {
-                backgroundColor: COLORS.neutral10,
-                borderBottom: `2px solid ${COLORS.neutral05}`,
-                "&:last-of-type": { borderBottom: "none" },
-                "& > *": {
-                    display: "flex",
-                    padding: "10px 16px",
-                },
-            },
             [screenWidthAbove(NAV_BREAKPOINT)]: {
-                "& > li:last-child > a": {
-                    borderRadius: `0 0 ${SIDE_BOX_BORDER_RADIUS}px ${SIDE_BOX_BORDER_RADIUS}px`,
+                "& > li:last-child": {
+                    "> a, > form button": {
+                        borderRadius: `0 0 ${SIDE_BOX_BORDER_RADIUS}px ${SIDE_BOX_BORDER_RADIUS}px`,
+                    },
                 },
                 "&:first-child > li:first-child > a": {
                     borderRadius: `${SIDE_BOX_BORDER_RADIUS}px ${SIDE_BOX_BORDER_RADIUS}px 0 0`,
@@ -56,40 +59,20 @@ export const LinkList: React.FC<LinkListProps> = ({ items, ...rest }) => (
         }}
         {...rest}
     >
-        {items.map((child, i) => <li key={i}>{child}</li>)}
-    </ul>
-);
-
-
-
-type LinkWithIconProps = {
-    to: string;
-    iconPos: "left" | "right";
-    active?: boolean;
-    className?: string;
-    children: ReactNode;
-    close?: () => void;
+        {items.map((child, i) => <li css={itemStyle} key={i}>{child}</li>)}
+    </ul>;
 };
 
-/** A link designed for `LinkList`. Has an icon on the left or right side. */
-export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
-    to,
-    iconPos,
-    children,
-    active = false,
-    close,
-    ...rest
-}) => {
-    const isDark = useColorScheme().scheme === "dark";
-    const TRANSITION_DURATION = "0.1s";
 
+export const linkWithIconStyle = (isDark: boolean, iconPos: "left" | "right", active?: boolean) => {
+    const TRANSITION_DURATION = "0.1s";
     const hoverActiveStyle = {
         transitionDuration: "0s",
         backgroundColor: COLORS.neutral20,
         ...isDark && { color: COLORS.primary2 },
     };
 
-    const style = {
+    return {
         display: "flex",
         justifyContent: match(iconPos, {
             "left": () => "flex-start",
@@ -114,6 +97,28 @@ export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
             "&": hoverActiveStyle,
         },
     };
+};
+
+type LinkWithIconProps = {
+    to: string;
+    iconPos: "left" | "right";
+    active?: boolean;
+    className?: string;
+    children: ReactNode;
+    close?: () => void;
+};
+
+/** A link designed for `LinkList`. Has an icon on the left or right side. */
+export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
+    to,
+    iconPos,
+    children,
+    active = false,
+    close,
+    ...rest
+}) => {
+    const isDark = useColorScheme().scheme === "dark";
+    const style = linkWithIconStyle(isDark, iconPos, active);
 
     return active
         ? <span css={style} aria-current="page" {...rest}>{children}</span>


### PR DESCRIPTION
Following the discussion in #808, this is a proposal as to how a more coherent version of the dashboard and management pages could look.

Things that were adjusted:
- Dashboard item descriptions (I tried to find a compromise between the discussed suggestions)
- "Manage pages?" text was removed (there's still the question if and where that text should be shown instead. @oas777  and @dagraf suggested moving this to the user page instead and I think this makes sense - perhaps we could add this to the info tooltip)
- The navigation for the "dashboard", "my videos" and "upload" pages were removed. This is a little controversial but I do agree with the points from #808 (i.e. it's somewhat confusing to not have every item from the actual dashboard page present, and navigation is redundant as there are breadcrumbs as well as the user menu which basically fill the same function)

Still missing but not forgotton:
- updated icon for the "my page" links.

This all is of course still subject to change, but maybe this PR-deployment can give us a better base for further discussions.