### PR TITLE
Clean up translations

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -7,7 +7,6 @@ general:
   loading: Lade...
   home: Startseite
   homepage: Startseite
-  navigation: Navigation
   leave-page-confirmation: >
     Seite verlassen? Vorgenommene Änderungen sind möglicherweise noch nicht gespeichert!
   action:
@@ -15,13 +14,12 @@ general:
     cancel: Abbrechen
     save: Speichern
     back: Zurück
-    rename: Umbenennen
     goto-homepage: Zur Startseite
     share: Teilen
   version-information: Version
   logo-alt: Das Logo von „{{title}}“
   no-root-children: Noch keine Seiten ...
-  failed-to-load-thumbnail: Vorschaubild konnte nicht geladen werden.
+  failed-to-load-thumbnail: Konnte Vorschaubild nicht laden
   yes: Ja
   no: Nein
   form:
@@ -93,12 +91,9 @@ about-tobira:
 
 footer:
   about-tobira: Über Tobira
-  legal-notice: Impressum
 
 main-menu:
   label: Menü
-  settings: Einstellungen
-  about: Info
   color-scheme:
     label: Farbschema
     auto: Auto
@@ -110,7 +105,6 @@ user:
   logout: Abmelden
   settings: Nutzereinstellungen
   manage-content: Verwalten
-  logged-in-as: Angemeldet als
 
 login-page:
   heading: Anmeldung 
@@ -123,7 +117,6 @@ login-page:
 video:
   video: Video
   video-page: 'Video Seite: „{{video}}“'
-  deleted: Gelöschtes Video
   created: Erstellt
   updated: Zuletzt angepasst
   duration: Abspielzeit
@@ -154,7 +147,6 @@ video:
     show-more: Mehr anzeigen
     show-less: Weniger anzeigen
   embed:
-    title: Video einbetten
     copy-embed-code-to-clipboard: Einbettungscode in Zwischenablage kopieren
   caption: Untertitel
   download:
@@ -176,12 +168,6 @@ video:
     embed: Einbetten
     rss: RSS
     show-qr-code: QR Code anzeigen
-    direct-link-info: >
-      Hiermit wird das Video direkt verlinkt, also ohne seine Position im
-      Videoportal (die Seite, auf der es inkludiert ist). Das heißt, dass der
-      Link weiterhin funktioniert, auch wenn die Seite gelöscht oder verschoben
-      wird. Allerdings werden Empfänger des Links nicht die gleiche Navigation
-      sehen.
 
 series:
   series: Serie
@@ -192,7 +178,6 @@ series:
   videos:
     heading: Videos
   not-ready:
-    name: Ausstehende Serie
     title: Serie noch nicht synchronisiert
     text: >
       Die Daten der gewünschten Serie wurden leider noch nicht vollständig übertragen. Dies sollte
@@ -325,8 +310,6 @@ manage:
       referencing-pages: Referenzierende Seiten
       referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'
       no-referencing-pages: Dieses Video wird von keiner Seite referenziert.
-    thumbnail:
-      title: Vorschaubild
     acl:
       title: Zugangsbeschränkung
     technical-details:
@@ -359,8 +342,6 @@ manage:
       Pfadsegment darf nicht folgende Zeichen enthalten: {{illegalChars}}
     reserved-char-in-path: >
       Pfadsegment darf nicht mit den folgenden Zeichen beginnen: {{reservedChars}}
-
-    no-path: Pfad fehlt! Den Link, den Sie aufgerufen haben, ist ungültig.
 
     general:
       page-name: Seitenname
@@ -446,9 +427,7 @@ manage:
       series:
         series:
           heading: Serie
-          none: Keine Serie ausgewählt
           invalid: Bitte eine Serie auswählen
-          waiting: Nicht synchronisierte Serie
         layout:
           heading: Layout
           videos-only: Nur Videos
@@ -459,7 +438,6 @@ manage:
       event:
         event:
           heading: Video
-          none: Kein Video ausgewählt
           invalid: Bitte ein Video auswählen
           no-read-access-to-current: >
             Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -1,33 +1,34 @@
-language-name: Deutsch
-language: Sprache
-language-selection: Sprachauswahl, Deutsch ausgewählt
-loading: Lade...
-close: Schließen
-cancel: Abbrechen
-save: Speichern
-back: Zurück
-home: Startseite
-navigation: Navigation
-rename: Umbenennen
-this-field-is-required: Dieses Feld ist erforderlich.
-version-information: Version
-
 general:
