### PR TITLE
Add `changelog:nope` to `release.yml`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,5 +8,7 @@ changelog:
       labels: ['changelog:admin']
     - title: Changes primarily for developers
       labels: ['changelog:dev']
+    - title: 'NOPE: delete from changelog'
+      labels: ['changelog:nope']
     - title: No category
       labels: ['*']


### PR DESCRIPTION
Before, they were sorted into "no category" like all untagged PRs, which wasn't very useful. After all we set `changelog:nope` specifically bc we already decided that it doesn't need to be in the changelog.