### PR TITLE
Fix router bug accessing `null` `history.state`

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -23,7 +23,12 @@ if (window.location.pathname === "/~login" && redirectTo) {
     const newUri = new URL(redirectTo, document.baseURI).href;
     // eslint-disable-next-line no-console
     console.debug(`Requested login page after login: redirecting to previous page ${newUri}`);
-    window.history.replaceState(null, "", newUri);
+    const state = {
+        scrollY: 0,
+        index: 0,
+        ...window.history.state,
+    };
+    window.history.replaceState(state, "", newUri);
     window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
 }
 

--- a/frontend/src/rauta.tsx
+++ b/frontend/src/rauta.tsx
@@ -266,7 +266,7 @@ export const makeRouter = <C extends Config, >(config: C): RouterLib => {
                 debugLog(`Setting active route for '${href}' (index ${currentIndex}) `
                     + "to: ", newRoute);
             },
-            internalOrigin: window.history.state.index > 0,
+            internalOrigin: window.history.state?.index > 0,
         };
     };
 


### PR DESCRIPTION
This lead to a critical error in situation where Tobira redirected internally after a login. We accidentally replaced the state by `null`, which was later accessed. Both of these change-snippets solve the bug, but both are useful. The redirect forward shouldn't just set the state to null, and the router should never assume the state is non-null.

This was found by @KatrinIhler when deploying for Bern.