### PR TITLE
Replace feather icons with lucide icons

### DIFF
--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { FiChevronRight, FiChevronLeft, FiCornerLeftUp } from "react-icons/fi";
+import { LuChevronLeft, LuChevronRight, LuCornerLeftUp } from "react-icons/lu";
 import { graphql, useFragment } from "react-relay";
 
 import type { NavigationData$key } from "./__generated__/NavigationData.graphql";
@@ -76,8 +76,8 @@ export const Nav: React.FC<Props> = ({ fragRef }) => {
                 }}
             >
                 {/* Show arrow and hide chevron in burger menu */}
-                <FiCornerLeftUp css={{ display: "none" }}/>
-                <FiChevronLeft />
+                <LuCornerLeftUp css={{ display: "none" }}/>
+                <LuChevronLeft />
                 {parent.isMainRoot ? t("general.home") : parent.name ?? <MissingRealmName />}
             </LinkWithIcon>
             <div css={{
@@ -109,6 +109,6 @@ type ItemProps = {
 const Item: React.FC<ItemProps> = ({ label, link }) => (
     <LinkWithIcon to={link} iconPos="right">
         <div css={ellipsisOverflowCss(3)}>{label}</div>
-        <FiChevronRight />
+        <LuChevronRight />
     </LinkWithIcon>
 );

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-    FiAlertTriangle, FiUserCheck, FiChevronDown,
-    FiFolder, FiLogOut, FiUpload, FiLogIn, FiFilm, FiVideo, FiMoon, FiSun,
-} from "react-icons/fi";
+    LuAlertTriangle, LuLogIn, LuMoon, LuSun, LuFolder, LuFilm,
+    LuUpload, LuVideo, LuLogOut, LuChevronDown, LuUserCheck,
+} from "react-icons/lu";
 import { HiOutlineFire, HiOutlineTranslate } from "react-icons/hi";
 import {
     match, ProtoButton, screenWidthAbove, screenWidthAtMost,
@@ -25,6 +25,7 @@ import { COLORS } from "../../color";
 import { translatedConfig } from "../../util";
 
 
+
 /** User-related UI in the header. */
 export const UserBox: React.FC = () => {
     const { t } = useTranslation();
@@ -42,7 +43,7 @@ export const UserBox: React.FC = () => {
         boxContent = <Spinner css={iconCss} />;
     } else if (user === "error") {
         // TODO: tooltip
-        boxContent = <FiAlertTriangle css={iconCss} />;
+        boxContent = <LuAlertTriangle css={iconCss} />;
     } else if (user === "none") {
         boxContent = <LoggedOut />;
     } else {
@@ -96,7 +97,7 @@ const LoggedOut: React.FC = () => {
                 },
             }}
         >
-            <FiLogIn />
+            <LuLogIn />
             <span>{t("user.login")}</span>
         </Link>
     );
@@ -124,7 +125,7 @@ export const ColorSchemeSettings: React.FC = () => {
             }}
         >
             <ActionIcon title={t("main-menu.color-scheme.label")}>
-                {scheme === "light" ? <FiMoon /> : <FiSun />}
+                {scheme === "light" ? <LuMoon /> : <LuSun />}
             </ActionIcon>
         </WithHeaderMenu>
     );
@@ -176,7 +177,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
     const indent = { paddingLeft: 30 };
     const items: HeaderMenuProps["items"] = [
         {
-            icon: <FiFolder />,
+            icon: <LuFolder />,
             wrapper: <Link to="/~manage" />,
             children: t("user.manage-content"),
             css: { minWidth: 200 },
@@ -188,19 +189,19 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
             css: indent,
         }] : [],
         {
-            icon: <FiFilm />,
+            icon: <LuFilm />,
             wrapper: <Link to="/~manage/videos" />,
             children: t("manage.my-videos.title"),
             css: indent,
         },
         ...user.canUpload ? [{
-            icon: <FiUpload />,
+            icon: <LuUpload />,
             wrapper: <Link to="/~manage/upload" />,
             children: t("upload.title"),
             css: indent,
         }] : [],
         ...user.canUseStudio ? [{
-            icon: <FiVideo />,
+            icon: <LuVideo />,
             wrapper: <ExternalLink
                 service="STUDIO"
                 params={{
@@ -217,9 +218,9 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
         // Logout button
         {
             icon: match(logoutState, {
-                "idle": () => <FiLogOut />,
+                "idle": () => <LuLogOut />,
                 "pending": () => <Spinner />,
-                "error": () => <FiAlertTriangle />,
+                "error": () => <LuAlertTriangle />,
             }),
             children: t("user.logout"),
             css: {
@@ -301,7 +302,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
                 }}>
                     {user.displayName}
                 </span>
-                <FiChevronDown size={20}/>
+                <LuChevronDown size={20}/>
             </ProtoButton>
             {/* Show icon on mobile devices. */}
             <ActionIcon
@@ -311,7 +312,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
                         display: "none",
                     },
                 }}>
-                <FiUserCheck css={{ polyline: { stroke: COLORS.happy1 } }}/>
+                <LuUserCheck css={{ polyline: { stroke: COLORS.happy1 } }}/>
             </ActionIcon>
         </div>
     </WithHeaderMenu>;

--- a/frontend/src/layout/header/index.tsx
+++ b/frontend/src/layout/header/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FiArrowLeft, FiMenu, FiX } from "react-icons/fi";
+import { LuArrowLeft, LuMenu, LuX } from "react-icons/lu";
 import { HiOutlineSearch } from "react-icons/hi";
 import { useTranslation } from "react-i18next";
 import { match, screenWidthAbove } from "@opencast/appkit";
