### PR TITLE
Add optional link to video page for video blocks

### DIFF
--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -207,6 +207,7 @@ pub(crate) struct VideoBlock {
     // Is `None` if the video was removed from the DB.
     pub(crate) event: Option<Id>,
     pub(crate) show_title: bool,
+    pub(crate) show_link: bool,
 }
 
 impl Block for VideoBlock {
@@ -228,6 +229,10 @@ impl VideoBlock {
 
     fn show_title(&self) -> bool {
         self.show_title
+    }
+
+    fn show_link(&self) -> bool {
+        self.show_link
     }
 
     fn id(&self) -> Id {
@@ -255,6 +260,7 @@ impl_from_db!(
             videolist_order,
             video,
             show_title,
+            show_link,
             show_metadata,
             realm,
         },
@@ -290,6 +296,7 @@ impl_from_db!(
                 shared,
                 event: row.video::<Option<Key>>().map(Id::event),
                 show_title: unwrap_type_dep(row.show_title(), "event", "show_title"),
+                show_link: unwrap_type_dep(row.show_link(), "event", "show_link"),
             }.into(),
         }
     }

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -82,9 +82,9 @@ impl BlockValue {
 
         context.db
             .execute(
-                "insert into blocks (realm, index, type, video, show_title) \
-                    values ($1, $2, 'video', $3, $4)",
-                &[&realm.key, &index, &event, &block.show_title],
+                "insert into blocks (realm, index, type, video, show_title, show_link) \
+                    values ($1, $2, 'video', $3, $4, $5)",
+                &[&realm.key, &index, &event, &block.show_title, &block.show_link],
             )
             .await?;
 
@@ -309,13 +309,14 @@ impl BlockValue {
         let query = format!(
             "update blocks set \
                 video = coalesce($2, video), \
-                show_title = coalesce($3, show_title) \
+                show_title = coalesce($3, show_title), \
+                show_link = coalesce($4, show_link) \
                 where id = $1 \
                 and type = 'video' \
                 returning {selection}",
         );
         context.db
-            .query_one(&query, &[&Self::key_for(id)?, &video_id, &set.show_title])
+            .query_one(&query, &[&Self::key_for(id)?, &video_id, &set.show_title, &set.show_link])
             .await?
             .pipe(|row| Ok(Self::from_row_start(&row)))
     }
@@ -395,6 +396,7 @@ pub(crate) struct NewSeriesBlock {
 pub(crate) struct NewVideoBlock {
     event: Id,
     show_title: bool,
+    show_link: bool,
 }
 
 
@@ -420,6 +422,7 @@ pub(crate) struct UpdateSeriesBlock {
 pub(crate) struct UpdateVideoBlock {
     event: Option<Id>,
     show_title: Option<bool>,
+    show_link: Option<bool>,
 }
 
 

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -337,4 +337,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     20: "fix-queue-triggers",
     21: "fix-user-root-realm-name-block",
     22: "user-email",
+    23: "video-block-show-link",
 ];

--- a/backend/src/db/migrations/23-video-block-show-link.sql
+++ b/backend/src/db/migrations/23-video-block-show-link.sql
@@ -1,10 +1,10 @@
 -- Adds a single `show_link` field to blocks, used for video blocks to also show
 -- a link to the corresponding video page. We also drop and re-add the appropriate constraint.
 alter table blocks
-    add column show_link boolean default false,
+    add column show_link boolean default true,
     drop constraint video_block_has_fields,
     add constraint video_block_has_fields check (type <> 'video' or (
         show_title is not null and
         show_link is not null
     ));
-    
+

--- a/backend/src/db/migrations/23-video-block-show-link.sql
+++ b/backend/src/db/migrations/23-video-block-show-link.sql
@@ -1,0 +1,10 @@
+-- Adds a single `show_link` field to blocks, used for video blocks to also show
+-- a link to the corresponding video page. We also drop and re-add the appropriate constraint.
+alter table blocks
+    add column show_link boolean default false,
+    drop constraint video_block_has_fields,
+    add constraint video_block_has_fields check (type <> 'video' or (
+        show_title is not null and
+        show_link is not null
+    ));
+    

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -473,6 +473,8 @@ manage:
       titled:
         title: Titel
         show-title: Titel anzeigen
+      
+      show-link: Link anzeigen
 
       save: Speichern
       cancel: Verwerfen

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -128,6 +128,7 @@ video:
   duration: Abspielzeit
   language_one: Sprache
   language_other: Sprachen
+  link: Videoseite
   part-of-series: Teil von Serie
   more-from-series: Mehr von „{{series}}“
   deleted-video-block: Das hier referenzierte Video wurde gelöscht.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -128,7 +128,7 @@ video:
   duration: Abspielzeit
   language_one: Sprache
   language_other: Sprachen
-  link: Videoseite
+  link: Zur Videoseite
   part-of-series: Teil von Serie
   more-from-series: Mehr von „{{series}}“
   deleted-video-block: Das hier referenzierte Video wurde gelöscht.
@@ -471,7 +471,7 @@ manage:
             Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.
 
       show-title: Titel anzeigen
-      show-link: Link anzeigen
+      show-link: Link zur Videoseite anzeigen
 
       save: Speichern
       cancel: Verwerfen

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -470,10 +470,7 @@ manage:
           no-read-access-to-current: >
             Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.
 
-      titled:
-        title: Titel
-        show-title: Titel anzeigen
-      
+      show-title: Titel anzeigen
       show-link: Link anzeigen
 
       save: Speichern

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -457,10 +457,7 @@ manage:
           no-read-access-to-current: >
             You do not have read access to the video that is currently referenced here.
 
-      titled:
-        title: Title
-        show-title: Show title
-
+      show-title: Show title
       show-link: Show link
 
       save: Save

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -125,6 +125,7 @@ video:
   duration: Duration
   language_one: Language
   language_other: Languages
+  link: Video page
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
   deleted-video-block: The video referenced here was deleted.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -125,7 +125,7 @@ video:
   duration: Duration
   language_one: Language
   language_other: Languages
-  link: Video page
+  link: Go to video page
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
   deleted-video-block: The video referenced here was deleted.
@@ -458,7 +458,7 @@ manage:
             You do not have read access to the video that is currently referenced here.
 
       show-title: Show title
-      show-link: Show link
+      show-link: Show link to video page
 
       save: Save
       cancel: Discard

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -461,6 +461,8 @@ manage:
         title: Title
         show-title: Show title
 
+      show-link: Show link
+
       save: Save
       cancel: Discard
       confirm-cancel: Discard changes?

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -150,7 +150,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                         label={t("manage.realm.content.add-video")}
                         onClick={() => addBlock("Video", (_store, block) => {
                             block.setValue(true, "showTitle");
-                            block.setValue(false, "showLink");
+                            block.setValue(true, "showLink");
                         })}
                     />
                 </ul>

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -150,6 +150,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                         label={t("manage.realm.content.add-video")}
                         onClick={() => addBlock("Video", (_store, block) => {
                             block.setValue(true, "showTitle");
+                            block.setValue(false, "showLink");
                         })}
                     />
                 </ul>

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useState } from "react";
 import { fetchQuery, graphql, useFragment, useMutation } from "react-relay";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
-import { Controller, useFormContext } from "react-hook-form";
+import { Controller, UseFormReturn, useFormContext } from "react-hook-form";
 
 import { Card } from "../../../../../../ui/Card";
 import { EditModeForm } from ".";
@@ -81,6 +81,11 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
         ? { ...event, ...event.syncedData, seriesTitle: event.series?.title }
         : undefined;
 
+    const optionProps: ["showTitle" | "showLink", boolean, string][] = [
+        ["showTitle", showTitle, t("manage.realm.content.show-title")],
+        ["showLink", showLink, t("manage.realm.content.show-link")],
+    ];
+
     return <EditModeForm create={create} save={save} map={(data: VideoFormData) => data}>
         <Heading>{t("manage.realm.content.event.event.heading")}</Heading>
         {"event" in errors && <div css={{ margin: "8px 0" }}>
@@ -98,27 +103,33 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
             )}
         />
 
-        <Heading>{t("manage.realm.content.titled.title")}</Heading>
-        <label>
-            <input
-                type="checkbox"
-                defaultChecked={showTitle}
-                {...form.register("showTitle")}
-                css={{ marginRight: 6 }}
-            />
-            {t("manage.realm.content.titled.show-title")}
-        </label>
-        <label>
-            <input
-                type="checkbox"
-                defaultChecked={showLink}
-                {...form.register("showLink")}
-                css={{ marginRight: 6 }}
-            />
-            {t("manage.realm.content.show-link")}
-        </label>
+        <div css={{ display: "flex", flexDirection: "row", gap: 16, marginTop: 8 }}>
+            {optionProps.map(([option, checked, title]) =>
+                // eslint-disable-next-line react/jsx-key
+                <DisplayOption form={form} option={option} checked={checked} title={title} />)
+            }
+        </div>
     </EditModeForm>;
 };
