### PR TITLE
Adjust grey tones (add new ones and change brightness values)

### DIFF
--- a/backend/src/config/color.rs
+++ b/backend/src/config/color.rs
@@ -87,14 +87,14 @@ impl ColorConfig {
         //
         // Regarding the minimum of 35: We have two variations, with one being
         // having 24 less brightness. So with 35 starting brightness, that only
-        // leaves 11, which is quite dim. The color should still be noticable
+        // leaves 11, which is quite dim. The color should still be noticeable
         // there.
         //
-        // Regarding the maximum: We want to place this color on our grey1
-        // background, which has 95.6% brightness. The WCAG contrast between
+        // Regarding the maximum: We want to place this color on our neutral15
+        // background, which has 94.3% brightness. The WCAG contrast between
         // two colors only depend on the `l` channel, i.e. the perceived
         // lightness (well, there are differences and rounding errors, but it's
-        // not relevant here). For a contrast ratio of 4.5:1 to the grey1
+        // not relevant here). For a contrast ratio of 4.5:1 to the neutral15
         // background, a brightness of at most 46.5 is required.
         let primary = Lch::from_color(self.primary.0.into_format::<f32>());
         if primary.l < 35.0 || primary.l > 46.5 {
@@ -185,7 +185,7 @@ impl ColorConfig {
             // definitions for "contrast", there are multiple way to do this.
             // We could say we want to maximize the WCAG contrast, but:
             // - This is a bit more involved.
-            // - The WCAG contrast defintion is likely changing soon to address
+            // - The WCAG contrast definition is likely changing soon to address
             //   new research in perceived contrast.
             // - In fact, the current WCAG contrast formula is not based
             //   on "perceived lightness" of a color. See [1].

--- a/backend/src/config/color.rs
+++ b/backend/src/config/color.rs
@@ -258,32 +258,33 @@ impl ColorConfig {
         }
 
 
-        // Grey
+        // Neutral colors (05 = background, 90 = foreground)
         let base_grey = Lch::from_color(self.grey50.0.into_format::<f32>());
-        add(&mut light, "grey0", Lch { l: 97.3, ..base_grey });
-        add(&mut light, "grey1", Lch { l: 95.6, ..base_grey });
-        add(&mut light, "grey2", Lch { l: 92.9, ..base_grey });
-        add(&mut light, "grey3", Lch { l: 87.5, ..base_grey });
-        add(&mut light, "grey4", Lch { l: 82.0, ..base_grey });
-        add(&mut light, "grey5", Lch { l: 68.0, ..base_grey });
-        add(&mut light, "grey6", Lch { l: 43.2, ..base_grey });
-        add(&mut light, "grey7", Lch { l: 21.2, ..base_grey });
+        add(&mut light, "neutral05", Lch { l: 99.7, ..base_grey });
+        add(&mut light, "neutral10", Lch { l: 95.9, ..base_grey });
+        add(&mut light, "neutral20", Lch { l: 92.0, ..base_grey });
+        add(&mut light, "neutral25", Lch { l: 88.0, ..base_grey });
+        add(&mut light, "neutral30", Lch { l: 83.9, ..base_grey });
+        add(&mut light, "neutral35", Lch { l: 78.0, ..base_grey });
+        add(&mut light, "neutral40", Lch { l: 67.0, ..base_grey });
+        add(&mut light, "neutral50", Lch { l: 50.0, ..base_grey });
+        add(&mut light, "neutral60", Lch { l: 37.0, ..base_grey });
+        add(&mut light, "neutral70", Lch { l: 27.0, ..base_grey });
+        add(&mut light, "neutral80", Lch { l: 17.0, ..base_grey });
+        add(&mut light, "neutral90", Lch { l: 8.0, ..base_grey });
 
-        add(&mut dark, "grey0", Lch { l: 10.7, ..base_grey });
-        add(&mut dark, "grey1", Lch { l: 12.5, ..base_grey });
-        add(&mut dark, "grey2", Lch { l: 15.0, ..base_grey });
-        add(&mut dark, "grey3", Lch { l: 18.2, ..base_grey });
-        add(&mut dark, "grey4", Lch { l: 24.0, ..base_grey });
-        add(&mut dark, "grey5", Lch { l: 36.0, ..base_grey });
-        add(&mut dark, "grey6", Lch { l: 60.0, ..base_grey });
-        add(&mut dark, "grey7", Lch { l: 68.0, ..base_grey });
-
-
-        // Foreground & background
-        add(&mut light, "background", Lch::new(100.0, 0.0, 0.0));
-        add(&mut light, "foreground", Lch::new(0.0, 0.0, 0.0));
-        add(&mut dark, "background", Lch { l: 7.7, ..base_grey });
-        add(&mut dark, "foreground", Lch::new(79.0, 0.0, 0.0));
+        add(&mut dark, "neutral05", Lch { l: 7.7, ..base_grey });
+        add(&mut dark, "neutral10", Lch { l: 11.5, ..base_grey });
+        add(&mut dark, "neutral20", Lch { l: 15.3, ..base_grey });
+        add(&mut dark, "neutral25", Lch { l: 19.1, ..base_grey });
+        add(&mut dark, "neutral30", Lch { l: 22.9, ..base_grey });
+        add(&mut dark, "neutral35", Lch { l: 26.7, ..base_grey });
+        add(&mut dark, "neutral40", Lch { l: 32.7, ..base_grey });
+        add(&mut dark, "neutral50", Lch { l: 43.4, ..base_grey });
+        add(&mut dark, "neutral60", Lch { l: 56.0, ..base_grey });
+        add(&mut dark, "neutral70", Lch { l: 62.0, ..base_grey });
+        add(&mut dark, "neutral80", Lch { l: 68.0, ..base_grey });
+        add(&mut dark, "neutral90", Lch { l: 79.0, ..base_grey });
 
         (light, dark)
     }

--- a/frontend/src/color.tsx
+++ b/frontend/src/color.tsx
@@ -26,17 +26,17 @@ export const COLORS = {
     happy2: "var(--color-happy2)",
     happy2BwInverted: "var(--color-happy2-bw-inverted)",
 
-    grey0: "var(--color-grey0)",
-    grey1: "var(--color-grey1)",
-    grey2: "var(--color-grey2)",
-    grey3: "var(--color-grey3)",
-    grey4: "var(--color-grey4)",
-    grey5: "var(--color-grey5)",
-    grey6: "var(--color-grey6)",
-    grey7: "var(--color-grey7)",
+    grey0: "var(--color-neutral10)",
+    grey1: "var(--color-neutral10)",
+    grey2: "var(--color-neutral20)",
+    grey3: "var(--color-neutral25)",
+    grey4: "var(--color-neutral30)",
+    grey5: "var(--color-neutral40)",
+    grey6: "var(--color-neutral60)",
+    grey7: "var(--color-neutral80)",
 
-    background: "var(--color-background)",
-    foreground: "var(--color-foreground)",
+    background: "var(--color-neutral05)",
+    foreground: "var(--color-neutral90)",
 
     // Additional aliases for colors set by the backend.
     focus: "var(--color-primary1)",


### PR DESCRIPTION
This is in an attempt to unify grey tones across all our apps. I think this new 12 tone palette is a good, actually, given all the constraints we had and properties we wanted to optimize for. 

Short recap: Tobira organically developed some grey tones during development; then Lisa's suggested a design for editor, studio and Tobira, which also had a palette of grey tones. Of course, those two sets of greys were not the same. So we decided to unify it and once and for all just set a fixed set of grey tones for these three applications, and for our applications in the future. This set shouldn't have too many colors, shouldn't have too few, should be close enough to Lisa's set so that it's easy looking up colors from the Figma, should be close to Tobira's set so that Tobira still works.

I decided for the values you see in the PR's diff. Here is a visualization of the brighter half of the light mode values:

![image](https://github.com/elan-ev/tobira/assets/7419664/51932d18-9250-4f63-b8a5-e9e35a6acf89)

Note how Tobiras grey0 and grey1 both map to neutral10. Both colors were never used next to one another (the contrast would be way too low). And I think the distinction there was really not necessary. So I think that's totally fine and even good that we have one tone fewer in Tobira!

Regarding naming: the PR as is uses the name of the closest Lisa grey. This has the advantage that if we check the designs in Figma, and we see an element with neutral200, we can just use our neutral20 color and get almost the same value, i.e. no need to think about anything. The disadvantage is that the numbers do not reflect brightness values at all; and we have no n15. I would much prefer the alternative naming shown in the image above, which would change the name of four colors. That way, we have n05, n10, n15, n20, n25, n30 and then we start with a step size of 10. That's much better than just randomly having n25 and n35, but no n15. Also, the brightness difference in the alternative names between n05, n10, n15, n20, n25, and n30 is almost constant (only increases slowly in one direction). And then the distance between n30, n40, n50 ... n90 is also fairly constant again. But the disadvantage: looking at Figma, seeing neutral200 or neutral300, those wouldn't map to neutral20 or neutral30 anymore, but to neutral15 and neutral25 respectively. 

I also adjusted the dark mode values a bit such that they have more regular step sizes. The most notable change is that the series-block background got a bit darker. I don't mind that and might actually prefer it? But let me know what you think.

---

(Once everyone is happy with the colors, I will also refactor the frontend so that the fields of the `COLORS` constant are also called `neutralXX`.)