### PR TITLE
Wrap `delete realm` button text

### DIFF
--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -219,7 +219,9 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
         </p>
         <div css={{ marginTop: 32, textAlign: "center" }}>
             <Button kind="danger" onClick={() => currentRef(modalRef).open()}>
-                <span>{buttonContent}</span>
+                <span css={{ whiteSpace: "normal", textWrap: "balance" }}>
+                    {buttonContent}
+                </span>
             </Button>
         </div>
         <ConfirmationModal


### PR DESCRIPTION
Note that this also uses the `text-wrap: balance` rule to balance text width if shown on two lines. As of now this is only supported by chrome and simply ignored by other browsers, so it shouldn't break anything.

Closes #991 