@@ -63,7 +63,7 @@ const SearchMode: React.FC = () => {
             onClick={() => menu.close()}
             css={{ marginLeft: 8 }}
         >
-            <FiArrowLeft />
+            <LuArrowLeft />
         </ActionIcon>
         <SearchField variant="mobile" />
     </>;
@@ -81,7 +81,7 @@ const OpenMenuMode: React.FC = () => {
                 onClick={() => menu.close()}
                 css={buttonOutline}
             >
-                <FiX />
+                <LuX />
             </ActionIcon>
         </ButtonContainer>
     </>;
@@ -120,7 +120,7 @@ const DefaultMode: React.FC<{ hideNavIcon: boolean }> = ({ hideNavIcon }) => {
                         },
                     }}
                 >
-                    <FiMenu />
+                    <LuMenu />
                 </ActionIcon>
             )}
         </ButtonContainer>

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, Suspense } from "react";
-import { FiAlertTriangle, FiFrown } from "react-icons/fi";
+import { LuFrown, LuAlertTriangle } from "react-icons/lu";
 import { Translation, useTranslation } from "react-i18next";
 import { graphql, PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { unreachable } from "@opencast/appkit";
@@ -79,14 +79,14 @@ const Embed: React.FC<EmbedProps> = ({ queryRef }) => {
 
     if (!event) {
         return <PlayerPlaceholder>
-            <FiFrown />
+            <LuFrown />
             <div>{t("not-found.video-not-found")}</div>
         </PlayerPlaceholder>;
     }
 
     if (event.__typename === "NotAllowed") {
         return <PlayerPlaceholder>
-            <FiAlertTriangle />
+            <LuAlertTriangle />
             <div>{t("api-remote-errors.view.event")}</div>
         </PlayerPlaceholder>;
     }
@@ -118,7 +118,7 @@ export const BlockEmbedRoute = makeRoute(url => {
 
     return {
         render: () => <PlayerPlaceholder>
-            <FiAlertTriangle />
+            <LuAlertTriangle />
             <div>
                 <Translation>{t => t("embed.not-supported")}</Translation>
             </div>
@@ -133,7 +133,7 @@ class ErrorBoundary extends GlobalErrorBoundary {
         }
 
         return <PlayerPlaceholder>
-            <FiAlertTriangle />
+            <LuAlertTriangle />
             <div>
                 <Translation>{t => t("errors.embedded")}</Translation>
             </div>

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -14,7 +14,7 @@ import { useForm } from "react-hook-form";
 import { boxError } from "../ui/error";
 import { translatedConfig, useNoindexTag } from "../util";
 import { Spinner } from "../ui/Spinner";
-import { FiCheck, FiChevronLeft, FiLogIn } from "react-icons/fi";
+import { LuCheck, LuChevronLeft, LuLogIn } from "react-icons/lu";
 import { Card } from "../ui/Card";
 import CONFIG from "../config";
 import { LOGIN_PATH } from "./paths";
@@ -114,7 +114,7 @@ const BackButton: React.FC = () => {
             borderRadius: 4,
             textDecoration: "none",
         }}
-    ><FiChevronLeft />{t("general.action.back")}</Link>;
+    ><LuChevronLeft />{t("general.action.back")}</Link>;
 };
 
 type FormData = {
@@ -252,12 +252,12 @@ const LoginBox: React.FC = () => {
                         ...focusStyle({ offset: 1 }),
                     }}
                 >
-                    <FiLogIn size={20} />
+                    <LuLogIn size={20} />
                     {t("user.login")}
                     {match(state, {
                         "idle": () => null,
                         "pending": () => <Spinner size={20} />,
-                        "success": () => <FiCheck />,
+                        "success": () => <LuCheck />,
                     })}
                 </ProtoButton>
 

--- a/frontend/src/routes/NotFound.tsx
+++ b/frontend/src/routes/NotFound.tsx
@@ -7,7 +7,7 @@ import { Link } from "../router";
 import { useNoindexTag } from "../util";
 import { loadQuery } from "../relay";
 import { NotFoundQuery } from "./__generated__/NotFoundQuery.graphql";
-import { FiFrown } from "react-icons/fi";
+import { LuFrown } from "react-icons/lu";
 import { PageTitle } from "../layout/header/ui";
 import { CenteredContent } from "../ui";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
@@ -53,7 +53,7 @@ export const NotFound: React.FC<Props> = ({ kind }) => {
 
     return <>
         <Breadcrumbs path={[]} tail={<i>{title}</i>} />
-        <FiFrown css={{ margin: "0 auto", display: "block", fontSize: 90 }} />
+        <LuFrown css={{ margin: "0 auto", display: "block", fontSize: 90 }} />
         <PageTitle
             title={title}
             css={{ textAlign: "center", margin: "32px 0 48px 0 !important" }}

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useState } from "react";
 import { graphql, loadQuery, useMutation } from "react-relay/hooks";
 import type { RealmQuery, RealmQuery$data } from "./__generated__/RealmQuery.graphql";
 import { useTranslation } from "react-i18next";
-import { FiEdit, FiInfo, FiPlusCircle, FiSettings, FiSunrise } from "react-icons/fi";
+import { LuSunrise, LuInfo, LuSettings, LuPlusCircle, LuPenSquare } from "react-icons/lu";
 import { WithTooltip, screenWidthAtMost } from "@opencast/appkit";
 
 import { environment as relayEnv } from "../relay";
@@ -183,7 +183,7 @@ const WelcomeMessage: React.FC = () => {
             backgroundColor: COLORS.neutral10,
             border: `2px dashed ${COLORS.happy0}`,
         }}>
-            <FiSunrise css={{ marginTop: 8, fontSize: 32, minWidth: 32 }} />
+            <LuSunrise css={{ marginTop: 8, fontSize: 32, minWidth: 32 }} />
             <div>
                 <h2 css={{ textAlign: "center", fontSize: 20, marginBottom: 16 }}>
                     {t("welcome.title")}
@@ -212,7 +212,7 @@ const UserRealmNote: React.FC<Props> = ({ realm }) => {
                 display: "flex",
                 gap: 4,
             }}>
-                <FiInfo />
+                <LuInfo />
                 {t("realm.user-realm.note-label")}
             </div>
         </WithTooltip>
@@ -295,9 +295,9 @@ export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
 
     /* eslint-disable react/jsx-key */
     const buttons: [string, string, ReactElement][] = [
-        ["/~manage/realm?path=", t("realm.page-settings"), <FiSettings />],
-        ["/~manage/realm/content?path=", t("realm.edit-page-content"), <FiEdit />],
-        ["/~manage/realm/add-child?parent=", t("realm.add-sub-page"), <FiPlusCircle />],
+        ["/~manage/realm?path=", t("realm.page-settings"), <LuSettings />],
+        ["/~manage/realm/content?path=", t("realm.edit-page-content"), <LuPenSquare />],
+        ["/~manage/realm/add-child?parent=", t("realm.add-sub-page"), <LuPlusCircle />],
     ];
     /* eslint-enable react/jsx-key */
 

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { FiFolder } from "react-icons/fi";
+import { LuFolder } from "react-icons/lu";
 import { ReactNode } from "react";
 import { screenWidthAtMost, unreachable } from "@opencast/appkit";
 
@@ -242,7 +242,7 @@ type SearchRealmProps = {
 const SearchRealm: React.FC<SearchRealmProps> = ({ id, name, ancestorNames, fullPath }) => (
     <Item key={id} link={fullPath}>
         <div css={{ textAlign: "center" }}>
-            <FiFolder css={{ margin: 8, fontSize: 26 }}/>
+            <LuFolder css={{ margin: 8, fontSize: 26 }}/>
         </div>
         <div>
             <BreadcrumbsContainer>

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 import { keyframes } from "@emotion/react";
 import { Controller, useController, useForm } from "react-hook-form";
-import { FiCheckCircle, FiInfo, FiUpload } from "react-icons/fi";
+import { LuCheckCircle, LuUpload, LuInfo } from "react-icons/lu";
 import { WithTooltip, assertNever, bug, unreachable } from "@opencast/appkit";
 
 import { RootLoader } from "../layout/Root";
@@ -197,7 +197,7 @@ const UploadMain: React.FC<UploadMainProps> = ({ knownRoles }) => {
             marginTop: "max(16px, 10vh - 50px)",
             gap: 32,
         }}>
-            <FiCheckCircle css={{ fontSize: 64, color: COLORS.happy0 }} />
+            <LuCheckCircle css={{ fontSize: 64, color: COLORS.happy0 }} />
             {t("upload.finished")}
         </div>;
     } else {
@@ -427,13 +427,13 @@ const FileSelect: React.FC<FileSelectProps> = ({ onSelect }) => {
                     does not guarantee that and could change it at any time. But we decided it's
                     fine in this case. It is unlikely to change and if it breaks, nothing bad could
                     happen. Only the animation is broken. */}
-                <FiUpload css={{
+                <LuUpload css={{
                     position: "absolute",
                     top: isDragging ? 8 : 0,
                     transition: "top var(--transition-length)",
                     "& > path": { display: "none" },
                 }} />
-                <FiUpload css={{ "& > polyline, & > line": { display: "none" } }} />
+                <LuUpload css={{ "& > polyline, & > line": { display: "none" } }} />
             </div>
 
             {t("upload.drop-to-upload")}
@@ -749,7 +749,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
                             marginLeft: 8,
                         }}
                     >
-                        <span><FiInfo tabIndex={0} /></span>
+                        <span><LuInfo tabIndex={0} /></span>
                     </WithTooltip>
                 </label>
                 <SeriesSelector

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -2,10 +2,7 @@ import React, { ReactElement, ReactNode, useEffect, useRef, useState } from "rea
 import { graphql, GraphQLTaggedNode, PreloadedQuery, useFragment } from "react-relay/hooks";
 import { useTranslation } from "react-i18next";
 import { OperationType } from "relay-runtime";
-import {
-    FiCode, FiSettings, FiShare2, FiDownload,
-} from "react-icons/fi";
-import { LuLink, LuQrCode } from "react-icons/lu";
+import { LuCode, LuDownload, LuLink, LuQrCode, LuSettings, LuShare2 } from "react-icons/lu";
 import { QRCodeCanvas } from "qrcode.react";
 import {
     match, unreachable, ProtoButton,
@@ -420,7 +417,7 @@ const Metadata: React.FC<MetadataProps> = ({ id, event }) => {
                         "&:not([disabled])": { color: COLORS.primary0 },
                         ...shrinkOnMobile,
                     }}>
-                        <FiSettings size={16} />
+                        <LuSettings size={16} />
                         {t("video.manage")}
                     </LinkButton>
                 )}