+
+type DisplayOption = {
+    form: UseFormReturn<VideoFormData>;
+    option: "showTitle" | "showLink";
+    checked: boolean;
+    title: string;
+}
+
+const DisplayOption: React.FC<DisplayOption> = (
+    { form, option, checked, title }
+) => <label>
+    <input
+        type="checkbox"
+        defaultChecked={checked}
+        {...form.register(option)}
+        css={{ marginRight: 6 }}
+    />
+    {title}
+</label>;
 
 type EventSelectorProps = {
     onChange: (eventId?: string) => void;

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -24,6 +24,7 @@ import { ErrorDisplay } from "../../../../../../util/err";
 type VideoFormData = {
     event: string;
     showTitle: boolean;
+    showLink: boolean;
 };
 
 type EditVideoBlockProps = {
@@ -31,7 +32,7 @@ type EditVideoBlockProps = {
 };
 
 export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef }) => {
-    const { event, showTitle } = useFragment(graphql`
+    const { event, showTitle, showLink } = useFragment(graphql`
         fragment VideoEditModeBlockData on VideoBlock {
             event {
                 __typename,
@@ -47,6 +48,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
                 }
             }
             showTitle
+            showLink
         }
     `, blockRef);
 
@@ -105,6 +107,15 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
                 css={{ marginRight: 6 }}
             />
             {t("manage.realm.content.titled.show-title")}
+        </label>
+        <label>
+            <input
+                type="checkbox"
+                defaultChecked={showLink}
+                {...form.register("showLink")}
+                css={{ marginRight: 6 }}
+            />
+            {t("manage.realm.content.show-link")}
         </label>
     </EditModeForm>;
 };

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -103,10 +103,10 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
             )}
         />
 
-        <div css={{ display: "flex", flexDirection: "row", gap: 16, marginTop: 8 }}>
+        <div css={{ display: "flex", flexDirection: "column", marginTop: 8 }}>
             {optionProps.map(([option, checked, title]) =>
                 // eslint-disable-next-line react/jsx-key
-                <DisplayOption form={form} option={option} checked={checked} title={title} />)
+                <DisplayOption {...{ form, option, checked, title }} />)
             }
         </div>
     </EditModeForm>;

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -123,6 +123,7 @@ union EventSearchOutcome = SearchUnavailable | EventSearchResults
 input NewVideoBlock {
   event: ID!
   showTitle: Boolean!
+  showLink: Boolean!
 }
 
 type SyncedEventData {
@@ -154,12 +155,14 @@ type NotAllowed {
 input UpdateVideoBlock {
   event: ID
   showTitle: Boolean
+  showLink: Boolean
 }
 
 "A block for presenting a single Opencast event"
 type VideoBlock implements Block & RealmNameSourceBlock {
   event: Event
   showTitle: Boolean!
+  showLink: Boolean!
   id: ID!
   index: Int!
   realm: Realm!

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -8,13 +8,15 @@ import { Card } from "../Card";
 import { useTranslation } from "react-i18next";
 import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
+import { FiArrowRightCircle } from "react-icons/fi";
 
 
 type Props = {
     fragRef: VideoBlockData$key;
+    basePath: string;
 };
 
-export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
+export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
     const { t } = useTranslation();
     const { event, showTitle, showLink } = useFragment(graphql`
         fragment VideoBlockData on VideoBlock {
@@ -58,8 +60,10 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
         {isSynced(event)
             ? <InlinePlayer event={event} css={{ maxWidth: 800 }} />
             : <Card kind="info">{t("video.not-ready.title")}</Card>}
-        {showLink && <Link
-            to={`/!v/${keyOfId(event.id)}`}
-        >{t("video.link")}</Link>}
+        {showLink && <Link to={`${basePath}/${keyOfId(event.id)}`}
+        >
+            {t("video.link")}
+            <FiArrowRightCircle />
+        </Link>}
     </>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -55,15 +55,25 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
         return unreachable();
     }
 
-    return <>
+    return <div css={{ maxWidth: 800 }}>
         {showTitle && <Title title={event.title} />}
         {isSynced(event)
             ? <InlinePlayer event={event} css={{ maxWidth: 800 }} />
             : <Card kind="info">{t("video.not-ready.title")}</Card>}
-        {showLink && <Link to={`${basePath}/${keyOfId(event.id)}`}
+        {showLink && <Link
+            to={`${basePath}/${keyOfId(event.id)}`}
+            css={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginTop: 8,
+                marginLeft: "auto",
+                width: "fit-content",
+            }}
         >
             {t("video.link")}
-            <FiArrowRightCircle />
-        </Link>}
-    </>;
+            <FiArrowRightCircle size={18} css={{ marginTop: 1 }} />
+        </Link>
+        }
+    </div>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
     const { t } = useTranslation();
