### PR TITLE
Fix footer once again in presence of browser extensions

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -86,10 +86,6 @@ const GLOBAL_STYLE = css({
         // width: 320px. It does make sense to set a minimum width early on in
         // order to know where we can stop caring.
         minWidth: "var(--min-page-width)",
-
-        "& > div:first-of-type": {
-            height: "100%",
-        },
     },
     h1: {
         fontSize: 30,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -29,6 +29,7 @@ if (window.location.pathname === "/~login" && redirectTo) {
 
 const initialRoute = matchInitialRoute();
 const root = document.createElement("div");
+root.style.height = "100svh";
 document.body.appendChild(root);
 const reactRoot = ReactDOM.createRoot(root);
 reactRoot.render(<App initialRoute={initialRoute} />);


### PR DESCRIPTION
Follow up to #1022 where stupidly suggested `:first-of-kind` because suuurely, browser extensions would only add elements to the end of the `<body>` but not the beginning, riiight? Of course that's a wrong assumption. I noticed this with Bitwarden on the login page.

This whole "extensions randomly modifying DOM" thing seems super brittle to me, oof.