### PR TITLE
Store user info in DB and make them searchable in ACL UI

### DIFF
--- a/.deployment/deploy.yml
+++ b/.deployment/deploy.yml
@@ -185,21 +185,27 @@
         cmd: /opt/tobira/{{ id }}/tobira search-index update
         chdir: /opt/tobira/{{ id }}/
 
-    - name: Add test-data known groups
+    - name: Add test-data known groups/users
       become: true
       copy:
-        src: known-groups.json
-        dest: /opt/tobira/{{ id }}/known-groups.json
+        src: known-{{item}}.json
+        dest: /opt/tobira/{{ id }}/known-{{item}}.json
         owner: root
         group: root
         mode: '0644'
+      with_items:
+        - groups
+        - users
 
-    - name: Configure known groups
+    - name: Configure known groups/users
       become: true
       become_user: tobira
       command:
-        cmd: /opt/tobira/{{ id }}/tobira known-groups upsert known-groups.json
+        cmd: /opt/tobira/{{ id }}/tobira known-{{item}} upsert known-{{item}}.json
         chdir: /opt/tobira/{{ id }}/
+      with_items:
+        - groups
+        - users
 
     - name: install tobira service files
       become: true

--- a/.deployment/files/known-users.json
+++ b/.deployment/files/known-users.json
@@ -1,0 +1,6 @@
+{
+    "ROLE_USER_SABINE": { "username": "sabine", "displayName": "Sabine Rudolfs", "email": "sabine@example.org" },
+    "ROLE_USER_BJOERK": { "username": "björk", "displayName": "Prof. Björk Guðmundsdóttir", "email": "bjoerk@example.org" },
+    "ROLE_USER_MORGAN": { "username": "morgan", "displayName": "Morgan Yu", "email": "morgan@example.org" },
+    "ROLE_USER_JOSE": { "username": "jose", "displayName": "José Carreño Quiñones" }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:11
+        image: postgres:12
         env:
           POSTGRES_USER: tobira
           POSTGRES_PASSWORD: tobira

--- a/.github/workflows/upload-db-dump.yml
+++ b/.github/workflows/upload-db-dump.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: tobira
           POSTGRES_PASSWORD: tobira

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -532,6 +532,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.2",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2527,7 @@ dependencies = [
  "clap",
  "confique",
  "cookie",
+ "dashmap",
  "deadpool",
  "deadpool-postgres",
  "elliptic-curve",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "std"
 clap = { version = "4.2.2", features = ["derive", "string"] }
 confique = { version = "0.2.0", default-features = false, features = ["toml"] }
 cookie = "0.17.0"
+dashmap = "5.5.3"
 deadpool = { version = "0.9.0", default-features = false, features = ["managed", "rt_tokio_1"] }
 deadpool-postgres = { version = "0.10", default-features = false, features = ["rt_tokio_1"] }
 elliptic-curve = { version = "0.13.4", features = ["jwk", "sec1"] }

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -93,26 +93,4 @@ where
             }),
         }
     }).await.map_err(Into::into)
-
-    // let mut labels = context.db.query_raw(&sql, params)
-    //     .await?
-    //     .map_ok(|row| (row.get::<_, String>(0), row.get::<_, Option<TranslatedString<String>>>(1)))
-    //     .try_collect::<HashMap<_, _>>()
-    //     .await?;
-
-    // // Assemble everything. This will likely change in the future once we
-    // // allow arbitrary actions.
-    // let mut map = <HashMap<_, Vec<String>>>::new();
-    // for (list, action) in [(&self.read_roles, "read"), (&self.write_roles, "write")] {
-    //     for role in list {
-    //         map.entry(role).or_default().push(action.into());
-    //     }
-    // }
-
-    // Ok(map.into_iter().map(|(role, actions)| AclItem {
-    //     role: role.into(),
-    //     // Roles are unique so we can `remove` her to avoid cloning.
-    //     label: labels.remove(role).flatten(),
-    //     actions,
-    // }).collect())
 }

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -1,0 +1,118 @@
+use juniper::GraphQLObject;
+use postgres_types::BorrowToSql;
+
+use crate::{api::{util::TranslatedString, Context, err::ApiResult}, db::util::select};
+
+
+
+
+pub(crate) type Acl = Vec<AclItem>;
+
+/// A role being granted permission to perform certain actions.
+#[derive(Debug, GraphQLObject)]
+#[graphql(context = Context)]
+pub(crate) struct AclItem {
+    /// Role. In arrays of AclItems, no two items have the same `role`.
+    pub role: String,
+
+    /// List of actions this role can perform (e.g. `read`, `write`,
+    /// `annotate`). This is a set, i.e. no duplicate elements.
+    pub actions: Vec<String>,
+
+    /// Additional info we have about the role. Is `null` if the role is unknown
+    /// or is `ROLE_ANONYMOUS`, `ROLE_ADMIN` or `ROLE_USER`, as those are
+    /// handled in a special way in the frontend.
+    pub info: Option<RoleInfo>,
+}
+
+/// Some extra information we know about a role.
+#[derive(Debug, GraphQLObject)]
+#[graphql(context = Context)]
+pub(crate) struct RoleInfo {
+    /// A user-facing label for this role (group or person). If the label does
+    /// not depend on the language (e.g. a name), `{ "_": "Peter" }` is
+    /// returned.
+    pub label: TranslatedString<String>,
+
+    /// For user roles this is `null`. For groups, it defines a list of other
+    /// group roles that this role implies. I.e. a user with this role always
+    /// also has these other roles.
+    pub implies: Option<Vec<String>>,
+
+    /// Is `true` if this role represents a large group. Used to warn users
+    /// accidentally giving write access to large groups.
+    pub large: bool,
+}
+
+pub(crate) async fn load_for<P, I>(
+    context: &Context,
+    raw_roles: &str,
+    params: I,
+) -> ApiResult<Acl>
+where
+    P: BorrowToSql,
+    I: IntoIterator<Item = P> + std::fmt::Debug,
+    I::IntoIter: ExactSizeIterator,
+{
+    // First: load labels for roles from the DB. For that we use the `users`
+    // and `known_groups` table.
+    let (selection, mapping) = select!(
+        role: "roles.role",
+        actions,
+        implies,
+        large: "coalesce(known_groups.large, false)",
+        label: "coalesce(
+            known_groups.label,
+            case when users.display_name is null
+                then null
+                else hstore('_', users.display_name)
+            end
+        )",
+    );
+    let sql = format!("\
+        with raw_roles as ({raw_roles}),
+        roles as (
+            select role, array_agg(action) as actions
+            from raw_roles
+            group by role
+        )
+        select {selection}
+        from roles
+        left join users on users.user_role = role
+        left join known_groups on known_groups.role = roles.role\
+    ");
+
+    context.db.query_mapped(&sql, params, |row| {
+        AclItem {
+            role: mapping.role.of(&row),
+            actions: mapping.actions.of(&row),
+            info: mapping.label.of::<Option<_>>(&row).map(|label| RoleInfo {
+                label,
+                implies: mapping.implies.of(&row),
+                large: mapping.large.of(&row),
+            }),
+        }
+    }).await.map_err(Into::into)
+
+    // let mut labels = context.db.query_raw(&sql, params)
+    //     .await?
+    //     .map_ok(|row| (row.get::<_, String>(0), row.get::<_, Option<TranslatedString<String>>>(1)))
+    //     .try_collect::<HashMap<_, _>>()
+    //     .await?;
+
+    // // Assemble everything. This will likely change in the future once we
+    // // allow arbitrary actions.
+    // let mut map = <HashMap<_, Vec<String>>>::new();
+    // for (list, action) in [(&self.read_roles, "read"), (&self.write_roles, "write")] {
+    //     for role in list {
+    //         map.entry(role).or_default().push(action.into());
+    //     }
+    // }
+
+    // Ok(map.into_iter().map(|(role, actions)| AclItem {
+    //     role: role.into(),
+    //     // Roles are unique so we can `remove` her to avoid cloning.
+    //     label: labels.remove(role).flatten(),
+    //     actions,
+    // }).collect())
+}

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -1,10 +1,12 @@
 use crate::{
     api::{Context, err::ApiResult, util::TranslatedString},
     prelude::*,
-    db::util::impl_from_db,
+    db::util::{impl_from_db, select},
 };