@@ -514,7 +511,7 @@ const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
         >
             <FloatingTrigger>
                 <Button>
-                    <FiDownload size={16}/>
+                    <LuDownload size={16}/>
                     {t("video.download.title")}
                 </Button>
             </FloatingTrigger>
@@ -537,7 +534,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     /* eslint-disable react/jsx-key */
     const entries: [Exclude<MenuState, "closed">, ReactElement][] = [
         ["main", <LuLink />],
-        ["embed", <FiCode />],
+        ["embed", <LuCode />],
         // ["rss", <FiRss />],
     ];
     /* eslint-enable react/jsx-key */
@@ -748,7 +745,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         });
                     }
                 }}>
-                    <FiShare2 size={16} />
+                    <LuShare2 size={16} />
                     {t("general.action.share")}
                 </Button>
             </FloatingTrigger>

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
 import { bug, unreachable, useColorScheme, WithTooltip } from "@opencast/appkit";
 
-import { FiArrowDown, FiArrowUp } from "react-icons/fi";
+import { LuArrowUp, LuArrowDown } from "react-icons/lu";
 import { RealmOrder } from "../../../layout/__generated__/NavigationData.graphql";
 import {
     ChildOrderEditData$data,
@@ -233,12 +233,12 @@ const ChildEntry: React.FC<ChildEntryProps> = ({ index, swap, realmName, numChil
             }}>
                 <WithTooltip tooltip={t("manage.realm.children.move-up")} placement="left">
                     <button onClick={() => swap(index - 1)} disabled={index === 0}>
-                        <FiArrowUp />
+                        <LuArrowUp />
                     </button>
                 </WithTooltip>
                 <WithTooltip tooltip={t("manage.realm.children.move-down")} placement="left">
                     <button onClick={() => swap(index)} disabled={index === numChildren - 1}>
-                        <FiArrowDown />
+                        <LuArrowDown />
                     </button>
                 </WithTooltip>
             </div>

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, commitLocalUpdate, useRelayEnvironment } from "react-relay";
 import type { RecordProxy, RecordSourceProxy } from "relay-runtime";
