### PR TITLE
Fix paella dual stream layout

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -223,6 +223,7 @@ const PAELLA_CONFIG = {
         hideUITimer: 2000,
         hideOnMouseLeave: true,
     },
+    defaultLayout: "presenter-presentation",
 
     plugins: {
         "es.upv.paella.singleVideoDynamic": {
@@ -248,7 +249,7 @@ const PAELLA_CONFIG = {
                 },
             ],
         },
-        "es.upv.paella.dualVideo": {
+        "es.upv.paella.dualVideoDynamic": {
             enabled: true,
             validContent: [
                 {


### PR DESCRIPTION
Closes #956

Before:
<img width="510" alt="Bildschirmfoto 2023-11-06 um 14 06 18" src="https://github.com/elan-ev/tobira/assets/94838646/669735e4-1c27-4871-972c-97c6402cf28e">

After:
<img width="510" alt="Bildschirmfoto 2023-11-06 um 14 05 56" src="https://github.com/elan-ev/tobira/assets/94838646/05695a80-2678-464a-9b62-5ef8c459e60f">

~~Two unexpected sideeffects:~~
- ~~The "fullscreen" and "swap" icons somehow changed. Huh?~~ this is desired and simply part of the dynamic layout it appears. Well it can be configured as I understand, but these seem to be the default.
- ~~Default layout is now "Presenter" for some reason. Which is unfortunate. With this, users might think dual stream isn't working. There must be a way to configure that but I couldn't find it yet.~~
