### PR TITLE
Add arrow navigation to remaining popover menus

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-typescript": "^7.22.15",
         "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.1",
-        "@opencast/appkit": "^0.1.4",
+        "@opencast/appkit": "^0.2.4",
         "@svgr/webpack": "^8.1.0",
         "babel-loader": "^9.1.3",
         "babel-plugin-relay": "^15.0.0",
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/@opencast/appkit": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.1.4.tgz",
-      "integrity": "sha512-c+4N7VQPE6eWX6+lBUFQH1YWKPniBp0Lg4zgyw1TEKnNXOFDjeRsScxULomq79JabWrtbVhrD5TVN+H+3MXbhQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.2.4.tgz",
+      "integrity": "sha512-EHByrN6o8elbQIOI4XB1vqxA5IxStLGgoX8nfOQ3EXWHbx0n/ZNeZ/DrOTTmxgTNfRxvjZR7sbjIlbSIyL5SKw==",
       "peerDependencies": {
         "@emotion/react": "^11.11.1",
         "@floating-ui/react": "^0.24.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-typescript": "^7.22.15",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.1",
-    "@opencast/appkit": "^0.1.4",
+    "@opencast/appkit": "^0.2.4",
     "@svgr/webpack": "^8.1.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-relay": "^15.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ type Props = {
 export const App: React.FC<Props> = ({ initialRoute }) => (
     <StrictMode>
         <SilenceEmotionWarnings>
-            <ColorSchemeProvider>
+            <ColorSchemeProvider allowedSchemes={["light", "dark"]}>
                 <AppkitConfigProvider config={{
                     ...DEFAULT_CONFIG,
                     colors: {

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -1,11 +1,11 @@
-import React, { useRef } from "react";
+import React, { RefObject, useId, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, commitLocalUpdate, useRelayEnvironment } from "react-relay";
 import type { RecordProxy, RecordSourceProxy } from "relay-runtime";
-import { LuPlus, LuHash, LuType, LuGrid, LuFilm } from "react-icons/lu";
+import { LuPlus, LuHash, LuType, LuFilm, LuLayoutGrid } from "react-icons/lu";
 import {
-    ProtoButton, bug, useColorScheme,
-    Floating, FloatingContainer, FloatingHandle, FloatingTrigger, WithTooltip,
+    ProtoButton, bug, useColorScheme, Floating, FloatingContainer,
+    FloatingHandle, FloatingTrigger, WithTooltip, useFloatingContext,
 } from "@opencast/appkit";
 
 import { AddButtonsRealmData$key } from "./__generated__/AddButtonsRealmData.graphql";
@@ -21,40 +21,7 @@ type Props = {
 
 export const AddButtons: React.FC<Props> = ({ index, realm }) => {
     const { t } = useTranslation();
-    const isDark = useColorScheme().scheme === "dark";
-
     const floatingRef = useRef<FloatingHandle>(null);
-
-    const { id: realmId } = useFragment(graphql`
-        fragment AddButtonsRealmData on Realm {
-            id
-        }
-    `, realm);
-
-    const env = useRelayEnvironment();
-
-    const addBlock = (
-        type: string,
-        prepareBlock?: (store: RecordSourceProxy, block: RecordProxy) => void,
-    ) => {
-        commitLocalUpdate(env, store => {
-            const realm = store.get(realmId) ?? bug("could not find realm");
-
-            const blocks = [
-                ...realm.getLinkedRecords("blocks") ?? bug("realm does not have blocks"),
-            ];
-
-            const id = "clNEWBLOCK";
-            const block = store.create(id, `${type}Block`);
-            prepareBlock?.(store, block);
-            block.setValue(true, "editMode");
-            block.setValue(id, "id");
-
-            blocks.splice(index, 0, block);
-
-            realm.setLinkedRecords(blocks, "blocks");
-        });
-    };
 
     const BUTTON_SIZE = 36;
 
@@ -99,63 +66,100 @@ export const AddButtons: React.FC<Props> = ({ index, realm }) => {
                     </WithTooltip>
                 </div>
             </FloatingTrigger>
-
-            <Floating
-                padding={0}
-                borderWidth={isDark ? 1 : 0}
-                backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
-                shadowBlur={12}
-                shadowColor="rgba(0, 0, 0, 30%)"
-                css={{ width: 200 }}
-            >
-                <div css={{
-                    fontSize: 14,
-                    color: COLORS.neutral60,
-                    padding: "8px 16px",
-                    cursor: "default",
-                }}>{t("manage.realm.content.add-popup-title")}</div>
-                <ul css={{
-                    listStyle: "none",
-                    margin: 0,
-                    padding: 0,
-                    "& > li:not(:last-child)": {
-                        borderBottom: `1px solid ${isDark ? COLORS.neutral25 : COLORS.neutral15}`,
-                    },
-                }}>
-                    <AddItem
-                        close={() => floatingRef.current?.close()}
-                        Icon={LuHash}
-                        label={t("manage.realm.content.add-title")}
-                        onClick={() => addBlock("Title")}
-                    />
-                    <AddItem
-                        close={() => floatingRef.current?.close()}
-                        Icon={LuType}
-                        label={t("manage.realm.content.add-text")}
-                        onClick={() => addBlock("Text")}
-                    />
-                    <AddItem
-                        close={() => floatingRef.current?.close()}
-                        Icon={LuGrid}
-                        label={t("manage.realm.content.add-series")}
-                        onClick={() => addBlock("Series", (_store, block) => {
-                            block.setValue("NEW_TO_OLD", "order");
-                            block.setValue(true, "showTitle");
-                            block.setValue(false, "showMetadata");
-                        })}
-                    />
-                    <AddItem
-                        close={() => floatingRef.current?.close()}
-                        Icon={LuFilm}
-                        label={t("manage.realm.content.add-video")}
-                        onClick={() => addBlock("Video", (_store, block) => {
-                            block.setValue(true, "showTitle");
-                            block.setValue(true, "showLink");
-                        })}
-                    />
-                </ul>
-            </Floating>
+            <AddButtonsMenu {...{ index, realm, floatingRef }} />
         </FloatingContainer>
+    );
+};
+
+const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}> = ({
+    index, realm, floatingRef,
+}) => {
+    const isDark = useColorScheme().scheme === "dark";
+    const { t } = useTranslation();
+    const { refs } = useFloatingContext();
+    const menuId = useId();
+
+    const { id: realmId } = useFragment(graphql`
+        fragment AddButtonsRealmData on Realm {
+            id
+        }
+    `, realm);
+
+    const env = useRelayEnvironment();
+
+    const addBlock = (
+        type: string,
+        prepareBlock?: (store: RecordSourceProxy, block: RecordProxy) => void,
+    ) => {
+        commitLocalUpdate(env, store => {
+            const realm = store.get(realmId) ?? bug("could not find realm");
+
+            const blocks = [
+                ...realm.getLinkedRecords("blocks") ?? bug("realm does not have blocks"),
+            ];
+
+            const id = "clNEWBLOCK";
+            const block = store.create(id, `${type}Block`);
+            prepareBlock?.(store, block);
+            block.setValue(true, "editMode");
+            block.setValue(id, "id");
+
+            blocks.splice(index, 0, block);
+
+            realm.setLinkedRecords(blocks, "blocks");
+        });
+    };
+
+    type Block = "title" | "text" | "series" | "video";
+    const buttonProps: [IconType, Block, () => void][] = [
+        [LuHash, "title", () => addBlock("Title")],
+        [LuType, "text", () => addBlock("Text")],
+        [LuLayoutGrid, "series", () => addBlock("Series", (_store, block) => {
+            block.setValue("NEW_TO_OLD", "order");
+            block.setValue(true, "showTitle");
+            block.setValue(false, "showMetadata");
+        })],
+        [LuFilm, "video", () => addBlock("Video", (_store, block) => {
+            block.setValue(true, "showTitle");
+            block.setValue(true, "showLink");
+        })],
+    ];
+
+    return (
+        <Floating
+            padding={0}
+            borderWidth={isDark ? 1 : 0}
+            backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
+            shadowBlur={12}
+            shadowColor="rgba(0, 0, 0, 30%)"
+            css={{ width: 200 }}
+        >
+            <div css={{
+                fontSize: 14,
+                color: COLORS.neutral60,
+                padding: "8px 16px",
+                cursor: "default",
+            }}>{t("manage.realm.content.add-popup-title")}</div>
+            <ul css={{
+                listStyle: "none",
+                margin: 0,
+                padding: 0,
+                "& > li:not(:last-child)": {
+                    borderBottom: `1px solid ${isDark ? COLORS.neutral25 : COLORS.neutral15}`,
+                },
+            }}>
+                {buttonProps.map(([icon, type, onClick], index) => <AddItem
+                    key={`${menuId}-${type}`}
+                    close={() => floatingRef.current?.close()}
+                    Icon={icon}
+                    label={t(`manage.realm.content.add-${type}`)}
+                    ref={node => {
+                        refs.listRef.current[index] = node;
+                    }}
+                    {...{ onClick }}
+                />)}
+            </ul>
+        </Floating>
     );
 };
 
@@ -166,7 +170,9 @@ type AddItemProps = {
     close: () => void;
 };
 
-const AddItem: React.FC<AddItemProps> = ({ label, Icon, onClick, close }) => (
+const AddItem = React.forwardRef<HTMLButtonElement, AddItemProps>(({
+    label, Icon, onClick, close,
+}, ref) => (
     <li role="menuitem" css={{
         "&:last-child > button": {
             borderBottomLeftRadius: 8,
@@ -174,6 +180,7 @@ const AddItem: React.FC<AddItemProps> = ({ label, Icon, onClick, close }) => (
         },
     }}>
         <ProtoButton
+            {...{ ref }}
             onClick={() => {
                 onClick();
                 close();
@@ -196,4 +203,4 @@ const AddItem: React.FC<AddItemProps> = ({ label, Icon, onClick, close }) => (
             {label}
         </ProtoButton>
     </li>
-);
+));

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -5,7 +5,7 @@ import type { RecordProxy, RecordSourceProxy } from "relay-runtime";
 import { LuPlus, LuHash, LuType, LuFilm, LuLayoutGrid } from "react-icons/lu";
 import {
     ProtoButton, bug, useColorScheme, Floating, FloatingContainer,
-    FloatingHandle, FloatingTrigger, WithTooltip, useFloatingContext,
+    FloatingHandle, FloatingTrigger, WithTooltip, useFloatingItemProps,
 } from "@opencast/appkit";
 
 import { AddButtonsRealmData$key } from "./__generated__/AddButtonsRealmData.graphql";
@@ -76,7 +76,7 @@ const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}>
 }) => {
     const isDark = useColorScheme().scheme === "dark";
     const { t } = useTranslation();
-    const { refs } = useFloatingContext();
+    const itemProps = useFloatingItemProps();
     const menuId = useId();
 
     const { id: realmId } = useFragment(graphql`
@@ -153,9 +153,7 @@ const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}>
                     close={() => floatingRef.current?.close()}
                     Icon={icon}
                     label={t(`manage.realm.content.add-${type}`)}
-                    ref={node => {
-                        refs.listRef.current[index] = node;
-                    }}
+                    {...itemProps(index)}
                     {...{ onClick }}
                 />)}
             </ul>

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -3,6 +3,7 @@ import React, {
     createContext,
     useContext,
     useEffect,
+    useId,
     useRef,
     useState,
 } from "react";
@@ -26,7 +27,9 @@ import {
 import { isPastLiveEvent, isUpcomingLiveEvent, Thumbnail } from "../Video";
 import { RelativeDate } from "../time";
 import { Card } from "../Card";
-import { LuColumns, LuGrid, LuList, LuChevronLeft, LuChevronRight, LuPlay } from "react-icons/lu";
+import {
+    LuColumns, LuList, LuChevronLeft, LuChevronRight, LuPlay, LuLayoutGrid,
+} from "react-icons/lu";
 import { keyframes } from "@emotion/react";
 import { Description, SmallDescription } from "../metadata";
 import { darkModeBoxShadow, ellipsisOverflowCss, focusStyle } from "..";
@@ -332,7 +335,7 @@ const ViewMenu: React.FC = () => {
 
     const icon = match(state.viewState, {
         slider: () => <LuColumns />,
-        gallery: () => <LuGrid />,
+        gallery: () => <LuLayoutGrid />,
         list: () => <LuList />,
     });
 
@@ -362,6 +365,7 @@ const List: React.FC<ListProps> = ({ type, close }) => {
     const isDark = useColorScheme().scheme === "dark";
     const { viewState, setViewState } = useContext(ViewContext);
     const { eventOrder, setEventOrder } = useContext(OrderContext);
+    const itemId = useId();
 
     const listStyle = {
         minWidth: 125,
@@ -384,60 +388,44 @@ const List: React.FC<ListProps> = ({ type, close }) => {
         }
     };
 
+    const viewItems: [View, IconType][] = [
+        ["slider", LuColumns],
+        ["gallery", LuLayoutGrid],
+        ["list", LuList],
+    ];
+
+    type OrderTranslationKey = "new-to-old" | "old-to-new" | "a-z" | "z-a";
+    const orderItems: [ExtendedVideoListOrder, OrderTranslationKey][] = [
+        ["NEW_TO_OLD", "new-to-old"],
+        ["OLD_TO_NEW", "old-to-new"],
+        ["A-Z", "a-z"],
+        ["Z-A", "z-a"],
+    ];
+
     const list = match(type, {
         view: () => <>
             <div>{t("series.settings.view")}</div>
             <ul role="menu" onBlur={handleBlur}>
-                <MenuItem
-                    disabled={viewState === "slider"}
-                    onClick={() => setViewState("slider")}
-                    close={close}
-                    Icon={LuColumns}
-                    label={t("series.settings.slider")}
-                />
-                <MenuItem
-                    disabled={viewState === "gallery"}
-                    onClick={() => setViewState("gallery")}
-                    close={close}
-                    Icon={LuGrid}
-                    label={t("series.settings.gallery")}
-                />
-                <MenuItem
-                    disabled={viewState === "list"}
-                    onClick={() => setViewState("list")}
-                    close={close}
-                    Icon={LuList}
-                    label={t("series.settings.list")}
-                />
+                {viewItems.map(([view, icon]) => <MenuItem
+                    key={`${itemId}-${view}`}
+                    disabled={viewState === view}
+                    onClick={() => setViewState(view)}
+                    {...{ close }}
+                    Icon={icon}
+                    label={t(`series.settings.${view}`)}
+                />)}
             </ul>
         </>,
         order: () => <>
             <div>{t("series.settings.order")}</div>
             <ul role="menu" onBlur={handleBlur}>
-                <MenuItem
-                    disabled={eventOrder === "NEW_TO_OLD"}
-                    onClick={() => setEventOrder("NEW_TO_OLD")}
-                    close={close}
-                    label={t("series.settings.new-to-old")}
-                />
-                <MenuItem
-                    disabled={eventOrder === "OLD_TO_NEW"}
-                    onClick={() => setEventOrder("OLD_TO_NEW")}
-                    close={close}
-                    label={t("series.settings.old-to-new")}
-                />
-                <MenuItem
-                    disabled={eventOrder === "A-Z"}
-                    onClick={() => setEventOrder("A-Z")}
-                    close={close}
-                    label={t("series.settings.a-z")}
-                />
-                <MenuItem
-                    disabled={eventOrder === "Z-A"}
-                    onClick={() => setEventOrder("Z-A")}
-                    close={close}
-                    label={t("series.settings.z-a")}
-                />
+                {orderItems.map(([order, key]) => <MenuItem
+                    key={`${itemId}-${order}`}
+                    disabled={eventOrder === order}
+                    onClick={() => setEventOrder(order)}
+                    {...{ close }}
+                    label={t(`series.settings.${key}`)}
+                />)}
             </ul>
         </>,
     });

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 import {
     match, unreachable, ProtoButton, screenWidthAtMost, screenWidthAbove,
-    useColorScheme, Floating, FloatingHandle, useFloatingContext,
+    useColorScheme, Floating, FloatingHandle, useFloatingItemProps,
 } from "@opencast/appkit";
 
 import { keyOfId, isSynced, SyncedOpencastEntity } from "../../util";
@@ -365,7 +365,7 @@ const List: React.FC<ListProps> = ({ type, close }) => {
     const isDark = useColorScheme().scheme === "dark";
     const { viewState, setViewState } = useContext(ViewContext);
     const { eventOrder, setEventOrder } = useContext(OrderContext);
-    const { refs } = useFloatingContext();
+    const itemProps = useFloatingItemProps();
     const itemId = useId();
 
     const listStyle = {
@@ -404,19 +404,9 @@ const List: React.FC<ListProps> = ({ type, close }) => {
     ];
 
     const sharedProps = (index: number, key: View | OrderTranslationKey) => ({
-        // Even though https://floating-ui.com/docs/uselistnavigation recommends using
-        // a roving tabindex, this introduces some weird behavior when a user mixes tab-
-        // and arrow navigation. Experimenting with this showed that not using a roving
-        // tabindex (i.e. letting it be 0 unconditionally by not setting the tabindex manually)
-        // still enables arrow navigation while also allowing mixing in tab navigation,
-        // without breaking either.
         close: close,
         label: t(`series.settings.${key}`),
-        ref: (node: HTMLButtonElement) => {
-            if (refs.listRef.current !== null) {
-                refs.listRef.current[index] = node;
-            }
-        },
+        ...itemProps(index),
     });
 
     const list = match(type, {
@@ -462,10 +452,10 @@ type MenuItemProps = {
     onClick: () => void;
     close: () => void;
     disabled: boolean;
-    ref: RefObject<HTMLButtonElement>;
+    ref: RefObject<HTMLElement>;
 };
 
-const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(({
+const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(({
     Icon, label, onClick, close, disabled,
 }, ref) => {
     const isDark = useColorScheme().scheme === "dark";

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -403,10 +403,9 @@ const List: React.FC<ListProps> = ({ type, close }) => {
         ["Z-A", "z-a"],
     ];
 
-    const sharedProps = (index: number, key: View | OrderTranslationKey) => ({
+    const sharedProps = (key: View | OrderTranslationKey) => ({
         close: close,
         label: t(`series.settings.${key}`),
-        ...itemProps(index),
     });
 
     const list = match(type, {
@@ -416,9 +415,9 @@ const List: React.FC<ListProps> = ({ type, close }) => {
                 {viewItems.map(([view, icon], index) => <MenuItem
                     key={`${itemId}-${view}`}
                     disabled={viewState === view}
-                    onClick={() => setViewState(view)}
                     Icon={icon}
-                    {...sharedProps(index, view)}
+                    {...sharedProps(view)}
+                    {...itemProps(index, () => setViewState(view))}
                 />)}
             </ul>
         </>,
@@ -428,8 +427,8 @@ const List: React.FC<ListProps> = ({ type, close }) => {
                 {orderItems.map(([order, orderKey], index) => <MenuItem
                     key={`${itemId}-${order}`}
                     disabled={eventOrder === order}
-                    onClick={() => setEventOrder(order)}
-                    {...sharedProps(index, orderKey)}
+                    {...sharedProps(orderKey)}
+                    {...itemProps(index, () => setEventOrder(order))}
                 />)}
             </ul>
         </>,
@@ -449,7 +448,7 @@ const List: React.FC<ListProps> = ({ type, close }) => {
 type MenuItemProps = {
     Icon?: IconType;
     label: string;
-    onClick: () => void;
+    onClick?: () => void;
     close: () => void;
     disabled: boolean;
     ref: RefObject<HTMLElement>;
@@ -473,7 +472,9 @@ const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(({
                 {...{ ref, disabled }}
                 role="menuitem"
                 onClick={() => {
-                    onClick();
+                    if (onClick) {
+                        onClick();
+                    }
                     close();
                 }}
                 css={{

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -1,6 +1,5 @@
 import React, {
     ReactNode,
-    RefObject,
     createContext,
     useContext,
     useEffect,
@@ -417,7 +416,8 @@ const List: React.FC<ListProps> = ({ type, close }) => {
                     disabled={viewState === view}
                     Icon={icon}
                     {...sharedProps(view)}
-                    {...itemProps(index, () => setViewState(view))}
+                    {...itemProps(index)}
+                    onClick={() => setViewState(view)}
                 />)}
             </ul>
         </>,
@@ -428,7 +428,8 @@ const List: React.FC<ListProps> = ({ type, close }) => {
                     key={`${itemId}-${order}`}
                     disabled={eventOrder === order}
                     {...sharedProps(orderKey)}
-                    {...itemProps(index, () => setEventOrder(order))}
+                    {...itemProps(index)}
+                    onClick={() => setEventOrder(order)}
                 />)}
             </ul>
         </>,
@@ -451,10 +452,9 @@ type MenuItemProps = {
     onClick?: () => void;
     close: () => void;
     disabled: boolean;
-    ref: RefObject<HTMLElement>;
 };
 
-const MenuItem = React.forwardRef<HTMLElement, MenuItemProps>(({
+const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(({
     Icon, label, onClick, close, disabled,
 }, ref) => {
     const isDark = useColorScheme().scheme === "dark";

--- a/frontend/src/ui/FloatingBaseMenu.tsx
+++ b/frontend/src/ui/FloatingBaseMenu.tsx
@@ -13,8 +13,6 @@ type FloatingBaseMenuProps = {
     triggerStyles?: CSSObject;
 };
 
-
-// TODO: Make menus work with arrow keys.
 export const FloatingBaseMenu = React.forwardRef<FloatingHandle, FloatingBaseMenuProps>(
     ({ triggerContent, list, label, triggerStyles }, ref) => (
         <FloatingContainer


### PR DESCRIPTION
This enables arrow navigation for the series block sorting menus and the menus for adding block content.
Waiting for https://github.com/opencast/appkit/pull/3, which is needed in order for this to work.

Together they will close #753.