### PR TITLE
Prevent search form submission

### DIFF
--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -90,7 +90,8 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                 fontSize: 23,
                 color: COLORS.neutral60,
             }} />
-            <form onSubmit={() => {
+            <form onSubmit={event => {
+                event.preventDefault();
                 clearTimeout(lastTimeout.current);
                 search(currentRef(ref).value);
             }}>


### PR DESCRIPTION
Submitting the search `form` currently triggers our CSP, which only allows form submissions to Studio/the editor, if at all.

That's fine, though, since we don't actually want to ever submit that form. And even though we don't have a submit button, this can still happen for example if you press enter in the search input. The `form` doesn't have an `action`, but the default seems to be to submit to the current page. 🤷‍♀️