### PR TITLE
Change debug info to "line-tables-only"

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -82,7 +82,7 @@ built = { version = "0.6", features = ["chrono", "git2"] }
 # Codegen options
 
 [profile.release]
-debug = 1
+debug = "line-tables-only"
 codegen-units = 1
 lto = "thin"
 

--- a/util/scripts/check-system.sh
+++ b/util/scripts/check-system.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MIN_RUST_VERSION="1.65.0"
+MIN_RUST_VERSION="1.71.0"
 MIN_NPM_VERSION="7.0"
 
 has_command() {


### PR DESCRIPTION
This still gives line information in backtraces, but reduces some other debug data. This change reduces the release binary size from 28.8 MB to 26.4 MB. Not a huge win, but why not take it.

This pushes the required Rust version to the latest one which was released on July 13th. Not a long time ago, but I suppose we can expect every dev to be able to update?