### PR TITLE
Revise search page design

### DIFF
--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -119,5 +119,5 @@ pub(crate) async fn search_known_users(
         items.extend(results.hits.into_iter().map(|h| h.result));
     }
 
-    Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
+    Ok(KnownUsersSearchOutcome::Results(SearchResults { items, total_hits: None }))
 }

--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -22,6 +22,14 @@ impl search::Event {
         &self.title
     }
 
+    fn series_id(&self) -> Option<Id> {
+        if let Some(id) = self.series_id {
+            Some(Id::search_series(id.0))
+        } else {
+            None
+        }
+    }
+
     fn series_title(&self) -> Option<&str> {
         self.series_title.as_deref()
     }

--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -23,11 +23,7 @@ impl search::Event {
     }
 
     fn series_id(&self) -> Option<Id> {
-        if let Some(id) = self.series_id {
-            Some(Id::search_series(id.0))
-        } else {
-            None
-        }
+        self.series_id.map(|id| Id::search_series(id.0))
     }
 
     fn series_title(&self) -> Option<&str> {

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -229,6 +229,7 @@ realm:
 search:
   input-label: Suche
   title: Suchergebnisse für „{{query}}“ ({{hits}} Treffer)
+  no-query: Suchergebnisse
   no-results: Keine Ergebnisse
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
   unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -228,7 +228,7 @@ realm:
 
 search:
   input-label: Suche
-  title: Suchergebnisse für „{{query}}“
+  title: Suchergebnisse für „{{query}}“ ({{hits}} Treffer)
   no-results: Keine Ergebnisse
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
   unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -227,6 +227,7 @@ realm:
 search:
   input-label: Search
   title: Search results for “{{query}}” ({{hits}} hits)
+  no-query: Search results
   no-results: No results
   too-few-characters: Please type more characters to start the search.
   unavailable: The search is currently unavailable. Try again later.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -226,7 +226,7 @@ realm:
 
 search:
   input-label: Search
-  title: Search results for “{{query}}”
+  title: Search results for “{{query}}” ({{hits}} hits)
   no-results: No results
   too-few-characters: Please type more characters to start the search.
   unavailable: The search is currently unavailable. Try again later.

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -111,11 +111,6 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                                 search(e.target.value);
                             }, 30);
                         }}
