### PR TITLE
Switch to GitHub LFS for DB dumps

### DIFF
--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -111,7 +111,7 @@
     - name: Download latest DB dump
       become: true
       get_url:
-        url: 'https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz'
+        url: 'https://github.com/elan-ev/tobira/raw/db-dumps/db-dump-latest.xz'
         dest: /opt/tobira/{{ id }}/db-dump.pgc.xz
         owner: root
         group: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
     # Test DB migrations
     - name: Download latest DB dump
-      run: curl --silent --output db-dump.xz https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz
+      run: curl --silent --output db-dump.xz -L https://github.com/elan-ev/tobira/raw/db-dumps/db-dump-latest.xz
     - name: Decompress DB dump
       run: xz -d db-dump.xz
     # We need to use the same version as the DB, so we use 'docker exec'

--- a/.github/workflows/upload-db-dump.yml
+++ b/.github/workflows/upload-db-dump.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '0' # We need to do a full clone to be able to switch the branch later
 
       - name: Download Tobira binary
         run: curl --location --output tobira 'https://github.com/elan-ev/tobira/releases/download/${{github.ref_name}}/tobira-x86_64-unknown-linux-gnu'
@@ -64,20 +66,17 @@ jobs:
         run: xz --best db-dump
 
 
-      # Upload
-      - name: Install s3cmd
+      # Upload to GitHub. We store it twice so that we have an archive of all
+      # dumps but also can easily access the latest dump. Finding out the
+      # latest dump URL in other ways is really tricky actually. And given that
+      # the dump is 2MB, this "waste" of storage and bandwidth is miniscule.
+      - name: Commit & push
         run: |
-          sudo apt update
-          sudo apt install s3cmd --yes
-
-      - name: Setup s3cfg
-        run: echo "${{ secrets.S3_CONFIG }}" > ~/.s3cfg
-
-      # We upload it twice so that we have an archive of all dumps but also can
-      # easily access the latest dump. Finding out the latest dump URL in other
-      # ways is really tricky actually. And given that the dump is 2MB,
-      # this "waste" of storage and bandwidth is miniscule.
-      - name: Upload DB dump
-        run: |
-          s3cmd put db-dump.xz s3://tobira/db-dump-${{github.ref_name}}.xz
-          s3cmd put db-dump.xz s3://tobira/db-dump-latest.xz
+          git checkout db-dumps
+          cp db-dump.xz db-dump-latest.xz
+          mv db-dump.xz db-dump-${{github.ref_name}}.xz
+          git add db-dump-latest.xz db-dump-${{github.ref_name}}.xz
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'noreply@github.com'
+          git commit -m "Add DB dump for ${{github.ref_name}}"
+          git push origin db-dumps

--- a/util/scripts/db-load-dump.sh
+++ b/util/scripts/db-load-dump.sh
@@ -16,7 +16,7 @@ fi
 # Download dump
 TMP_DIR=$(mktemp -d)
 echo "Downloading DB dump"
-curl --output "$TMP_DIR/db-dump.xz" https://s3.opencast-niedersachsen.de/tobira/db-dump-latest.xz
+curl --output "$TMP_DIR/db-dump.xz" -L https://github.com/elan-ev/tobira/raw/db-dumps/db-dump-latest.xz
 xz -d "$TMP_DIR/db-dump.xz"
 
 # Prompt to notify that the current DB is deleted.


### PR DESCRIPTION
"Our" S3 is currently broken and it might not be maintained anymore. Using LFS is nice because it's also hosted with GitHub, reducing the number of points of failure. The dumps are small enough so that we likely won't run into any limitations.

I already pushed all current DB dumps to the `db-dumps` orphan branch.

**Note**: this does not adjust the `upload-db-dump` action yet. I first wanted to see CI working again.