-  goto-homepage: Zur Startseite
+  language:
+    language_one: Sprache
+    language_other: Sprachen
+    name: Deutsch
+    selection: Sprachauswahl, Deutsch ausgewählt
+  loading: Lade...
+  home: Startseite
   homepage: Startseite
+  navigation: Navigation
   leave-page-confirmation: >
     Seite verlassen? Vorgenommene Änderungen sind möglicherweise noch nicht gespeichert!
+  action:
+    close: Schließen
+    cancel: Abbrechen
+    save: Speichern
+    back: Zurück
+    rename: Umbenennen
+    goto-homepage: Zur Startseite
+    share: Teilen
+  version-information: Version
   logo-alt: Das Logo von „{{title}}“
   no-root-children: Noch keine Seiten ...
-  failed-to-load-thumbnail: Konnte Vorschaubild nicht laden
+  failed-to-load-thumbnail: Vorschaubild konnte nicht geladen werden.
   yes: Ja
   no: Nein
-  share: Teilen
   form:
+    this-field-is-required: Dieses Feld ist erforderlich.
     select:
       no-options: Keine Optionen
       select-option: Option auswählen...
-
 
 welcome:
   title: Willkommen zu Tobira!
@@ -50,7 +51,7 @@ errors:
   are-you-connected-to-internet: Sind Sie mit dem Internet verbunden?
   unknown: Unbekannter Fehler.
   detailed-error-info: Detaillierte Fehlerinformationen für Entwickler
-  embedded: In der eingebetteten Anwendung ist ein Fehler aufgetreten
+  embedded: In der eingebetteten Anwendung ist ein Fehler aufgetreten.
 
 not-found:
   page-not-found: Seite nicht gefunden
@@ -126,8 +127,6 @@ video:
   created: Erstellt
   updated: Zuletzt angepasst
   duration: Abspielzeit
-  language_one: Sprache
-  language_other: Sprachen
   link: Zur Videoseite
   part-of-series: Teil von Serie
   more-from-series: Mehr von „{{series}}“
@@ -147,15 +146,14 @@ video:
   source: Quelle
   stream-ended: Dieser Stream ist beendet.
   stream-not-started-yet: Dieser Stream hat noch nicht begonnen.
-  started-generic: Gestartet
-  started: Gestartet {{duration}}
+  started: Gestartet
+  started-when: Gestartet {{duration}}
   starts: Startet 
   starts-in: Startet {{duration}}
   description:
     show-more: Mehr anzeigen
     show-less: Weniger anzeigen
   embed:
-    button: Einbetten
     title: Video einbetten
     copy-embed-code-to-clipboard: Einbettungscode in Zwischenablage kopieren
   caption: Untertitel
@@ -295,10 +293,6 @@ upload:
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
 
 manage:
-  nav:
-    dashboard: Dashboard
-    my-videos: Meine Videos
-
   dashboard:
     title: Dashboard
     upload-tile: Hier können Sie Videos von Ihrem Computer hochladen.
@@ -473,10 +467,8 @@ manage:
       show-title: Titel anzeigen
       show-link: Link zur Videoseite anzeigen
 
-      save: Speichern
       cancel: Verwerfen
       confirm-cancel: Änderungen verwerfen?
-
       cancel-warning: Ihre Änderungen wurden noch nicht gespeichert!
 
       removing-failed: Entfernen ist fehlgeschlagen.
@@ -524,4 +516,4 @@ api-remote-errors:
       Kontaktieren Sie einen Systemadministrator für weitere Unterstützung.
 
 embed:
-  not-supported: Diese Seite kann nicht eingebettet werden
+  not-supported: Diese Seite kann nicht eingebettet werden.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -7,20 +7,18 @@ general:
   loading: Loading...
   home: Home
   homepage: Homepage
-  navigation: Navigation
   leave-page-confirmation: Leave page? Changes you made may not be saved!
   action:
     close: Close
     cancel: Cancel
     save: Save
     back: Back
-    rename: Rename
     goto-homepage: Go to homepage
     share: Share
   version-information: Version
   logo-alt: Logo of “{{title}}”
   no-root-children: No pages yet ...
