### PR TITLE
Change edit series block label "layout" to "Metadata"

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -483,8 +483,8 @@ manage:
         series:
           heading: Serie
           invalid: Bitte eine Serie auswählen
-        layout:
-          heading: Layout
+        metadata:
+          heading: Metadaten
 
       event:
         event:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -468,8 +468,8 @@ manage:
         series:
           heading: Series
           invalid: Please select a series
-        layout:
-          heading: Layout
+        metadata:
+          heading: Metadata
 
       event:
         event:

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -168,7 +168,7 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
                 ]} />
             </div>
             <div>
-                <Heading>{t("manage.realm.content.series.layout.heading")}</Heading>
+                <Heading>{t("manage.realm.content.series.metadata.heading")}</Heading>
                 <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
                     {
                         option: "showTitle",


### PR DESCRIPTION
Since we removed the "description above box" layout, there is no point in calling that "layout" anyway. And now it even clashes with the video layout option. The name "metadata" didn't convince everyone but I think it's rather unimportant, so in the interest of time I moved forward with it. It can still be changed later.

Thanks @geichelberger for noticing.