### PR TITLE
Replace most Hero icons by ones from Lucide

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -5,8 +5,7 @@ import { OperationType } from "relay-runtime";
 import {
     FiCode, FiSettings, FiShare2, FiDownload,
 } from "react-icons/fi";
-import { HiLink } from "react-icons/hi";
-import { HiOutlineQrCode } from "react-icons/hi2";
+import { LuLink, LuQrCode } from "react-icons/lu";
 import { QRCodeCanvas } from "qrcode.react";
 import {
     match, unreachable, ProtoButton,
@@ -534,7 +533,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     type State = "closed" | "main" | "embed" | "rss";
     /* eslint-disable react/jsx-key */
     const entries: [Exclude<State, "closed">, ReactElement][] = [
-        ["main", <HiLink />],
+        ["main", <LuLink />],
         ["embed", <FiCode />],
         // ["rss", <FiRss />],
     ];
@@ -618,7 +617,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             onClick={() => currentRef(qrModalRef).open()}
             css={{ width: "max-content" }}
         >
-            <HiOutlineQrCode />
+            <LuQrCode />
             {t("video.share.show-qr-code")}
         </Button>
         <Modal

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
-import { HiSortAscending, HiSortDescending } from "react-icons/hi";
+import { LuArrowDownNarrowWide, LuArrowUpWideNarrow } from "react-icons/lu";
 import { graphql, VariablesOf } from "react-relay";
 import { match, useColorScheme } from "@opencast/appkit";
 
@@ -252,8 +252,8 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => 
             {vars.order.column === sortKey && match(vars.order.direction, {
                 // Seems like this is flipped right? But no, a short internal
                 // poll showed that this matches the intuition of almost everyone.
-                "ASCENDING": () => <HiSortDescending />,
-                "DESCENDING": () => <HiSortAscending />,
+                "ASCENDING": () => <LuArrowDownNarrowWide />,
+                "DESCENDING": () => <LuArrowUpWideNarrow />,
             }, () => null)}
         </Link>
     </th>

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -1,7 +1,8 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { FiExternalLink, FiFilm, FiUpload, FiVideo } from "react-icons/fi";
-import { HiOutlineFire, HiOutlineTemplate } from "react-icons/hi";
+import { HiOutlineFire } from "react-icons/hi";
+import { LuLayoutTemplate } from "react-icons/lu";
 import { graphql } from "react-relay";
 import { useColorScheme } from "@opencast/appkit";
 
@@ -79,7 +80,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
 
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
-        ["/~manage", t("manage.dashboard.title"), <HiOutlineTemplate />],
+        ["/~manage", t("manage.dashboard.title"), <LuLayoutTemplate />],
         ["/~manage/videos", t("manage.my-videos.title"), <FiFilm />],
     ];
     if (isRealUser(user) && user.canCreateUserRealm) {

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiAlertTriangle, FiFilm, FiRadio, FiVolume2 } from "react-icons/fi";
-import { HiOutlineUserCircle } from "react-icons/hi";
+import { LuUserCircle } from "react-icons/lu";
 import { useColorScheme } from "@opencast/appkit";
 
 import { COLORS } from "../color";
@@ -251,7 +251,7 @@ export const Creators: React.FC<CreatorsProps> = ({ creators, className }) => (
             }}
             {...{ className }}
         >
-            <HiOutlineUserCircle css={{
+            <LuUserCircle css={{
                 color: COLORS.neutral60,
                 fontSize: 16,
                 flexShrink: 0,


### PR DESCRIPTION
Closes #923 

This does not yet replace `HiOutlineFire` because this will happen later anyway, since we want to replace completely.