+use super::search::{SearchUnavailable, SearchResults};
 
 
+// ===== Groups ===============================================================
 
 /// A group selectable in the ACL UI. Basically a mapping from role to a nice
 /// label and info about the relationship to other roles/groups.
@@ -39,4 +41,78 @@ impl KnownGroup {
             .await?
             .pipe(Ok)
     }
+}
+
+// ===== Users ===============================================================
+
+#[derive(juniper::GraphQLUnion)]
+#[graphql(Context = Context)]
+pub(crate) enum KnownUsersSearchOutcome {
+    #[allow(dead_code)] // TODO
+    SearchUnavailable(SearchUnavailable),
+    Results(SearchResults<KnownUser>),
+}
+
+#[derive(juniper::GraphQLObject)]
+#[graphql(Context = Context)]
+pub(crate) struct KnownUser {
+    display_name: String,
+    user_role: String,
+}
+
+#[juniper::graphql_object(Context = Context, name = "KnownUserSearchResults")]
+impl SearchResults<KnownUser> {
+    fn items(&self) -> &[KnownUser] {
+        &self.items
+    }
+}
+
+pub(crate) async fn search_known_users(
+    query: String,
+    context: &Context,
+) -> ApiResult<KnownUsersSearchOutcome> {
+    if !context.auth.is_user() {
+        return Err(context.not_logged_in_error());
+    }
+
+    if context.config.general.users_searchable {
+        // TODO: Replace this with MeiliSearch
+        let (selection, mapping) = select!(display_name, user_role);
+        let sql = format!("select {selection} \
+            from users \
+            where position($1 in lower(display_name)) > 0 \
+                or position($1 in lower(username)) > 0 \
+                or lower(email) = $1 \
+                or lower(user_role) = $1 \
+            limit 30"
+        );
+        let items = context.db.query_mapped(&sql, dbargs![&query.to_lowercase()], |row| {
+            KnownUser {
+                display_name: mapping.display_name.of(&row),
+                user_role: mapping.user_role.of(&row),
+            }
+        }).await?;
+
+        Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
+    } else {
+        // TODO: Add DB indices for this if this stays!
+        let (selection, mapping) = select!(display_name, user_role);
+        let sql = format!("select {selection} \
+            from users \
+            where lower(display_name) = $1 \
+                or lower(username) = $1 \
+                or lower(email) = $1 \
+                or lower(user_role) = $1 \
+            limit 30"
+        );
+        let items = context.db.query_mapped(&sql, dbargs![&query.to_lowercase()], |row| {
+            KnownUser {
+                display_name: mapping.display_name.of(&row),
+                user_role: mapping.user_role.of(&row),
+            }
+        }).await?;
+
+        Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
+    }
+
 }

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -1,9 +1,12 @@
+use meilisearch_sdk::{Selectors, MatchingStrategies};
+use serde::Deserialize;
+
 use crate::{
     api::{Context, err::ApiResult, util::TranslatedString},
     prelude::*,
     db::util::{impl_from_db, select},
 };
-use super::search::{SearchUnavailable, SearchResults};
+use super::search::{SearchUnavailable, SearchResults, handle_search_result};
 
 
 // ===== Groups ===============================================================
