### PR TITLE
Remove timestamp and download menu from livestreams

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -513,12 +513,12 @@ const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             trigger="click"
             viewPortMargin={12}
         >
-            <FloatingTrigger>
+            {!event.isLive && <FloatingTrigger>
                 <Button>
                     <LuDownload size={16}/>
                     {t("video.download.title")}
                 </Button>
-            </FloatingTrigger>
+            </FloatingTrigger>}
             <Floating
                 backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
                 padding={[8, 16, 16, 16]}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -668,7 +668,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         css={{ fontSize: 14, width: 400, marginBottom: 6 }}
                         value={url}
                     />
-                    <InputWithCheckbox
+                    {!event.isLive && <InputWithCheckbox
                         checkboxChecked={addLinkTimestamp}
                         setCheckboxChecked={setAddLinkTimestamp}
                         label={t("manage.my-videos.details.set-time")}
@@ -676,7 +676,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             {...{ timestamp, setTimestamp }}
                             disabled={!addLinkTimestamp}
                         />}
-                    />
+                    />}
                 </div>
                 <ShowQRCodeButton target={url} label={menuState} />
             </>;
@@ -711,7 +711,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         multiline
                         css={{ fontSize: 14, width: 400, height: 75, marginBottom: 6 }}
                     />
-                    <InputWithCheckbox
+                    {!event.isLive && <InputWithCheckbox
                         checkboxChecked={addEmbedTimestamp}
                         setCheckboxChecked={setAddEmbedTimestamp}
                         label={t("manage.my-videos.details.set-time")}
@@ -719,7 +719,7 @@ const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             {...{ timestamp, setTimestamp }}
                             disabled={!addEmbedTimestamp}
                         />}
-                    />
+                    />}
                 </div>
                 <ShowQRCodeButton target={embedCode} label={menuState} />
             </>;

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -119,13 +119,15 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({
             });
 
 
-            const time = new URL(window.location.href).searchParams.get("t");
-            player.bindEvent("paella:playerLoaded", () => {
-                setPlayerIsLoaded(true);
-                if (time) {
-                    player.videoContainer.setCurrentTime(timeStringToSeconds(time));
-                }
-            });
+            if (!isLive) {
+                const time = new URL(window.location.href).searchParams.get("t");
+                player.bindEvent("paella:playerLoaded", () => {
+                    setPlayerIsLoaded(true);
+                    if (time) {
+                        player.videoContainer.setCurrentTime(timeStringToSeconds(time));
+                    }
+                });
+            }
 
             player.bindEvent("paella:play", () => {
                 players?.forEach(playerInstance => {


### PR DESCRIPTION
Closes #1011
Closes #1012

Livestreams need neither download menus nor timestamp options, as outlined in the issues above.