### PR TITLE
Add return label to studio link

### DIFF
--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -11,7 +11,7 @@ import {
 } from "@opencast/appkit";
 
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
-import { languages } from "../../i18n";
+import i18n, { languages } from "../../i18n";
 import { Link } from "../../router";
 import { User, useUser } from "../../User";
 import { ActionIcon, ICON_STYLE } from "./ui";
@@ -22,6 +22,7 @@ import { REDIRECT_STORAGE_KEY } from "../../routes/Login";
 import { focusStyle } from "../../ui";
 import { ExternalLink } from "../../relay/auth";
 import { COLORS } from "../../color";
+import { translatedConfig } from "../../util";
 
 
 /** User-related UI in the header. */
@@ -202,7 +203,10 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
             icon: <FiVideo />,
             wrapper: <ExternalLink
                 service="STUDIO"
-                params={{ "return.target": new URL(document.location.href) }}
+                params={{
+                    "return.target": document.location.href,
+                    "return.label": translatedConfig(CONFIG.siteTitle, i18n),
+                }}
                 fallback="link"
             />,
             keepOpenAfterClick: true,

--- a/frontend/src/relay/auth.tsx
+++ b/frontend/src/relay/auth.tsx
@@ -23,7 +23,8 @@ export type ExternalLinkProps = PropsWithChildren<{
 } & ({
     service: "STUDIO";
     params: {
-        "return.target": URL;
+        "return.target": string;
+        "return.label": string;
     };
 } | {
     service: "EDITOR";

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -19,6 +19,9 @@ import {
 } from "./__generated__/manageDashboardQuery.graphql";
 import { COLORS } from "../../color";
 import { useMenu } from "../../layout/MenuState";
+import CONFIG from "../../config";
+import { translatedConfig } from "../../util";
+import i18n from "../../i18n";
 
 
 const PATH = "/~manage";
@@ -106,7 +109,10 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
         items.push(
             <ExternalLink
                 service="STUDIO"
-                params={{ "return.target": new URL(document.location.href) }}
+                params={{
+                    "return.target": document.location.href,
+                    "return.label": translatedConfig(CONFIG.siteTitle, i18n),
+                }}
                 fallback="link"
                 css={{
                     backgroundColor: "inherit",


### PR DESCRIPTION
Closes #910 

This adds a return label to the query parameters of Tobira's studio link. With this, studio users coming from Tobira will see where they are returning to after finishing their studio work.