### PR TITLE
Simplify edit series form

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -490,6 +490,7 @@ manage:
       show-title: Titel anzeigen
       show-link: Link zur Videoseite anzeigen
       show-description: Beschreibung anzeigen
+      display-options: Anzeigeoptionen
 
       cancel: Verwerfen
       confirm-cancel: Änderungen verwerfen?

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -479,10 +479,6 @@ manage:
           invalid: Bitte eine Serie auswählen
         layout:
           heading: Layout
-          videos-only: Nur Videos
-          title-and-videos: Titel und Videos
-          description-and-videos: Beschreibung und Videos
-          everything: Titel, Beschreibung und Videos
 
       event:
         event:
@@ -493,6 +489,7 @@ manage:
 
       show-title: Titel anzeigen
       show-link: Link zur Videoseite anzeigen
+      show-description: Beschreibung anzeigen
 
       cancel: Verwerfen
       confirm-cancel: Änderungen verwerfen?

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -464,10 +464,6 @@ manage:
           invalid: Please select a series
         layout:
           heading: Layout
-          videos-only: Videos only
-          title-and-videos: Title and videos
-          description-and-videos: Description and videos
-          everything: Title, description and videos
 
       event:
         event:
@@ -478,6 +474,7 @@ manage:
 
       show-title: Show title
       show-link: Show link to video page
+      show-description: Show description
 
       cancel: Discard
       confirm-cancel: Discard changes?

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -475,6 +475,7 @@ manage:
       show-title: Show title
       show-link: Show link to video page
       show-description: Show description
+      display-options: Display options
 
       cancel: Discard
       confirm-cancel: Discard changes?

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -92,18 +92,22 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
             onChange={data => seriesField.onChange(data?.id)}
             onBlur={seriesField.onBlur}
         />