-import { FiPlus, FiType, FiGrid, FiFilm, FiHash } from "react-icons/fi";
+import { LuPlus, LuHash, LuType, LuGrid, LuFilm } from "react-icons/lu";
 import {
     ProtoButton, bug, useColorScheme,
     Floating, FloatingContainer, FloatingHandle, FloatingTrigger, WithTooltip,
@@ -94,7 +94,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                             },
                             ...focusStyle({ offset: 1 }),
                         }}>
-                            <FiPlus />
+                            <LuPlus />
                         </ProtoButton>
                     </WithTooltip>
                 </div>
@@ -124,19 +124,19 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                 }}>
                     <AddItem
                         close={() => floatingRef.current?.close()}
-                        Icon={FiHash}
+                        Icon={LuHash}
                         label={t("manage.realm.content.add-title")}
                         onClick={() => addBlock("Title")}
                     />
                     <AddItem
                         close={() => floatingRef.current?.close()}
-                        Icon={FiType}
+                        Icon={LuType}
                         label={t("manage.realm.content.add-text")}
                         onClick={() => addBlock("Text")}
                     />
                     <AddItem
                         close={() => floatingRef.current?.close()}
-                        Icon={FiGrid}
+                        Icon={LuGrid}
                         label={t("manage.realm.content.add-series")}
                         onClick={() => addBlock("Series", (_store, block) => {
                             block.setValue("NEW_TO_OLD", "order");
@@ -146,7 +146,7 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                     />
                     <AddItem
                         close={() => floatingRef.current?.close()}
-                        Icon={FiFilm}
+                        Icon={LuFilm}
                         label={t("manage.realm.content.add-video")}
                         onClick={() => addBlock("Video", (_store, block) => {
                             block.setValue(true, "showTitle");

--- a/frontend/src/routes/manage/Realm/Content/Edit/MoveButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/MoveButtons.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, graphql, useMutation } from "react-relay";
-import { FiArrowDown, FiArrowUp } from "react-icons/fi";
+import { LuArrowDown, LuArrowUp } from "react-icons/lu";
 import { WithTooltip } from "@opencast/appkit";
 
 import type { MoveButtonsData$key } from "./__generated__/MoveButtonsData.graphql";
@@ -66,7 +66,7 @@ export const MoveButtons: React.FC<Props> = ({
                 disabled={index === blocks.length - 1}
                 onClick={() => move(1)}
             >
-                <FiArrowDown />
+                <LuArrowDown />
             </Button>
         </WithTooltip>
         <WithTooltip tooltip={t("manage.realm.content.move-up")}>
@@ -75,7 +75,7 @@ export const MoveButtons: React.FC<Props> = ({
                 disabled={index === 0}
                 onClick={() => move(-1)}
             >
-                <FiArrowUp />
+                <LuArrowUp />
             </Button>
         </WithTooltip>
     </>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useFragment, graphql, useMutation } from "react-relay";
-import { FiTrash } from "react-icons/fi";
+import { LuTrash } from "react-icons/lu";
 import { WithTooltip } from "@opencast/appkit";
 
 import type { RemoveButtonData$key } from "./__generated__/RemoveButtonData.graphql";
@@ -81,7 +81,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
                     }
                 }}
             >
-                <FiTrash />
+                <LuTrash />
             </Button>
         </WithTooltip>
         <Modal ref={cannotDeleteModalRef} title={t("manage.realm.content.cannot-remove-block")}>

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
-import { FiEdit } from "react-icons/fi";
+import { LuPenSquare } from "react-icons/lu";
 import { WithTooltip } from "@opencast/appkit";
 
 import type {
@@ -54,7 +54,7 @@ export const EditButtons: React.FC<Props> = ({
         <MoveButtons {...{ realm, index, onCommit, onCompleted }} onError={onMoveError} />
         <WithTooltip tooltip={t("manage.realm.content.edit")}>
             <Button aria-label={t("manage.realm.content.edit")} onClick={onEdit}>
-                <FiEdit />
+                <LuPenSquare />
             </Button>
         </WithTooltip>
         <RemoveButton

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
-import { FiEye } from "react-icons/fi";
+import { LuEye } from "react-icons/lu";
 import { bug } from "@opencast/appkit";
 
 import { RootLoader } from "../../../../layout/Root";
@@ -145,7 +145,7 @@ const ManageContent: React.FC<Props> = ({ data }) => {
 
             <LinkButton to={path}>
                 {t("manage.realm.content.view-page")}
-                <FiEye />
+                <LuEye />
             </LinkButton>
 
             <div css={{

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -12,7 +12,7 @@ import { ChildOrder } from "./ChildOrder";
 import { General } from "./General";
 import { DangerZone } from "./DangerZone";
 import { LinkButton } from "../../../ui/Button";
-import { FiArrowRightCircle, FiPlusCircle } from "react-icons/fi";
+import { LuArrowRightCircle, LuPlusCircle } from "react-icons/lu";
 import { Card } from "../../../ui/Card";
 import { Nav } from "../../../layout/Navigation";
 import { CenteredContent } from "../../../ui";
@@ -106,11 +106,11 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
             }}>
                 <LinkButton to={realm.path}>
                     {t("manage.realm.view-page")}
-                    <FiArrowRightCircle />
+                    <LuArrowRightCircle />
                 </LinkButton>
                 <LinkButton to={`/~manage/realm/add-child?parent=${pathToQuery(realm.path)}`}>
                     {t("realm.add-sub-page")}
-                    <FiPlusCircle />
+                    <LuPlusCircle />
                 </LinkButton>
             </div>
             <section><General fragRef={realm} /></section>

--- a/frontend/src/routes/manage/Video/Access.tsx
+++ b/frontend/src/routes/manage/Video/Access.tsx
@@ -4,7 +4,7 @@ import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { PageTitle } from "../../../layout/header/ui";
 import { Dispatch, RefObject, SetStateAction, useRef, useState } from "react";
 import { COLORS } from "../../../color";
-import { FiInfo } from "react-icons/fi";
+import { LuInfo } from "react-icons/lu";
 import { Button, Kind as ButtonKind } from "../../../ui/Button";
 import { isRealUser, useUser } from "../../../User";
 import { NotAuthorized } from "../../../ui/error";
@@ -75,7 +75,7 @@ const UnlistedNote: React.FC = () => {
                 gap: 4,
                 marginBottom: 16,
             }}>
-                <FiInfo />
+                <LuInfo />
                 {t("manage.access.unlisted.note")}
             </div>
         </WithTooltip>

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { FiExternalLink } from "react-icons/fi";
+import { LuExternalLink } from "react-icons/lu";
 
 import { useId, useState } from "react";
 import { Link } from "../../../router";
@@ -61,7 +61,7 @@ const Page: React.FC<Props> = ({ event }) => {
                         }}
                     >
                         {t("manage.my-videos.details.open-in-editor")}
-                        <FiExternalLink size={16} />
+                        <LuExternalLink size={16} />
                     </ExternalLink>
                 )}
                 <DirectLink event={event} />

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { FiCornerLeftUp, FiEdit3, FiInfo, FiPlay, FiShield } from "react-icons/fi";
+import { LuCornerLeftUp, LuInfo, LuShield, LuPlay, LuPenLine } from "react-icons/lu";
 import { graphql } from "react-relay";
 
 import { RootLoader } from "../../../layout/Root";
@@ -109,7 +109,7 @@ const BackLink: React.FC = () => {
     const { t } = useTranslation();
     const items = [
         <LinkWithIcon key={MANAGE_VIDEOS_PATH} to={MANAGE_VIDEOS_PATH} iconPos="left">
-            <FiCornerLeftUp />
+            <LuCornerLeftUp />
             {t("manage.my-videos.title")}
         </LinkWithIcon>,
     ];
@@ -139,12 +139,12 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         {
             url: `/~manage/videos/${id}`,
             page: "details",
-            body: <><FiEdit3 />{t("manage.my-videos.details.title")}</>,
+            body: <><LuPenLine />{t("manage.my-videos.details.title")}</>,
         },
         {
             url: `/~manage/videos/${id}/technical-details`,
             page: "technical-details",
-            body: <><FiInfo />{t("manage.my-videos.technical-details.title")}</>,
+            body: <><LuInfo />{t("manage.my-videos.technical-details.title")}</>,
         },
     ];
 
@@ -152,7 +152,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         entries.splice(1, 0, {
             url: `/~manage/videos/${id}/access`,
             page: "acl",
-            body: <><FiShield />{t("manage.my-videos.acl.title")}</>,
+            body: <><LuShield />{t("manage.my-videos.acl.title")}</>,
         });
     }
 
@@ -192,7 +192,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
                 backgroundColor: "black",
                 borderRadius: 8,
             }}>
-                <FiPlay />
+                <LuPlay />
                 <Thumbnail event={event} />
             </Link>
             <div css={{

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,7 +1,8 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
-import { LuArrowDownNarrowWide, LuArrowUpWideNarrow } from "react-icons/lu";
+import {
+    LuArrowDownNarrowWide, LuArrowUpWideNarrow, LuChevronLeft, LuChevronRight,
+} from "react-icons/lu";
 import { graphql, VariablesOf } from "react-relay";
 import { match, useColorScheme } from "@opencast/appkit";
 
@@ -357,11 +358,11 @@ const PageNavigation: React.FC<PageNavigationProps> = ({ connection, vars }) => 
                 <PageLink
                     vars={{ order: vars.order, before: pageInfo.startCursor, last: LIMIT }}
                     disabled={!pageInfo.hasPreviousPage}
-                ><FiChevronLeft /></PageLink>
+                ><LuChevronLeft /></PageLink>
                 <PageLink
                     vars={{ order: vars.order, after: pageInfo.endCursor, first: LIMIT }}
                     disabled={!pageInfo.hasNextPage}
-                ><FiChevronRight /></PageLink>
+                ><LuChevronRight /></PageLink>
                 <PageLink
                     vars={{ order: vars.order, last: LIMIT }}
                     disabled={!pageInfo.hasNextPage}

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -1,8 +1,7 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { FiExternalLink, FiFilm, FiUpload, FiVideo } from "react-icons/fi";
 import { HiOutlineFire } from "react-icons/hi";
-import { LuLayoutTemplate } from "react-icons/lu";
+import { LuExternalLink, LuFilm, LuLayoutTemplate, LuUpload, LuVideo } from "react-icons/lu";
 import { graphql } from "react-relay";
 import { useColorScheme } from "@opencast/appkit";
 
@@ -81,7 +80,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     /* eslint-disable react/jsx-key */
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         ["/~manage", t("manage.dashboard.title"), <LuLayoutTemplate />],
-        ["/~manage/videos", t("manage.my-videos.title"), <FiFilm />],
+        ["/~manage/videos", t("manage.my-videos.title"), <LuFilm />],
     ];
     if (isRealUser(user) && user.canCreateUserRealm) {
         entries.splice(
@@ -89,7 +88,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
         );
     }
     if (isRealUser(user) && user.canUpload) {
-        entries.push(["/~manage/upload", t("upload.title"), <FiUpload />]);
+        entries.push(["/~manage/upload", t("upload.title"), <LuUpload />]);
     }
     /* eslint-enable react/jsx-key */
 
@@ -125,9 +124,9 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
                     ":hover, :focus-visible": { color: isDark ? COLORS.primary2 : COLORS.primary1 },
                 }}
             >
-                <FiVideo />
+                <LuVideo />
                 {t("manage.dashboard.studio-tile-title")}
-                <FiExternalLink size={18} css={{ marginLeft: 4 }} />
+                <LuExternalLink size={18} css={{ marginLeft: 4 }} />
             </ExternalLink>
         );
     }

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -11,7 +11,7 @@ import {
 } from "@opencast/appkit";
 import { createContext, useRef, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
-import { FiX, FiAlertTriangle } from "react-icons/fi";
+import { LuX, LuAlertTriangle } from "react-icons/lu";
 import { MultiValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import { graphql } from "react-relay";
@@ -412,7 +412,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind }) => {
                         ...focusStyle({ offset: -1 }),
                     }}
                 >
