### PR TITLE
Add contextual video link to "referencing pages"

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -7,6 +7,7 @@ general:
   loading: Lade...
   home: Startseite
   homepage: Startseite
+  page: Seite
   leave-page-confirmation: >
     Seite verlassen? Vorgenommene Änderungen sind möglicherweise noch nicht gespeichert!
   action:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -7,6 +7,7 @@ general:
   loading: Loading...
   home: Home
   homepage: Homepage
+  page: Page
   leave-page-confirmation: Leave page? Changes you made may not be saved!
   action:
     close: Close

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -170,11 +170,13 @@ const HostRealms: React.FC<Props> = ({ event }) => {
             : <>
                 <p>{t("manage.my-videos.details.referencing-pages-explanation")}</p>
                 <ul>{event.hostRealms.map(realm => <li key={realm.id}>
-                    <Link to={realm.path}>{
-                        realm.isMainRoot
-                            ? <i>{t("general.homepage")}</i>
-                            : realm.name
-                    }</Link>
+                    {realm.isMainRoot ? <i>{t("general.homepage")}</i> : realm.name}
+                    &nbsp;
+                    (<Link to={realm.path}>{t("general.page")}</Link>,
+                    &nbsp;
+                    <Link to={`${realm.isMainRoot ? "" : realm.path}/v/${keyOfId(event.id)}`}>
+                        {t("video.video")}
+                    </Link>)
                 </li>)}</ul>
             </>}
     </>;


### PR DESCRIPTION
This adds a link to the video itself (in context, i.e. with breacrumbs showing its referencing page) to the "referencing pages" section of "videodetails".

@dagraf: you wanted the link to the referencing page to be replaced, but I think it still has some value. For instance, a user might actually want to visit the referencing page. While that could be accomplished via the breadcrumbs of the video, I think it's more convenient have a dedicated link for that.
Of course the points you made in #882 are also valid, so I decided to supply both links with this PR, as shown in the screenshot below: 
<img width="384" alt="Bildschirmfoto 2023-11-14 um 13 09 17" src="https://github.com/elan-ev/tobira/assets/94838646/828429b1-fa0a-4b0f-96ae-9252b99bf14b">

Closes #882