-        <div css={{
-            display: "flex",
-            flexDirection: "row",
-            marginTop: 12,
-            marginRight: 48,
-            justifyContent: "space-between",
-            maxWidth: 400,
-            [screenWidthAtMost(BREAKPOINT_SMALL)]: {
-                flexDirection: "column",
-                gap: 12,
-            },
-        }}>
+        <div
+            role="group"
+            aria-labelledby={t("manage.realm.content.display-options")}
+            css={{
+                display: "flex",
+                flexDirection: "row",
+                marginTop: 12,
+                marginRight: 48,
+                justifyContent: "space-between",
+                maxWidth: 400,
+                [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                    flexDirection: "column",
+                    gap: 12,
+                },
+            }}
+        >
             <div>
                 <Heading>{t("series.settings.order")}</Heading>
                 <DisplayOptionGroup type="radio" {...{ form }} optionProps={[

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
-import { useController, useFormContext, UseFormReturn } from "react-hook-form";
-import { match } from "@opencast/appkit";
+import { useController, useFormContext } from "react-hook-form";
 
 import { Card } from "../../../../../../ui/Card";
 import { EditModeForm } from ".";
-import { Heading, NiceRadio, NiceRadioOption } from "./util";
+import { Heading } from "./util";
 import type {
     VideoListOrder,
     SeriesEditModeBlockData$key,
@@ -17,17 +16,18 @@ import {
 import {
     SeriesEditCreateMutation,
 } from "./__generated__/SeriesEditCreateMutation.graphql";
-import { BREAKPOINT_MEDIUM } from "../../../../../../GlobalStyle";
 import { SeriesSelector } from "../../../../../../ui/SearchableSelect";
+import { DisplayOptionGroup } from "../../../../../../ui/Input";
+import { screenWidthAtMost } from "@opencast/appkit";
+import { BREAKPOINT_SMALL } from "../../../../../../GlobalStyle";
 
 
 type SeriesFormData = {
     series: string;
     order: VideoListOrder;
-    layout: Layout;
+    showTitle: boolean;
+    showMetadata: boolean;
 };
-
-type Layout = "videos-only" | "title-and-videos" | "description-and-videos" | "everything";
 
 type EditSeriesBlockProps = {
     block: SeriesEditModeBlockData$key;
@@ -41,7 +41,7 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
                 opencastId
                 title
                 syncedData {
-                    # only queried to see wether syncedData is null
+                    # only queried to see whether syncedData is null
                     description
                 }
             }
@@ -50,10 +50,6 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
             order
         }
     `, blockRef);
-    const currentLayout = showTitle
-        ? (showMetadata ? "everything" : "title-and-videos")
-        : (showMetadata ? "description-and-videos" : "videos-only");
-
 
     const [save] = useMutation<SeriesEditSaveMutation>(graphql`
         mutation SeriesEditSaveMutation($id: ID!, $set: UpdateSeriesBlock!) {
@@ -72,17 +68,6 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
         }
     `);
 
-    const mapFormData = ({ layout, order, series }: SeriesFormData) => {
-        const [showTitle, showMetadata] = match(layout, {
-            "videos-only": () => [false, false],
-            "title-and-videos": () => [true, false],
-            "description-and-videos": () => [false, true],
-            "everything": () => [true, true],
-        });
-
-        return { series, order, showTitle, showMetadata };
-    };
-
     const { t } = useTranslation();
 
     const form = useFormContext<SeriesFormData>();
@@ -94,7 +79,7 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
         rules: { required: true },
     });
 
-    return <EditModeForm create={create} save={save} map={mapFormData}>
+    return <EditModeForm create={create} save={save} map={(data: SeriesFormData) => data}>
         <Heading>{t("manage.realm.content.series.series.heading")}</Heading>
         {"series" in errors && <div css={{ margin: "8px 0" }}>
             <Card kind="error">{t("manage.realm.content.series.series.invalid")}</Card>
@@ -107,53 +92,50 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
             onChange={data => seriesField.onChange(data?.id)}
             onBlur={seriesField.onBlur}
         />
-
-        <Heading>{t("series.settings.order")}</Heading>
-        <NiceRadio breakpoint={0}>
-            <NiceRadioOption
-                value="NEW_TO_OLD"
-                defaultChecked={order === "NEW_TO_OLD"}
-                {...form.register("order")}
-            >{t("series.settings.new-to-old")}</NiceRadioOption>
-            <NiceRadioOption
-                value="OLD_TO_NEW"
-                defaultChecked={order === "OLD_TO_NEW"}
-                {...form.register("order")}
-            >{t("series.settings.old-to-new")}</NiceRadioOption>
-        </NiceRadio>
-
-        <Heading>{t("manage.realm.content.series.layout.heading")}</Heading>
-        <LayoutChooser {...{ currentLayout, form }} />
+        <div css={{
+            display: "flex",
+            flexDirection: "row",
+            marginTop: 12,
+            marginRight: 48,
+            justifyContent: "space-between",
+            maxWidth: 400,
+            [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                flexDirection: "column",
+                gap: 12,
+            },
+        }}>
+            <div>
+                <Heading>{t("series.settings.order")}</Heading>
+                <DisplayOptionGroup type="radio" {...{ form }} optionProps={[
+                    {
+                        option: "order",
+                        title: t("series.settings.new-to-old"),
+                        checked: order === "NEW_TO_OLD",
+                        value: "NEW_TO_OLD",
+                    },
+                    {
+                        option: "order",
+                        title: t("series.settings.old-to-new"),
+                        checked: order === "OLD_TO_NEW",
+                        value: "OLD_TO_NEW",
+                    },
+                ]} />
+            </div>
+            <div>
+                <Heading>{t("manage.realm.content.series.layout.heading")}</Heading>
+                <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
+                    {
+                        option: "showTitle",
+                        title: t("manage.realm.content.show-title"),
+                        checked: showTitle,
+                    },
+                    {
+                        option: "showMetadata",
+                        title: t("manage.realm.content.show-description"),
+                        checked: showMetadata,
+                    },
+                ]} />
+            </div>
+        </div>
     </EditModeForm>;
-};
-
-type LayoutChooserProps = {
-    currentLayout: Layout;
-    form: UseFormReturn<SeriesFormData>;
-};
-
-const LayoutChooser: React.FC<LayoutChooserProps> = ({ currentLayout, form }) => {
-    const { t } = useTranslation();
-    const inputProps = (layout: Layout) => ({
-        value: layout,
-        defaultChecked: currentLayout === layout,
-        ...form.register("layout"),
-    });
-
-    return (
-        <NiceRadio breakpoint={BREAKPOINT_MEDIUM}>
-            <NiceRadioOption {...inputProps("videos-only")}>
-                {t("manage.realm.content.series.layout.videos-only")}
-            </NiceRadioOption>
-            <NiceRadioOption {...inputProps("title-and-videos")}>
-                {t("manage.realm.content.series.layout.title-and-videos")}
-            </NiceRadioOption>
-            <NiceRadioOption {...inputProps("description-and-videos")}>
-                {t("manage.realm.content.series.layout.description-and-videos")}
-            </NiceRadioOption>
-            <NiceRadioOption {...inputProps("everything")}>
-                {t("manage.realm.content.series.layout.everything")}
-            </NiceRadioOption>
-        </NiceRadio>
-    );
 };

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useState } from "react";
 import { fetchQuery, graphql, useFragment, useMutation } from "react-relay";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
-import { Controller, UseFormReturn, useFormContext } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 
 import { Card } from "../../../../../../ui/Card";
 import { EditModeForm } from ".";
@@ -19,6 +19,7 @@ import { environment } from "../../../../../../relay";
 import { VideoEditModeSearchQuery } from "./__generated__/VideoEditModeSearchQuery.graphql";
 import { MovingTruck } from "../../../../../../ui/Waiting";
 import { ErrorDisplay } from "../../../../../../util/err";
+import { DisplayOptionGroup } from "../../../../../../ui/Input";
 
 
 type VideoFormData = {
@@ -71,7 +72,6 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
         }
     `);
 
-
     const { t } = useTranslation();
 
     const form = useFormContext<VideoFormData>();
@@ -80,11 +80,6 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
     const currentEvent = event?.__typename === "AuthorizedEvent"
         ? { ...event, ...event.syncedData, seriesTitle: event.series?.title }
         : undefined;
-
-    const optionProps: ["showTitle" | "showLink", boolean, string][] = [
-        ["showTitle", showTitle, t("manage.realm.content.show-title")],
-        ["showLink", showLink, t("manage.realm.content.show-link")],
-    ];
 
     return <EditModeForm create={create} save={save} map={(data: VideoFormData) => data}>
         <Heading>{t("manage.realm.content.event.event.heading")}</Heading>
@@ -102,34 +97,20 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
                 <EventSelector defaultValue={currentEvent} {...{ onChange, onBlur }} />
             )}
         />
