### PR TITLE
Fix cut-off thumbails on vertically narrow screens

### DIFF
--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -126,6 +126,14 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
             },
             "div.preview-container": {
                 backgroundColor: `${COLORS.neutral15} !important`,
+                "div, div img": {
+                    height: "inherit",
+                },
+                "div img": {
+                    display: "block",
+                    margin: "0 auto",
+                    width: "unset !important",
+                },
             },
             display: "flex",
             flexDirection: "column",


### PR DESCRIPTION
Closes #909 

Since the thumbnails being cut-off is default paella behaviour, this won't be fixed with the new eth design (see https://polimediaupv.github.io/paella-ethz/ for comparison).
So to fix this we need to overwrite some styles.