-  failed-to-load-thumbnail: Failed to load thumbnail.
+  failed-to-load-thumbnail: Failed to load thumbnail
   yes: "Yes"
   no: "No"
   form:
@@ -91,12 +89,9 @@ about-tobira:
 
 footer:
   about-tobira: About Tobira
-  legal-notice: Legal Notice
 
 main-menu:
   label: Menu
-  settings: Settings
-  about: About
   color-scheme:
     label: Color scheme
     auto: Auto
@@ -108,7 +103,6 @@ user:
   logout: Log out
   settings: User settings
   manage-content: Manage
-  logged-in-as: Logged in as
 
 login-page:
   heading: Login 
@@ -121,7 +115,6 @@ login-page:
 video:
   video: Video
   video-page: 'Video page: “{{video}}”'
-  deleted: Deleted video
   created: Created
   updated: Last updated
   duration: Duration
@@ -152,7 +145,6 @@ video:
     show-more: Show more
     show-less: Show less
   embed:
-    title: Embed video
     copy-embed-code-to-clipboard: Copy embed code to clipboard
   caption: Caption
   download:
@@ -173,11 +165,6 @@ video:
     embed: Embed
     rss: RSS
     show-qr-code: Show QR code
-    direct-link-info: >
-      This links to the video only, without including its location in this video portal
-      (the page it is included in). That means the link will continue to work as long as
-      the video exists, even if the including page is deleted or moved. However,
-      recipients of this link will not see the same navigation.
 
 series:
   series: Series
@@ -188,8 +175,7 @@ series:
   videos:
     heading: Videos
   not-ready:
-    name: Pending series
-    title: Series not synchronized, yet
+    title: Series not synchronized yet
     text: >
       The data of the requested series has not been fully transferred yet. This should
       happen automatically soon. Try again in a few minutes.
@@ -317,8 +303,6 @@ manage:
       referencing-pages: Referencing pages
       referencing-pages-explanation: 'This video is referenced on the following pages:'
       no-referencing-pages: No pages reference this video.
-    thumbnail:
-      title: Thumbnail
     acl:
       title: Manage access
     technical-details:
@@ -351,8 +335,6 @@ manage:
       Path segment may not include the following characters: {{illegalChars}}
     reserved-char-in-path: >
       Path segment may not start with the following characters: {{reservedChars}}
-
-    no-path: Missing path! You opened an invalid link.
 
     general:
       page-name: Page name
@@ -434,9 +416,7 @@ manage:
       series:
         series:
           heading: Series
-          none: No series selected
           invalid: Please select a series
-          waiting: Non-synchronized series
         layout:
           heading: Layout
           videos-only: Videos only
@@ -447,7 +427,6 @@ manage:
       event:
         event:
           heading: Event
-          none: No event selected
           invalid: Please select an event
           no-read-access-to-current: >
             You do not have read access to the video that is currently referenced here.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -1,28 +1,30 @@
-language-name: English
-language: Language
-language-selection: Language selection, English selected
-loading: Loading...
-close: Close
-cancel: Cancel
-save: Save
-back: Back
-home: Home
-navigation: Navigation
-rename: Rename
-this-field-is-required: This field is required.
-version-information: Version
-
 general:
+  language:
+    language_one: Language
+    language_other: Languages
+    name: English
+    selection: Language selection, English selected
+  loading: Loading...
+  home: Home
   homepage: Homepage
-  goto-homepage: Go to homepage
+  navigation: Navigation
   leave-page-confirmation: Leave page? Changes you made may not be saved!
+  action:
+    close: Close
+    cancel: Cancel
+    save: Save
+    back: Back
+    rename: Rename
+    goto-homepage: Go to homepage
+    share: Share
+  version-information: Version
   logo-alt: Logo of “{{title}}”
   no-root-children: No pages yet ...
-  failed-to-load-thumbnail: Failed to load thumbnail
+  failed-to-load-thumbnail: Failed to load thumbnail.
   yes: "Yes"
   no: "No"
-  share: Share
   form:
+    this-field-is-required: This field is required.
     select:
       no-options: No options
       select-option: Select option...
@@ -48,7 +50,7 @@ errors:
   are-you-connected-to-internet: Are you connected to the internet?
   unknown: Unknown error.
   detailed-error-info: Detailed error information for developers
