### PR TITLE
Remove highlight when clicking external studio link

### DIFF
--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -91,7 +91,7 @@ export const linkWithIconStyle = (isDark: boolean, iconPos: "left" | "right", ac
             }),
         },
 
-        "&:hover, &:focus": hoverActiveStyle,
+        "&:hover, &:focus-visible": hoverActiveStyle,
         ...active && {
             color: COLORS.primary2,
             "&": hoverActiveStyle,


### PR DESCRIPTION
The "Record video" link kept being highlighted after it was clicked, meaning more than one nav item was highlighted at once (since the active route always is). This fixes the issue.