### PR TITLE
Fix routing after adding sub-realms

### DIFF
--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -32,7 +32,7 @@ const PATH = "/~manage/realm/content";
 
 export const ManageRealmContentRoute = makeRoute({
     url: ({ realmPath }: { realmPath: string }) =>
-        `${PATH}?${new URLSearchParams({ realm: realmPath })}`,
+        `${PATH}?${new URLSearchParams({ path: realmPath })}`,
     match: url => {
         if (url.pathname !== PATH) {
             return null;


### PR DESCRIPTION
This would fail previously, displaying "page not found" directly after adding a new realm.