### PR TITLE
Add admin check to `no entries` label in group acl

### DIFF
--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -123,6 +123,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
     const { t, i18n } = useTranslation();
     const { change, knownGroups, groupDag } = useAclContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
+    const userIsAdmin = isRealUser(user) && user.roles.includes(COMMON_ROLES.ADMIN);
 
     // Turn known roles into selectable options that react-select understands.
     const knownRoles = kind === "Group" ? knownGroups : KNOWN_USERS;
@@ -287,7 +288,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                 </thead>
                 <tbody>
                     {/* Placeholder if there are no entries */}
-                    {selection.length === 0 && <tr>
+                    {selection.length === 0 && !userIsAdmin && <tr>
                         <td colSpan={3} css={{ textAlign: "center", fontStyle: "italic" }}>
                             {t("acl.no-entries")}
                         </td>
@@ -304,8 +305,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                     {(
                         kind === "Group"
                         && !selection.some(s => s.value === COMMON_ROLES.ADMIN)
-                        && isRealUser(user)
-                        && user.roles.includes(COMMON_ROLES.ADMIN)
+                        && userIsAdmin
                     ) && (
                         <ListEntry
                             item={{ label: t("acl.groups.admins"), value: COMMON_ROLES.ADMIN }}


### PR DESCRIPTION
Just noticed this special case:
<img width="1461" alt="Bildschirmfoto 2023-10-24 um 14 43 35" src="https://github.com/elan-ev/tobira/assets/94838646/eba06161-4b3c-46df-a862-7665e0d16f9c">

Maybe this is ok, since a) only admins will see this and b) my guess is that the list will usually have at least one real (i.e. not the `Administrators`) entry. On the other hand, adding a check for this is rather trivial.