-  embedded: An error occurred in the embedded application
+  embedded: An error occurred in the embedded application.
 
 not-found:
   page-not-found: Page not found
@@ -123,17 +125,15 @@ video:
   created: Created
   updated: Last updated
   duration: Duration
-  language_one: Language
-  language_other: Languages
   link: Go to video page
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
   deleted-video-block: The video referenced here was deleted.
   not-allowed-video-block: You are not allowed to view the video embedded here.
   not-ready:
-    title: Video not processed, yet
+    title: Video not processed yet
     text: >
-      This video hasn't been processed, yet. This should
+      This video hasn't been processed yet. This should
       happen automatically soon. Try again in a few minutes.
     label: unprocessed
   thumbnail-for: Thumbnail for “{{video}}”
@@ -144,15 +144,14 @@ video:
   source: Source
   stream-ended: This stream has ended.
   stream-not-started-yet: This stream has not started yet.
-  started-generic: Started
-  started: Started {{duration}}
+  started: Started
+  started-when: Started {{duration}}
   starts: Starts
   starts-in: Starts {{duration}}
   description:
     show-more: Show more
     show-less: Show less
   embed:
-    button: Embed
     title: Embed video
     copy-embed-code-to-clipboard: Copy embed code to clipboard
   caption: Caption
@@ -288,10 +287,6 @@ upload:
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
 
 manage:
-  nav:
-    dashboard: Dashboard
-    my-videos: My videos
-
   dashboard:
     title: Dashboard
     upload-tile: Here you can upload a new video from your computer.
@@ -460,10 +455,8 @@ manage:
       show-title: Show title
       show-link: Show link to video page
 
-      save: Save
       cancel: Discard
       confirm-cancel: Discard changes?
-
       cancel-warning: Your changes have not yet been saved!
 
       removing-failed: Removing failed.
@@ -511,4 +504,4 @@ api-remote-errors:
       further assistance.
 
 embed:
-  not-supported: This page can't be embedded
+  not-supported: This page can't be embedded.

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -49,7 +49,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
     const parent = realm.isUserRoot
         ? {
             path: "/",
-            name: t("home"),
+            name: t("general.home"),
             isMainRoot: true,
         }
         : realm.parent;
@@ -78,7 +78,7 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 {/* Show arrow and hide chevron in burger menu */}
                 <FiCornerLeftUp css={{ display: "none" }}/>
                 <FiChevronLeft />
