### PR TITLE
Add series rss feed to share button

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -1,5 +1,6 @@
 [general]
 site_title.en = "Tobira Test Deployment"
+tobira_url = "https://{% if id != 'master' %}{{id}}.{% endif %}tobira.opencast.org"
 
 [general.metadata]
 dcterms.source = "builtin:source"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -266,7 +266,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ac489d939a3b4eac4a574ec70a5af015e01231983d0ef1f0833984522f04ab8"
 dependencies = [
- "litrs",
+ "litrs 0.2.3",
  "proc-macro2",
  "quote",
  "unicode-xid",
@@ -1345,6 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1511,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ogrim"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de9a8f5658ca59ffe6e7a18b98bd49f3b648bc6ea472642285f366fbf49b806"
+dependencies = [
+ "ogrim-macros",
+]
+
+[[package]]
+name = "ogrim-macros"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f170c5e3a3fc56d40bd38c90f98a705d513f4b2621de7f1aa3d13a30eac6654a"
+dependencies = [
+ "litrs 0.4.1",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2502,6 +2531,7 @@ dependencies = [
  "log",
  "meilisearch-sdk",
  "mime_guess",
+ "ogrim",
  "once_cell",
  "p256",
  "p384",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1515,18 +1515,18 @@ dependencies = [
 
 [[package]]
 name = "ogrim"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de9a8f5658ca59ffe6e7a18b98bd49f3b648bc6ea472642285f366fbf49b806"
+checksum = "e9a9f13f20f041c757ade45879cb9c8a2f7fa069f7f106c1683436ace5f975b4"
 dependencies = [
  "ogrim-macros",
 ]
 
 [[package]]
 name = "ogrim-macros"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f170c5e3a3fc56d40bd38c90f98a705d513f4b2621de7f1aa3d13a30eac6654a"
+checksum = "d9c178ca94f950c8be8f915ebe59c797e2bd855e21e848d4afe6caf0115f3903"
 dependencies = [
  "litrs 0.4.1",
  "proc-macro2",
@@ -2562,7 +2562,6 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "xml-builder",
 ]
 
 [[package]]
@@ -3117,12 +3116,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "xml-builder"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc4f1a86af7800dfc4056c7833648ea4515ae21502060b5c98114d828f5333b"
 
 [[package]]
 name = "yaup"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2532,6 +2532,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "xml-builder",
 ]
 
 [[package]]
@@ -3086,6 +3087,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "xml-builder"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc4f1a86af7800dfc4056c7833648ea4515ae21502060b5c98114d828f5333b"
 
 [[package]]
 name = "yaup"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,7 +44,7 @@ libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", features = ["serde", "std"] }
 meilisearch-sdk = "0.23.0"
 mime_guess = { version = "2", default-features = false }
-ogrim = "0.1.0"
+ogrim = "0.1.1"
 once_cell = "1.5"
 p256 = { version = "0.13.2", features = ["jwk"] }
 p384 = { version = "0.13.0", features = ["jwk"] }
@@ -73,7 +73,6 @@ time = "0.3"
 tokio = { version = "=1.28", features = ["fs", "rt-multi-thread", "macros", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.10.0"
-xml-builder = "0.5.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.15.1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -72,6 +72,7 @@ time = "0.3"
 tokio = { version = "=1.28", features = ["fs", "rt-multi-thread", "macros", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.10.0"
+xml-builder = "0.5.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.15.1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,6 +44,7 @@ libz-sys = { version = "1", features = ["static"] }
 log = { version = "0.4", features = ["serde", "std"] }
 meilisearch-sdk = "0.23.0"
 mime_guess = { version = "2", default-features = false }
+ogrim = "0.1.0"
 once_cell = "1.5"
 p256 = { version = "0.13.2", features = ["jwk"] }
 p384 = { version = "0.13.0", features = ["jwk"] }

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -91,10 +91,6 @@ impl GeneralConfig {
             .map(|s| s.strip_prefix("/").unwrap_or(s))
             .chain(INTERNAL_RESERVED_PATHS.iter().copied())
     }
-
-    pub(crate) fn tobira_url(&self) -> &HttpHost {
-        &self.tobira_url
-    }
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -16,7 +16,7 @@ pub(crate) struct GeneralConfig {
     /// Used for RSS feeds, as those require specifying absolute URLs to resources.
     /// 
     /// Example: "https://tobira.my-uni.edu".
-    pub(crate) tobira_url: Option<HttpHost>,
+    pub(crate) tobira_url: HttpHost,
 
 
     /// Whether or not to show a download button on the video page.
@@ -93,7 +93,7 @@ impl GeneralConfig {
     }
 
     pub(crate) fn tobira_url(&self) -> &HttpHost {
-        self.tobira_url.as_ref().unwrap()
+        &self.tobira_url
     }
 }
 

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use crate::util::HttpHost;
+
 use super::TranslatedString;
 
 
@@ -9,6 +11,13 @@ pub(crate) struct GeneralConfig {
     /// heading on the home page, and potentially more.
     // TODO: fix automatically generated `site_title =` template output.
     pub(crate) site_title: TranslatedString,
+
+    /// Public URL to Tobira (without path).
+    /// Used for RSS feeds, as those require specifying absolute URLs to resources.
+    /// 
+    /// Example: "https://tobira.my-uni.edu".
+    pub(crate) tobira_url: Option<HttpHost>,
+
 
     /// Whether or not to show a download button on the video page.
     #[config(default = true)]
@@ -81,6 +90,10 @@ impl GeneralConfig {
             .iter()
             .map(|s| s.strip_prefix("/").unwrap_or(s))
             .chain(INTERNAL_RESERVED_PATHS.iter().copied())
+    }
+
+    pub(crate) fn tobira_url(&self) -> &HttpHost {
+        self.tobira_url.as_ref().unwrap()
     }
 }
 

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -50,7 +50,7 @@ impl fmt::Debug for Key {
 
 
 /// Represents the `event_track` type defined in `5-events.sql`.
-#[derive(Debug, FromSql, ToSql)]
+#[derive(Debug, FromSql, ToSql, Clone)]
 #[postgres(name = "event_track")]
 pub struct EventTrack {
     pub uri: String,

--- a/backend/src/http/response.rs
+++ b/backend/src/http/response.rs
@@ -27,3 +27,11 @@ pub(crate) fn internal_server_error() -> Response {
         .body("Internal server error".into())
         .unwrap()
 }
+
+pub(crate) fn not_found() -> Response {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body("Not found".into())
+        .unwrap()
+}
+

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -29,6 +29,7 @@ mod search;
 mod sync;
 mod util;
 mod version;
+mod rss;
 
 
 #[tokio::main]

--- a/backend/src/rss.rs
+++ b/backend/src/rss.rs
@@ -1,0 +1,192 @@
+use std::{sync::Arc, str::FromStr};
+use chrono::{DateTime, Utc};
+use deadpool_postgres::{GenericClient, Client};
+use anyhow::{Error, Result};
+
+use crate::{
+    db::types::{EventTrack, Key},
+    http::Context,
+    api::Id,
+};
+
+#[derive(Debug)]
+struct Event {
+    id: Key,
+    title: String,
+    description: Option<String>,
+    created: DateTime<Utc>,
+    creators: Vec<String>,
+    tracks: Vec<EventTrack>,
+}
+
+/// Generates the xml for an RSS feed of a series in Tobira.
+pub(crate) async fn generate_rss_feed(context: &Arc<Context>, id: &str) -> Result<String, Error> {
+    let db_pool = &context.db_pool;
+    let tobira_url = context.config.opencast.tobira_url();
+    let series_link = format!("{}/!s/{}", tobira_url, id);
+    let rss_link = format!("{}/~rss/series/{}", tobira_url, id);
+    let id_string = format!("sr{}", id);
+    let series_id = Id::from_str(&id_string).unwrap().key_for(Id::SERIES_KIND).unwrap();
+    
+    let db = db_pool.get().await?;
+    let query = "select opencast_id, title, description from series where id = $1";
+    let series_data = db.query_one(query, &[&series_id]).await?;
+    let series_oc_id = series_data.get::<_, String>("opencast_id");
+    let series_title = series_data.get::<_, String>("title");
+    let series_description = series_data.get::<_, Option<String>>("description");
+
+    let video_items_result = generate_video_items(
+        &db,
+        &series_oc_id,
+        &series_title,
+        &rss_link,
+        &tobira_url,
+    );
+    
+    let rss_content = video_items_result
+        .await
+        .map(|video_items| {
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" ?>
+                <rss
+                    version="2.0"
+                    xmlns:dc="http://purl.org/dc/elements/1.1/"
+                    xmlns:atom="http://www.w3.org/2005/Atom"
+                >
+                <channel>
+                    <title>{}</title>
+                    <link>{}</link>
+                    <description>{}</description>
+                    <atom:link href="{}" rel="self" type="application/rss+xml" />
+                    {}
+                </channel>
+                </rss>"#,
+                series_title,
+                series_link,
+                series_description.unwrap_or_default(),
+                rss_link,
+                video_items
+            )
+        })
+        .map_err(|error| Error::msg(format!("Error generating video items: {:?}", error)));
+        
+    rss_content
+}
+
+/// Generates the single video items of a series in Tobira for inclusion in an RSS feed.
+async fn generate_video_items(
+    db: &Client,
+    series_oc_id: &str,
+    series_title: &str,
+    rss_link: &str,
+    tobira_url: &str,
+) -> Result<String, Error> {
+    let events = gather_event_data(&db, &series_oc_id).await?;
+
+    let mut video_items = String::new();
+
+    for event in events {
+        let mut buf = [0; 11];
+        let tobira_event_id = event.id.to_base64(&mut buf);
+        let event_link = format!("{}/!v/{}", tobira_url, tobira_event_id);
+
+        let preferred_track = choose_preferred_track(event.tracks).unwrap();
+
+        let enclosure_url = &preferred_track.uri;
+        let mimetype = &preferred_track.mimetype.unwrap();
+
+        let item = format!(
+            r#"
+            <item>
+              <title>{}</title>
+              <link>{}</link>
+              <description>{}</description>
+              <dc:creator>{}</dc:creator>
+              <enclosure url="{}" type="{}" length="0" />
+              <guid isPermaLink="true">{}</guid>
+              <pubDate>{}</pubDate>
+              <source url="{}">{}</source>
+            </item>"#,
+            event.title,
+            event_link,
+            event.description.unwrap_or_default(),
+            event.creators.join(", "),
+            enclosure_url,
+            mimetype,
+            event_link,
+            event.created.to_rfc2822(),
+            rss_link,
+            series_title,
+        );
+
+        video_items.push_str(&item);
+    }
+
+    Ok(video_items)
+}
+
+// Gathers the needed event data for video items to include in an RSS feed of a series in Tobira.
+async fn gather_event_data(db: &Client, series_id: &str) -> Result<Vec<Event>, Error> {
+    let query = "select id, title, description, created, creators, tracks from events where part_of = $1";
+    let rows = db.query(query, &[&series_id]).await?;
+
+    let mut events = Vec::new();
+
+    for row in rows {
+        let id = row.get::<_, Key>("id");
+        let title = row.get("title");
+        let description = row.get("description");
+        let created = row.get("created");
+        let creators = row.get("creators");
+        let tracks = row.get("tracks");
+
+        let event = Event {
+            id,
+            title,
+            description,
+            created,
+            creators,
+            tracks,
+        };
+
+        events.push(event);
+    }
+
+    Ok(events)
+}
+
+/// This returns a track that:
+/// a) is the `presentation`` track.
+/// Defaults to any track meeting the b) criteria if none there is no `presentation` track.
+/// b) has a resolution that is closest to full hd.
+fn choose_preferred_track(tracks: Vec<EventTrack>) -> Option<EventTrack> {
+    let target_resolution = tracks.first().map_or([1920, 1080], |first_track| {
+        let [x, y] = first_track.resolution.unwrap();
+        if x >= y {
+            [1920, 1080] // Landscape
+        } else {
+            [1080, 1920] // Portrait
+        }
+    });
+
+    let mut tracks_to_check: Vec<EventTrack> = tracks
+        .iter()
+        .filter(|track| track.flavor.contains("presentation"))
+        .cloned()
+        .collect();
+
+    if tracks_to_check.is_empty() {
+        tracks_to_check = tracks.clone();
+    }
+
+    let preferred_track = tracks_to_check.iter().min_by_key(|&track| {
+        let track_resolution = track.resolution.unwrap();
+        let diff_x = (track_resolution[0] - target_resolution[0]).abs();
+        let diff_y = (track_resolution[1] - target_resolution[1]).abs();
+        diff_x + diff_y
+    });
+
+    preferred_track.cloned()
+}
+
+

--- a/backend/src/rss.rs
+++ b/backend/src/rss.rs
@@ -1,12 +1,14 @@
-use std::{sync::Arc, str::FromStr};
+use std::{sync::Arc, future};
 use chrono::{DateTime, Utc};
 use deadpool_postgres::{GenericClient, Client};
 use anyhow::{Error, Result};
+use futures::TryStreamExt;
+use xml_builder::{XMLBuilder, XMLElement, XMLVersion};
 
 use crate::{
-    db::types::{EventTrack, Key},
-    http::Context,
-    api::Id,
+    db::{types::{EventTrack, Key}, self, util::{impl_from_db, FromDb, dbargs}},
+    http::{Context, response::bad_request, Response},
+    util::HttpHost,
 };
 
 #[derive(Debug)]
@@ -20,67 +22,110 @@ struct Event {
     tracks: Vec<EventTrack>,
 }
 
+impl_from_db!(
+    Event,
+    select: {
+        events.{ id, title, description, creators, thumbnail, created, tracks },
+    },
+    |row| {
+        Self {
+            id: row.id(),
+            title: row.title(),
+            description: row.description(),
+            created: row.created(),
+            creators: row.creators(),
+            thumbnail_url: row.thumbnail(),
+            tracks: row.tracks(),
+        }
+    }
+);
+
 /// Generates the xml for an RSS feed of a series in Tobira.
-pub(crate) async fn generate_rss_feed(context: &Arc<Context>, id: &str) -> Result<String, Error> {
+pub(crate) async fn generate_feed(context: &Arc<Context>, id: &str) -> Result<String, Response> {
     let db_pool = &context.db_pool;
-    let tobira_url = context.config.opencast.tobira_url();
+    let tobira_url = context.config.general.tobira_url();
     let series_link = format!("{}/!s/{}", tobira_url, id);
     let rss_link = format!("{}/~rss/series/{}", tobira_url, id);
-    let id_string = format!("sr{}", id);
-    let series_id = Id::from_str(&id_string).unwrap().key_for(Id::SERIES_KIND).unwrap();
+
+    let Some(series_id) = Key::from_base64(id) else {
+        return Err(bad_request("unknown series"));
+    };
     
-    let db = db_pool.get().await?;
+    let db = db::get_conn_or_service_unavailable(db_pool).await?;
+
     let query = "select opencast_id, title, description from series where id = $1";
-    let series_data = db.query_one(query, &[&series_id]).await?;
+    let series_data = match db.query_one(query, &[&series_id]).await {
+        Ok(data) => data,
+        Err(_) => return Err(bad_request("DB error querying series data")),
+    };
+
     let series_oc_id = series_data.get::<_, String>("opencast_id");
-    let series_title = series_data.get::<_, String>("title");
+    let series_title = series_data.get::<_, String>("title").clone();
     let series_description = series_data.get::<_, Option<String>>("description");
     let cover_image = context.config.theme.logo.large.path.clone();
 
-    let video_items_result = generate_video_items(
-        &db,
-        &series_oc_id,
-        &series_title,
-        &rss_link,
-        &tobira_url,
-    );
+    // Build rss xml
+    let mut xml = XMLBuilder::new()
+        .version(XMLVersion::XML1_0)
+        .encoding("UTF-8".into())
+        .build();
+
+    let mut rss = XMLElement::new("rss");
+
+    // Add rss attributes
+    let attributes = [
+        ("version", "2.0"),
+        ("xmlns:dc", "http://purl.org/dc/elements/1.1/"),
+        ("xmlns:content", "http://purl.org/rss/1.0/modules/content/"),
+        ("xmlns:atom", "http://www.w3.org/2005/Atom"),
+        ("xmlns:media", "http://search.yahoo.com/mrss/"),
+        ("xmlns:itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"),
+    ];
+    for (name, value) in attributes {
+        rss.add_attribute(name, value);
+    }
+
+    let mut channel = XMLElement::new("channel");
+
+    // Add channel tags
+    let channel_data = [
+        ("title", vec![("", series_title.clone())]),
+        ("link", vec![("", series_link)]),
+        ("description", vec![("", series_description.unwrap_or_default())]),
+        ("language", vec![("", "und".to_string())]),
+        ("itunes:explicit",vec![("", "true".to_string())]),
+        ("itunes:image", vec![("href", (&cover_image.to_string_lossy()).to_string())]),
+        ("itunes:category", vec![("text", "Education".to_string())]),
+        ("atom:link", vec![
+            ("href", rss_link.clone()),
+            ("rel", "self".to_string()),
+            ("type", "application/rss+xml".to_string()),
+        ]),
+    ];
+    add_elements_to_xml(&channel_data, &mut channel);
+
+    // Add video items
+    let video_items = match generate_video_items(
+        &db, &series_oc_id, &series_title, &rss_link, &tobira_url).await {
+        Ok(items) => items,
+        Err(_) => return Err(bad_request("empty series")),
+    };
+
+    for item in video_items {
+        // I have no idea how to correctly handle items that are resulting in an error.
+        // Pretty sure however that this here is a bad solution and would result in
+        // potentially broken feeds.
+        let _ = channel.add_child(item);
+    }
+
+    rss.add_child(channel).unwrap();
+    xml.set_root_element(rss);
+    let mut writer: Vec<u8> = Vec::new();
+    xml.generate(&mut writer).unwrap();
+
+    let xml_string = String::from_utf8(writer).unwrap();
     
-    let rss_content = video_items_result
-        .await
-        .map(|video_items| {
-            format!(
-                r#"<?xml version="1.0" encoding="UTF-8" ?>
-                <rss
-                    version="2.0"
-                    xmlns:dc="http://purl.org/dc/elements/1.1/"
-                    xmlns:atom="http://www.w3.org/2005/Atom"
-                    xmlns:media="http://search.yahoo.com/mrss/"
-                    xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
-                    xmlns:content="http://purl.org/rss/1.0/modules/content/"
-                >
-                <channel>
-                    <title>{}</title>
-                    <link>{}</link>
-                    <description>{}</description>
-                    <language>und</language>
-                    <atom:link href="{}" rel="self" type="application/rss+xml" />
-                    <itunes:category text="Education" />
-                    <itunes:image href={:?} />
-                    <itunes:explicit>no</itunes:explicit>
-                    {}
-                </channel>
-                </rss>"#,
-                series_title,
-                series_link,
-                series_description.unwrap_or_default(),
-                rss_link,
-                cover_image,
-                video_items
-            )
-        })
-        .map_err(|error| Error::msg(format!("Error generating video items: {:?}", error)));
-        
-    rss_content
+    Ok(xml_string)
 }
 
 /// Generates the single video items of a series in Tobira for inclusion in an RSS feed.
@@ -89,98 +134,81 @@ async fn generate_video_items(
     series_oc_id: &str,
     series_title: &str,
     rss_link: &str,
-    tobira_url: &str,
-) -> Result<String, Error> {
-    let events = gather_event_data(&db, &series_oc_id).await?;
+    tobira_url: &HttpHost,
+) -> Result<Vec<XMLElement>, Error> {
+    let selection = Event::select();
+    let query = format!("select {selection} from events where part_of = $1");
+    let rows = db.query_raw(&query, dbargs![&series_oc_id]).await?;
 
-    let mut video_items = String::new();
+    let mut video_items: Vec<XMLElement> = Vec::new();
 
-    for event in events {
+    rows.try_for_each(|row| {
+        let event = Event::from_row_start(&row);
+        
         let mut buf = [0; 11];
         let tobira_event_id = event.id.to_base64(&mut buf);
         let event_link = format!("{}/!v/{}", tobira_url, tobira_event_id);
 
         let preferred_track = choose_preferred_track(event.tracks).unwrap();
-
         let enclosure_url = &preferred_track.uri;
         let mimetype = &preferred_track.mimetype.unwrap();
-        let thumbnail = event.thumbnail_url.unwrap_or_default();
+        let thumbnail = &event.thumbnail_url.unwrap_or_default();
 
-        let item = format!(r#"
-            <item>
-                <title>{}</title>
-                <link>{}</link>
-                <description>{}</description>
-                <dc:creator>{}</dc:creator>
-                <enclosure url="{}" type="{}" length="0" />
-                <guid isPermaLink="true">{}</guid>
-                <pubDate>{}</pubDate>
-                <source url="{}">{}</source>
-                <media:thumbnail url="{}" />
-                <media:content url="{}" type="{}" />
-                <itunes:image href="{}" />
-            </item>"#,
-            event.title,
-            event_link,
-            event.description.unwrap_or_default(),
-            event.creators.join(", "),
-            enclosure_url,
-            mimetype,
-            event_link,
-            event.created.to_rfc2822(),
-            rss_link,
-            series_title,
-            thumbnail,
-            enclosure_url,
-            mimetype,
-            thumbnail,
-        );
+        let mut item = XMLElement::new("item");
 
-        video_items.push_str(&item);
-    }
+        let item_data = [
+            ("title", vec![("", event.title)]),
+            ("link", vec![("", event_link.clone())]),
+            ("description", vec![("", event.description.unwrap_or_default())]),
+            ("dc:creator", vec![("", event.creators.join(", "))]),
+            ("pubDate", vec![("", event.created.to_rfc2822())]),
+            ("guid", vec![("", event_link)]),
+            ("media:thumbnail", vec![("url", thumbnail.to_string())]),
+            ("itunes:image", vec![("href", thumbnail.to_string())]),
+            ("enclosure", vec![
+                ("url", enclosure_url.to_string()),
+                ("type", mimetype.to_string()),
+                ("length", "0".to_string()),
+            ]),
+            ("source", vec![
+                ("url", rss_link.to_string()),
+                ("", series_title.to_string()),
+            ]),
+            ("media:content", vec![
+                ("url", enclosure_url.to_string()),
+                ("type", mimetype.to_string()),
+            ]),
+        ];
+        add_elements_to_xml(&item_data, &mut item);
+
+        video_items.push(item);
+        future::ready(Ok(()))
+    }).await?;
 
     Ok(video_items)
 }
 
-// Gathers the needed event data for video items to include in an RSS feed of a series in Tobira.
-async fn gather_event_data(db: &Client, series_id: &str) -> Result<Vec<Event>, Error> {
-    let query = format!("\
-        select id, title, description, created, creators, thumbnail, tracks \
-        from events \
-        where part_of = $1",
-    );
-    let rows = db.query(&query, &[&series_id]).await?;
 
-    let mut events = Vec::new();
+fn add_elements_to_xml(data: &[(&str, Vec<(&str, String)>)], target: &mut XMLElement) {
+    for (element_name, attributes) in data {
+        let mut element = XMLElement::new(element_name);
 
-    for row in rows {
-        let id = row.get::<_, Key>("id");
-        let title = row.get("title");
-        let description = row.get("description");
-        let created = row.get("created");
-        let creators = row.get("creators");
-        let thumbnail_url = row.get("thumbnail");
-        let tracks = row.get("tracks");
+        for (attribute_name, text_content) in attributes {
+            if !attribute_name.is_empty() {
+                element.add_attribute(attribute_name, text_content);
+            } else {
+                element.add_text(text_content.to_string()).unwrap();
+            }
+        }
 
-        let event = Event {
-            id,
-            title,
-            description,
-            created,
-            creators,
-            thumbnail_url,
-            tracks,
-        };
-
-        events.push(event);
+        target.add_child(element).unwrap();
     }
-
-    Ok(events)
 }
 
+
 /// This returns a track that:
-/// a) is the `presentation`` track.
-/// Defaults to any track meeting the b) criteria if none there is no `presentation` track.
+/// a) is a `presentation` track.
+/// Defaults to any track meeting the b) criteria if there is no `presentation` track.
 /// b) has a resolution that is closest to full hd.
 fn choose_preferred_track(tracks: Vec<EventTrack>) -> Option<EventTrack> {
     let target_resolution = tracks.first().map_or([1920, 1080], |first_track| {

--- a/backend/src/rss.rs
+++ b/backend/src/rss.rs
@@ -120,11 +120,9 @@ async fn video_items(
                 {|doc| for track in tracks {
                     xml!(doc,
                         <media:content
-                            url={&track.uri}
-                            type={&track.mimetype.clone().unwrap()}
-                            medium={"video"}
-                            height={track.resolution.unwrap()[1]}
-                            width={track.resolution.unwrap()[0]}
+                            url={track.uri}
+                            {..track.mimetype.clone().map(|t| ("type", t))}
+                            {..track.resolution.into_iter().flat_map(|[w, h]| [("width", w), ("height", h)])}
                         />
                     )}
                 }
@@ -195,7 +193,7 @@ fn preferred_tracks(tracks: Vec<EventTrack>) -> (Option<EventTrack>, HashMap<Str
     }
 
     let enclosure_track = preferred_tracks.iter().min_by_key(|&track| {
-        let track_resolution = track.resolution.unwrap();
+        let track_resolution = track.resolution.unwrap_or_default();
         let diff = (track_resolution[0] * track_resolution[1] - target_resolution).abs();
         diff
     });

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -20,6 +20,12 @@
 # Required! This value must be specified.
 #site_title =
 
+# Public URL to Tobira (without path).
+# Used for RSS feeds, as those require specifying absolute URLs to resources.
+# 
+# Example: "https://tobira.my-uni.edu".
+#tobira_url =
+
 # Whether or not to show a download button on the video page.
 #
 # Default value: true

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -24,6 +24,8 @@
 # Used for RSS feeds, as those require specifying absolute URLs to resources.
 # 
 # Example: "https://tobira.my-uni.edu".
+#
+# Required! This value must be specified.
 #tobira_url =
 
 # Whether or not to show a download button on the video page.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -148,6 +148,8 @@ video:
     show-less: Weniger anzeigen
   embed:
     copy-embed-code-to-clipboard: Einbettungscode in Zwischenablage kopieren
+  rss:
+    copy-link-to-clipboard: RSS Link in Zwischenablage kopieren
   caption: Untertitel
   download:
     title: Download

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -146,6 +146,8 @@ video:
     show-less: Show less
   embed:
     copy-embed-code-to-clipboard: Copy embed code to clipboard
+  rss:
+    copy-link-to-clipboard: Copy RSS link to clipboard
   caption: Caption
   download:
     title: Download

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -728,7 +728,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             return <>
                 <div>
                     <CopyableInput
-                        label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
+                        label={t("video.rss.copy-link-to-clipboard")}
                         css={{ fontSize: 14, width: 400, marginBottom: 6 }}
                         value={rssUrl}
                     />

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -722,9 +722,19 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             </>;
         },
         "rss": () => {
-            // TODO
-            const dummy = "Implement me!";
-            return <>{dummy}</>;
+            const seriesId = event.series?.id.replace("sr", "");
+            const rssUrl = window.location.origin + `/~rss/series/${seriesId}`;
+
+            return <>
+                <div>
+                    <CopyableInput
+                        label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
+                        css={{ fontSize: 14, width: 400, marginBottom: 6 }}
+                        value={rssUrl}
+                    />
+                </div>
+                <ShowQRCodeButton target={rssUrl} label={menuState} />
+            </>;
         },
     });
 

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode, useEffect, useRef, useState } from "rea
 import { graphql, GraphQLTaggedNode, PreloadedQuery, useFragment } from "react-relay/hooks";
 import { useTranslation } from "react-i18next";
 import { OperationType } from "relay-runtime";
-import { LuCode, LuDownload, LuLink, LuQrCode, LuSettings, LuShare2 } from "react-icons/lu";
+import { LuCode, LuDownload, LuLink, LuQrCode, LuRss, LuSettings, LuShare2 } from "react-icons/lu";
 import { QRCodeCanvas } from "qrcode.react";
 import {
     match, unreachable, ProtoButton,
@@ -29,6 +29,7 @@ import {
     currentRef,
     secondsToTimeString,
     eventId,
+    keyOfId,
 } from "../util";
 import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
 import { Button, LinkButton } from "../ui/Button";
@@ -416,7 +417,7 @@ const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
                 "> button": { ...shrinkOnMobile },
             }}>
                 {event.canWrite && user !== "none" && user !== "unknown" && (
-                    <LinkButton to={`/~manage/videos/${id.slice(2)}`} css={{
+                    <LinkButton to={`/~manage/videos/${keyOfId(id)}`} css={{
                         "&:not([disabled])": { color: COLORS.primary0 },
                         ...shrinkOnMobile,
                     }}>
@@ -538,8 +539,10 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const entries: [Exclude<MenuState, "closed">, ReactElement][] = [
         ["main", <LuLink />],
         ["embed", <LuCode />],
-        // ["rss", <FiRss />],
     ];
+    if (event.series) {
+        entries.push(["rss", <LuRss />]);
+    }
     /* eslint-enable react/jsx-key */
 
     const { t } = useTranslation();
@@ -687,7 +690,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             url.search = addEmbedTimestamp && timestamp
                 ? `?t=${secondsToTimeString(timestamp)}`
                 : "";
-            url.pathname = `/~embed/!v/${event.id.slice(2)}`;
+            url.pathname = `/~embed/!v/${keyOfId(event.id)}`;
 
             const embedCode = `<iframe ${[
                 'name="Tobira Player"',
@@ -722,19 +725,21 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             </>;
         },
         "rss": () => {
-            const seriesId = event.series?.id.replace("sr", "");
-            const rssUrl = window.location.origin + `/~rss/series/${seriesId}`;
-
-            return <>
-                <div>
-                    <CopyableInput
-                        label={t("video.rss.copy-link-to-clipboard")}
-                        css={{ fontSize: 14, width: 400, marginBottom: 6 }}
-                        value={rssUrl}
-                    />
-                </div>
-                <ShowQRCodeButton target={rssUrl} label={menuState} />
-            </>;
+            if (event.series) {
+                const rssUrl = window.location.origin + `/~rss/series/${keyOfId(event.series.id)}`;
+                return <>
+                    <div>
+                        <CopyableInput
+                            label={t("video.rss.copy-link-to-clipboard")}
+                            css={{ fontSize: 14, width: 400, marginBottom: 6 }}
+                            value={rssUrl}
+                        />
+                    </div>
+                    <ShowQRCodeButton target={rssUrl} label={menuState} />
+                </>;
+            } else {
+                return null;
+            }
         },
     });
 
@@ -896,11 +901,11 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({ 
     const { t, i18n } = useTranslation();
     const pairs: [string, ReactNode][] = [];
 
-    if (event.series !== null) {
+    if (event.series) {
         pairs.push([
             t("video.part-of-series"),
             // eslint-disable-next-line react/jsx-key
-            <Link to={`/!s/${event.series.id.slice(2)}`}>{event.series.title}</Link>,
+            <Link to={`/!s/${keyOfId(event.series.id)}`}>{event.series.title}</Link>,
         ]);
     }
 

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -3,6 +3,7 @@
 
 [general]
 site_title.en = "Tobira Videoportal"
+tobira_url = "http://localhost:8030"
 
 [http]
 # To make our Docker based development setup work, Tobira needs to listen


### PR DESCRIPTION
This adds RSS feeds for series in tobira as outlined in #791.
It is still missing the caching that @LukasKalbertodt mentions in the issue, which is to be done in a follow up PR.

~~- [ ] This is also missing a mechanism for updating the feed when new events are added, which I realize makes these feeds kind of useless at the moment. At least that should still be added in this PR.~~
~~- [ ] I don't know exactly yet how we can tell feed readers that the feed has new content, or if that is even necessary.~~
Edit 2: My limited knowledge about RSS led to the above assumptions, but after doing some testing as described below it turns out we don't need to implement anything like that.
- [x] And I also still need to look into some specific tags like the `<itunes:...>` ones that are present in the feeds of the current ETH video portal. They aren't part of the current (but pretty much ancient) RSS specs but might be a worthwhile, if not mandatory addition (even if they are only necessary for the feeds to work with itunes).

We need to test how the generated xml works in different RSS readers (they all appear to be doing their own thing), and probably adjust a couple of things based on these tests.
  - Edit: I tested different desktop/web ("Feedly", "Inoreader", "The Old Reader", "CommaFeed" and mobile (android "RSS Reader", "Feeder") feed readers. Some findings:
    - the desktop readers don't show thumbnails, which kinda sucks (mobile readers do tho). There is a workaround in adding an image to the `description`, but that would also clutter the entry itself. I also considered adding an embedded video to each item, but besides the cluttering argument, the items a) link to the videos, b) some readers already embed the videos automatically and c) all readers also feature a download option (not sure if that can be disabled, which might be an issue seeing as some institutions don't want their videos downloadable).
    - when adding a video to a subscribed series in tobira, the mobile feed readers update automatically. Desktop readers "Inoreader" and "The Old Reader" also pick up on the updated feed, but updating has to be done manually. "CommaFeed" has an option to "fetch all feeds" or sth, which also updates the feed. "Feedly" however ~~does not update the feeds, even when using their "refresh" button. So this might still need to be imlemented on our side (sigh...)~~ updates automatically, but less regularly, it appears (I have found no way of configuring this, might be behind a paywall). Actually, now I suspect that every reader updates automatically after a certain time period. Again - total RSS noob here.