### PR TITLE
Reduce log noise when the `/tobira/stats` endpoint does not exist in OC

### DIFF
--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -110,19 +110,14 @@ impl OcClient {
     }
 
     /// Sends the given serialized JSON to the `/stats` endpoint in Opencast.
-    pub async fn send_stats(&self, stats: String) -> Result<()> {
+    pub async fn send_stats(&self, stats: String) -> Result<Response<Body>> {
         let req = self.req_builder(Self::STATS_PATH)
             .method(http::Method::POST)
             .header(http::header::CONTENT_TYPE, "application/json")
             .body(stats.into())
             .expect("failed to build request");
 
-        let res = self.http_client.request(req).await?;
-        if !res.status().is_success() {
-            bail!("Unexpected non 2xx status returned by Opencast. Response: {res:#?}");
-        }
-
-        Ok(())
+        self.http_client.request(req).await.map_err(Into::into)
     }
 
     fn build_req(&self, path_and_query: &str) -> (Uri, Request<Body>) {


### PR DESCRIPTION
Currently a whole error with backtrace is printed, which is not very useful. A simple warning for the common case of the endpoint not existing seems better.

For reference this is currently printed into the log every 24h:

<details>

```
2023-08-03 09:01:09.671 WARN  tobira::sync::stats >  Failed to send stats for adopter registration to Opencast: Unexpected non 2xx status returned by Opencast. Response: Response {
                                                  >      status: 404,
                                                  >      version: HTTP/2.0,
                                                  >      headers: {
                                                  >          "server": "nginx",
                                                  >          "date": "Thu, 03 Aug 2023 07:01:09 GMT",
                                                  >          "content-type": "text/plain",
                                                  >          "content-length": "37",
                                                  >          "set-cookie": "JSESSIONID=node0esv5cly1zb3w7f4atysg7i262711941.node0; Path=/; HTTPOnly; Secure; SameSite=none; HttpOnly",
                                                  >          "expires": "Thu, 01 Jan 1970 00:00:00 GMT",
                                                  >          "access-control-allow-methods": "GET, POST, OPTIONS",
                                                  >          "access-control-allow-headers": "Origin,Content-Type,Accept,Authorization",
                                                  >      },
                                                  >      body: Body(
                                                  >          Streaming,
                                                  >      ),
                                                  >  }
                                                  >  
                                                  >  Stack backtrace:
                                                  >     0: anyhow::__private::format_err
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.71/src/lib.rs:672:13
                                                  >        tobira::sync::client::OcClient::send_stats::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/sync/client.rs:122:13
                                                  >        tobira::sync::stats::send_stats::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/sync/stats.rs:36:28
                                                  >        tobira::sync::stats::run_daemon::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/sync/stats.rs:26:57
                                                  >        tobira::start_worker::{{closure}}::{{closure}}
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/macros/select.rs:524:49
                                                  >        <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/future/poll_fn.rs:58:9
                                                  >        tobira::start_worker::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/main.rs:147:5
                                                  >        tobira::run::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/main.rs:104:33
                                                  >     1: tobira::main::{{closure}}
                                                  >               at /home/runner/work/tobira/tobira/backend/src/main.rs:32:26
                                                  >     2: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/park.rs:283:63
                                                  >        tokio::runtime::coop::with_budget
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/coop.rs:107:5
                                                  >        tokio::runtime::coop::budget
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/coop.rs:73:5
                                                  >        tokio::runtime::park::CachedParkThread::block_on
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/park.rs:283:31
                                                  >        tokio::runtime::context::BlockingRegionGuard::block_on
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/context.rs:315:13
                                                  >        tokio::runtime::scheduler::multi_thread::MultiThread::block_on
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/scheduler/multi_thread/mod.rs:66:9
                                                  >        tokio::runtime::runtime::Runtime::block_on
                                                  >               at /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.28.1/src/runtime/runtime.rs:304:45
                                                  >        tobira::main
                                                  >               at /home/runner/work/tobira/tobira/backend/src/main.rs:32:5
                                                  >     3: core::ops::function::FnOnce::call_once
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:250:5
                                                  >        std::sys_common::backtrace::__rust_begin_short_backtrace
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/sys_common/backtrace.rs:134:18
                                                  >     4: std::rt::lang_start::{{closure}}
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/rt.rs:166:18
                                                  >     5: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:287:13
                                                  >        std::panicking::try::do_call
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:487:40
                                                  >        std::panicking::try
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:451:19
                                                  >        std::panic::catch_unwind
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panic.rs:140:14
                                                  >        std::rt::lang_start_internal::{{closure}}
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/rt.rs:148:48
                                                  >        std::panicking::try::do_call
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:487:40
                                                  >        std::panicking::try
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:451:19
                                                  >        std::panic::catch_unwind
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panic.rs:140:14
                                                  >        std::rt::lang_start_internal
                                                  >               at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/rt.rs:148:20
                                                  >     6: main
                                                  >     7: __libc_start_main
                                                  >     8: _start
```

</details>