### PR TITLE
Check upload permission for upload route and "upload" nav item

### DIFF
--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -132,7 +132,7 @@ const UploadMain: React.FC = () => {
 
     // Get user info
     const user = useUser();
-    if (!isRealUser(user)) {
+    if (!isRealUser(user) || !user.canUpload) {
         // TODO: if not logged in, suggest doing so
         return <div css={{ textAlign: "center" }}>
             <ErrorBox>{t("upload.not-authorized")}</ErrorBox>

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -138,13 +138,16 @@ type ManageNavProps = {
 
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const { t } = useTranslation();
+    const user = useUser();
 
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         ["/~manage", t("manage.nav.dashboard"), <HiOutlineTemplate />],
         ["/~manage/videos", t("manage.nav.my-videos"), <FiFilm />],
-        ["/~manage/upload", t("upload.title"), <FiUpload />],
     ];
+    if (isRealUser(user) && user.canUpload) {
+        entries.push(["/~manage/upload", t("upload.title"), <FiUpload />]);
+    }
     /* eslint-enable react/jsx-key */
 
     const items = entries.map(([path, label, icon]) => (


### PR DESCRIPTION
This PR fixes the problem that Jose sees the upload menu entry and can access the upload form without having the appropriate role.

![grafik](https://github.com/elan-ev/tobira/assets/35195803/c744dd76-f323-4859-9f8b-ca4706bab3de)

Expected:
![grafik](https://github.com/elan-ev/tobira/assets/35195803/79cb054a-7486-4a67-b4a8-57c9d3a7fde2)
