### PR TITLE
Add scrollbar to multiline copyable inputs

### DIFF
--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -101,8 +101,9 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
     const inner = multiline
         ? <textarea {...sharedProps} css={{
             ...sharedStyle,
-            overflow: "hidden",
+            overflow: "auto",
             resize: "none",
+            color: COLORS.neutral90,
         }} />
         : <input {...sharedProps} css={sharedStyle} />;
 

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -104,6 +104,8 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
             overflow: "auto",
             resize: "none",
             color: COLORS.neutral90,
+            "::-webkit-scrollbar": { display: "none" },
+            scrollbarWidth: "none",
         }} />
         : <input {...sharedProps} css={sharedStyle} />;
 


### PR DESCRIPTION
Since the font of this changed to `monospace`, the embed code was cut off at the bottom (might have been the case before, I'm not sure). This adds a scrollbar and also changes the color to the same as non-multiline copyable inputs.

We could consider hiding the scollbar, as the copy-to-clipboard button is initially partly in front of it and the single-line inputs also use a hidden scrollbar (being actual inputs, so I believe that comes as a built-in feature).
Though it's probably not a big deal, and hiding it might impact accessibility. 