-                    <FiX size={20} />
+                    <LuX size={20} />
                 </ProtoButton>
             </td>
         </tr>
@@ -426,7 +426,7 @@ type WarningProps = {
 const Warning: React.FC<WarningProps> = ({ tooltip }) => (
     <WithTooltip {...{ tooltip }} css={{ display: "flex" }}>
         <span css={{ marginLeft: 6, display: "flex" }}>
-            <FiAlertTriangle css={{ color: COLORS.danger0, alignSelf: "center" }} />
+            <LuAlertTriangle css={{ color: COLORS.danger0, alignSelf: "center" }} />
         </span>
     </WithTooltip>
 );

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -26,14 +26,7 @@ import {
 import { isPastLiveEvent, isUpcomingLiveEvent, Thumbnail } from "../Video";
 import { RelativeDate } from "../time";
 import { Card } from "../Card";
-import {
-    FiChevronLeft,
-    FiChevronRight,
-    FiColumns,
-    FiGrid,
-    FiList,
-    FiPlay,
-} from "react-icons/fi";
+import { LuColumns, LuGrid, LuList, LuChevronLeft, LuChevronRight, LuPlay } from "react-icons/lu";
 import { keyframes } from "@emotion/react";
 import { Description, SmallDescription } from "../metadata";
 import { darkModeBoxShadow, ellipsisOverflowCss, focusStyle } from "..";
@@ -338,9 +331,9 @@ const ViewMenu: React.FC = () => {
     const ref = useRef<FloatingHandle>(null);
 
     const icon = match(state.viewState, {
-        slider: () => <FiColumns />,
-        gallery: () => <FiGrid />,
-        list: () => <FiList />,
+        slider: () => <LuColumns />,
+        gallery: () => <LuGrid />,
+        list: () => <LuList />,
     });
 
     const triggerContent = (
@@ -399,21 +392,21 @@ const List: React.FC<ListProps> = ({ type, close }) => {
                     disabled={viewState === "slider"}
                     onClick={() => setViewState("slider")}
                     close={close}
-                    Icon={FiColumns}
+                    Icon={LuColumns}
                     label={t("series.settings.slider")}
                 />
                 <MenuItem
                     disabled={viewState === "gallery"}
                     onClick={() => setViewState("gallery")}
                     close={close}
-                    Icon={FiGrid}
+                    Icon={LuGrid}
                     label={t("series.settings.gallery")}
                 />
                 <MenuItem
                     disabled={viewState === "list"}
                     onClick={() => setViewState("list")}
                     close={close}
-                    Icon={FiList}
+                    Icon={LuList}
                     label={t("series.settings.list")}
                 />
             </ul>
@@ -743,12 +736,12 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items }) => {
                 aria-label={t("series.slider.scroll-left")}
                 onClick={() => scroll(-scrollDistance)}
                 css={{ left: 8, ...buttonCss }}
-            ><FiChevronLeft /></ProtoButton>}
+            ><LuChevronLeft /></ProtoButton>}
             {rightVisible && <ProtoButton
                 aria-label={t("series.slider.scroll-right")}
                 onClick={() => scroll(scrollDistance)}
                 css={{ right: 8, ...buttonCss }}
-            ><FiChevronRight /></ProtoButton>}
+            ><LuChevronRight /></ProtoButton>}
         </div>
     </div>;
 };
