### PR TITLE
Use fixed background/color for inputs and textareas

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -120,5 +120,12 @@ const GLOBAL_STYLE = css({
         borderTop: `1px solid ${COLORS.neutral25}`,
     },
     "p, label": { color: COLORS.neutral80 },
-    input: { color: COLORS.neutral90 },
+    "input, textarea": {
+        backgroundColor: COLORS.neutral05,
+        color: COLORS.neutral90,
+        ":disabled": {
+            backgroundColor: COLORS.neutral10,
+            color: COLORS.neutral70,
+        },
+    },
 });


### PR DESCRIPTION
Closes #932

I noticed that disabled textareas also use a slightly greyed-out font-color, so I added this effect to disabled inputs as well.