### PR TITLE
Filter out past live events from search results in backend

### DIFF
--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -25,6 +25,7 @@ pub(crate) struct Event {
     pub(crate) created: DateTime<Utc>,
     pub(crate) start_time: Option<DateTime<Utc>>,
     pub(crate) end_time: Option<DateTime<Utc>>,
+    pub(crate) end_time_timestamp: Option<i64>,
     pub(crate) is_live: bool,
     pub(crate) audio_only: bool,
 
@@ -65,6 +66,7 @@ impl_from_db!(
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
+        let end_time = row.end_time();
         Self {
             id: row.id(),
             series_id: row.series(),
@@ -78,7 +80,8 @@ impl_from_db!(
             audio_only: row.audio_only(),
             created: row.created(),
             start_time: row.start_time(),
-            end_time: row.end_time(),
+            end_time,
+            end_time_timestamp: end_time.map(|date_time| date_time.timestamp()),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
             listed: host_realms.iter().any(|realm| !realm.is_user_realm()),
@@ -113,6 +116,6 @@ pub(super) async fn prepare_index(index: &Index) -> Result<()> {
         index,
         "event",
         &["title", "creators", "description", "series_title"],
-        &["listed", "read_roles", "write_roles"],
+        &["listed", "read_roles", "write_roles", "is_live", "end_time_timestamp"],
     ).await
 }

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use self::{
 
 /// The version of search index schema. Increase whenever there is a change that
 /// requires an index rebuild.
-const VERSION: u32 = 3;
+const VERSION: u32 = 4;
 
 
 // ===== Configuration ============================================================================

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -9,7 +9,7 @@ import { SearchQuery, SearchQuery$data } from "./__generated__/SearchQuery.graph
 import { RouterControl, makeRoute } from "../rauta";
 import { loadQuery } from "../relay";
 import { Link, useRouter } from "../router";
-import { Creators, isPastLiveEvent, Thumbnail } from "../ui/Video";
+import { Creators, Thumbnail } from "../ui/Video";
 import { SmallDescription } from "../ui/metadata";
 import { Card } from "../ui/Card";
 import { Breadcrumbs, BreadcrumbsContainer, BreadcrumbSeparator } from "../ui/Breadcrumbs";
@@ -141,13 +141,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
     <ul css={{ listStyle: "none", padding: 0 }}>
         {items.map(item => {
             if (item.__typename === "SearchEvent") {
-                // Filter out live events that are over
-                const endTime = unwrapUndefined(item.endTime);
-                const isLive = unwrapUndefined(item.isLive);
-                if (isPastLiveEvent(endTime, isLive)) {
-                    return null;
-                }
-
                 return <SearchEvent key={item.id} {...{
                     id: item.id,
                     title: unwrapUndefined(item.title),
@@ -157,11 +150,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                     creators: unwrapUndefined(item.creators),
                     seriesTitle: unwrapUndefined(item.seriesTitle),
                     seriesId: unwrapUndefined(item.seriesId),
-                    isLive,
+                    isLive: unwrapUndefined(item.isLive),
                     audioOnly: unwrapUndefined(item.audioOnly),
                     created: unwrapUndefined(item.created),
                     startTime: unwrapUndefined(item.startTime),
-                    endTime,
+                    endTime: unwrapUndefined(item.endTime),
                     hostRealms: unwrapUndefined(item.hostRealms),
                 }}/>;
             } else if (item.__typename === "SearchRealm") {


### PR DESCRIPTION
Previously the frontend filtered out those events. But this lead to weirdness where there "number of hits" were incorrect and if everything was filtered out, the "no results" was not shown, but no result was shown either.

This moves this completely to the backend. Which means that due to communication delay, the frontend could show live events that just ended. But that's fine I think.

Also, this filtering is not done for the event search in the block edit UI. Maybe people want to find past live events there :shrug:

---

This can be tested by searching for `"NASA TV"` (with quotes). On our current deployment one result is shown but it says "2 hits".