### PR TITLE
Adjust Paella scaling and background

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -315,7 +315,11 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
         <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
         <PlayerContextProvider>
-            <InlinePlayer event={event} css={{ margin: "0 auto" }} onEventStateChange={rerender} />
+            <InlinePlayer
+                event={event}
+                css={{ margin: "-4px auto 0" }}
+                onEventStateChange={rerender}
+            />
             <Metadata id={event.id} event={event} />
         </PlayerContextProvider>
 
@@ -400,8 +404,7 @@ const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
             alignItems: "center",
             flexWrap: "wrap",
             justifyContent: "space-between",
-            marginTop: 24,
-            marginBottom: 16,
+            margin: "16px 0",
             gap: 8,
         }}>
             <div>

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -166,6 +166,8 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
         "--highlight-bg-color-progress-indicator": "var(--color-player-accent-light)",
         "--volume-slider-fill-color": "var(--color-player-accent-light)",
         "--volume-slider-empty-color": "#555",
+        "--video-container-background-color": "#000",
+        "--base-video-rect-background-color": "#000",
     };
 
     return <>

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -162,8 +162,8 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
             // So: full height minus header, minus separation line (18px), minus main
             // padding (16px), minus breadcrumbs (roughly 42px), minus the amount of space
             // we want to see below the video (roughly 120px).
-            maxHeight: "calc(100vh - var(--header-height) - 18px - 16px - 42px - 120px)",
-            minHeight: 180,
+            maxHeight: "calc(100vh - var(--header-height) - 18px - 16px - 38px - 60px)",
+            minHeight: `min(320px, (100vw - 32px) / (${aspectRatio[0]} / ${aspectRatio[1]}))`,
             width: controlsFit ? "unset" : "100%",
             aspectRatio: `${aspectRatio[0]} / ${aspectRatio[1]}`,
 

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -121,13 +121,14 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
 
     return (
         <div className={className} css={{
-            "--video-container-background-color": COLORS.neutral10,
-            "--base-video-rect-background-color": COLORS.neutral10,
             "div.loader-container": {
                 backgroundColor: isDark ? COLORS.neutral20 : "inherit",
             },
+            "div.video-canvas": {
+                backgroundColor: "#000",
+            },
             "div.preview-container": {
-                backgroundColor: `${COLORS.neutral15} !important`,
+                backgroundColor: "#000 !important",
                 "div, div img": {
                     height: "inherit",
                 },


### PR DESCRIPTION
Closes #954 

This is.. the best I could come up with. Might seem weird to infer the initial video width using it's height and resolution but I don't see a better way.
I was wondering if this needs a special handling for multi-stream videos but couldn't make out a difference. Even though there is more space, the individual streams don't really care to use it (related: #956).