### PR TITLE
Close burger menu when clicking specific items

### DIFF
--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -26,6 +26,7 @@ import { boxError } from "../ui/error";
 import { Spinner } from "../ui/Spinner";
 import { useRouter } from "../router";
 import { COLORS } from "../color";
+import { useMenu } from "../layout/MenuState";
 
 
 // eslint-disable-next-line @typescript-eslint/quotes
@@ -287,6 +288,7 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
 
 export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
     const { t } = useTranslation();
+    const menu = useMenu();
 
     /* eslint-disable react/jsx-key */
     const buttons: [string, string, ReactElement][] = [
@@ -305,6 +307,7 @@ export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
             to={`${route}${encodedPath}`}
             iconPos="left"
             active={isActive(route)}
+            close={() => menu.state === "burger" && menu.close()}
         >
             {icon}
             {label}

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "./__generated__/manageDashboardQuery.graphql";
 import { css } from "@emotion/react";
 import { COLORS } from "../../color";
+import { useMenu } from "../../layout/MenuState";
 
 
 const PATH = "/~manage";
@@ -140,6 +141,7 @@ type ManageNavProps = {
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const { t } = useTranslation();
     const user = useUser();
+    const menu = useMenu();
 
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
@@ -152,7 +154,13 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     /* eslint-enable react/jsx-key */
 
     const items = entries.map(([path, label, icon]) => (
-        <LinkWithIcon key={path} to={path} iconPos="left" active={path === active}>
+        <LinkWithIcon
+            key={path}
+            to={path}
+            iconPos="left"
+            active={path === active}
+            close={() => menu.state === "burger" && menu.close()}
+        >
             {icon}
             {label}
         </LinkWithIcon>

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -68,6 +68,7 @@ type LinkWithIconProps = {
     active?: boolean;
     className?: string;
     children: ReactNode;
+    close?: () => void;
 };
 
 /** A link designed for `LinkList`. Has an icon on the left or right side. */
@@ -76,6 +77,7 @@ export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
     iconPos,
     children,
     active = false,
+    close,
     ...rest
 }) => {
     const isDark = useColorScheme().scheme === "dark";
@@ -115,7 +117,7 @@ export const LinkWithIcon: React.FC<LinkWithIconProps> = ({
 
     return active
         ? <span css={style} aria-current="page" {...rest}>{children}</span>
-        : <Link to={to} css={style} {...rest}>{children}</Link>;
+        : <Link to={to} css={style} onClick={close} {...rest}>{children}</Link>;
 };
 
 export const CenteredContent: React.FC<{ children: ReactNode }> = ({ children }) => (


### PR DESCRIPTION
Closes #906 

The items on which the menu closes are:
  - realm editing buttons
  - management nav buttons

The solution presented here is a little hacky since the burger menu as written currently gets passed the navigation lists as nested JSX elements, which makes passing the `close` handler directly to the specific items quite complicated (if possible at all).

This should be taken into consideration when/if the sidebox/burger navigation get refactored or rewritten eventually.