-                {parent.isMainRoot ? t("home") : parent.name ?? <MissingRealmName />}
+                {parent.isMainRoot ? t("general.home") : parent.name ?? <MissingRealmName />}
             </LinkWithIcon>
             <div css={{
                 padding: "8px 14px 8px 16px",

--- a/frontend/src/layout/Root.tsx
+++ b/frontend/src/layout/Root.tsx
@@ -105,7 +105,7 @@ export const InitialLoading: React.FC = () => {
                         marginTop: 32,
                         animation: `${pulsing} 1.2s infinite`,
                         fontSize: 20,
-                    }}>{t("loading")}</div>
+                    }}>{t("general.loading")}</div>
                 </div>
             </Main>
             <Footer />

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -137,7 +137,7 @@ export const LanguageSettings: React.FC = () => {
 
     const menuItems = Object.keys(languages).map(lng => checkboxMenuItem({
         checked: isCurrentLanguage(lng),
-        children: <>{t("language-name", { lng })}</>,
+        children: <>{t("general.language.name", { lng })}</>,
         onClick: () => {
             if (!isCurrentLanguage(lng)) {
                 i18n.changeLanguage(lng);
@@ -145,7 +145,7 @@ export const LanguageSettings: React.FC = () => {
         },
     }));
 
-    const label = t("language");
+    const label = t("general.language.language_one");
     return (
         <WithHeaderMenu
             menu={{
@@ -154,7 +154,7 @@ export const LanguageSettings: React.FC = () => {
                 breakpoint: BREAKPOINT_MEDIUM,
             }}
         >
-            <ActionIcon title={t("language-selection")}>
+            <ActionIcon title={t("general.language.selection")}>
                 <HiOutlineTranslate />
             </ActionIcon>
         </WithHeaderMenu>

--- a/frontend/src/layout/header/index.tsx
+++ b/frontend/src/layout/header/index.tsx
@@ -58,7 +58,11 @@ const SearchMode: React.FC = () => {
     const menu = useMenu();
 
     return <>
-        <ActionIcon title={t("back")} onClick={() => menu.close()} css={{ marginLeft: 8 }}>
+        <ActionIcon
+            title={t("general.action.back")}
+            onClick={() => menu.close()}
+            css={{ marginLeft: 8 }}
+        >
             <FiArrowLeft />
         </ActionIcon>
         <SearchField variant="mobile" />
@@ -73,7 +77,7 @@ const OpenMenuMode: React.FC = () => {
         <Logo />
         <ButtonContainer>
             <ActionIcon
-                title={t("close")}
+                title={t("general.action.close")}
                 onClick={() => menu.close()}
                 css={buttonOutline}
             >

--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -52,7 +52,7 @@ const About: React.FC = () => {
                     <a href="https://github.com/elan-ev/tobira">GitHub repo</a>
                 </Trans>
             </p>
-            <h2>{t("version-information")}</h2>
+            <h2>{t("general.version-information")}</h2>
             <a href={`https://github.com/elan-ev/tobira/releases/tag/${version.identifier}`}>
                 Tobira <strong>{version.identifier}</strong>
             </a>

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -114,7 +114,7 @@ const BackButton: React.FC = () => {
             borderRadius: 4,
             textDecoration: "none",
         }}
-    ><FiChevronLeft />{t("back")}</Link>;
+    ><FiChevronLeft />{t("general.action.back")}</Link>;
 };
 
 type FormData = {
@@ -129,7 +129,7 @@ const LoginBox: React.FC = () => {
     const userid = watch("userid", "");
     const password = watch("password", "");
 
-    const validation = { required: t("this-field-is-required") };
+    const validation = { required: t("general.form.this-field-is-required") };
 
     type State = "idle" | "pending" | "success";
     const [state, setState] = useState<State>("idle");

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -701,7 +701,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             <FloatingTrigger>
                 <Button onClick={() => setState(state => state === "closed" ? "main" : "closed")}>
                     <FiShare2 size={16} />
-                    {t("general.share")}
+                    {t("general.action.share")}
                 </Button>
             </FloatingTrigger>
             <Floating
@@ -772,7 +772,7 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
     } else if (event.isLive) {
         tooltip = <>
             <i>{hasStarted
-                ? t("video.started-generic")
+                ? t("video.started")
                 : t("video.starts")
             }
             </i>: {startFull}
@@ -804,7 +804,7 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
 
         tooltip = <>
             {startedDate
-                ? <><i>{t("video.started-generic")}</i>: {startFull}</>
+                ? <><i>{t("video.started")}</i>: {startFull}</>
                 : <><i>{t("video.created")}</i>: {createdFull}</>
             }
             {updatedFull && <>
@@ -851,7 +851,7 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({ 
         const languages = event.metadata.dcterms.language.map(lng => languageNames.of(lng) ?? lng);
 
         pairs.push([
-            t("video.language", { count: languages.length }),
+            t("general.language.language", { count: languages.length }),
             languages.join(", "),
         ]);
     }

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -140,7 +140,7 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
             </ChildList>
 
             <div css={{ display: "flex", alignItems: "center" }}>
-                <Button onClick={save} disabled={!anyChange}>{t("save")}</Button>
+                <Button onClick={save} disabled={!anyChange}>{t("general.action.save")}</Button>
                 {isInFlight && <Spinner size={20} css={{ marginLeft: 16 }} />}
             </div>
             {boxError(commitError)}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -185,7 +185,7 @@ const EditModeButtons: React.FC<EditModeButtonsProps> = ({ onCancel }) => {
             kind="happy"
             type="submit"
         >
-            {t("manage.realm.content.save")}
+            {t("general.action.save")}
         </Button>
     </div>;
 };

--- a/frontend/src/routes/manage/Realm/General.tsx
+++ b/frontend/src/routes/manage/Realm/General.tsx
@@ -244,7 +244,9 @@ export const NameForm: React.FC<NameFormProps> = ({ realm }) => {
             </div>
 
             <div css={{ display: "flex", alignItems: "center" }}>
-                <Button type="submit"disabled={isInFlight || !canSave}>{t("save")}</Button>
+                <Button type="submit"disabled={isInFlight || !canSave}>
+                    {t("general.action.save")}
+                </Button>
                 {isInFlight && <Spinner size={20} css={{ marginLeft: 16 }} />}
             </div>
 

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -106,7 +106,7 @@ const BackLink: React.FC = () => {
     const items = [
         <LinkWithIcon key={MANAGE_VIDEOS_PATH} to={MANAGE_VIDEOS_PATH} iconPos="left">
             <FiCornerLeftUp />
-            {t("manage.nav.my-videos")}
+            {t("manage.my-videos.title")}
         </LinkWithIcon>,
     ];
 

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -79,8 +79,8 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
 
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
-        ["/~manage", t("manage.nav.dashboard"), <HiOutlineTemplate />],
-        ["/~manage/videos", t("manage.nav.my-videos"), <FiFilm />],
+        ["/~manage", t("manage.dashboard.title"), <HiOutlineTemplate />],
+        ["/~manage/videos", t("manage.my-videos.title"), <FiFilm />],
     ];
     if (isRealUser(user) && user.canCreateUserRealm) {
         entries.splice(

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -42,7 +42,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
                         padding: 2,
                         ...focusStyle({ inset: true }),
                     }}>
-                        <FiHome aria-label={t("home")} />
+                        <FiHome aria-label={t("general.home")} />
                     </Link>
                 </li>
                 {path.map((segment, i) => (

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -100,7 +100,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                     }}>
                         <h2 css={{ flex: 1 }}>{title}</h2>
                         {closable && <ProtoButton
-                            aria-label={t("close")}
+                            aria-label={t("general.action.close")}
                             tabIndex={0}
                             onClick={() => setOpen(false)}
                             css={{
@@ -185,7 +185,7 @@ export const ConfirmationModal
                         <Button disabled={inFlight} onClick={
                             () => currentRef(modalRef).close?.()
                         }>
-                            {t("cancel")}
+                            {t("general.action.cancel")}
                         </Button>
                         <Button disabled={inFlight} type="submit" kind="danger" css={{
                             whiteSpace: "normal",

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -92,7 +92,7 @@ export const SearchableSelect = <T, >({
         isClearable
         defaultOptions
         theme={theme}
-        loadingMessage={() => t("loading")}
+        loadingMessage={() => t("general.loading")}
         noOptionsMessage={noOptionsMessage ?? (() => t("general.form.select.no-options"))}
         placeholder={placeholder ?? t("general.form.select.select-option")}
         {...props}

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -212,7 +212,7 @@ const PlayerFallback: React.FC<{ image: string | null }> = ({ image }) => {
                 },
             }}>
                 <Spinner size={32} />
-                <div css={{ marginTop: 8 }}>{t("loading")}</div>
+                <div css={{ marginTop: 8 }}>{t("general.loading")}</div>
             </div>
         </div>
     );

--- a/frontend/src/ui/time.tsx
+++ b/frontend/src/ui/time.tsx
@@ -56,7 +56,7 @@ export const RelativeDate: React.FC<RelativeDateProps> = ({ date, isLive, noTool
             timeAndUnit = [secsAgo / YEAR, "year"];
         }
         const [time, unit] = timeAndUnit;
-        const prefix = time < 0 ? "video.starts-in" : "video.started";
+        const prefix = time < 0 ? "video.starts-in" : "video.started-when";
         const relative = intl.format(Math.round(-time), unit);
         return isLive ? t(prefix, { duration: relative }) : relative;
     })();


### PR DESCRIPTION
Closes #841 

This moves any top-level strings to `general`, removes some (but not all) duplications, renames some strings and fixes some punctuation stuff, and removes one unsued translation. I suppose we could still move these around further/regroup some of them, but this should already be an improvement.

~~I also used an [external tool](https://www.npmjs.com/package/i18n-unused) to check for any further unused translations, but it didn't report any. (Take that result with a grain of salt though, mainly because I'm not super sure I did the check correctly...)~~ Edit: That tool didn't work... I checked some other tools but ultimately found it easier to go over the translations manually, and found a some more that were not being used.

Another thing that is somewhat related to this is #857, which is still open but not forgotten. Maybe we can go over @oas777's suggestions soon and decide how to proceed with this.