### PR TITLE
Add "start at:" option to share menu

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -305,6 +305,7 @@ manage:
     details:
       title: Videodetails
       share-direct-link: Via Direktlink teilen
+      set-time: 'Starten bei: '
       copy-direct-link-to-clipboard: Videolink in Zwischenablage kopieren
       open-in-editor: Im Videoeditor öffnen
       referencing-pages: Referenzierende Seiten

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -298,6 +298,7 @@ manage:
     details:
       title: Video details
       share-direct-link: Share via direct link
+      set-time: 'Start at: '
       copy-direct-link-to-clipboard: Copy video link to clipboard
       open-in-editor: Open in video editor
       referencing-pages: Referencing pages

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -13,6 +13,7 @@ import { Spinner } from "../ui/Spinner";
 import { MovingTruck } from "../ui/Waiting";
 import { b64regex } from "./util";
 import { EmbedQuery } from "./__generated__/EmbedQuery.graphql";
+import { PlayerContextProvider } from "../ui/player/PlayerContext";
 
 
 const query = graphql`
@@ -60,7 +61,9 @@ export const EmbedVideoRoute = makeRoute(url => {
                     }} />
                 </PlayerPlaceholder>
             }>
-                <Embed queryRef={queryRef} />
+                <PlayerContextProvider>
+                    <Embed queryRef={queryRef} />
+                </PlayerContextProvider>
             </Suspense>
         </ErrorBoundary>,
         dispose: () => queryRef.dispose(),

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -545,7 +545,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
 
     const { t } = useTranslation();
     const [menuState, setMenuState] = useState<MenuState>("closed");
-    const [timestamp, setTimestamp] = useState<number>(0);
+    const [timestamp, setTimestamp] = useState(0);
     const [addLinkTimestamp, setAddLinkTimestamp] = useState(false);
     const [addEmbedTimestamp, setAddEmbedTimestamp] = useState(false);
     const isDark = useColorScheme().scheme === "dark";
@@ -663,7 +663,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 <div>
                     <CopyableInput
                         label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
-                        css={{ fontSize: 14, width: 400 }}
+                        css={{ fontSize: 14, width: 400, marginBottom: 6 }}
                         value={url}
                     />
                     <InputWithCheckbox
@@ -707,7 +707,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         label={t("video.embed.copy-embed-code-to-clipboard")}
                         value={embedCode}
                         multiline
-                        css={{ fontSize: 14, width: 400, height: 75 }}
+                        css={{ fontSize: 14, width: 400, height: 75, marginBottom: 6 }}
                     />
                     <InputWithCheckbox
                         checkboxChecked={addEmbedTimestamp}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -545,7 +545,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
 
     const { t } = useTranslation();
     const [menuState, setMenuState] = useState<MenuState>("closed");
-    const [timestamp, setTimestamp] = useState<string>("0m0s");
+    const [timestamp, setTimestamp] = useState<number>(0);
     const [addLinkTimestamp, setAddLinkTimestamp] = useState(false);
     const [addEmbedTimestamp, setAddEmbedTimestamp] = useState(false);
     const isDark = useColorScheme().scheme === "dark";
@@ -655,7 +655,9 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
         "closed": () => null,
         "main": () => {
             let url = window.location.href.replace(timeStringPattern, "");
-            url += addLinkTimestamp && timestamp ? `?t=${timestamp}` : "";
+            url += addLinkTimestamp && timestamp
+                ? `?t=${secondsToTimeString(timestamp)}`
+                : "";
 
             return <>
                 <div>
@@ -683,7 +685,9 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 : getPlayerAspectRatio(event.syncedData.tracks);
 
             const url = new URL(location.href.replace(timeStringPattern, ""));
-            url.search = addEmbedTimestamp && timestamp ? `?t=${timestamp}` : "";
+            url.search = addEmbedTimestamp && timestamp
+                ? `?t=${secondsToTimeString(timestamp)}`
+                : "";
             url.pathname = `/~embed/!v/${event.id.slice(2)}`;
 
             const embedCode = `<iframe ${[
@@ -741,7 +745,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                     setMenuState(state => state === "closed" ? "main" : "closed");
                     if (playerIsLoaded) {
                         paella.current?.player.videoContainer.currentTime().then(res => {
-                            setTimestamp(secondsToTimeString(res));
+                            setTimestamp(res);
                         });
                     }
                 }}>

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -314,8 +314,10 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
     return <>
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
         <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
