### PR TITLE
Add player context to video blocks

### DIFF
--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
 import { FiArrowRightCircle } from "react-icons/fi";
+import { PlayerContextProvider } from "../player/PlayerContext";
 
 
 type Props = {
@@ -58,7 +59,9 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
     return <div css={{ maxWidth: 800 }}>
         {showTitle && <Title title={event.title} />}
         {isSynced(event)
-            ? <InlinePlayer event={event} css={{ maxWidth: 800 }} />
+            ? <PlayerContextProvider>
+                <InlinePlayer event={event} css={{ maxWidth: 800 }} />
+            </PlayerContextProvider>
             : <Card kind="info">{t("video.not-ready.title")}</Card>}
         {showLink && <Link
             to={`${basePath}/${keyOfId(event.id)}`}

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -112,6 +112,8 @@ const delayTill = (date: Date): number => {
 /**
  * A more constrained version of the player component for use in normal page flow.
  * You probably want this one.
+ * Important note: This needs to be placed inside a `<PlayerContextProvider>`
+ * in order to work correctly.
  */
 export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playerProps }) => {
     const aspectRatio = getPlayerAspectRatio(event.syncedData.tracks);


### PR DESCRIPTION
This fixes the issue of video blocks not working because they were missing the newly added `PlayerContext`.

While we could theoretically add the provider for this to the `InlinePlayer` component instead, the context was explicitly added to have access to the player from "outside", i.e. sibling components. So I think this solution is preferable.