### PR TITLE
Drop support for PG11 (bump minimum required version to 12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:11
+        image: postgres:12
         env:
           POSTGRES_USER: tobira
           POSTGRES_PASSWORD: tobira

--- a/docs/docs/setup/requirements.md
+++ b/docs/docs/setup/requirements.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 To run, Tobira requires:
 
 - A Unix system.
-- A **PostgreSQL** (≥11) database (see below for further requirements).
+- A **PostgreSQL** (≥12) database (see below for further requirements).
 - [**Meilisearch**](https://www.meilisearch.com/) (≥ v1.4). For installation, see [Meili's docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html#step-1-setup-and-installation).
 - An **Opencast** that satisfies certain condition. See below.
 


### PR DESCRIPTION
PG11 reaches its EOL in about two weeks anyway. The next Tobira release contains a bunch of breaking changes already, so it's convenient for admins to cluster breaking changes into one release. So let's bump it already.

PG 12 adds a number of features that we might want to take advantage of in the future.