-        <InlinePlayer event={event} css={{ margin: "0 auto" }} onEventStateChange={rerender} />
-        <Metadata id={event.id} event={event} />
+        <PlayerContextProvider>
+            <InlinePlayer event={event} css={{ margin: "0 auto" }} onEventStateChange={rerender} />
+            <Metadata id={event.id} event={event} />
+        </PlayerContextProvider>
 
         <div css={{ height: 80 }} />
 

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -546,6 +546,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const isDark = useColorScheme().scheme === "dark";
     const ref = useRef(null);
     const qrModalRef = useRef<ModalHandle>(null);
+    const timeStringPattern = /\?t=(\d+h)?(\d+m)?(\d+s)?/;
 
     const isActive = (label: State) => label === state;
 
@@ -644,16 +645,14 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const inner = match(state, {
         "closed": () => null,
         "main": () => {
-            let url = window.location.href;
-            if (timestamp) {
-                url = url + `?t=${timestamp}`;
-            }
+            let url = window.location.href.replace(timeStringPattern, "");
+            url += timestamp ? `?t=${timestamp}` : "";
+
             return <>
                 <div>
                     <CopyableInput
                         label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
                         css={{ fontSize: 14, width: 400 }}
-                        // TODO
                         value={url}
                     />
                     <TimePicker {...{ setTimestamp }} />
@@ -666,10 +665,8 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 ? [16, 9]
                 : getPlayerAspectRatio(event.syncedData.tracks);
 
-            let url = new URL(location.href);
-            if (timestamp) {
-                url = new URL(url + `?t=${timestamp}`);
-            }
+            const url = new URL(location.href.replace(timeStringPattern, ""));
+            url.search = timestamp ? `?t=${timestamp}` : "";
             url.pathname = `/~embed/!v/${event.id.slice(2)}`;
 
             const embedCode = `<iframe ${[

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -545,7 +545,6 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
 
     const { t } = useTranslation();
     const [menuState, setMenuState] = useState<MenuState>("closed");
-    const prevMenuState = useRef<MenuState>(menuState);
     const [timestamp, setTimestamp] = useState<string>("0m0s");
     const [addLinkTimestamp, setAddLinkTimestamp] = useState(false);
     const [addEmbedTimestamp, setAddEmbedTimestamp] = useState(false);
@@ -555,16 +554,6 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const { paella, playerIsLoaded } = usePlayerContext();
 
     const timeStringPattern = /\?t=(\d+h)?(\d+m)?(\d+s)?/;
-
-
-    useEffect(() => {
-        if (prevMenuState.current === "closed" && playerIsLoaded) {
-            paella.current?.player.videoContainer.currentTime().then(res => {
-                setTimestamp(secondsToTimeString(res));
-            });
-        }
-        prevMenuState.current = menuState;
-    }, [menuState]);
 
     const isActive = (label: MenuState) => label === menuState;
 
@@ -748,9 +737,14 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             viewPortMargin={12}
         >
             <FloatingTrigger>
-                <Button onClick={() =>
-                    setMenuState(state => state === "closed" ? "main" : "closed")}
-                >
+                <Button onClick={() => {
+                    setMenuState(state => state === "closed" ? "main" : "closed");
+                    if (playerIsLoaded) {
+                        paella.current?.player.videoContainer.currentTime().then(res => {
+                            setTimestamp(secondsToTimeString(res));
+                        });
+                    }
+                }}>
                     <FiShare2 size={16} />
                     {t("general.action.share")}
                 </Button>

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -39,7 +39,7 @@ import { Link, useRouter } from "../router";
 import { useUser } from "../User";
 import { b64regex } from "./util";
 import { ErrorPage } from "../ui/error";
-import { CopyableInput } from "../ui/Input";
+import { CopyableInput, InputWithCheckbox, TimeInput } from "../ui/Input";
 import { VideoPageInRealmQuery } from "./__generated__/VideoPageInRealmQuery.graphql";
 import {
     VideoPageEventData$data,
@@ -63,7 +63,6 @@ import { TrackInfo } from "./manage/Video/TechnicalDetails";
 import { COLORS } from "../color";
 import { RelativeDate } from "../ui/time";
 import { Modal, ModalHandle } from "../ui/Modal";
-import { TimePicker } from "./manage/Video/Details";
 import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
 
 
@@ -676,10 +675,14 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         css={{ fontSize: 14, width: 400 }}
                         value={url}
                     />
-                    <TimePicker
-                        {...{ timestamp, setTimestamp }}
+                    <InputWithCheckbox
                         checkboxChecked={addLinkTimestamp}
                         setCheckboxChecked={setAddLinkTimestamp}
+                        label={t("manage.my-videos.details.set-time")}
+                        input={<TimeInput
+                            {...{ timestamp, setTimestamp }}
+                            disabled={!addLinkTimestamp}
+                        />}
                     />
                 </div>
                 <ShowQRCodeButton target={window.location.href} label={menuState} />
@@ -713,10 +716,14 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         multiline
                         css={{ fontSize: 14, width: 400, height: 75 }}
                     />
-                    <TimePicker
-                        {...{ timestamp, setTimestamp }}
+                    <InputWithCheckbox
                         checkboxChecked={addEmbedTimestamp}
                         setCheckboxChecked={setAddEmbedTimestamp}
+                        label={t("manage.my-videos.details.set-time")}
+                        input={<TimeInput
+                            {...{ timestamp, setTimestamp }}
+                            disabled={!addEmbedTimestamp}
+                        />}
                     />
                 </div>
                 <ShowQRCodeButton target={embedCode} label={menuState} />

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -676,7 +676,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         />}
                     />
                 </div>
-                <ShowQRCodeButton target={window.location.href} label={menuState} />
+                <ShowQRCodeButton target={url} label={menuState} />
             </>;
         },
         "embed": () => {

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -14,6 +14,7 @@ import { AuthorizedEvent, makeManageVideoRoute, PAGE_WIDTH } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
 import { buttonStyle } from "../../../ui/Button";
 import { COLORS } from "../../../color";
+import { secondsToTimeString } from "../../../util";
 
 
 export const ManageVideoDetailsRoute = makeManageVideoRoute(
@@ -75,12 +76,12 @@ const Page: React.FC<Props> = ({ event }) => {
 
 const DirectLink: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
-    const [timestamp, setTimestamp] = useState<string>("0m0s");
+    const [timestamp, setTimestamp] = useState<number>(0);
     const [checkboxChecked, setCheckboxChecked] = useState(false);
 
     let url = new URL(`/!v/${event.id.slice(2)}`, document.baseURI);
     if (timestamp && checkboxChecked) {
-        url = new URL(url + `?t=${timestamp}`);
+        url = new URL(url + `?t=${secondsToTimeString(timestamp)}`);
     }
 
     return (

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -76,7 +76,7 @@ const Page: React.FC<Props> = ({ event }) => {
 
 const DirectLink: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
-    const [timestamp, setTimestamp] = useState<number>(0);
+    const [timestamp, setTimestamp] = useState(0);
     const [checkboxChecked, setCheckboxChecked] = useState(false);
 
     let url = new URL(`/!v/${event.id.slice(2)}`, document.baseURI);
@@ -92,7 +92,7 @@ const DirectLink: React.FC<Props> = ({ event }) => {
             <CopyableInput
                 label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
                 value={url.href}
-                css={{ width: "100%", fontSize: 14 }}
+                css={{ width: "100%", fontSize: 14, marginBottom: 6 }}
             />
             <InputWithCheckbox
                 {...{ checkboxChecked, setCheckboxChecked }}

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { FiExternalLink } from "react-icons/fi";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Form } from "../../../ui/Form";
@@ -74,60 +74,47 @@ const Page: React.FC<Props> = ({ event }) => {
 };
 
 type TimePickerProps = {
+    timestamp: string;
     setTimestamp: (newTime: string) => void;
+    checkboxChecked: boolean;
+    setCheckboxChecked: (newValue: boolean) => void;
 }
 
-export const TimePicker: React.FC<TimePickerProps> = ({ setTimestamp }) => {
+export const TimePicker: React.FC<TimePickerProps> = (
+    { timestamp, setTimestamp, checkboxChecked, setCheckboxChecked }
+) => {
     const { t } = useTranslation();
-    const [time, setTime] = useState<string>("00:00:00");
 
-    const formatTime = (timeValue: string): string => {
-        const [hours, minutes, seconds] = timeValue.split(":");
-        let formattedTime = "";
-        if (hours && hours !== "00") {
-            formattedTime += hours + "h";
-        }
-        if (minutes && minutes !== "00") {
-            formattedTime += minutes + "m";
-        }
-        if (seconds && seconds !== "00") {
-            formattedTime += seconds + "s";
-        }
-
-        return formattedTime;
-    };
-
-    useEffect(() => {
-        setTimestamp(formatTime(time));
-    }, [time]);
-
-    return <div css={{ paddingLeft: 2 }}>
+    return <>
+        <input
+            type="checkbox"
+            checked={checkboxChecked}
+            onChange={() => setCheckboxChecked(!checkboxChecked)}
+            css={{ margin: "0 4px" }}
+        />
         <label css={{ color: COLORS.neutral90, fontSize: 14 }}>
             {t("manage.my-videos.details.set-time")}
         </label>
         <input
-            value={time}
-            type="time"
-            step="1"
-            onChange={e => setTime(e.target.value)}
+            disabled={!checkboxChecked}
+            value={timestamp}
+            onChange={e => setTimestamp(e.target.value)}
             css={{
                 border: 0,
                 backgroundColor: "transparent",
                 fontSize: 14,
-                "::-webkit-calendar-picker-indicator": {
-                    display: "none",
-                },
             }}
         />
-    </div>;
+    </>;
 };
 
 const DirectLink: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
-    const [timestamp, setTimestamp] = useState<string>("");
+    const [timestamp, setTimestamp] = useState<string>("0m0s");
+    const [checkboxChecked, setCheckboxChecked] = useState(false);
 
     let url = new URL(`/!v/${event.id.slice(2)}`, document.baseURI);
-    if (timestamp) {
+    if (timestamp && checkboxChecked) {
         url = new URL(url + `?t=${timestamp}`);
     }
 
@@ -141,7 +128,12 @@ const DirectLink: React.FC<Props> = ({ event }) => {
                 value={url.href}
                 css={{ width: "100%", fontSize: 14 }}
             />
-            <TimePicker {...{ setTimestamp }} />
+            <TimePicker {...{
+                timestamp,
+                setTimestamp,
+                checkboxChecked,
+                setCheckboxChecked,
+            }} />
         </div>
     );
 };

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { FiExternalLink } from "react-icons/fi";
 
+import { useEffect, useState } from "react";
 import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Form } from "../../../ui/Form";
@@ -72,9 +73,63 @@ const Page: React.FC<Props> = ({ event }) => {
     </>;
 };
 
+type TimePickerProps = {
+    setTimestamp: (newTime: string) => void;
+}
+
+export const TimePicker: React.FC<TimePickerProps> = ({ setTimestamp }) => {
+    const { t } = useTranslation();
+    const [time, setTime] = useState<string>("00:00:00");
+
+    const formatTime = (timeValue: string): string => {
+        const [hours, minutes, seconds] = timeValue.split(":");
+        let formattedTime = "";
+        if (hours && hours !== "00") {
+            formattedTime += hours + "h";
+        }
+        if (minutes && minutes !== "00") {
+            formattedTime += minutes + "m";
+        }
+        if (seconds && seconds !== "00") {
+            formattedTime += seconds + "s";
+        }
+
+        return formattedTime;
+    };
+
+    useEffect(() => {
+        setTimestamp(formatTime(time));
+    }, [time]);
+
+    return <div css={{ paddingLeft: 2 }}>
+        <label css={{ color: COLORS.neutral90, fontSize: 14 }}>
+            {t("manage.my-videos.details.set-time")}
+        </label>
+        <input
+            value={time}
+            type="time"
+            step="1"
+            onChange={e => setTime(e.target.value)}
+            css={{
+                border: 0,
+                backgroundColor: "transparent",
+                fontSize: 14,
+                "::-webkit-calendar-picker-indicator": {
+                    display: "none",
+                },
+            }}
+        />
+    </div>;
+};
+
 const DirectLink: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
-    const url = new URL(`/!v/${event.id.slice(2)}`, document.baseURI);
+    const [timestamp, setTimestamp] = useState<string>("");
+
+    let url = new URL(`/!v/${event.id.slice(2)}`, document.baseURI);
+    if (timestamp) {
+        url = new URL(url + `?t=${timestamp}`);
+    }
 
     return (
         <div css={{ marginBottom: 40 }}>
@@ -86,6 +141,7 @@ const DirectLink: React.FC<Props> = ({ event }) => {
                 value={url.href}
                 css={{ width: "100%", fontSize: 14 }}
             />
+            <TimePicker {...{ setTimestamp }} />
         </div>
     );
 };

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Form } from "../../../ui/Form";
-import { CopyableInput, Input, TextArea } from "../../../ui/Input";
+import { CopyableInput, Input, InputWithCheckbox, TextArea, TimeInput } from "../../../ui/Input";
 import { InputContainer, TitleLabel } from "../../../ui/metadata";
 import { isRealUser, useUser } from "../../../User";
 import { Breadcrumbs } from "../../../ui/Breadcrumbs";
@@ -73,41 +73,6 @@ const Page: React.FC<Props> = ({ event }) => {
     </>;
 };
 
-type TimePickerProps = {
-    timestamp: string;
-    setTimestamp: (newTime: string) => void;
-    checkboxChecked: boolean;
-    setCheckboxChecked: (newValue: boolean) => void;
-}
-
-export const TimePicker: React.FC<TimePickerProps> = (
-    { timestamp, setTimestamp, checkboxChecked, setCheckboxChecked }
-) => {
-    const { t } = useTranslation();
-
-    return <>
-        <input
-            type="checkbox"
-            checked={checkboxChecked}
-            onChange={() => setCheckboxChecked(!checkboxChecked)}
-            css={{ margin: "0 4px" }}
-        />
-        <label css={{ color: COLORS.neutral90, fontSize: 14 }}>
-            {t("manage.my-videos.details.set-time")}
-        </label>
-        <input
-            disabled={!checkboxChecked}
-            value={timestamp}
-            onChange={e => setTimestamp(e.target.value)}
-            css={{
-                border: 0,
-                backgroundColor: "transparent",
-                fontSize: 14,
-            }}
-        />
-    </>;
-};
-
 const DirectLink: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
     const [timestamp, setTimestamp] = useState<string>("0m0s");
@@ -128,12 +93,11 @@ const DirectLink: React.FC<Props> = ({ event }) => {
                 value={url.href}
                 css={{ width: "100%", fontSize: 14 }}
             />
-            <TimePicker {...{
-                timestamp,
-                setTimestamp,
-                checkboxChecked,
-                setCheckboxChecked,
-            }} />
+            <InputWithCheckbox
+                {...{ checkboxChecked, setCheckboxChecked }}
+                label={t("manage.my-videos.details.set-time")}
+                input={<TimeInput {...{ timestamp, setTimestamp }} disabled={!checkboxChecked} />}
+            />
         </div>
     );
 };

--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -22,8 +22,6 @@ declare module "paella-core" {
             unregisterOnUnload?: boolean
         ): () => void;
 
-        public setCurrentTime: (t: number) => Promise<void>;
-
         public unload(): Promise<void>;
     }
 
@@ -58,6 +56,7 @@ declare module "paella-core" {
 
     export interface VideoContainer {
         setCurrentTime: (t: number) => Promise<void>;
+        currentTime: () => Promise<number>;
     }
 
     export type PluginConfig = Record<string, unknown> & {

--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -14,6 +14,16 @@ declare module "paella-core" {
          */
         public loadManifest(): Promise<void>;
 
+        public videoContainer: VideoContainer;
+
+        public bindEvent(
+            event: string,
+            callback: () => void,
+            unregisterOnUnload?: boolean
+        ): () => void;
+
+        public setCurrentTime: (t: number) => Promise<void>;
+
         public unload(): Promise<void>;
     }
 
@@ -44,6 +54,10 @@ declare module "paella-core" {
 
         logLevel?: "DISABLED" | "ERROR" | "WARN" | "INFO" | "DEBUG" | "VERBOSE";
         plugins: Record<string, PluginConfig>;
+    }
+
+    export interface VideoContainer {
+        setCurrentTime: (t: number) => Promise<void>;
     }
 
     export type PluginConfig = Record<string, unknown> & {

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useState } from "react";
+import React, { Fragment, ReactNode, useId, useState } from "react";
 import { FiCheck, FiCopy } from "react-icons/fi";
 import { WithTooltip } from "@opencast/appkit";
 
@@ -49,6 +49,93 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         />
     ),
 );
+
+type InputWithCheckboxProps = {
+    checkboxChecked: boolean;
+    setCheckboxChecked: (newValue: boolean) => void;
+    label: string;
+    input: ReactNode;
+}
+
+/** Checkbox with a label to enable/disable an adjacent input */
+export const InputWithCheckbox: React.FC<InputWithCheckboxProps> = (
+    { checkboxChecked, setCheckboxChecked, label, input }
+) => <div css={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
+    <input
+        type="checkbox"
+        checked={checkboxChecked}
+        onChange={() => setCheckboxChecked(!checkboxChecked)}
+        css={{ margin: "0 4px" }}
+    />
+    <label css={{ color: COLORS.neutral90, fontSize: 14 }}>
+        {label}
+    </label>
+    {input}
+</div>;
+
+type TimeInputProps = {
+    timestamp: string;
+    setTimestamp: (newTime: string) => void;
+    disabled: boolean;
+}
+
+/** A custom three-part input for time inputs split into hours, minutes and seconds */
+export const TimeInput: React.FC<TimeInputProps> = ({ timestamp, setTimestamp, disabled }) => {
+    const timeParts = (/(\d+h)?(\d+m)?(\d+s)?/).exec(timestamp)?.slice(1) ?? [];
+    const [hours, minutes, seconds] = timeParts
+        .map(part => part ? parseInt(part.replace(/\D/g, "")) : 0);
+
+    const handleTimeChange = (newValue: number, type: TimeUnit) => {
+        if (isNaN(newValue)) {
+            return;
+        }
+
+        const cappedValue = Math.min(newValue, 59);
+        const newTimestamp = `${type === "h" ? cappedValue : hours}h`
+            + `${type === "m" ? cappedValue : minutes}m`
+            + `${type === "s" ? cappedValue : seconds}s`;
+
+        setTimestamp(newTimestamp);
+    };
+
+    type TimeUnit = "h" | "m" | "s";
+    const entries: [number, TimeUnit][] = [
+        [hours, "h"],
+        [minutes, "m"],
+        [seconds, "s"],
+    ];
+
+    return (
+        <div css={{ color: disabled ? COLORS.neutral70 : COLORS.neutral90 }}>
+            {entries.map(([time, unit]) => <Fragment key={`${unit}-input`}>
+                <input
+                    {...{ disabled }}
+                    value={time}
+                    maxLength={2}
+                    onChange={e => handleTimeChange(Number(e.target.value), unit)}
+                    css={{
+                        width: time > 9 ? 24 : "2ch",
+                        lineHeight: 1,
+                        padding: 0,
+                        border: 0,
+                        textAlign: "center",
+                        borderRadius: 4,
+                        outline: `1px solid ${COLORS.neutral20}`,
+                        outlineOffset: "-2px",
+                        userSelect: "all",
+                        ...focusStyle({ inset: true }),
+                        ":disabled": {
+                            textAlign: "right",
+                            backgroundColor: "transparent",
+                            outline: "none",
+                        },
+                    }}
+                />
+                <span>{unit}</span>
+            </Fragment>)}
+        </div>
+    );
+};
 
 export type SelectProps = React.ComponentPropsWithoutRef<"select"> & {
     error?: boolean;

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -74,14 +74,16 @@ export const InputWithCheckbox: React.FC<InputWithCheckboxProps> = (
 </div>;
 
 type TimeInputProps = {
-    timestamp: string;
-    setTimestamp: (newTime: string) => void;
+    timestamp: number;
+    setTimestamp: (newTime: number) => void;
     disabled: boolean;
 }
 
 /** A custom three-part input for time inputs split into hours, minutes and seconds */
 export const TimeInput: React.FC<TimeInputProps> = ({ timestamp, setTimestamp, disabled }) => {
-    const timeParts = (/(\d+h)?(\d+m)?(\d+s)?/).exec(timestamp)?.slice(1) ?? [];
+    const timeParts = (/(\d+h)?(\d+m)?(\d+s)?/)
+        .exec(secondsToTimeString(timestamp))?.slice(1) ?? [];
+
     const [hours, minutes, seconds] = timeParts
         .map(part => part ? parseInt(part.replace(/\D/g, "")) : 0);
 
@@ -95,7 +97,7 @@ export const TimeInput: React.FC<TimeInputProps> = ({ timestamp, setTimestamp, d
             + `${type === "m" ? cappedValue : minutes}m`
             + `${type === "s" ? cappedValue : seconds}s`;
 
-        setTimestamp(newTimestamp);
+        setTimestamp(timeStringToSeconds(timeString));
     };
 
     type TimeUnit = "h" | "m" | "s";

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -7,6 +7,7 @@ import { Caption, isHlsTrack, Track } from ".";
 import { SPEEDS } from "./consts";
 import { useTranslation } from "react-i18next";
 import { timeStringToSeconds } from "../../util";
+import { usePlayerContext } from "./PlayerContext";
 
 
 type PaellaPlayerProps = {
@@ -20,7 +21,7 @@ type PaellaPlayerProps = {
     previewImage: string | null;
 };
 
-type PaellaState = {
+export type PaellaState = {
     player: Paella;
     loadPromise: Promise<void>;
 };
@@ -30,7 +31,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
 }) => {
     const { t } = useTranslation();
     const ref = useRef<HTMLDivElement>(null);
-    const paella = useRef<PaellaState>();
+    const { paella, setPlayerIsLoaded } = usePlayerContext();
 
     useEffect(() => {
         // If the ref is not set yet (which should not usually happen), we do
@@ -115,11 +116,12 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
             });
 
             const time = new URL(window.location.href).searchParams.get("t");
-            if (time) {
-                player.bindEvent("paella:playerLoaded", () => {
+            player.bindEvent("paella:playerLoaded", () => {
+                setPlayerIsLoaded(true);
+                if (time) {
                     player.videoContainer.setCurrentTime(timeStringToSeconds(time));
-                });
-            }
+                }
+            });
 
             const loadPromise = player.loadManifest();
             paella.current = { player, loadPromise };

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -6,6 +6,7 @@ import getZoomPluginContext from "paella-zoom-plugin";
 import { Caption, isHlsTrack, Track } from ".";
 import { SPEEDS } from "./consts";
 import { useTranslation } from "react-i18next";
+import { timeStringToSeconds } from "../../util";
 
 
 type PaellaPlayerProps = {
@@ -112,9 +113,16 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
                     getZoomPluginContext(),
                 ],
             });
+
+            const time = new URL(window.location.href).searchParams.get("t");
+            if (time) {
+                player.bindEvent("paella:playerLoaded", () => {
+                    player.videoContainer.setCurrentTime(timeStringToSeconds(time));
+                });
+            }
+
             const loadPromise = player.loadManifest();
             paella.current = { player, loadPromise };
-
         }
 
         const paellaSnapshot = paella.current;

--- a/frontend/src/ui/player/PlayerContext.tsx
+++ b/frontend/src/ui/player/PlayerContext.tsx
@@ -1,0 +1,33 @@
+import {
+    Dispatch,
+    MutableRefObject,
+    PropsWithChildren,
+    SetStateAction,
+    createContext,
+    useContext,
+    useRef,
+    useState,
+} from "react";
+import { PaellaState } from "./Paella";
+import { bug } from "@opencast/appkit";
+
+type PlayerContext = {
+    paella: MutableRefObject<PaellaState | undefined>;
+    playerIsLoaded: boolean;
+    setPlayerIsLoaded: Dispatch<SetStateAction<boolean>>;
+};
+
+const PlayerContext = createContext<PlayerContext | null>(null);
+
+export const PlayerContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
+    const paella = useRef<PaellaState>();
+    const [playerIsLoaded, setPlayerIsLoaded] = useState(false);
+
+    return <PlayerContext.Provider value={{ paella, playerIsLoaded, setPlayerIsLoaded }}>
+        {children}
+    </PlayerContext.Provider>;
+};
+
+export const usePlayerContext = () => useContext(PlayerContext)
+    ?? bug("Player context is not initialized!");
+

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -165,3 +165,13 @@ export const toIsoDuration = (milliseconds: number): string => {
 export const isExperimentalFlagSet = () => (
     window.localStorage.getItem("tobiraExperimentalFeatures") === "true"
 );
+
+export const timeStringToSeconds = (timeString: string): number => {
+    const timeSplit = /((\d+)h)?((\d+)m)?((\d+)s)?/.exec(timeString);
+    const hours = timeSplit && timeSplit[2] ? parseInt(timeSplit[2]) * 60 * 60 : 0;
+    const minutes = timeSplit && timeSplit[4] ? parseInt(timeSplit[4]) * 60 : 0;
+    const seconds = timeSplit && timeSplit[6] ? parseInt(timeSplit[6]) : 0;
+
+    return hours + minutes + seconds;
+};
+

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { bug } from "@opencast/appkit";
 
 import CONFIG, { TranslatedString } from "../config";
+import { TimeUnit } from "../ui/Input";
 
 
 /** Retrieves the key of an ID by stripping the "kind" prefix. */
@@ -180,9 +181,12 @@ export const timeStringToSeconds = (timeString: string): number => {
  * e.g. "0h2m4s".
  */
 export const secondsToTimeString = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600) + "h";
-    const minutes = Math.floor((seconds % 3600) / 60) + "m";
-    const remainingSeconds = Math.floor(seconds % 60) + "s";
+    const formatTime = (time: number, unit: TimeUnit): string =>
+        time > 0 ? time.toString().padStart(2, "0") + unit : "";
+
+    const hours = formatTime(Math.floor(seconds / 3600), "h");
+    const minutes = formatTime(Math.floor((seconds % 3600) / 60), "m");
+    const remainingSeconds = formatTime(Math.floor(seconds % 60), "s");
 
     return hours + minutes + remainingSeconds;
 };

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -175,3 +175,15 @@ export const timeStringToSeconds = (timeString: string): number => {
     return hours + minutes + seconds;
 };
 
+export const secondsToTimeString = (seconds: number): string => {
+    type TimeUnit = "h" | "m" | "s";
+    const formatTime = (time: number, unit: TimeUnit): string =>
+        unit === "h" && time === 0 ? "" : time.toString().padStart(2, "0") + unit;
+
+    const hours = formatTime(Math.floor(seconds / 3600), "h");
+    const minutes = formatTime(Math.floor((seconds % 3600) / 60), "m");
+    const remainingSeconds = formatTime(Math.floor(seconds % 60), "s");
+
+    return hours + minutes + remainingSeconds;
+};
+

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -175,14 +175,14 @@ export const timeStringToSeconds = (timeString: string): number => {
     return hours + minutes + seconds;
 };
 
+/**
+ * Formats the given number of seconds as string containing hours, minutes and seconds,
+ * e.g. "0h2m4s".
+ */
 export const secondsToTimeString = (seconds: number): string => {
-    type TimeUnit = "h" | "m" | "s";
-    const formatTime = (time: number, unit: TimeUnit): string =>
-        unit === "h" && time === 0 ? "" : time.toString().padStart(2, "0") + unit;
-
-    const hours = formatTime(Math.floor(seconds / 3600), "h");
-    const minutes = formatTime(Math.floor((seconds % 3600) / 60), "m");
-    const remainingSeconds = formatTime(Math.floor(seconds % 60), "s");
+    const hours = Math.floor(seconds / 3600) + "h";
+    const minutes = Math.floor((seconds % 3600) / 60) + "m";
+    const remainingSeconds = Math.floor(seconds % 60) + "s";
 
     return hours + minutes + remainingSeconds;
 };


### PR DESCRIPTION
Closes #191

- This adds a "Start at: {time}" timepicker to the direct link on the `Video details` page and both share options of the video page's share menu. 
- Picking a time will append said time as a search query to the shared link.
- The linked video will start at the chosen time.
- Users can also manually add a time to a link in their browser by appending `?t=2h2m20s` (or any other combination of  hours, minutes and seconds like `?t=2m` or `?t=1h20s` or `?t=20s` etc). You can try it out with https://pr943.tobira.opencast.org/v/GjDqXFlukkH?t=20s (or any other video).

- There is unfortunately one visual issue with the time picker in chrome, where the rightmost number is slightly cut off. I don't know what causes this yet. 
<img width="246" alt="Bildschirmfoto 2023-09-20 um 23 11 22" src="https://github.com/elan-ev/tobira/assets/94838646/5e2c515e-71aa-44bf-ab01-2ff59fac06a1">

- As always, visuals and wording (and I also the places where this is included) are open for discussion and feedback is appreciated.

