### PR TITLE
Change type of event duration in DB from i32 to i64

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -41,14 +41,14 @@ pub(crate) struct AuthorizedEvent {
     synced_data: Option<SyncedEventData>,
 }
 
-#[derive(Debug, GraphQLObject)]
+#[derive(Debug)]
 pub(crate) struct SyncedEventData {
     updated: DateTime<Utc>,
     start_time: Option<DateTime<Utc>>,
     end_time: Option<DateTime<Utc>>,
 
     /// Duration in milliseconds
-    duration: i32,
+    duration: i64,
     tracks: Vec<Track>,
     thumbnail: Option<String>,
     captions: Vec<Caption>,
@@ -118,6 +118,32 @@ pub(crate) struct Caption {
 impl Node for AuthorizedEvent {
     fn id(&self) -> Id {
         Id::event(self.key)
+    }
+}
+
+#[graphql_object(Context = Context, impl = NodeValue)]
+impl SyncedEventData {
+    fn updated(&self) -> DateTime<Utc> {
+        self.updated
+    }
+    fn start_time(&self) -> Option<DateTime<Utc>> {
+        self.start_time
+    }
+    fn end_time(&self) -> Option<DateTime<Utc>> {
+        self.end_time
+    }
+    /// Duration in ms.
+    fn duration(&self) -> f64 {
+        self.duration as f64
+    }
+    fn tracks(&self) -> &[Track] {
+        &self.tracks
+    }
+    fn thumbnail(&self) -> Option<&str> {
+        self.thumbnail.as_deref()
+    }
+    fn captions(&self) -> &[Caption] {
+        &self.captions
     }
 }
 
@@ -555,7 +581,7 @@ pub(crate) struct EventCursor {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum CursorSortFilter {
     Title(String),
-    Duration(Option<i32>),
+    Duration(Option<i64>),
     Created(DateTime<Utc>),
     Updated(Option<DateTime<Utc>>),
 }

--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -38,8 +38,8 @@ impl search::Event {
         self.thumbnail.as_deref()
     }
 
-    fn duration(&self) -> i32 {
-        self.duration
+    fn duration(&self) -> f64 {
+        self.duration as f64
     }
 
     fn is_live(&self) -> bool {

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -339,4 +339,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     22: "user-email",
     23: "video-block-show-link",
     24: "known-groups",
+    25: "longer-videos",
 ];

--- a/backend/src/db/migrations/25-longer-videos.sql
+++ b/backend/src/db/migrations/25-longer-videos.sql
@@ -1,0 +1,18 @@
+-- Changes the type of event.duration from i32 to i64.
+
+do $$
+    declare view_def text;
+begin
+    -- Unfortunately, the view depends on 'events' and prevents the type change.
+    -- So we backup its defintion and drop it.
+    view_def := pg_get_viewdef('search_events');
+    drop view search_events;
+
+    -- The actual change
+    alter table events
+        alter column duration type bigint;
+
+    -- Recreate the view
+    execute format('create view search_events as %s', view_def);
+end $$;
+

--- a/backend/src/db/tests/util.rs
+++ b/backend/src/db/tests/util.rs
@@ -104,7 +104,7 @@ impl TestDb {
             )
             returning id";
 
-        let row = self.query_one(sql, &[&opencast_id, &title, &series, &(duration as i32)]).await?;
+        let row = self.query_one(sql, &[&opencast_id, &title, &series, &(duration as i64)]).await?;
         Ok(row.get(0))
     }
 

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -21,7 +21,7 @@ pub(crate) struct Event {
     pub(crate) description: Option<String>,
     pub(crate) creators: Vec<String>,
     pub(crate) thumbnail: Option<String>,
-    pub(crate) duration: i32,
+    pub(crate) duration: i64,
     pub(crate) created: DateTime<Utc>,
     pub(crate) start_time: Option<DateTime<Utc>>,
     pub(crate) end_time: Option<DateTime<Utc>>,

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -27,7 +27,7 @@ pub(crate) enum HarvestItem {
         #[serde(with = "chrono::serde::ts_milliseconds")]
         created: DateTime<Utc>,
         creators: Vec<String>,
-        duration: i32,
+        duration: i64,
         tracks: Vec<Track>,
         #[serde(default)] // For backwards compatibility
         captions: Vec<Caption>,

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -67,7 +67,7 @@ type SearchEvent implements Node {
   description: String
   creators: [String!]!
   thumbnail: String
-  duration: Int!
+  duration: Float!
   isLive: Boolean!
   created: DateTimeUtc!
   startTime: DateTimeUtc
@@ -137,12 +137,12 @@ type KnownGroup {
   large: Boolean!
 }
 
-type SyncedEventData {
+type SyncedEventData implements Node {
   updated: DateTimeUtc!
   startTime: DateTimeUtc
   endTime: DateTimeUtc
-  "Duration in milliseconds"
-  duration: Int!
+  "Duration in ms."
+  duration: Float!
   tracks: [Track!]!
   thumbnail: String
   captions: [Caption!]!


### PR DESCRIPTION
A recent change to the Tobira module in OC changed how durations are acquired. Before, the duration of our "always live" events was reported as 0. But now the "correct" duration is reported, i.e. the difference between start and end time. That's many years. 2^31 ms are roughly 25 days. So this broke for our live events. Note that I had to really try convince Opencast of even creating this live event with more than 24h between start and end time. So I would bet that out there, there is no Opencast event longer than 25 days.

Unfortunately, Juniper does not support i64 as scalar type. That's partially ... correct. JSON does in principle only support f64 numbers as that's what JS is using. But since JSON is text and the numbers are decimal numbers, no one stops you from writing a number to JSON that is not representable as f64. And apparently this is sometimes done. Either way, we now cast the i64 to f64 for the API. Note that f64 can exactly represent integers up to 2^53. That in ms is 285 thousand years. Also note that the duration from Opencast is also transmitted to us via JSON.

So while this whole situation is not ideal, it's healthy to remember that basically no event out there will ever run into this situation and I there are no real world events for which the "i64 to f64" conversion is not exact.

I am also aware that our live streams currently say "Duration 2431753:00:00". But let's not worry about this. If there are actual uses of >24h events out there, we can still improve that part.