-
-        <div css={{ display: "flex", flexDirection: "column", marginTop: 8 }}>
-            {optionProps.map(([option, checked, title]) =>
-                // eslint-disable-next-line react/jsx-key
-                <DisplayOption {...{ form, option, checked, title }} />)
-            }
-        </div>
+        <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
+            {
+                option: "showTitle",
+                title: t("manage.realm.content.show-title"),
+                checked: showTitle,
+            },
+            {
+                option: "showLink",
+                title: t("manage.realm.content.show-link"),
+                checked: showLink,
+            },
+        ]} />
     </EditModeForm>;
 };
-
-type DisplayOption = {
-    form: UseFormReturn<VideoFormData>;
-    option: "showTitle" | "showLink";
-    checked: boolean;
-    title: string;
-}
-
-const DisplayOption: React.FC<DisplayOption> = (
-    { form, option, checked, title }
-) => <label>
-    <input
-        type="checkbox"
-        defaultChecked={checked}
-        {...form.register(option)}
-        css={{ marginRight: 6 }}
-    />
-    {title}
-</label>;
 
 type EventSelectorProps = {
     onChange: (eventId?: string) => void;

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -6,6 +6,7 @@ import { Button } from "./Button";
 import { COLORS } from "../color";
 import { timeStringToSeconds } from "../util";
 import { focusStyle } from ".";
+import { FieldValues, Path, UseFormReturn } from "react-hook-form";
 
 
 const style = (error: boolean) => ({
@@ -287,3 +288,36 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
         </div>
     );
 };
+
+type DisplayOptionGroup<TFieldValues extends FieldValues> = {
+    form: UseFormReturn<TFieldValues>;
+    type: "radio" | "checkbox";
+    optionProps: {
+        option: Path<TFieldValues>;
+        title: string;
+        checked?: boolean;
+        value?: string;
+    }[];
+}
+
+/** Group of input elements to be used with react-hook-form */
+export function DisplayOptionGroup<TFieldValues extends FieldValues>(
+    { form, type, optionProps }: DisplayOptionGroup<TFieldValues>
+): JSX.Element {
+    const id = useId();
+
+    return <div css={{ display: "flex", flexDirection: "column", marginTop: 8 }}>
+        {optionProps.map(({ option, title, checked, value }, index) =>
+            <label key={`${id}-${option}${index}`} css={{ display: "flex" }}>
+                <input
+                    {...{ type, value }}
+                    defaultChecked={checked}
+                    {...form.register(option)}
+                    style={{ marginRight: 6 }}
+                />
+                {title}
+            </label>)
+        }
+    </div>;
+}
+


### PR DESCRIPTION
This refactors the layout/order option inputs of series and video add/edit forms and simplifies the edit series buttons into regular radio/checkbox inputs.

Closes #1009 