-    const { event, showTitle } = useFragment(graphql`
+    const { event, showTitle, showLink } = useFragment(graphql`
         fragment VideoBlockData on VideoBlock {
             event {
                 __typename
@@ -38,6 +38,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
                 }
             }
             showTitle
+            showLink
         }
     `, fragRef);
 
@@ -57,8 +58,8 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
         {isSynced(event)
             ? <InlinePlayer event={event} css={{ maxWidth: 800 }} />
             : <Card kind="info">{t("video.not-ready.title")}</Card>}
-        <Link
+        {showLink && <Link
             to={`/!v/${keyOfId(event.id)}`}
-        >{t("video.link")}</Link>
+        >{t("video.link")}</Link>}
     </>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -6,7 +6,8 @@ import { VideoBlockData$key } from "./__generated__/VideoBlockData.graphql";
 import { Title } from "..";
 import { Card } from "../Card";
 import { useTranslation } from "react-i18next";
-import { isSynced } from "../../util";
+import { isSynced, keyOfId } from "../../util";
+import { Link } from "../../router";
 
 
 type Props = {
@@ -21,6 +22,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
                 __typename
                 ... on NotAllowed { dummy } # workaround
                 ... on AuthorizedEvent {
+                    id
                     title
                     isLive
                     created
@@ -55,5 +57,8 @@ export const VideoBlock: React.FC<Props> = ({ fragRef }) => {
         {isSynced(event)
             ? <InlinePlayer event={event} css={{ maxWidth: 800 }} />
             : <Card kind="info">{t("video.not-ready.title")}</Card>}
+        <Link
+            to={`/!v/${keyOfId(event.id)}`}
+        >{t("video.link")}</Link>
     </>;
 };

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -70,7 +70,7 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             "TitleBlock": () => <TitleBlock fragRef={block} />,
             "TextBlock": () => <TextBlockByQuery fragRef={block} />,
             "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} basePath={basePath} />,
-            "VideoBlock": () => <VideoBlock fragRef={block} />,
+            "VideoBlock": () => <VideoBlock fragRef={block} basePath={basePath} />,
         })}
     </div>;
 };


### PR DESCRIPTION
closes #854

This adds an optional link to video blocks which links directly to the video page of that block.
Right now it is a link button but I wouldn't mind if this were just a link (just text + icon without the background and outline).