-                        onKeyUp={() => {
-                            if (ref.current?.value === "") {
-                                handleNavigation(router, ref);
-                            }
-                        }}
                         css={{
                             flex: 1,
                             color: COLORS.neutral60,

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -1,15 +1,17 @@
 import React, { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HiOutlineSearch } from "react-icons/hi";
+import { LuX } from "react-icons/lu";
 import { useRouter } from "../../router";
-import { isSearchActive } from "../../routes/Search";
+import { STORAGE_KEY, handleNavigation, isSearchActive } from "../../routes/Search";
 import { focusStyle } from "../../ui";
 import { Spinner } from "../../ui/Spinner";
 import { currentRef } from "../../util";
 
 import { BREAKPOINT as NAV_BREAKPOINT } from "../Navigation";
 import { COLORS } from "../../color";
-import { screenWidthAtMost } from "@opencast/appkit";
+import { ProtoButton, screenWidthAtMost } from "@opencast/appkit";
+
 
 type SearchFieldProps = {
     variant: "desktop" | "mobile";
@@ -23,6 +25,12 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
     // Register global shortcut to focus search bar
     useEffect(() => {
         const handleShortcut = (ev: KeyboardEvent) => {
+            // Clear input field. See comment inside `handleNavigation` function
+            // in `routes/Search.tsx` for explanation. I'd rather do this here than
+            // needing to pass the input ref.
+            if (ev.key === "Escape" && ref.current) {
+                ref.current.value = "";
+            }
             // If any element is focussed that could receive character input, we
             // don't do anything.
             if (/^input|textarea|select|button$/i.test(document.activeElement?.tagName ?? "")) {
@@ -47,6 +55,8 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
     const height = 42;
     const spinnerSize = 24;
     const paddingSpinner = (height - spinnerSize) / 2;
+    const iconStyle = { position: "absolute", right: paddingSpinner, top: paddingSpinner } as const;
+
 
     const lastTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     useEffect(() => () => clearTimeout(lastTimeout.current));
@@ -101,6 +111,16 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                                 search(e.target.value);
                             }, 30);
                         }}
+                        onFocus={() => {
+                            if (!onSearchRoute) {
+                                window.sessionStorage.setItem(STORAGE_KEY, "true");
+                            }
+                        }}
+                        onKeyUp={() => {
+                            if (ref.current?.value === "") {
+                                handleNavigation(router, ref);
+                            }
+                        }}
                         css={{
                             flex: 1,
                             color: COLORS.neutral60,
@@ -128,8 +148,22 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
             </form>
             {router.isTransitioning && isSearchActive() && <Spinner
                 size={spinnerSize}
-                css={{ position: "absolute", right: paddingSpinner, top: paddingSpinner }}
+                css={iconStyle}
             />}
+            {!router.isTransitioning && isSearchActive() && <ProtoButton
+                onClick={() => handleNavigation(router, ref)}
+                css={{
+                    ":hover, :focus": {
+                        color: COLORS.neutral90,
+                        borderColor: COLORS.neutral25,
+                        outline: `2.5px solid ${COLORS.neutral25}`,
+                    },
+                    ...focusStyle({}),
+                    borderRadius: 4,
+                    color: COLORS.neutral60,
+                    ...iconStyle,
+                }}
+            ><LuX size={spinnerSize} css={{ display: "block" }} /></ProtoButton>}
         </div>
     );
 };

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { HiOutlineSearch } from "react-icons/hi";
 import { LuX } from "react-icons/lu";
 import { useRouter } from "../../router";
-import { STORAGE_KEY, handleNavigation, isSearchActive } from "../../routes/Search";
+import { handleNavigation, isSearchActive } from "../../routes/Search";
 import { focusStyle } from "../../ui";
 import { Spinner } from "../../ui/Spinner";
 import { currentRef } from "../../util";
@@ -110,11 +110,6 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                             lastTimeout.current = setTimeout(() => {
                                 search(e.target.value);
                             }, 30);
-                        }}
-                        onFocus={() => {
-                            if (!onSearchRoute) {
-                                window.sessionStorage.setItem(STORAGE_KEY, "true");
-                            }
                         }}
                         onKeyUp={() => {
                             if (ref.current?.value === "") {

--- a/frontend/src/rauta.tsx
+++ b/frontend/src/rauta.tsx
@@ -169,6 +169,11 @@ export interface RouterControl {
      * to show a loading indicator.
      */
     isTransitioning: boolean;
+
+    /**
+     * Indicates whether a user navigated to the current route from outside Tobira.
+     */
+    internalOrigin: boolean;
 }
 
 export const makeRouter = <C extends Config, >(config: C): RouterLib => {
@@ -261,6 +266,7 @@ export const makeRouter = <C extends Config, >(config: C): RouterLib => {
                 debugLog(`Setting active route for '${href}' (index ${currentIndex}) `
                     + "to: ", newRoute);
             },
+            internalOrigin: window.history.state.index > 0,
         };
     };
 

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -21,7 +21,6 @@ import { keyOfId } from "../util";
 import { IconType } from "react-icons";
 
 
-export const STORAGE_KEY = "internal-origin";
 export const isSearchActive = (): boolean => document.location.pathname === "/~search";
 
 export const SearchRoute = makeRoute(url => {
@@ -84,12 +83,6 @@ type Props = {
 const SearchPage: React.FC<Props> = ({ q, outcome }) => {
     const { t } = useTranslation();
     const router = useRouter();
-
-    // TODO: when navigating away from search, do `window.sessionStorage.removeItem(STORAGE_KEY)`.
-    // Otherwise this will still be set when a user visits an external url from the search route.
-    // The search query should also be cleared upon any navigation to prevent an edge case where
-    // it isn't cleared automatically after the search page has been reloaded and then navigated
-    // away from.
 
     useEffect(() => {
         const handleEscape = ((ev: KeyboardEvent) => {
@@ -186,10 +179,9 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
     </ul>
 );
 
-type WithIconProps = {
+type WithIconProps = React.PropsWithChildren<{
     Icon: IconType;
-    children: ReactNode;
-};
+}>;
 
 const WithIcon: React.FC<WithIconProps> = ({ Icon, children }) => (
     <div css={{
@@ -366,12 +358,9 @@ export const handleNavigation = ((router: RouterControl, ref?: RefObject<HTMLInp
         // Why is this necessary? When a user reloads the search page and then navigates
         // away within Tobira, the search input isn't cleared like it would be usually.
         // So it needs to be done manually.
-        // Alternatively, I guess we could also ignore that edge case.
         ref.current.value = "";
     }
-    const internalOrigin = window.sessionStorage.getItem(STORAGE_KEY);
-    if (internalOrigin) {
-        window.sessionStorage.removeItem(STORAGE_KEY);
+    if (router.internalOrigin) {
         window.history.back();
     } else {
         router.goto("/");

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -61,6 +61,7 @@ const query = graphql`
                         duration
                         creators
                         seriesTitle
+                        seriesId
                         isLive
                         audioOnly
                         startTime
@@ -161,6 +162,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                     duration: unwrapUndefined(item.duration),
                     creators: unwrapUndefined(item.creators),
                     seriesTitle: unwrapUndefined(item.seriesTitle),
+                    seriesId: unwrapUndefined(item.seriesId),
                     isLive,
                     audioOnly: unwrapUndefined(item.audioOnly),
                     created: unwrapUndefined(item.created),
@@ -197,9 +199,10 @@ const WithIcon: React.FC<WithIconProps> = ({ Icon, children }) => (
         [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
             flexDirection: "row-reverse",
             justifyContent: "space-between",
+            paddingLeft: 4,
         },
     }}>
-        <Icon size={40} css={{ flexShrink: 0 }} />
+        <Icon size={40} css={{ flexShrink: 0, color: COLORS.primary0 }} />
         <div css={{
             height: "96%",
             borderLeft: `1px solid ${COLORS.neutral15}`,
@@ -217,6 +220,7 @@ type SearchEventProps = {
     duration: number;
     creators: readonly string[];
     seriesTitle: string | null;
+    seriesId: string | null;
     isLive: boolean;
     audioOnly: boolean;
     created: string;
@@ -233,6 +237,7 @@ const SearchEvent: React.FC<SearchEventProps> = ({
     duration,
     creators,
     seriesTitle,
+    seriesId,
     isLive,
     audioOnly,
     created,
@@ -259,9 +264,14 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                     }}>{title}</h3>
                     <Creators creators={creators} />
                     <SmallDescription text={description} lines={3} />
-                    {/* TODO: link to series */}
-                    {seriesTitle && <div css={{ fontSize: 14, marginTop: 4 }}>
-                        {t("video.part-of-series") + ": " + seriesTitle}
+                    {seriesTitle && seriesId && <div css={{ fontSize: 14, marginTop: 4 }}>
+                        {t("video.part-of-series") + ": "}
+                        <Link to={`/!s/${keyOfId(seriesId)}`} css={{
+                            borderRadius: 4,
+                            outlineOffset: 1,
+                            position: "relative",
+                            zIndex: 1,
+                        }}>{seriesTitle}</Link>
                     </div>}
                 </div>
             </WithIcon>
@@ -299,7 +309,7 @@ type SearchRealmProps = {
 const SearchRealm: React.FC<SearchRealmProps> = ({ id, name, ancestorNames, fullPath }) => (
     <Item key={id} link={fullPath}>
         <WithIcon Icon={LuLayout}>
-            <div>
+            <div css={{ color: COLORS.primary0 }}>
                 <BreadcrumbsContainer>
                     {ancestorNames.map((name, i) => <li key={i}>
                         {name ?? <MissingRealmName />}
@@ -318,30 +328,33 @@ type ItemProps = {
 };
 
 const Item: React.FC<ItemProps> = ({ link, children }) => (
-    <li>
-        <Link
-            to={link}
-            css={{
-                display: "flex",
-                borderRadius: 16,
-                border: `1px solid ${COLORS.neutral15}`,
-                margin: 16,
-                padding: 8,
-                paddingLeft: 10,
-                gap: 8,
-                textDecoration: "none",
-                "&:hover, &:focus": {
-                    backgroundColor: COLORS.neutral10,
-                },
-                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-                    flexDirection: "column",
-                    gap: 12,
-                    "& > *:last-child": {
-                        width: "100%",
-                    },
-                },
-            }}
-        >{children}</Link>
+    <li css={{
+        position: "relative",
+        display: "flex",
+        borderRadius: 16,
+        border: `1px solid ${COLORS.neutral15}`,
+        margin: 16,
+        padding: 8,
+        gap: 8,
+        textDecoration: "none",
+        "&:hover, &:focus": {
+            backgroundColor: COLORS.neutral10,
+        },
+        [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+            flexDirection: "column",
+            gap: 12,
+            "& > *:last-child": {
+                width: "100%",
+            },
+        },
+    }}>
+        <Link to={link} css={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 1,
+            borderRadius: 16,
+        }}/>
+        {children}
     </li>
 );
 

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { LuFolder } from "react-icons/lu";
+import { LuLayout, LuPlaySquare } from "react-icons/lu";
 import { ReactNode, RefObject, useEffect } from "react";
 import { screenWidthAtMost, unreachable } from "@opencast/appkit";
 
@@ -12,13 +12,13 @@ import { Link, useRouter } from "../router";
 import { Creators, isPastLiveEvent, Thumbnail } from "../ui/Video";
 import { SmallDescription } from "../ui/metadata";
 import { Card } from "../ui/Card";
-import { PageTitle } from "../layout/header/ui";
 import { Breadcrumbs, BreadcrumbsContainer, BreadcrumbSeparator } from "../ui/Breadcrumbs";
 import { MissingRealmName } from "./util";
 import { ellipsisOverflowCss } from "../ui";
 import { COLORS } from "../color";
-import { BREAKPOINT_SMALL } from "../GlobalStyle";
+import { BREAKPOINT_MEDIUM } from "../GlobalStyle";
 import { keyOfId } from "../util";
+import { IconType } from "react-icons";
 
 
 export const STORAGE_KEY = "internal-origin";
@@ -116,9 +116,11 @@ const SearchPage: React.FC<Props> = ({ q, outcome }) => {
     }
 
     return <>
-        <Breadcrumbs path={[]} tail={t("search.title", { query: q })} />
+        <Breadcrumbs path={[]} tail={t("search.title", {
+            query: q,
+            hits: outcome.__typename === "SearchResults" ? outcome.items.length : 0,
+        })} />
         <div css={{ maxWidth: 950, margin: "0 auto" }}>
-            <PageTitle title={t("search.title", { query: q })} />
             {body}
         </div>
     </>;
@@ -182,6 +184,31 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
     </ul>
 );
 
+type WithIconProps = {
+    Icon: IconType;
+    children: ReactNode;
+};
+
+const WithIcon: React.FC<WithIconProps> = ({ Icon, children }) => (
+    <div css={{
+        display: "flex",
+        flexDirection: "row",
+        gap: 6,
+        [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+            flexDirection: "row-reverse",
+            justifyContent: "space-between",
+        },
+    }}>
+        <Icon size={40} css={{ flexShrink: 0 }} />
+        <div css={{
+            height: "96%",
+            borderLeft: `1px solid ${COLORS.neutral15}`,
+            alignSelf: "center",
+        }} />
+        {children}
+    </div>
+);
+
 type SearchEventProps = {
     id: string;
     title: string;
@@ -223,6 +250,21 @@ const SearchEvent: React.FC<SearchEventProps> = ({
 
     return (
         <Item key={id} link={link}>
+            <WithIcon Icon={LuPlaySquare}>
+                <div css={{ color: COLORS.neutral90 }}>
+                    <h3 css={{
+                        color: COLORS.primary0,
+                        marginBottom: 6,
+                        ...ellipsisOverflowCss(2),
+                    }}>{title}</h3>
+                    <Creators creators={creators} />
+                    <SmallDescription text={description} lines={3} />
+                    {/* TODO: link to series */}
+                    {seriesTitle && <div css={{ fontSize: 14, marginTop: 4 }}>
+                        {t("video.part-of-series") + ": " + seriesTitle}
+                    </div>}
+                </div>
+            </WithIcon>
             <Thumbnail
                 event={{
                     title,
@@ -236,20 +278,13 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                         audioOnly,
                     },
                 }}
-                css={{ width: "100%" }}
+                css={{
+                    outline: `1px solid ${COLORS.neutral15}`,
+                    minWidth: 270,
+                    width: 270,
+                    marginLeft: "auto",
+                }}
             />
-            <div css={{ color: COLORS.neutral90 }}>
-                <h3 css={{
-                    marginBottom: 6,
-                    ...ellipsisOverflowCss(2),
-                }}>{title}</h3>
-                <Creators creators={creators} />
-                <SmallDescription text={description} lines={3} />
-                {/* TODO: link to series */}
-                {seriesTitle && <div css={{ fontSize: 14, marginTop: 4 }}>
-                    {t("video.part-of-series") + ": " + seriesTitle}
-                </div>}
-            </div>
         </Item>
     );
 };
@@ -263,18 +298,17 @@ type SearchRealmProps = {
 
 const SearchRealm: React.FC<SearchRealmProps> = ({ id, name, ancestorNames, fullPath }) => (
     <Item key={id} link={fullPath}>
-        <div css={{ textAlign: "center" }}>
-            <LuFolder css={{ margin: 8, fontSize: 26 }}/>
-        </div>
-        <div>
-            <BreadcrumbsContainer>
-                {ancestorNames.map((name, i) => <li key={i}>
-                    {name ?? <MissingRealmName />}
-                    <BreadcrumbSeparator />
-                </li>)}
-            </BreadcrumbsContainer>
-            <h3>{name ?? <MissingRealmName />}</h3>
-        </div>
+        <WithIcon Icon={LuLayout}>
+            <div>
+                <BreadcrumbsContainer>
+                    {ancestorNames.map((name, i) => <li key={i}>
+                        {name ?? <MissingRealmName />}
+                        <BreadcrumbSeparator />
+                    </li>)}
+                </BreadcrumbsContainer>
+                <h3>{name ?? <MissingRealmName />}</h3>
+            </div>
+        </WithIcon>
     </Item>
 );
 
@@ -289,22 +323,20 @@ const Item: React.FC<ItemProps> = ({ link, children }) => (
             to={link}
             css={{
                 display: "flex",
-                borderRadius: 4,
+                borderRadius: 16,
+                border: `1px solid ${COLORS.neutral15}`,
                 margin: 16,
                 padding: 8,
-                gap: 16,
+                paddingLeft: 10,
+                gap: 8,
                 textDecoration: "none",
                 "&:hover, &:focus": {
                     backgroundColor: COLORS.neutral10,
                 },
-                "& > *:first-child": {
-                    minWidth: 200,
-                    width: 200,
-                },
-                [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
                     flexDirection: "column",
                     gap: 12,
-                    "& > *:first-child": {
+                    "& > *:last-child": {
                         width: "100%",
                     },
                 },

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { LuLayout, LuPlaySquare } from "react-icons/lu";
+import { LuLayout, LuPlayCircle } from "react-icons/lu";
 import { ReactNode, RefObject, useEffect } from "react";
 import { screenWidthAtMost, unreachable } from "@opencast/appkit";
 
@@ -16,7 +16,7 @@ import { Breadcrumbs, BreadcrumbsContainer, BreadcrumbSeparator } from "../ui/Br
 import { MissingRealmName } from "./util";
 import { ellipsisOverflowCss } from "../ui";
 import { COLORS } from "../color";
-import { BREAKPOINT_MEDIUM } from "../GlobalStyle";
+import { BREAKPOINT_MEDIUM, BREAKPOINT_SMALL } from "../GlobalStyle";
 import { keyOfId } from "../util";
 import { IconType } from "react-icons";
 
@@ -182,24 +182,30 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
 
 type WithIconProps = React.PropsWithChildren<{
     Icon: IconType;
+    hideIconOnMobile?: boolean;
 }>;
 
-const WithIcon: React.FC<WithIconProps> = ({ Icon, children }) => (
+const WithIcon: React.FC<WithIconProps> = ({ Icon, children, hideIconOnMobile }) => (
     <div css={{
         display: "flex",
         flexDirection: "row",
-        gap: 6,
+        minWidth: 0,
+        gap: 24,
         [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
             flexDirection: "row-reverse",
             justifyContent: "space-between",
             paddingLeft: 4,
         },
     }}>
-        <Icon size={40} css={{ flexShrink: 0, color: COLORS.primary0 }} />
-        <div css={{
-            height: "96%",
-            borderLeft: `1px solid ${COLORS.neutral15}`,
-            alignSelf: "center",
+        <Icon size={30} css={{
+            flexShrink: 0,
+            color: COLORS.primary0,
+            strokeWidth: 1.5,
+            ...hideIconOnMobile && {
+                [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                    display: "none",
+                },
+            },
         }} />
         {children}
     </div>
@@ -248,16 +254,45 @@ const SearchEvent: React.FC<SearchEventProps> = ({
 
     return (
         <Item key={id} link={link}>
-            <WithIcon Icon={LuPlaySquare}>
-                <div css={{ color: COLORS.neutral90 }}>
+            <WithIcon Icon={LuPlayCircle} hideIconOnMobile>
+                <div css={{
+                    color: COLORS.neutral90,
+                    marginRight: "clamp(12px, 4vw - 13px, 40px)",
+                    display: "flex",
+                    flexDirection: "column",
+                    minWidth: 0,
+                }}>
                     <h3 css={{
                         color: COLORS.primary0,
                         marginBottom: 6,
+                        fontSize: 17,
+                        lineHeight: 1.3,
                         ...ellipsisOverflowCss(2),
                     }}>{title}</h3>
-                    <Creators creators={creators} />
-                    <SmallDescription text={description} lines={3} />
-                    {seriesTitle && seriesId && <div css={{ fontSize: 14, marginTop: 4 }}>
+                    <Creators creators={creators} css={{
+                        ul: {
+                            display: "inline-block",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                        },
+                        li: {
+                            display: "inline",
+                        },
+                    }} />
+                    {description && <SmallDescription
+                        text={description}
+                        lines={3}
+                    />}
+                    {seriesTitle && seriesId && <div css={{
+                        fontSize: 14,
+                        marginTop: "auto",
+                        paddingTop: 8,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        padding: 3,
+                    }}>
                         {t("video.part-of-series") + ": "}
                         <Link to={`/!s/${keyOfId(seriesId)}`} css={{
                             borderRadius: 4,
@@ -286,6 +321,14 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                     minWidth: 270,
                     width: 270,
                     marginLeft: "auto",
+                    [screenWidthAtMost(800)]: {
+                        minWidth: 240,
+                        width: 240,
+                    },
+                    [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+                        maxWidth: 400,
+                        margin: "0 auto",
+                    },
                 }}
             />
         </Item>
@@ -302,14 +345,14 @@ type SearchRealmProps = {
 const SearchRealm: React.FC<SearchRealmProps> = ({ id, name, ancestorNames, fullPath }) => (
     <Item key={id} link={fullPath}>
         <WithIcon Icon={LuLayout}>
-            <div css={{ color: COLORS.primary0 }}>
+            <div>
                 <BreadcrumbsContainer>
                     {ancestorNames.map((name, i) => <li key={i}>
                         {name ?? <MissingRealmName />}
                         <BreadcrumbSeparator />
                     </li>)}
                 </BreadcrumbsContainer>
-                <h3>{name ?? <MissingRealmName />}</h3>
+                <h3 css={{ color: COLORS.primary0 }}>{name ?? <MissingRealmName />}</h3>
             </div>
         </WithIcon>
     </Item>
@@ -334,8 +377,9 @@ const Item: React.FC<ItemProps> = ({ link, children }) => (
             backgroundColor: COLORS.neutral10,
         },
         [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-            flexDirection: "column",
+            flexDirection: "column-reverse",
             gap: 12,
+            margin: "16px 0",
             "& > *:last-child": {
                 width: "100%",
             },

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -70,6 +70,7 @@ const query = graphql`
                     }
                     ... on SearchRealm { name path ancestorNames }
                 }
+                totalHits
             }
         }
     }
@@ -112,7 +113,7 @@ const SearchPage: React.FC<Props> = ({ q, outcome }) => {
     return <>
         <Breadcrumbs path={[]} tail={t("search.title", {
             query: q,
-            hits: outcome.__typename === "SearchResults" ? outcome.items.length : 0,
+            hits: outcome.__typename === "SearchResults" ? outcome.totalHits : 0,
         })} />
         <div css={{ maxWidth: 950, margin: "0 auto" }}>
             {body}

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -196,6 +196,11 @@ const WithIcon: React.FC<WithIconProps> = ({ Icon, children, hideIconOnMobile })
             justifyContent: "space-between",
             paddingLeft: 4,
         },
+        ...hideIconOnMobile && {
+            [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                justifyContent: "flex-end",
+            },
+        },
     }}>
         <Icon size={30} css={{
             flexShrink: 0,

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -111,10 +111,10 @@ const SearchPage: React.FC<Props> = ({ q, outcome }) => {
     }
 
     return <>
-        <Breadcrumbs path={[]} tail={t("search.title", {
+        <Breadcrumbs path={[]} tail={q ? t("search.title", {
             query: q,
             hits: outcome.__typename === "SearchResults" ? outcome.totalHits : 0,
-        })} />
+        }) : t("search.no-query")} />
         <div css={{ maxWidth: 950, margin: "0 auto" }}>
             {body}
         </div>

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -68,6 +68,7 @@ type RemovedRealm {
 type SearchEvent implements Node {
   id: ID!
   title: String!
+  seriesId: ID
   seriesTitle: String
   description: String
   creators: [String!]!

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -271,6 +271,7 @@ type Track {
 
 type SearchResults {
   items: [Node!]!
+  totalHits: Int!
 }
 
 input UpdateTextBlock {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -271,7 +271,7 @@ type Track {
 
 type SearchResults {
   items: [Node!]!
-  totalHits: Int!
+  totalHits: Int
 }
 
 input UpdateTextBlock {

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -6,6 +6,7 @@ test("Search", async ({ page }) => {
     await navigateTo("/", page);
     await page.waitForSelector("nav");
     const searchField = page.getByPlaceholder("Search");
+    const query = "video";
 
     await test.step("Should be focusable by keyboard shortcut", async () => {
         await page.keyboard.press("s");
@@ -13,18 +14,19 @@ test("Search", async ({ page }) => {
     });
 
     await test.step("Should allow search queries to be executed", async () => {
-        const url = "~search?q=Video";
-        await searchField.fill("Video");
+        const url = `~search?q=${query}`;
+        await searchField.fill(query);
 
         await expect(page).toHaveURL(url);
     });
 
     await test.step("Should show search results", async () => {
+        expect(page.getByText("Search results")).toBeVisible();
         const results = page
-            .locator("div")
-            .filter({ has: page.getByText("Search results for “Video”") })
-            .nth(4);
-        await expect(results).toBeVisible();
-        expect(await results.getByRole("link").count()).toBeGreaterThan(0);
+            .locator("li")
+            .filter({ hasText: "video" })
+            .locator("a");
+        await results.nth(1).waitFor();
+        expect(await results.count()).toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
This applies some smaller changes to the appearance of search items. In particular, thumbnails are now on the right side and an icon has been added to ease differentiating between the types of these items (not super useful right now as we only have videos and pages, but other types will be added in the future).

This also adds a button to close the search/return to the previous page the search has been initiated from. This will also happen upon pressing `Esc` or clearing the search input field.

Further improvements like highlighting search terms in the results and filtering for specific items will be done in a follow up PR.

Closes #883