### PR TITLE
Hide "drag and drop" prompt on small screens

### DIFF
--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -385,6 +385,13 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
         }
     };
 
+    const dragNDropSupported = () => {
+        const div = document.createElement("div");
+        const isSupported = ("draggable" in div) || ("ondragstart" in div && "ondrop" in div);
+        div.remove();
+        return isSupported;
+    };
+
     return (
         <div
             onDragEnter={e => {
@@ -436,7 +443,19 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
                 <FiUpload css={{ "& > polyline, & > line": { display: "none" } }} />
             </div>
 
-            {t("upload.drop-to-upload")}
+            {
+                // This infers the dragNdrop capability of the currently used device by checking
+                // a) whether or not the device has a pointer that can hover
+                // (like a mouse or stylus) and
+                // b) if DnD is supported by the browser that's being used.
+                <span css={{
+                    ["@media (not(pointer:fine)) and (not(hover))"]: {
+                        ...!dragNDropSupported() && { display: "none" },
+                    },
+                }}>
+                    {t("upload.drop-to-upload")}
+                </span>
+            }
 
             {/* "Select files" button */}
             <div css={{ marginTop: 16 }}>


### PR DESCRIPTION
While it might be possible to use drag and drop on certain mobile phones, we can't know for sure.
I also imagine that even if it's possible, it's rather hard to do on such a small screen.
So it is likely better to just hide the prompt for these devices.

Note on tablets: I believe most if not all tablets should support drag and drop. Can't say for certain, though at least the most common mobile browsers (chrome for android, safari for ios) offer support according to [caniuse](https://caniuse.com/dragndrop).

Closes #859