### PR TITLE
Fix series block video items for screen widths 880 - 890

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -53,7 +53,7 @@ const CSS_RESETS = css({
 
         // This prevents an increase in font size when changing from
         // portrait to landscape orientation in iOS safari.
-        "-webkit-text-size-adjust": "none",
+        WebkitTextSizeAdjust: "none",
     },
 
     // This improves the readability of underlines in links.

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -543,9 +543,9 @@ const Videos: React.FC<ViewProps> = ({ basePath, items }) => {
     });
 };
 
-const ITEM_MIN_SIZE = 240;
-const ITEM_MIN_SIZE_LARGE_SCREENS = 260;
-const ITEM_MAX_SIZE = 315;
+const ITEM_MIN_SIZE = 250;
+const ITEM_MIN_SIZE_SMALL_SCREENS = 240;
+const ITEM_MAX_SIZE = 330;
 const ITEM_MAX_SIZE_SMALL_SCREENS = 360;
 
 const GalleryView: React.FC<ViewProps> = ({ basePath, items }) => (
@@ -618,7 +618,7 @@ const GalleryView: React.FC<ViewProps> = ({ basePath, items }) => (
         columnGap: 12,
         rowGap: 28,
         [screenWidthAtMost(1600)]: {
-            gridTemplateColumns: `repeat(auto-fill, minmax(${ITEM_MIN_SIZE_LARGE_SCREENS}px, 1fr))`,
+            gridTemplateColumns: `repeat(auto-fill, minmax(${ITEM_MIN_SIZE_SMALL_SCREENS}px, 1fr))`,
         },
     }}>
         {items.map(({ event, active }) => (


### PR DESCRIPTION
It was somewhat broken for those widths. One constant was also incorrectly named, which I fixed. I also slightly increased the sizes for large screens, because it didn't make a ton of sense to me that the numbers were larger for small screens. All these changes should be very small though.