### PR TITLE
Add compile target to adopter registration stats

### DIFF
--- a/backend/src/sync/stats.rs
+++ b/backend/src/sync/stats.rs
@@ -67,6 +67,7 @@ struct VersionStats {
     build_time_utc: &'static str,
     git_commit_hash: &'static str,
     git_was_dirty: bool,
+    target: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -103,6 +104,7 @@ impl Stats {
                 build_time_utc: crate::version::build_time_utc(),
                 git_commit_hash: crate::version::git_commit_hash(),
                 git_was_dirty: crate::version::git_was_dirty(),
+                target: crate::version::target(),
             },
             config: ConfigStats {
                 download_button_shown: config.general.show_download_button,


### PR DESCRIPTION
Since we already show it on the "about" page, including it in this data seems like a good idea. Currently this could be `x86_64-unknown-linux-gnu` or `x86_64-unknown-linux-musl`. Well, in theory it could be anything, who knows, maybe people manage to build Tobira for `mipsel-sony-psp` or `armv6k-nintendo-3ds`.