### PR TITLE
Fix overlarge thumbnails in series slider view

### DIFF
--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -741,7 +741,8 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items }) => {
                     {...{ event, active, basePath }}
                     css={{
                         scrollSnapAlign: "start",
-                        flex: "0 0 265px",
+                        flex: "0 0 270px",
+                        maxWidth: 270,
                         margin: 6,
                         marginBottom: 24,
                     }}


### PR DESCRIPTION
This also slightly increases the size of the thumbnails, bringing it a bit closer to the other views.

Fixes #1077