@@ -48,12 +51,11 @@ impl KnownGroup {
 #[derive(juniper::GraphQLUnion)]
 #[graphql(Context = Context)]
 pub(crate) enum KnownUsersSearchOutcome {
-    #[allow(dead_code)] // TODO
     SearchUnavailable(SearchUnavailable),
     Results(SearchResults<KnownUser>),
 }
 
-#[derive(juniper::GraphQLObject)]
+#[derive(juniper::GraphQLObject, Deserialize)]
 #[graphql(Context = Context)]
 pub(crate) struct KnownUser {
     display_name: String,
@@ -75,44 +77,47 @@ pub(crate) async fn search_known_users(
         return Err(context.not_logged_in_error());
     }
 
-    if context.config.general.users_searchable {
-        // TODO: Replace this with MeiliSearch
+    // Load users with exact match from DB.
+    let db_load = async {
         let (selection, mapping) = select!(display_name, user_role);
         let sql = format!("select {selection} \
             from users \
-            where position($1 in lower(display_name)) > 0 \
-                or position($1 in lower(username)) > 0 \
+            where lower(username) = $1 \
                 or lower(email) = $1 \
                 or lower(user_role) = $1 \
-            limit 30"
+            limit 50"
         );
-        let items = context.db.query_mapped(&sql, dbargs![&query.to_lowercase()], |row| {
+        context.db.query_mapped(&sql, dbargs![&query.to_lowercase()], |row| {
             KnownUser {
                 display_name: mapping.display_name.of(&row),
                 user_role: mapping.user_role.of(&row),
             }
-        }).await?;
+        }).await
+    };
 
-        Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
-    } else {
-        // TODO: Add DB indices for this if this stays!
-        let (selection, mapping) = select!(display_name, user_role);
-        let sql = format!("select {selection} \
-            from users \
-            where lower(display_name) = $1 \
-                or lower(username) = $1 \
-                or lower(email) = $1 \
-                or lower(user_role) = $1 \
-            limit 30"
-        );
-        let items = context.db.query_mapped(&sql, dbargs![&query.to_lowercase()], |row| {
-            KnownUser {
-                display_name: mapping.display_name.of(&row),
-                user_role: mapping.user_role.of(&row),
-            }
-        }).await?;
+    // If the settings allow it, search users via MeiliSearch
+    let meili_search = async {
+        if context.config.general.users_searchable {
+            context.search.user_index.search()
+                .with_query(&query)
+                .with_limit(50)
+                .with_matching_strategy(MatchingStrategies::ALL)
+                .with_attributes_to_retrieve(Selectors::Some(&["display_name", "user_role"]))
+                .execute::<KnownUser>()
+                .await
+                .pipe(Some)
+        } else {
+            None
+        }
+    };
 
-        Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
+    // Run both loads concurrently and combine results.
+    let (db_results, meili_results) = tokio::join!(db_load, meili_search);
+    let mut items = db_results?;
+    if let Some(res) = meili_results {
+        let results = handle_search_result!(res, KnownUsersSearchOutcome);
+        items.extend(results.hits.into_iter().map(|h| h.result));
     }
 
+    Ok(KnownUsersSearchOutcome::Results(SearchResults { items }))
 }

--- a/backend/src/api/model/mod.rs
+++ b/backend/src/api/model/mod.rs
@@ -1,6 +1,7 @@
 //! This module and its children define most of the application logic of the
 //! API.
 
+pub(crate) mod acl;
 pub(crate) mod block;
 pub(crate) mod event;
 pub(crate) mod known_roles;

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -47,7 +47,7 @@ pub(crate) enum SearchOutcome {
 }
 
 pub(crate) struct SearchResults<T> {
-    items: Vec<T>,
+    pub(crate) items: Vec<T>,
 }
 
 #[juniper::graphql_object(Context = Context)]

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -1,11 +1,6 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{fmt, borrow::Cow};
-use meilisearch_sdk::errors::{
-    Error as MsError,
-    MeilisearchError as MsRespError,
-    ErrorCode as MsErrorCode,
-};
 
 use crate::{
     api::{
@@ -73,7 +68,13 @@ impl SearchResults<search::Series> {
 
 
 macro_rules! handle_search_result {
-    ($res:expr, $return_type:ty) => {
+    ($res:expr, $return_type:ty) => {{
+        use meilisearch_sdk::errors::{
+            Error as MsError,
+            MeilisearchError as MsRespError,
+            ErrorCode as MsErrorCode,
+        };
+
         match $res {
             Ok(v) => v,
 
@@ -97,11 +98,12 @@ macro_rules! handle_search_result {
             }
 
             // All other errors just result in a general "internal server error".
-            Err(e) => return Err(e.into()),
+            Err(e) => return ApiResult::Err(e.into()),
         }
-
-    };
+    }};
 }
+
+pub(crate) use handle_search_result;
 
 
 /// Main entry point for the main search (including all items).

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -28,6 +28,13 @@ impl User {
         self.roles.iter().map(AsRef::as_ref).collect()
     }
 
+    /// Returns the *user role* of this user. Each user has exactly one and this
+    /// role is used in ACLs to give access to a single user. This role is
+    /// always also contained in `roles`.
+    fn user_role(&self) -> &str {
+        &self.user_role
+    }
+
     /// The name of the user intended to be read by humans.
     fn display_name(&self) -> &str {
         &self.display_name

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -13,7 +13,7 @@ use super::{
         event::{AuthorizedEvent, Event},
         series::Series,
         search::{self, SearchOutcome, EventSearchOutcome, SeriesSearchOutcome},
-        known_roles::KnownGroup,
+        known_roles::{self, KnownUsersSearchOutcome, KnownGroup},
     },
     jwt::{JwtService, jwt},
 };
@@ -119,6 +119,17 @@ impl Query {
         context: &Context,
     ) -> ApiResult<SeriesSearchOutcome> {
         search::all_series(&query, writable_only, context).await
+    }
+
+    /// Searches through all known users. The behavior of this depends on the
+    /// `general.users_searchable` config value. If it is `false`, this returns
+    /// only users that have an exact match with the input query. The number of
+    /// results is limited to some fixed value.
+    async fn search_known_users(
+        query: String,
+        context: &Context,
+    ) -> ApiResult<KnownUsersSearchOutcome> {
+        known_roles::search_known_users(query, context).await
     }
 
     /// Returns all known groups selectable in the ACL UI.

--- a/backend/src/args.rs
+++ b/backend/src/args.rs
@@ -114,6 +114,16 @@ pub(crate) enum Command {
         #[clap(flatten)]
         shared: Shared,
     },
+
+    /// Managing "known users". This data is only used for the ACL UI and not
+    /// for auth at all!
+    KnownUsers {
+        #[clap(subcommand)]
+        options: cmd::known_users::Args,
+
+        #[clap(flatten)]
+        shared: Shared,
+    }
 }
 
 #[derive(Debug, clap::Args)]

--- a/backend/src/auth/cache.rs
+++ b/backend/src/auth/cache.rs
@@ -1,0 +1,97 @@
+use std::{time::{Instant, Duration}, collections::HashSet};
+
+use dashmap::{DashMap, mapref::entry::Entry};
+use deadpool_postgres::Client;
+
+use crate::prelude::*;
+
+
+const CACHE_DURATION: Duration = Duration::from_secs(60 * 10);
+
+struct CacheEntry {
+    display_name: String,
+    email: Option<String>,
+    roles: HashSet<String>,
+    user_role: String,
+    last_written_to_db: Instant,
+}
+
+/// Cache to remember what users we have seen. Its only purpose is to make
+/// writes to the `users` table less frequent. The data from this cache must
+/// not be used in any other way.
+///
+/// This works fine in multi-node setups: each node just has its local cache and
+/// prevents some DB writes. But as this data is never used otherwise, we don't
+/// run into data inconsistency problems.
+pub(crate) struct UserCache(DashMap<String, CacheEntry>);
+
+impl UserCache {
+    pub(crate) fn new() -> Self {
+        Self(DashMap::new())
+    }
+
+    pub(crate) async fn upsert_user_info(&self, user: &super::User, db: &Client) {
+        match self.0.entry(user.username.clone()) {
+            Entry::Occupied(mut occupied) => {
+                let entry = occupied.get();
+                let needs_update = entry.last_written_to_db.elapsed() > CACHE_DURATION
+                    || entry.display_name != user.display_name
+                    || entry.email != user.email
+                    || entry.roles != user.roles
+                    || entry.user_role != user.user_role;
+
+                if needs_update {
+                    let res = Self::write_to_db(user, db).await;
+                    if res.is_ok() {
+                        occupied.get_mut().last_written_to_db = Instant::now();
+                    }
+                }
+            },
+            Entry::Vacant(vacant) => {
+                let res = Self::write_to_db(user, db).await;
+                if res.is_ok() {
+                    vacant.insert(CacheEntry {
+                        display_name: user.display_name.clone(),
+                        email: user.email.clone(),
+                        roles: user.roles.clone(),
+                        user_role: user.user_role.clone(),
+                        last_written_to_db: Instant::now(),
+                    });
+                }
+            },
+        }
+    }
+
+    async fn write_to_db(user: &super::User, db: &Client) -> Result<(), ()> {
+        let sql = "\
+            insert into users (username, display_name, email, user_role, last_seen) \
+            values ($1, $2, $3, $4, now()) \
+            on conflict (username) do update set \
+                display_name = excluded.display_name, \
+                email = excluded.email, \
+                user_role = excluded.user_role, \
+                last_seen = excluded.last_seen \
+        ";
+        let res = db.execute(sql, &[
+            &user.username,
+            &user.display_name,
+            &user.email,
+            &user.user_role,
+        ]).await;
+
+        // We mostly just ignore errors. That's because saving the user data is
+        // not THAT important. Logging a warning should make sure that this
+        // doesn't fail all the time.
+        //
+        // It's important to note that this user saving makes every API request
+        // potentially writing to the DB. If the DB is in an emergency read
+        // only state, that would mean that all API requests would fail.
+        if let Err(e) = res {
+            warn!("Updating user data for '{}' failed: {e}", user.username);
+            return Err(());
+        }
+
+        Ok(())
+    }
+}
+

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -183,7 +183,7 @@ impl AuthConfig {
         if let Some(extra) = roles.find(is_user_role) {
             warn!(
                 "User '{username}' has multiple user roles ({user_role} and {extra}) \
-                    but there should be one unique user role per user. {note}",
+                    but there should be only one user role per user. {note}",
             );
         }
 

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -49,8 +49,10 @@ pub(crate) async fn run(shared: &args::Shared, args: &Args) -> Result<()> {
                 => println!("    ▸ DB up to date"),
             Ok(MigrationPlan::EmptyDb)
                 => println!("    ▸ DB is empty, all migrations will be applied"),
-            Ok(MigrationPlan::Migrate { new_migrations })
-                => println!("    ▸ DB is compatible, {new_migrations} new migrations will be applied"),
+            Ok(m @ MigrationPlan::Migrate { .. }) => println!(
+                "    ▸ DB is compatible, {} new migrations will be applied",
+                m.missing_migrations(),
+            ),
         }
     }
     print_outcome(&mut any_errors, "MeiliSearch", &meili);

--- a/backend/src/cmd/known_users.rs
+++ b/backend/src/cmd/known_users.rs
@@ -1,0 +1,149 @@
+use std::collections::{HashMap, HashSet};
+
+use deadpool_postgres::Transaction;
+use futures::pin_mut;
+use tokio_postgres::binary_copy::BinaryCopyInWriter;
+
+use crate::{
+    prelude::*,
+    db,
+    config::Config,
+};
+
+use super::prompt_for_yes;
+
+
+#[derive(Debug, clap::Parser)]
+pub(crate) enum Args {
+    /// Adds new known users and updates existing ones. Specified in a JSON file
+    /// in this format (the email is optional):
+    ///
+    /// {
+    ///     "ROLE_USER_PLUSTIG": {
+    ///         "username": "plustig",
+    ///         "display_name": "Peter Lustig",
+    ///         "email": "peter@lustig.de"
+    ///     }
+    /// }
+    Upsert {
+        /// File to JSON file containing users to add.
+        file: String,
+    },
+
+    /// Removes all known users.
+    Clear,
+}
+
+
+
+#[derive(serde::Deserialize)]
+struct UserData {
+    username: String,
+    display_name: String,
+    email: Option<String>,
+}
+
+
+pub(crate) async fn run(config: Config, args: &Args) -> Result<()> {
+    let db = db::create_pool(&config.db).await
+        .context("failed to create database connection pool (database not running?)")?;
+    let mut conn = db.get().await?;
+    let tx = conn.build_transaction()
+        .isolation_level(tokio_postgres::IsolationLevel::Serializable)
+        .start()
+        .await?;
+
+    match args {
+        Args::Upsert { file } => upsert(&file, &config, tx).await?,
+        // Args::Remove { roles } => remove(roles, tx).await?,
+        Args::Clear => clear(tx).await?,
+    }
+
+    Ok(())
+}
+
+async fn upsert(file: &str, config: &Config, tx: Transaction<'_>) -> Result<()> {
+    // Read JSON
+    let content = tokio::fs::read_to_string(file).await
+        .context("failed to read the file")?;
+    let users: HashMap<String, UserData> = serde_json::from_str(&content)
+        .context("failed to deserialize")?;
+
+    // Validate
+    for role in users.keys() {
+        if !config.auth.user_role_prefixes.iter().any(|prefix| role.starts_with(prefix)) {
+            bail!("Role {role} does not start with any prefix \
+                specified in 'auth.user_role_prefixes'!");
+        }
+    }
+    let mut usernames = HashSet::new();
+    for info in users.values() {
+        if !usernames.insert(&info.username) {
+            bail!("Username '{}' occurs more than once in the input data", info.username);
+        }
+    }
+
+    info!("Loaded {} users from file", users.len());
+
+
+    // Insert into DB. Since we could be dealing with lots of users, we want to
+    // use `copy in` instead of N inserts. However, we need to control the
+    // behavior on conflict. To do that we create a temporary table, copy in
+    // there and then copy everything over. It's a bit annoying but works. We
+    // also need a dummy insert to acquire the col types.
+    let tmp_table = format!("tmp_table_{}", rand::random::<u64>());
+    let sql = format!("create temp table {tmp_table} \
+        (like users including defaults including identity) \
+        on commit drop");
+    tx.execute(&sql, &[]).await?;
+
+    let col_list = "username, display_name, email, user_role";
+    let sql = format!("insert into users ({col_list}) values ($1, $2, $3, $4)");
+    let col_types = tx.prepare_cached(&sql).await?;
+    debug!("Prepared DB insertion");
+
+    let sink = tx.copy_in(&format!("copy {tmp_table} ({col_list}) from stdin binary")).await?;
+    let writer = BinaryCopyInWriter::new(sink, col_types.params());
+    pin_mut!(writer);
+
+
+    for (role, info) in users {
+        writer.as_mut().write_raw(dbargs![
+            &info.username,
+            &info.display_name,
+            &info.email,
+            &role,
+        ]).await?;
+    }
+    writer.finish().await?;
+    debug!("Sent user data to temporary table");
+
+    let sql = format!("
+        insert into users ({col_list})
+            select {col_list} from {tmp_table}
+            on conflict (user_role) do update set
+                username = excluded.username,
+                display_name = excluded.display_name,
+                email = excluded.email
+    ");
+    let affected = tx.execute(&sql, &[]).await?;
+    tx.commit().await?;
+    info!("Finished inserting users");
+
+
+    println!("Upserted {affected} known users");
+    Ok(())
+}
+
+async fn clear(tx: Transaction<'_>) -> Result<()> {
+    println!("Remove all known users? Type 'yes'");
+    prompt_for_yes()?;
+
+    // We use `delete from` instead of `truncate` as we don't need the speed
+    // here and `truncate` doesn't return the number of affected rows.
+    let affected = tx.execute("delete from users", &[]).await?;
+    tx.commit().await?;
+    println!("Removed {affected} known users");
+
+    Ok(())
+}

--- a/backend/src/cmd/mod.rs
+++ b/backend/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod export_api_schema;
 pub(crate) mod import_realm_tree;
 pub(crate) mod check;
 pub(crate) mod known_groups;
+pub(crate) mod known_users;
 
 
 /// Reads stdin and returns an error if the trimmed input is not exactly "yes".

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -79,6 +79,14 @@ pub(crate) struct GeneralConfig {
     /// Example: ["/Shibboleth.sso", "/something-else"]
     #[config(default = [])]
     pub reserved_paths: Vec<String>,
+
+    /// Whether users are allowed to search through all known users, e.g. in the
+    /// ACL UI to grant a friend access to a video. If `false`, users in the
+    /// ACL selector can only be added by typing the exact username or email.
+    /// If this is `true` instead, it is possible to search for users by
+    /// (partial) name.
+    #[config(default = false)]
+    pub users_searchable: bool,
 }
 
 const INTERNAL_RESERVED_PATHS: &[&str] = &["favicon.ico", "robots.txt", ".well-known"];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -341,4 +341,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     24: "known-groups",
     25: "longer-videos",
     26: "more-event-search-data",
+    27: "users",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -342,4 +342,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     25: "longer-videos",
     26: "more-event-search-data",
     27: "users",
+    28: "user-index-queue-triggers",
 ];

--- a/backend/src/db/migrations/27-users.sql
+++ b/backend/src/db/migrations/27-users.sql
@@ -23,3 +23,20 @@ create table users (
 
 -- Looking up users by role is a common operation for resolving roles in ACLs.
 create unique index idx_user_role on users (user_role);
+
+-- For searching users by exact match, we need these indices.
+create index idx_user_role_lower on users (lower(user_role));
+create index idx_user_username_lower on users (lower(username));
+create index idx_user_email_lower on users (lower(email));
+
+
+-- Search index ---------------------------------------------------------------
+
+-- Next we need to change the 'kind' of things we can insert into the queue to
+-- add 'user'.
+alter type search_index_item_kind add value 'user';
+
+-- And we also need to install triggers to queue users. However, we cannot do
+-- that in this script as a script is run as one transaction and we can't use
+-- the 'user' enum value in the same transaction it is added. So this is the
+-- next migration script.

--- a/backend/src/db/migrations/27-users.sql
+++ b/backend/src/db/migrations/27-users.sql
@@ -1,0 +1,25 @@
+select prepare_randomized_ids('users');
+
+-- This table stores user information, but note that it's not used for
+-- authentication or authorization. That's still handled using external systems,
+-- according to 'auth.mode'.
+create table users (
+    -- Users already have a unique ID but it's usually a good idea using a
+    -- artificial primary key anyway. See https://dba.stackexchange.com/q/1910/
+    id bigint primary key default randomized_id('users'),
+    username text not null unique,
+
+    -- These three are just a cache. For the actual user session, the values
+    -- from the login system are always used instead of this. This is just for
+    -- the ACL selector UI.
+    display_name text not null,
+    email text,
+    user_role text not null,
+
+    -- The last time this user has made an authenticated request. Is null if the
+    -- user was never seen (i.e. the data was imported in another way).
+    last_seen timestamp with time zone
+);
+
+-- Looking up users by role is a common operation for resolving roles in ACLs.
+create unique index idx_user_role on users (user_role);

--- a/backend/src/db/migrations/28-user-index-queue-triggers.sql
+++ b/backend/src/db/migrations/28-user-index-queue-triggers.sql
@@ -1,0 +1,32 @@
+-- Continuation from the previous migration script...
+
+-- Add a trigger to automatically add a user to the queue whenever its changed.
+create function queue_user_for_reindex(u users) returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    values (u.id, 'user')
+    on conflict do nothing
+$$;
+
+create function queue_touched_user_for_reindex()
+   returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_user_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_user_for_reindex(new);
+    end if;
+    return null;
+end;
+$$;
+
+-- We do not care about changed to `last_seen`. We don't currently use it and as
+-- this is a frequently changing field, it would cause many index modifications
+-- all the time.
+create trigger queue_touched_user_for_reindex
+after insert or delete or update of username, display_name, email, user_role
+on users
+for each row
+execute procedure queue_touched_user_for_reindex();

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -144,6 +144,7 @@ impl Assets {
         variables.insert("html-title".into(), config.general.site_title.en().into());
         variables.insert("site-title".into(), config.general.site_title.to_json());
         variables.insert("show-download-button".into(), json!(config.general.show_download_button).to_string());
+        variables.insert("users-searchable".into(), json!(config.general.users_searchable).to_string());
         variables.insert("footer-links".into(), json!(config.general.footer_links).to_string());
         variables.insert("metadata-labels".into(), json!(config.general.metadata).to_string());
         variables.insert(

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -264,7 +264,13 @@ async fn handle_api(req: Request<Body>, ctx: &Context) -> Result<Response, Respo
     let mut connection = db::get_conn_or_service_unavailable(&ctx.db_pool).await?;
 
     // Get auth session
-    let auth = match AuthContext::new(&parts.headers, &ctx.config.auth, &connection).await {
+    let auth_result = AuthContext::new(
+        &parts.headers,
+        &ctx.config.auth,
+        &connection,
+        &ctx.user_cache,
+    ).await;
+    let auth = match auth_result {
         Ok(auth) => auth,
         Err(e) => {
             error!("DB error when checking user session: {}", e);

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use crate::{
-    api, auth::JwtContext, config::Config, metrics, prelude::*, search, default_enable_backtraces,
+    api, auth::{JwtContext, UserCache}, config::Config, metrics, prelude::*, search, default_enable_backtraces,
 };
 use self::{
     assets::Assets,
@@ -69,6 +69,7 @@ pub(crate) struct Context {
     pub(crate) jwt: Arc<JwtContext>,
     pub(crate) search: Arc<search::Client>,
     pub(crate) metrics: Arc<metrics::Metrics>,
+    pub(crate) user_cache: UserCache,
 }
 
 
@@ -90,6 +91,7 @@ pub(crate) async fn serve(
         config: Arc::new(config),
         search: Arc::new(search),
         metrics: Arc::new(metrics::Metrics::new()),
+        user_cache: UserCache::new(),
     });
 
     // This sets up all the hyper server stuff. It's a bit of magic and touching

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -116,6 +116,10 @@ async fn run() -> Result<()> {
             let config = load_config_and_init_logger(shared, &args)?;
             cmd::known_groups::run(config, options).await?;
         }
+        Command::KnownUsers { options, shared } => {
+            let config = load_config_and_init_logger(shared, &args)?;
+            cmd::known_users::run(config, options).await?;
+        }
     }
 
     Ok(())

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -186,6 +186,8 @@ async fn status(meili: &Client) -> Result<()> {
     println!();
     index_status("realm", &meili.realm_index, meili.config.realm_index_name()).await?;
     println!();
+    index_status("user", &meili.user_index, meili.config.user_index_name()).await?;
+    println!();
 
     Ok(())
 }

--- a/backend/src/search/update.rs
+++ b/backend/src/search/update.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use super::{
-    Client, Event, IndexItemKind, Realm, IndexItem, SearchId, Series,
+    Client, Event, IndexItemKind, Realm, IndexItem, SearchId, Series, User,
     writer::{self, MeiliWriter},
 };
 
@@ -51,6 +51,7 @@ pub(crate) async fn update_index(meili: &Client, db: &mut DbConnection) -> Resul
             let mut event_ids = Vec::new();
             let mut realm_ids = Vec::new();
             let mut series_ids = Vec::new();
+            let mut user_ids = Vec::new();
             futures::pin_mut!(row_stream);
             while let Some(row) = row_stream.try_next().await? {
                 let key: Key = mapping.item_id.of(&row);
@@ -59,10 +60,11 @@ pub(crate) async fn update_index(meili: &Client, db: &mut DbConnection) -> Resul
                     IndexItemKind::Realm => realm_ids.push(key),
                     IndexItemKind::Event => event_ids.push(key),
                     IndexItemKind::Series => series_ids.push(key),
+                    IndexItemKind::User => user_ids.push(key),
                 }
             }
 
-            let count = event_ids.len() + realm_ids.len() + series_ids.len();
+            let count = event_ids.len() + realm_ids.len() + series_ids.len() + user_ids.len();
             if count == 0 {
                 trace!("No index update queued -> doing nothing");
                 return Ok(true);
@@ -78,13 +80,16 @@ pub(crate) async fn update_index(meili: &Client, db: &mut DbConnection) -> Resul
                 .context("failed to send events to search index")?;
             meili.update(&series_ids, || Series::load_by_ids(&**tx, &series_ids)).await
                 .context("failed to send series to search index")?;
+            meili.update(&user_ids, || User::load_by_ids(&**tx, &user_ids)).await
+                .context("failed to send users to search index")?;
 
             // Delete all items that we have sent to the search index already.
             let sql = "delete from search_index_queue \
                 where item_id = any($1) and kind = 'realm' \
                 or item_id = any($2) and kind = 'event' \
-                or item_id = any($3) and kind = 'series'";
-            let affected = tx.execute(sql, &[&realm_ids, &event_ids, &series_ids]).await
+                or item_id = any($3) and kind = 'series' \
+                or item_id = any($4) and kind = 'user'";
+            let affected = tx.execute(sql, &[&realm_ids, &event_ids, &series_ids, &user_ids]).await
                 .context("failed to remove items from search index queue")?;
             debug!("Removed {affected} items from the search index queue");
 
@@ -143,6 +148,7 @@ impl MeiliWriter<'_> {
             IndexItemKind::Realm => &self.realm_index,
             IndexItemKind::Event => &self.event_index,
             IndexItemKind::Series => &self.series_index,
+            IndexItemKind::User => &self.user_index,
         };
 
         // Actually update documents in Meili.

--- a/backend/src/search/user.rs
+++ b/backend/src/search/user.rs
@@ -1,0 +1,73 @@
+use meilisearch_sdk::indexes::Index;
+use serde::{Serialize, Deserialize};
+use tokio_postgres::GenericClient;
+
+use crate::{
+    prelude::*,
+    db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
+};
+
+use super::{SearchId, IndexItem, IndexItemKind, util};
+
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct User {
+    pub(crate) id: SearchId,
+    pub(crate) username: String,
+    pub(crate) user_role: String,
+    pub(crate) display_name: String,
+    pub(crate) email: Option<String>,
+}
+
+impl IndexItem for User {
+    const KIND: IndexItemKind = IndexItemKind::User;
+    fn id(&self) -> SearchId {
+        self.id
+    }
+}
+
+impl_from_db!(
+    User,
+    select: {
+        users.{id, username, user_role, display_name, email},
+    },
+    |row| {
+        Self {
+            id: row.id(),
+            username: row.username(),
+            user_role: row.user_role(),
+            display_name: row.display_name(),
+            email: row.email(),
+        }
+    }
+);
+
+impl User {
+    pub(crate) async fn load_by_ids(db: &impl GenericClient, ids: &[Key]) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from users where id = any($1)");
+        let rows = db.query_raw(&query, dbargs![&ids]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load users from DB")
+    }
+
+    pub(crate) async fn load_all(db: &impl GenericClient) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from users");
+        let rows = db.query_raw(&query, dbargs![]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load users from DB")
+    }
+}
+
+pub(super) async fn prepare_index(index: &Index) -> Result<()> {
+    util::lazy_set_special_attributes(
+        index,
+        "user",
+        &["display_name"],
+        &[],
+    ).await
+}

--- a/docs/docs/setup/auth/in-depth.md
+++ b/docs/docs/setup/auth/in-depth.md
@@ -16,6 +16,7 @@ Tobira requires the following information about each user:
   An alphabetic ID is preferred over a purely numeric one as it appears in the URL to the user's personal page.
 - **Display name**: the user's name in a format intended for humans; usually something like "Forename Surname".
 - **Roles**: a list of roles that are used for authorization (e.g. deciding whether a user is allowed to see a video or modify some data).
+- **User role**: the unique user role for that user (e.g. `ROLE_USER_PETER`).
 
 In the `"opencast"` mode, this data is retrieved via `/info/me.json` from Opencast.
 In the to `"*-proxy"` modes, you have to pass this data explicitly to Tobira via so called *auth headers*.
@@ -28,8 +29,9 @@ These are just designated HTTP headers, one for each kind of information describ
 
 - `x-tobira-username`: Username
 - `x-tobira-user-display-name`: Display name
-- `x-tobira-user-roles`: List of roles, comma separated
-- `x-tobira-user-email`: User email address
+- `x-tobira-user-roles`: List of roles, comma separated.
+  Needs to contain exactly one role starting with any of the configured `auth.user_role_prefixes`.
+- `x-tobira-user-email`: User email address (optional)
 
 All these header values have to be a **base64-encoded UTF-8** string!
 

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -88,6 +88,15 @@
 # Default value: []
 #reserved_paths = []
 
+# Whether users are allowed to search through all known users, e.g. in the
+# ACL UI to grant a friend access to a video. If `false`, users in the
+# ACL selector can only be added by typing the exact username or email.
+# If this is `true` instead, it is possible to search for users by
+# (partial) name.
+#
+# Default value: false
+#users_searchable = false
+
 
 [db]
 # The username of the database user.

--- a/frontend/src/User.tsx
+++ b/frontend/src/User.tsx
@@ -25,6 +25,7 @@ export type User = {
     canUseEditor: boolean;
     canCreateUserRealm: boolean;
     roles: readonly string[];
+    userRole: string;
 };
 
 export const isRealUser = (state: UserState): state is User => (
@@ -59,6 +60,7 @@ export const userDataFragment = graphql`
             canUseEditor
             canCreateUserRealm
             roles
+            userRole
         }
     }
 `;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -25,6 +25,7 @@ type Config = {
     auth: AuthConfig;
     siteTitle: TranslatedString;
     showDownloadButton: boolean;
+    usersSearchable: boolean;
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -291,6 +291,11 @@ manage:
   access:
     authorized-groups: Autorisierte Gruppen
     authorized-users: Autorisierte Personen
+    users-no-options:
+      initial-searchable: Nach Name suchen oder exakten Nutzernamen/exakte E-Mail angeben
+      none-found-searchable: Keine Personen gefunden
+      initial-not-searchable: Geben Sie Nutzernamen oder E-Mail an, um Personen hinzuzufügen
+      none-found-not-searchable: Keine Person mit diesem Nutzernamen bzw. dieser E-Mail gefunden
     select:
       groups: Gruppen hinzufügen
       users: Personen hinzufügen

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -287,6 +287,11 @@ manage:
   access:
     authorized-groups: Authorized groups
     authorized-users: Authorized users
+    users-no-options:
+      initial-searchable: Type to search for users by name (or enter exact email/username)
+      none-found-searchable: No user found
+      initial-not-searchable: Enter username or email of the person you want to add
+      none-found-not-searchable: No user with that username/email found
     select:
       groups: Add groups
       users: Add users

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -15,6 +15,7 @@
         "upload": {{: var:upload :}},
         "siteTitle": {{: var:site-title :}},
         "showDownloadButton": {{: var:show-download-button :}},
+        "usersSearchable": {{: var:users-searchable :}},
         "footerLinks": {{: var:footer-links :}},
         "metadataLabels": {{: var:metadata-labels :}},
         "opencast": {

--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -73,6 +73,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                 && "canUseEditor" in user && typeof user.canUseEditor === "boolean"
                 && "canCreateUserRealm" in user && typeof user.canCreateUserRealm === "boolean"
                 && "roles" in user && isStringArray(user.roles)
+                && "userRole" in user && typeof user.userRole === "string"
             ) {
                 // `userData = user` unfortunately doesn't work here as the type
                 // of the `user` object is not sufficiently narrowed. Relevant
@@ -85,6 +86,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                     canUseEditor: user.canUseEditor,
                     canCreateUserRealm: user.canCreateUserRealm,
                     roles: user.roles,
+                    userRole: user.userRole,
                 };
             }
         }

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -1038,14 +1038,6 @@ const finishUpload = async (
 
         // Add ACL
         {
-            // Retrieve primary user role for user.
-            // TODO: we could save this information from a previous request to info/me.
-            const userInfo = JSON.parse(await ocRequest("/info/me.json"));
-            const userRole = userInfo.userRole;
-            if (typeof userRole !== "string" || !userRole) {
-                throw `Field \`userRole\` from 'info/me.json' is not valid: ${userRole}`;
-            }
-
             const acl = constructAcl(metadata.acl);
             const body = new FormData();
             body.append("flavor", "security/xacml+episode");

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -30,7 +30,7 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { ManageNav } from "./manage";
 import { COLORS } from "../color";
 import { COMMON_ROLES } from "../util/roles";
-import { Acl, getUserRole, AclSelector, knownRolesFragement } from "../ui/Access";
+import { Acl, AclSelector, knownRolesFragement } from "../ui/Access";
 import {
     AccessKnownRolesData$data,
     AccessKnownRolesData$key,
@@ -673,14 +673,17 @@ type MetaDataEditProps = {
 const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRoles }) => {
     const { t } = useTranslation();
     const user = useUser();
-    const userRole = getUserRole(user);
+    if (!isRealUser(user)) {
+        return unreachable();
+    }
+
     const titleFieldId = useId();
     const descriptionFieldId = useId();
     const seriesFieldId = useId();
 
     const defaultAcl: Acl = {
-        readRoles: new Set([COMMON_ROLES.ANONYMOUS, userRole]),
-        writeRoles: new Set([userRole]),
+        readRoles: new Set([COMMON_ROLES.ANONYMOUS, user.userRole]),
+        writeRoles: new Set([user.userRole]),
     };
 
     const { register, handleSubmit, control, formState: { errors } } = useForm<Metadata>({

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -82,8 +82,7 @@ const query = graphql`
                 created
                 canWrite
                 isLive
-                readRoles
-                writeRoles
+                acl { role actions info { label implies large } }
                 syncedData {
                     duration
                     thumbnail

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -56,6 +56,11 @@ scalar Cursor
 """
 union SearchOutcome = SearchUnavailable | EmptyQuery | SearchResults
 
+type KnownUser {
+  displayName: String!
+  userRole: String!
+}
+
 type RemovedRealm {
   parent: Realm
 }
@@ -176,6 +181,8 @@ interface Block {
   index: Int!
   realm: Realm!
 }
+
+union KnownUsersSearchOutcome = SearchUnavailable | KnownUserSearchResults
 
 type NotAllowed {
   """
@@ -453,6 +460,10 @@ type Caption {
   lang: String
 }
 
+type KnownUserSearchResults {
+  items: [KnownUser!]!
+}
+
 type RemovedBlock {
   id: ID!
   realm: Realm!
@@ -507,6 +518,13 @@ type Query {
     searched.
   """
   searchAllSeries(query: String!, writableOnly: Boolean!): SeriesSearchOutcome!
+  """
+    Searches through all known users. The behavior of this depends on the
+    `general.users_searchable` config value. If it is `false`, this returns
+    only users that have an exact match with the input query. The number of
+    results is limited to some fixed value.
+  """
+  searchKnownUsers(query: String!): KnownUsersSearchOutcome!
   "Returns all known groups selectable in the ACL UI."
   knownGroups: [KnownGroup!]!
 }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -553,6 +553,12 @@ type User {
     This endpoint is only for debugging and for special cases like the ACL selector.
   """
   roles: [String!]!
+  """
+    Returns the *user role* of this user. Each user has exactly one and this
+    role is used in ACLs to give access to a single user. This role is
+    always also contained in `roles`.
+  """
+  userRole: String!
   "The name of the user intended to be read by humans."
   displayName: String!
   "`True` if the user has the permission to upload videos."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -119,13 +119,28 @@ type Series {
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!
 }
 
-union EventSearchOutcome = SearchUnavailable | EventSearchResults
-
-input NewVideoBlock {
-  event: ID!
-  showTitle: Boolean!
-  showLink: Boolean!
+"Some extra information we know about a role."
+type RoleInfo {
+  """
+    A user-facing label for this role (group or person). If the label does
+    not depend on the language (e.g. a name), `{ "_": "Peter" }` is
+    returned.
+  """
+  label: TranslatedString!
+  """
+    For user roles this is `null`. For groups, it defines a list of other
+    group roles that this role implies. I.e. a user with this role always
+    also has these other roles.
+  """
+  implies: [String!]
+  """
+    Is `true` if this role represents a large group. Used to warn users
+    accidentally giving write access to large groups.
+  """
+  large: Boolean!
 }
+
+union EventSearchOutcome = SearchUnavailable | EventSearchResults
 
 """
   A group selectable in the ACL UI. Basically a mapping from role to a nice
@@ -136,6 +151,12 @@ type KnownGroup {
   label: TranslatedString!
   implies: [String!]!
   large: Boolean!
+}
+
+input NewVideoBlock {
+  event: ID!
+  showTitle: Boolean!
+  showLink: Boolean!
 }
 
 type SyncedEventData implements Node {
@@ -207,6 +228,7 @@ type AuthorizedEvent implements Node {
   series: Series
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!
+  acl: [AclItem!]!
 }
 
 "A block just showing some title."
@@ -325,6 +347,23 @@ type Realm implements Node {
     - Otherwise, `false` is returned.
   """
   references(id: ID!): Boolean!
+}
+
+"A role being granted permission to perform certain actions."
+type AclItem {
+  "Role. In arrays of AclItems, no two items have the same `role`."
+  role: String!
+  """
+    List of actions this role can perform (e.g. `read`, `write`,
+    `annotate`). This is a set, i.e. no duplicate elements.
+  """
+  actions: [String!]!
+  """
+    Additional info we have about the role. Is `null` if the role is unknown
+    or is `ROLE_ANONYMOUS`, `ROLE_ADMIN` or `ROLE_USER`, as those are
+    handled in a special way in the frontend.
+  """
+  info: RoleInfo
 }
 
 union SeriesSearchOutcome = SearchUnavailable | SeriesSearchResults

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -11,7 +11,7 @@ import {
 } from "@opencast/appkit";
 import { createContext, useRef, useState, useContext, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { LuX, LuAlertTriangle } from "react-icons/lu";
+import { LuX, LuAlertTriangle, LuInfo } from "react-icons/lu";
 import { MultiValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import AsyncCreatableSelect from "react-select/async-creatable";
@@ -435,7 +435,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind }) => {
     return <TableRow
         labelCol={<>
             {label}
-            {isSubset && <Warning tooltip={
+            {isSubset && <Warning info tooltip={
                 t("manage.access.table.subset-warning", { groups: supersets.join(", ") })
             } />}
         </>}
@@ -511,12 +511,13 @@ const TableRow: React.FC<TableRowProps> = ({ labelCol, mutedLabel, actionCol, on
 
 type WarningProps = {
     tooltip: string;
+    info?: boolean;
 }
 
-const Warning: React.FC<WarningProps> = ({ tooltip }) => (
+const Warning: React.FC<WarningProps> = ({ tooltip, info }) => (
     <WithTooltip {...{ tooltip }} css={{ display: "flex" }}>
-        <span css={{ marginLeft: 6, display: "flex" }}>
-            <LuAlertTriangle css={{ color: COLORS.danger0, alignSelf: "center" }} />
+        <span css={{ marginLeft: 6, display: "flex", alignItems: "center" }}>
+            {info ? <LuInfo /> : <LuAlertTriangle css={{ color: COLORS.danger0 }}/>}
         </span>
     </WithTooltip>
 );

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -90,11 +90,7 @@ export const AclSelector: React.FC<AclSelectorProps> = (
     const change: AclContext["change"] = f => {
         const copy = new Map([...acl.entries()].map(([role, value]) => [role, {
             actions: new Set(value.actions),
-            info: value.info == null ? null : {
-                label: value.info.label,
-                implies: value.info.implies,
-                large: value.info.large,
-            },
+            info: value.info,
         }]));
         f(copy);
         onChange(copy);
@@ -376,7 +372,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                     ) && (
                         <TableRow
                             labelCol={<>{t("acl.groups.admins")}</>}
-                            actionCol={<UnchangableAllActions />}
+                            actionCol={<UnchangeableAllActions />}
                         />
                     )}
                 </tbody>
@@ -446,7 +442,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind }) => {
             } />}
         </>}
         mutedLabel={isSubset}
-        actionCol={immutable ? <UnchangableAllActions /> : <>
+        actionCol={immutable ? <UnchangeableAllActions /> : <>
             <ActionsMenu {...{ item, kind }} />
             {item.large && canWrite
                 ? <Warning tooltip={t("manage.access.table.actions.large-group-warning")} />
@@ -528,7 +524,7 @@ const Warning: React.FC<WarningProps> = ({ tooltip, info }) => (
     </WithTooltip>
 );
 
-const UnchangableAllActions = () => {
+const UnchangeableAllActions = () => {
     const { t } = useTranslation();
     return <span css={{ marginLeft: 8 }}>{t("manage.access.table.actions.write")}</span>;
 };

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -253,7 +253,13 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
         // TODO: for users, this should say "type to search" or "enter
         // username, email, ... to add user" depending on the
         // users_searchable config.
-        noOptionsMessage: () => t("general.form.select.no-options"),
+        noOptionsMessage: kind === "Group"
+            ? () => t("general.form.select.no-options")
+            : ({ inputValue }: { inputValue: string }) => (
+                t(`manage.access.users-no-options.${
+                    inputValue.length === 0 ? "initial" : "none-found"
+                }-${CONFIG.usersSearchable ? "" : "not-"}searchable`)
+            ),
         isValidNewOption: (input: string) => {
             const validUserRole = isUserRole(input);
             const validRole = /^ROLE_\w+/.test(input);

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -4,6 +4,7 @@
 [general]
 site_title.en = "Tobira Videoportal"
 tobira_url = "http://localhost:8030"
+users_searchable = true
 
 [http]
 # To make our Docker based development setup work, Tobira needs to listen

--- a/util/known-groups.sql
+++ b/util/known-groups.sql
@@ -1,0 +1,31 @@
+-- Inserts some known groups into the DB. Three large ones and then roughly 2k
+-- ones taken from the realm tree, representing individual courses.
+
+insert into known_groups (role, label, implies, large)
+values 
+    ('ROLE_STUDENTS', hstore(array['en', 'Students', 'de', 'Studierende']), '{}', true),
+    ('ROLE_STAFF', hstore(array['en', 'Staff', 'de', 'Angestellte']), '{}', true),
+    ('ROLE_LECTURER', hstore(array['en', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'], true);
+
+insert into known_groups (role, label, implies, large)
+select 
+    'ROLE_COURSE_' || path_segment || '_' || kind,
+    hstore(array['en', 'de'], array[
+        label_en || ' of „' || name || '“',
+        label_de || ' von „' || name || '“'
+    ]),
+    case 
+        when kind = 'STUDENTS' then array[]::text[]
+        when kind = 'ASSISTANTS' then array['ROLE_COURSE_' || path_segment || '_STUDENTS']
+        when kind = 'INSTRUCTORS' then array['ROLE_COURSE_' || path_segment || '_ASSISTANTS']
+    end,
+    false
+from realms, 
+    (values 
+        ('STUDENTS', 'Studierende', 'Students'), 
+        ('ASSISTANTS', 'Assistierende', 'Assistants'), 
+        ('INSTRUCTORS', 'Lehrende', 'Instructors')
+    ) as tmp (kind, label_de, label_en)
+where full_path similar to '/lectures/[^/]+/2020/(autumn|spring)/%'
+and name is not null
+on conflict do nothing;


### PR DESCRIPTION
Fixes #951 (also removing our dummy users from the code, unblocking the release)

The main goal of this PR was to make the ACL UI user selection work nicely. I.e. that one can search through users to add user entries to the ACL. Previously we had a bunch of hardcoded dummy users (which also made us unable to release Tobira). This is now done, but lots of related changed had to be done as well. There is also a configuration option which controls whether users can actually be searched by name or whether they can only be found by typing the exact username/email. The latter mode is the default for data privacy reasons.

User information is remembered whenever a user logs into Tobira or does anything there. It is also possible to import users from a JSON file. 

**Important**: this PR introduces a breaking change as it makes a "user role" mandatory for users. See second commit. I doubt this is a problem for anyone, but it's still technically breaking.

---

This can probably be reviewed commit by commit. The commit messages should be read for sure. However, the changes to `ui/Access.tsx` are likely very annoying to review because it's also lots of refactoring, over multiple commits. So yeah, not 100% sure how to best approach that.

---

Finally, there are a few things that still have to be improved. But not in this PR, it's already large enough. I will create issues for these after merging.

- [ ] Potentially add some basic user stats to `/~metrics`, e.g. "active user in last 24h
- [ ] Re-add the paste functionality
- [ ] Stop sending a list of all known groups to the frontend, that makes stuff slow.