@@ -847,7 +840,7 @@ const Item: React.FC<ItemProps> = ({
                 gap: 4,
                 marginBottom: 4,
             }}>
-                {active && <FiPlay css={{
+                {active && <LuPlay css={{
                     flex: "0 0 auto",
                     strokeWidth: 3,
                     animation: `${keyframes({

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -8,7 +8,7 @@ import { Card } from "../Card";
 import { useTranslation } from "react-i18next";
 import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
-import { FiArrowRightCircle } from "react-icons/fi";
+import { LuArrowRightCircle } from "react-icons/lu";
 import { PlayerContextProvider } from "../player/PlayerContext";
 
 
@@ -77,7 +77,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
             }}
         >
             {t("video.link")}
-            <FiArrowRightCircle size={18} css={{ marginTop: 1 }} />
+            <LuArrowRightCircle size={18} css={{ marginTop: 1 }} />
         </Link>}
     </div>;
 };

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { FiChevronRight, FiHome } from "react-icons/fi";
+import { LuHome, LuChevronRight } from "react-icons/lu";
 import { useTranslation } from "react-i18next";
 import { BreadcrumbList, WithContext } from "schema-dts";
 
@@ -43,7 +43,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
                         ...focusStyle({ inset: true }),
                         borderRadius: 4,
                     }}>
-                        <FiHome aria-label={t("general.home")} />
+                        <LuHome aria-label={t("general.home")} />
                     </Link>
                 </li>
                 {path.map((segment, i) => (
@@ -104,5 +104,5 @@ const Segment: React.FC<SegmentProps> = ({ target, children }) => (
 );
 
 export const BreadcrumbSeparator: React.FC = () => (
-    <FiChevronRight css={{ margin: "0 2px", flexShrink: 0, color: COLORS.neutral40 }} />
+    <LuChevronRight css={{ margin: "0 2px", flexShrink: 0, color: COLORS.neutral40 }} />
 );

--- a/frontend/src/ui/Card.tsx
+++ b/frontend/src/ui/Card.tsx
@@ -1,4 +1,4 @@
-import { FiAlertTriangle, FiInfo } from "react-icons/fi";
+import { LuAlertTriangle, LuInfo } from "react-icons/lu";
 import { match } from "@opencast/appkit";
 
 import { COLORS } from "../color";
@@ -37,8 +37,8 @@ export const Card: React.FC<Props> = ({ kind, iconPos = "left", children, ...res
         {...rest}
     >
         {match(kind, {
-            "error": () => <FiAlertTriangle />,
-            "info": () => <FiInfo css={{ color: COLORS.neutral60 }} />,
+            "error": () => <LuAlertTriangle />,
+            "info": () => <LuInfo css={{ color: COLORS.neutral60 }} />,
         })}
         <div>{children}</div>
     </div>

--- a/frontend/src/ui/FloatingBaseMenu.tsx
+++ b/frontend/src/ui/FloatingBaseMenu.tsx
@@ -1,6 +1,6 @@
 import { FloatingHandle, FloatingContainer, FloatingTrigger, ProtoButton } from "@opencast/appkit";
 import React, { ReactElement } from "react";
-import { FiChevronDown } from "react-icons/fi";
+import { LuChevronDown } from "react-icons/lu";
 import { focusStyle } from ".";
 import { COLORS } from "../color";
 import { CSSObject } from "@emotion/react";
@@ -41,7 +41,7 @@ export const FloatingBaseMenu = React.forwardRef<FloatingHandle, FloatingBaseMen
                     ...triggerStyles,
                 }}>
                     {triggerContent}
-                    <FiChevronDown css={{ fontSize: 20, flexShrink: 0 }} />
+                    <LuChevronDown css={{ fontSize: 20, flexShrink: 0 }} />
                 </ProtoButton>
             </FloatingTrigger>
             {list}

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, ReactNode, useId, useImperativeHandle, useRef, useState } from "react";
-import { FiCheck, FiCopy } from "react-icons/fi";
+import { LuCheck, LuCopy } from "react-icons/lu";
 import { WithTooltip } from "@opencast/appkit";
 
 import { Button } from "./Button";
@@ -279,7 +279,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
                                 : { borderBottomLeftRadius: 0 },
                         }}
                     >
-                        {wasCopied ? <FiCheck /> : <FiCopy />}
+                        {wasCopied ? <LuCheck /> : <LuCopy />}
                     </Button>
                 </WithTooltip>
             </div>

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -9,7 +9,7 @@ import {
     useEffect,
 } from "react";
 import ReactDOM from "react-dom";
-import { FiX } from "react-icons/fi";
+import { LuX } from "react-icons/lu";
 import { useTranslation } from "react-i18next";
 import FocusTrap from "focus-trap-react";
 import { bug, useColorScheme, ProtoButton } from "@opencast/appkit";
@@ -110,7 +110,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
                                 borderRadius: 4,
                                 ...focusStyle({}),
                             }}
-                        ><FiX /></ProtoButton>}
+                        ><LuX /></ProtoButton>}
                     </div>
                     <div css={{ padding: 16 }}>{children}</div>
                 </div>

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiAlertTriangle, FiFilm, FiRadio, FiVolume2 } from "react-icons/fi";
-import { LuUserCircle } from "react-icons/lu";
+import { LuAlertTriangle, LuFilm, LuRadio, LuUserCircle, LuVolume2 } from "react-icons/lu";
 import { useColorScheme } from "@opencast/appkit";
 
 import { COLORS } from "../color";
@@ -58,7 +57,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({
         // We have no thumbnail. If the resolution is `null` as well, we are
         // dealing with an audio-only event and show an appropriate icon.
         // Otherwise we use a generic icon.
-        const icon = audioOnly ? <FiVolume2 /> : <FiFilm />;
+        const icon = audioOnly ? <LuVolume2 /> : <LuFilm />;
 
         inner = (
             <div css={{
@@ -112,7 +111,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({
             innerOverlay = t("video.ended");
         } else if (hasStarted) {
             innerOverlay = <>
-                <FiRadio css={{ fontSize: 19, strokeWidth: 1.4 }} />
+                <LuRadio css={{ fontSize: 19, strokeWidth: 1.4 }} />
                 {t("video.live")}
             </>;
         } else {
@@ -211,7 +210,7 @@ const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
                 strokeWidth: 1.5,
             },
         }}>
-            <FiAlertTriangle />
+            <LuAlertTriangle />
             {t("general.failed-to-load-thumbnail")}
         </div>
         : <img

--- a/frontend/src/ui/Waiting.tsx
+++ b/frontend/src/ui/Waiting.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import { Card } from "../ui/Card";
-import { FiTruck } from "react-icons/fi";
+import { LuTruck } from "react-icons/lu";
 import { keyframes } from "@emotion/react";
 
 export const WaitingPage: React.FC<{ type: "video" | "series" }> = ({ type }) => {
@@ -17,7 +17,7 @@ export const WaitingPage: React.FC<{ type: "video" | "series" }> = ({ type }) =>
 };
 
 export const MovingTruck: React.FC = () => (
-    <FiTruck css={{
+    <LuTruck css={{
         fontSize: 40,
         animation: `500ms steps(2, end) infinite none ${keyframes({
             "0%": { transform: "translateY(5px)" },

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, Suspense, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { FiClock } from "react-icons/fi";
+import { LuClock } from "react-icons/lu";
 import { HiOutlineStatusOffline } from "react-icons/hi";
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { match, screenWidthAtMost, useColorScheme } from "@opencast/appkit";
@@ -266,7 +266,7 @@ const LiveEventPlaceholder: React.FC<LiveEventPlaceholderProps> = props => {
     return <PlayerPlaceholder>
         {match(props.mode, {
             "pending": () => <>
-                <FiClock />
+                <LuClock />
                 <div>{t("video.stream-not-started-yet")}</div>
             </>,
             "ended": () => <>


### PR DESCRIPTION
There are two feather icons the we use that are missing from lucide icons: `edit` and `edit3`. I left these as feather icons, but we could consider using similar ones from lucide (though I do like the feather ones more).

Closes #988 