### PR TITLE
Add granular permissions to the realm tree

### DIFF
--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -14,7 +14,7 @@ impl Realm {
         let Some(parent) = Self::load_by_id(realm.parent, context).await? else {
             return Err(invalid_input!("`parent` realm does not exist"));
         };
-        parent.require_write_access(context)?;
+        parent.require_moderator_rights(context)?;
         let db = &context.db;
 
         // Check if the path is a reserved one.
@@ -102,7 +102,7 @@ impl Realm {
             // is on the settings page. Maybe we want to give a hint.
             return Err(invalid_input!("`parent` realm does not exist (for `setChildOrder`)"));
         };
-        parent.require_write_access(context)?;
+        parent.require_moderator_rights(context)?;
         let db = &context.db;
 
         if let Some(child_indices) = child_indices {
@@ -189,7 +189,7 @@ impl Realm {
         let Some(realm) = Self::load_by_id(id, context).await? else {
             return Err(invalid_input!("`id` does not refer to an existing realm"));
         };
-        realm.require_write_access(context)?;
+        realm.require_moderator_rights(context)?;
 
         let db = &context.db;
         if name.plain.is_some() == name.block.is_some() {
@@ -230,7 +230,7 @@ impl Realm {
         let Some(realm) = Self::load_by_id(id, context).await? else {
             return Err(invalid_input!("`id` does not refer to an existing realm"));
         };
-        realm.require_write_access(context)?;
+        realm.require_admin_rights(context)?;
         let db = &context.db;
 
         db.execute(
@@ -262,7 +262,7 @@ impl Realm {
         let Some(realm) = Self::load_by_id(id, context).await? else {
             return Err(invalid_input!("`id` does not refer to an existing realm"));
         };
-        realm.require_write_access(context)?;
+        realm.require_admin_rights(context)?;
         let db = &context.db;
 
         if realm.is_user_root() {
@@ -316,7 +316,7 @@ impl Realm {
         let Some(realm) = Self::load_by_id(id, context).await? else {
             return Err(invalid_input!("`id` does not refer to an existing realm"));
         };
-        realm.require_write_access(context)?;
+        realm.require_admin_rights(context)?;
         let db = &context.db;
 
         if realm.is_main_root() {

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -14,6 +14,7 @@ use super::{
             Realm,
             RealmOrder,
             RemovedRealm,
+            UpdatedPermissions,
             UpdatedRealmName,
             UpdateRealm,
             RealmSpecifier,
@@ -72,6 +73,11 @@ impl Mutation {
     /// Changes the name of a realm.
     async fn rename_realm(id: Id, name: UpdatedRealmName, context: &Context) -> ApiResult<Realm> {
         Realm::rename(id, name, context).await
+    }
+
+    /// Changes the moderator and/or admin roles of a realm.
+    async fn update_permissions(id: Id, permissions: UpdatedPermissions, context: &Context) -> ApiResult<Realm> {
+        Realm::update_permissions(id, permissions, context).await
     }
 
     /// Updates a realm's data.

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -362,4 +362,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     27: "users",
     28: "user-index-queue-triggers",
     29: "extend-series-block",
+    30: "realm-permissions",
 ];

--- a/backend/src/db/migrations/30-realm-permissions.sql
+++ b/backend/src/db/migrations/30-realm-permissions.sql
@@ -1,0 +1,87 @@
+-- Adds two different permission levels to realm entries.
+
+-- The `flattened_*` roles contain the same roles, as well as those from each ancestor realm.
+-- These are used to handle inheritance of these roles, and are completely handled by triggers:
+-- When a child realm is inserted, it automatically inherits its parent's `flattened_*` roles,
+-- and when a realm's roles get updated, the changes are propagated to every child realm down the tree.
+
+alter table realms
+    add column moderator_roles text[] not null default '{}',
+    add column admin_roles text[] not null default '{}',
+    add column flattened_moderator_roles text[] not null default '{}',
+    add column flattened_admin_roles text[] not null default '{}';
+
+alter table realms
+    alter column flattened_moderator_roles drop default,
+    alter column flattened_admin_roles drop default;
+
+
+create function update_flattened_permissions_of_children()
+returns trigger as $$
+begin
+    update realms
+    set
+        flattened_moderator_roles = (
+            array(
+                select unnest(new.flattened_moderator_roles)
+                union
+                select unnest(moderator_roles)
+            )
+        ),
+        flattened_admin_roles = (
+            array(
+                select unnest(new.flattened_admin_roles)
+                union
+                select unnest(admin_roles)
+            )
+        )
+    where parent = new.id;
+
+    return null;
+end;
+$$ language plpgsql;
+
+create function update_own_flattened_permissions()
+returns trigger as $$
+begin
+    new.flattened_moderator_roles = (
+        array(
+            select unnest(
+                (select flattened_moderator_roles from realms where id = new.parent)
+            )
+            union
+            select unnest(new.moderator_roles)
+        )
+    );
+    new.flattened_admin_roles = (
+        array(
+            select unnest(
+                (select flattened_admin_roles from realms where id = new.parent)
+            )
+            union
+            select unnest(new.admin_roles)
+        )
+    );
+
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger set_flattened_permissions_after_update
+after update
+on realms
+for each row
+when (
+    new.flattened_moderator_roles <> old.flattened_moderator_roles or
+    new.flattened_admin_roles <> old.flattened_admin_roles
+)
+execute procedure update_flattened_permissions_of_children();
+
+create trigger set_flattened_permissions_before_insert_or_update
+before insert or update of 
+    moderator_roles,
+    admin_roles
+on realms
+for each row
+execute procedure update_own_flattened_permissions();
+

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -561,7 +561,8 @@ api-remote-errors:
   realm:
     path-is-reserved: Dieser Pfad ist reserviert und kann nicht für Seiten genutzt werden.
     path-collision: Eine Seite mit diesem Pfad existiert bereits.
-    no-write-access: Sie haben nicht die Berechtigung, diese Seite zu bearbeiten.
+    no-moderator-rights: Sie haben nicht die Berechtigung, diese Seite zu bearbeiten.
+    no-page-admin-rights: Sie haben nicht die Berechtigung, diese Aktion durchzuführen.
     cannot-create-user-realm: Sie haben nicht die Berechtigung, eine persönliche Seite anzulegen.
     user-realm-already-exists: Ihre persönliche Seite existiert bereits.
     username-not-valid-as-path: >

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -306,6 +306,9 @@ manage:
       user: Person
       yourself: Sie
       subset-warning: 'Diese Auswahl ist bereits in den folgenden Gruppen enthalten: {{groups}}.'
+      inherited: Geerbte Berechtigungen
+      inherited-tooltip: > 
+        Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden auf alle Unterseiten vererbt.
       actions:
         title: Berechtigung
         read: Lesen

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -312,11 +312,28 @@ manage:
         read-description_one: Kann das Video anschauen und Metadaten sehen.
         read-description_other: Können das Video anschauen und Metadaten sehen.
         write: Lesen und schreiben
-        large-group-warning: Sie geben einer großen Gruppe Schreibzugriff. Ist das beabsichtigt?
         write-description_one: >
           Kann außerdem das Video editieren und Metadaten sowie andere Videodetails verändern.
         write-description_other: >
           Können außerdem das Video editieren und Metadaten sowie andere Videodetails verändern.
+        moderate: Moderieren
+        moderate-description-one: >
+          Kann Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
+          der Unterseiten bearbeiten.
+        moderate-description-other: >
+          Können Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
+          der Unterseiten bearbeiten.
+        admin: Verwalten
+        admin-description-one: >
+          Kann moderieren, Seiten löschen und Berechtigungen bearbeiten.
+        admin-description-other: >
+          Können moderieren, Seiten löschen und Berechtigungen bearbeiten.
+        unknown: Unbekanntes Berechtigungsschema
+        unknown-description: Dieses Berechtigungsschema ist nicht bekannt.
+        write-access: Schreibzugriff
+        moderate-access: Moderationsrechte
+        admin-access: Adminrechte
+        large-group-warning: Sie geben einer großen Gruppe {{val}}. Ist das beabsichtigt?
     unlisted:
         note: Dieses Video ist ungelistet.
         explanation: >
@@ -328,8 +345,11 @@ manage:
       body: Von Ihnen getätigte Änderungen werden zurückgesetzt.
     save-modal:
       title: Eigenen Zugriff entfernen?
-      body: Die aktuelle Auswahl wird ihren Schreibzugriff entfernen.
-            Ohne diesen werden Sie keine weiteren Änderungen vornehmen können.
+      disclaimer-write: Die aktuelle Auswahl wird ihren Schreibzugriff entfernen.
+        Ohne diesen werden Sie keine weiteren Änderungen vornehmen können.
+      disclaimer-admin: Die aktuelle Auswahl wird ihre Verwaltungsrechte entfernen.
+        Ohne diese werden Sie keine weiteren Änderungen an diesen Berechtigungen und dem Seitenpfad
+        vornehmen können, und die Seite kann von Ihnen nicht mehr gelöscht werden.
       confirm: Bestätigen
 
   dashboard:

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -441,6 +441,9 @@ manage:
       move-up: Hoch schieben
       move-down: Runter schieben
 
+    permissions:
+      heading: Berechtigungen verwalten
+
     danger-zone:
       heading: Gefahrenbereich
       root-note: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -420,6 +420,9 @@ manage:
       move-up: Move up
       move-down: Move down
 
+    permissions:
+      heading: Manage permissions
+
     danger-zone:
       heading: Danger zone
       root-note: The homepage cannot be deleted or moved, nor can its path be changed.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -307,8 +307,17 @@ manage:
         read: Read
         read-description: Can watch the video and view metadata.
         write: Read and write
-        large-group-warning: You are giving write-access to a large group. Is this intentional?
         write-description: Can also edit the video, metadata and other details.
+        moderate: Moderate
+        moderate-description: Can edit content, add subpages and change the name and subpage order.
+        admin: Page admin
+        admin-description: Can moderate, delete pages and edit permissions.
+        unknown: Unknown permission
+        unknown-description: This permission isn't known.
+        write-access: write-access
+        moderate-access: moderating-rights
+        admin-access: page admin-rights
+        large-group-warning: You are giving {{val}} to a large group. Is this intentional?
     unlisted:
       note: This video is unlisted.
       explanation: >
@@ -319,8 +328,10 @@ manage:
       body: The changes you have made will be reset.
     save-modal:
       title: Remove own access?
-      body: The current selection will remove your write-access.
-            Without this, you will lose the ability to make any further edits.
+      disclaimer-write: The current selection will remove your write-access.
+        Without this, you will lose the ability to make any further edits.
+      disclaimer-admin: The current selection will remove your page admin-rights.
+        Without these, you can no longer edit these permissions, change the realm path, or delete the page.
       confirm: Confirm
 
   dashboard:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -201,7 +201,7 @@ series:
 realm:
   page-settings: Page settings
   edit-page-content: Edit page content
-  add-sub-page: Add sub-page
+  add-sub-page: Add subpage
   missing-name: Missing name
   user-realm:
     my-page: My page
@@ -215,7 +215,7 @@ realm:
       what-you-can-do: >
         On your personal page, you can freely arrange videos, text, and other elements.
         This allows you to better present and share your content.
-        You can even create sub-pages to create your own small video-portal.
+        You can even create subpages to create your own small video-portal.
       available-at: 'Your page will be available at:'
       find-and-delete: >
         Anyone who has this link or knows your username can visit your page.
@@ -302,6 +302,9 @@ manage:
       user: User
       yourself: You
       subset-warning: 'This selection is already included in the following group(s): {{groups}}.'
+      inherited: Inherited permissions
+      inherited-tooltip: >
+        The following permissions were granted in a higher level page and are inherited to all subpages.
       actions:
         title: Actions
         read: Read
@@ -385,7 +388,7 @@ manage:
       Error: invalid path to page. Was the page deleted or its path changed?
     heading: Settings of page “{{realm}}”
     heading-root: Homepage settings
-    descendants-count: This page has {{count}} direct and indirect sub-pages.
+    descendants-count: This page has {{count}} direct and indirect subpages.
     view-page: Go to page
 
     name-must-not-be-empty: Name must not be empty.
@@ -433,19 +436,19 @@ manage:
         cannot-userrealm: The path of your personal page cannot be changed.
         warning: >
           Important: Changing the path of this page invalidates all links to
-          this page, to all direct or indirect sub-pages, and to all videos
+          this page, to all direct or indirect subpages, and to all videos
           linked on any of those pages. Old links, e.g. in personal
           browser-bookmarks or published somewhere, won't work anymore.
       delete:
         heading: Delete page
-        button: Delete this page and <strong>{{numSubPages}}</strong> sub-pages
+        button: Delete this page and <strong>{{numSubPages}}</strong> subpages
         button-single: Delete page
         cannot-be-undone: This action <strong>cannot</strong> be undone!
         confirm-removal: Delete page?
         failed: Deleting the page failed.
         warning: >
           Deleting this page will also automatically delete all direct and
-          indirect sub-pages, as well as all content of these pages. This
+          indirect subpages, as well as all content of these pages. This
           cannot be undone!
 
     content:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -537,7 +537,8 @@ api-remote-errors:
   realm:
     path-is-reserved: The chosen path is reserved and cannot be used for pages.
     path-collision: A page with this path already exists.
-    no-write-access: You are not allowed to modify this page.
+    no-moderator-rights: You are not allowed to modify this page.
+    no-page-admin-rights: You are not allowed to carry out this action.
     cannot-create-user-realm: You are not allowed to create your own page.
     user-realm-already-exists: Your own page already exists.
     username-not-valid-as-path: >

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -98,7 +98,7 @@ export const RealmRoute = makeRoute({
                     }
 
                     const mainNav = <Nav key="nav" fragRef={data.realm} />;
-                    return data.realm.canCurrentUserEdit
+                    return data.realm.canCurrentUserModerate
                         ? [mainNav, <RealmEditLinks key="edit-buttons" path={realmPath} />]
                         : mainNav;
                 }}
@@ -125,7 +125,7 @@ const query = graphql`
             ownerDisplayName
             children { id }
             blocks { id }
-            canCurrentUserEdit
+            canCurrentUserModerate
             ancestors { name path ownerDisplayName }
             parent { id }
             ... BlocksData

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -34,6 +34,7 @@ import {
     AccessKnownRolesData$data,
     AccessKnownRolesData$key,
 } from "../ui/__generated__/AccessKnownRolesData.graphql";
+import { READ_WRITE_ACTIONS } from "../util/permissionLevels";
 
 
 const PATH = "/~manage/upload" as const;
@@ -791,6 +792,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
                         onChange={field.onChange}
                         acl={field.value}
                         knownRoles={knownRoles}
+                        permissionLevels={READ_WRITE_ACTIONS}
                     />}
                 />
             </InputContainer>

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -29,7 +29,7 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { ManageNav, ManageRoute } from "./manage";
 import { COLORS } from "../color";
 import { COMMON_ROLES } from "../util/roles";
-import { Acl, AclSelector, knownRolesFragement } from "../ui/Access";
+import { Acl, AclSelector, knownRolesFragment } from "../ui/Access";
 import {
     AccessKnownRolesData$data,
     AccessKnownRolesData$key,
@@ -78,7 +78,7 @@ type Props = {
 
 const Upload: React.FC<Props> = ({ knownRolesRef }) => {
     const { t } = useTranslation();
-    const knownRoles = useFragment(knownRolesFragement, knownRolesRef);
+    const knownRoles = useFragment(knownRolesFragment, knownRolesRef);
 
     return (
         <div css={{

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -61,7 +61,7 @@ export const AddChildRoute = makeRoute({
                     const parent = data.parent;
                     if (!parent) {
                         return <PathInvalid />;
-                    } else if (!parent.canCurrentUserEdit) {
+                    } else if (!parent.canCurrentUserModerate) {
                         return <NotAuthorized />;
                     } else {
                         return <AddChild parent={parent} />;
@@ -82,7 +82,7 @@ const query = graphql`
             name
             isMainRoot
             path
-            canCurrentUserEdit
+            canCurrentUserModerate
             ancestors { name path }
             children { path }
             ... NavigationData

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -58,7 +58,7 @@ export const ManageRealmContentRoute = makeRoute({
                 render={data => {
                     if (!data.realm) {
                         return <PathInvalid />;
-                    } else if (!data.realm.canCurrentUserEdit) {
+                    } else if (!data.realm.canCurrentUserModerate) {
                         return <NotAuthorized />;
                     } else {
                         return <ManageContent data={data} />;
@@ -74,7 +74,7 @@ const query = graphql`
     query ContentManageQuery($path: String!) {
         ... UserData
         realm: realmByPath(path: $path) {
-            canCurrentUserEdit
+            canCurrentUserModerate
             ... NavigationData
             ... ContentManageRealmData
         }

--- a/frontend/src/routes/manage/Realm/General.tsx
+++ b/frontend/src/routes/manage/Realm/General.tsx
@@ -244,7 +244,7 @@ export const NameForm: React.FC<NameFormProps> = ({ realm }) => {
             </div>
 
             <div css={{ display: "flex", alignItems: "center" }}>
-                <Button type="submit"disabled={isInFlight || !canSave}>
+                <Button type="submit" disabled={isInFlight || !canSave}>
                     {t("general.action.save")}
                 </Button>
                 {isInFlight && <Spinner size={20} css={{ marginLeft: 16 }} />}

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -15,6 +15,7 @@ const fragment = graphql`
     fragment RealmPermissionsData on Realm {
         id
         ownAcl { role actions info { label implies large } }
+        inheritedAcl { role actions info { label implies large } }
     }
 `;
 
@@ -29,12 +30,12 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const realm = useFragment(fragment, fragRef);
     const knownRoles = useFragment(knownRolesFragment, data);
 
-    const initialAcl: Acl = new Map(
-        realm.ownAcl.map(item => [item.role, {
+    const [initialAcl, inheritedAcl]: Acl[] = [realm.ownAcl, realm.inheritedAcl].map(acl => new Map(
+        acl.map(item => [item.role, {
             actions: new Set(item.actions),
             info: item.info,
         }])
-    );
+    ));
 
     const [selections, setSelections] = useState<Acl>(initialAcl);
 
@@ -80,11 +81,11 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclSelector
             acl={selections}
             onChange={setSelections}
-            {...{ knownRoles }}
+            {...{ knownRoles, inheritedAcl }}
             permissionLevels={MODERATE_ADMIN_ACTIONS}
         >
             <AclEditButtons
-                {...{ selections, setSelections, initialAcl, onSubmit, inFlight }}
+                {...{ selections, setSelections, initialAcl, onSubmit, inFlight, inheritedAcl }}
                 css={{ marginTop: 16 }}
             />
             {boxError(commitError)}

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -90,6 +90,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclSelector
             acl={selections}
             onChange={setSelections}
+            addAnonymous={false}
             {...{ knownRoles, inheritedAcl, ownerDisplayName }}
             permissionLevels={MODERATE_ADMIN_ACTIONS}
         />

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -16,6 +16,8 @@ const fragment = graphql`
         id
         ownAcl { role actions info { label implies large } }
         inheritedAcl { role actions info { label implies large } }
+        ownerDisplayName
+        ancestors { ownerDisplayName }
     }
 `;
 
@@ -29,6 +31,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const { t } = useTranslation();
     const realm = useFragment(fragment, fragRef);
     const knownRoles = useFragment(knownRolesFragment, data);
+    const ownerDisplayName = (realm.ancestors[0] ?? realm).ownerDisplayName;
 
     const [initialAcl, inheritedAcl]: Acl[] = [realm.ownAcl, realm.inheritedAcl].map(acl => new Map(
         acl.map(item => [item.role, {
@@ -81,15 +84,16 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclSelector
             acl={selections}
             onChange={setSelections}
-            {...{ knownRoles, inheritedAcl }}
+            {...{ knownRoles, inheritedAcl, ownerDisplayName }}
             permissionLevels={MODERATE_ADMIN_ACTIONS}
-        >
-            <AclEditButtons
-                {...{ selections, setSelections, initialAcl, onSubmit, inFlight, inheritedAcl }}
-                css={{ marginTop: 16 }}
-            />
-            {boxError(commitError)}
-        </AclSelector>
+        />
+        <AclEditButtons
+            {...{ selections, setSelections, initialAcl, onSubmit, inFlight, inheritedAcl }}
+            kind="admin"
+            userIsOwner={!!ownerDisplayName}
+            css={{ marginTop: 16 }}
+        />
+        {boxError(commitError)}
     </>;
 };
 

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { graphql, useFragment, useMutation } from "react-relay";
+
+import { RealmPermissionsData$key } from "./__generated__/RealmPermissionsData.graphql";
+import { Acl, AclSelector, AclEditButtons, knownRolesFragment } from "../../../ui/Access";
+import { AccessKnownRolesData$key } from "../../../ui/__generated__/AccessKnownRolesData.graphql";
+import { RealmPermissionsMutation } from "./__generated__/RealmPermissionsMutation.graphql";
+import { displayCommitError } from "./util";
+import { boxError } from "../../../ui/error";
+import { useTranslation } from "react-i18next";
+import { MODERATE_ADMIN_ACTIONS } from "../../../util/permissionLevels";
+
+
+const fragment = graphql`
+    fragment RealmPermissionsData on Realm {
+        id
+        ownAcl { role actions info { label implies large } }
+    }
+`;
+
+
+type Props = {
+    fragRef: RealmPermissionsData$key;
+    data: AccessKnownRolesData$key;
+};
+
+export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
+    const { t } = useTranslation();
+    const realm = useFragment(fragment, fragRef);
+    const knownRoles = useFragment(knownRolesFragment, data);
+
+    const initialAcl: Acl = new Map(
+        realm.ownAcl.map(item => [item.role, {
+            actions: new Set(item.actions),
+            info: item.info,
+        }])
+    );
+
+    const [selections, setSelections] = useState<Acl>(initialAcl);
+
+    const [commitError, setCommitError] = useState<JSX.Element | null>(null);
+    const [commit, inFlight] = useMutation<RealmPermissionsMutation>(graphql`
+        mutation RealmPermissionsMutation($id: ID!, $permissions: UpdatedPermissions!) {
+            updatePermissions(id: $id, permissions: $permissions) {
+                ownAcl { role actions info { label implies large } }
+                ... GeneralRealmData
+            }
+        }
+    `);
+
+    const mapSelections = (selections: Acl) => {
+        const [moderatorRoles, adminRoles]: string[][] = [[], []];
+
+        for (const [role, { actions }] of selections) {
+            if (actions.has("moderate")) {
+                moderatorRoles.push(role);
+            }
+
+            if (actions.has("admin")) {
+                adminRoles.push(role);
+            }
+        }
+
+        return { moderatorRoles, adminRoles };
+    };
+
+    const onSubmit = async () => {
+        commit({
+            variables: {
+                id: realm.id,
+                permissions: mapSelections(selections),
+            },
+            onError: e => setCommitError(displayCommitError(e)),
+            updater: store => store.invalidateStore(),
+        });
+    };
+
+    return <>
+        <h2>{t("manage.realm.permissions.heading")}</h2>
+        <AclSelector
+            acl={selections}
+            onChange={setSelections}
+            {...{ knownRoles }}
+            permissionLevels={MODERATE_ADMIN_ACTIONS}
+        >
+            <AclEditButtons
+                {...{ selections, setSelections, initialAcl, onSubmit, inFlight }}
+                css={{ marginTop: 16 }}
+            />
+            {boxError(commitError)}
+        </AclSelector>
+    </>;
+};
+

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -24,6 +24,7 @@ import { PageTitle } from "../../../layout/header/ui";
 import { RealmEditLinks } from "../../Realm";
 import { realmBreadcrumbs } from "../../../util/realm";
 import { AddChildRoute } from "./AddChild";
+import { RealmPermissions } from "./RealmPermissions";
 
 
 // Route definition
@@ -55,7 +56,10 @@ export const ManageRealmRoute = makeRoute({
                         <RealmEditLinks key="edit-buttons" path={data.realm.path} />,
                     ]
                     : []}
-                render={data => data.realm ? <SettingsPage realm={data.realm} /> : <PathInvalid />}
+                render={data => data.realm
+                    ? <SettingsPage realm={data.realm} {...{ data }} />
+                    : <PathInvalid />
+                }
             />,
             dispose: () => queryRef.dispose(),
         };
@@ -66,6 +70,7 @@ export const ManageRealmRoute = makeRoute({
 const query = graphql`
     query RealmManageQuery($path: String!) {
         ... UserData
+        ... AccessKnownRolesData
         realm: realmByPath(path: $path) {
             name
             isMainRoot
@@ -77,16 +82,18 @@ const query = graphql`
             ... ChildOrderEditData
             ... DangerZoneRealmData
             ... NavigationData
+            ... RealmPermissionsData
         }
     }
 `;
 
 type Props = {
     realm: Exclude<RealmManageQuery$data["realm"], null>;
+    data: RealmManageQuery$data;
 };
 
 /** The actual settings page */
-const SettingsPage: React.FC<Props> = ({ realm }) => {
+const SettingsPage: React.FC<Props> = ({ realm, data }) => {
     const { t } = useTranslation();
     if (!realm.canCurrentUserEdit) {
         return <NotAuthorized />;
@@ -120,6 +127,7 @@ const SettingsPage: React.FC<Props> = ({ realm }) => {
             </div>
             <section><General fragRef={realm} /></section>
             <section><ChildOrder fragRef={realm} /></section>
+            <section><RealmPermissions fragRef={realm} {...{ data }} /></section>
             <section><DangerZone fragRef={realm} /></section>
         </RealmSettingsContainer>
     );

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -75,7 +75,7 @@ const query = graphql`
             name
             isMainRoot
             path
-            currentUserIsPageAdmin
+            isCurrentUserPageAdmin
             canCurrentUserModerate
             numberOfDescendants
             ancestors { name path }
@@ -128,7 +128,7 @@ const SettingsPage: React.FC<Props> = ({ realm, data }) => {
             </div>
             <section><General fragRef={realm} /></section>
             <section><ChildOrder fragRef={realm} /></section>
-            {realm.currentUserIsPageAdmin && <>
+            {realm.isCurrentUserPageAdmin && <>
                 <section><RealmPermissions fragRef={realm} {...{ data }} /></section>
                 <section><DangerZone fragRef={realm} /></section>
             </>}

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -75,7 +75,8 @@ const query = graphql`
             name
             isMainRoot
             path
-            canCurrentUserEdit
+            currentUserIsPageAdmin
+            canCurrentUserModerate
             numberOfDescendants
             ancestors { name path }
             ... GeneralRealmData
@@ -95,7 +96,7 @@ type Props = {
 /** The actual settings page */
 const SettingsPage: React.FC<Props> = ({ realm, data }) => {
     const { t } = useTranslation();
-    if (!realm.canCurrentUserEdit) {
+    if (!realm.canCurrentUserModerate) {
         return <NotAuthorized />;
     }
 
@@ -127,8 +128,10 @@ const SettingsPage: React.FC<Props> = ({ realm, data }) => {
             </div>
             <section><General fragRef={realm} /></section>
             <section><ChildOrder fragRef={realm} /></section>
-            <section><RealmPermissions fragRef={realm} {...{ data }} /></section>
-            <section><DangerZone fragRef={realm} /></section>
+            {realm.currentUserIsPageAdmin && <>
+                <section><RealmPermissions fragRef={realm} {...{ data }} /></section>
+                <section><DangerZone fragRef={realm} /></section>
+            </>}
         </RealmSettingsContainer>
     );
 };

--- a/frontend/src/routes/manage/Video/Access.tsx
+++ b/frontend/src/routes/manage/Video/Access.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { WithTooltip } from "@opencast/appkit";
-import { Dispatch, RefObject, SetStateAction, useRef, useState } from "react";
+import { useState } from "react";
 import { LuInfo } from "react-icons/lu";
 import { useFragment } from "react-relay";
 
@@ -8,14 +8,9 @@ import { Breadcrumbs } from "../../../ui/Breadcrumbs";
 import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { PageTitle } from "../../../layout/header/ui";
 import { COLORS } from "../../../color";
-import { Button, Kind as ButtonKind } from "../../../ui/Button";
 import { isRealUser, useUser } from "../../../User";
 import { NotAuthorized } from "../../../ui/error";
-import { Modal, ModalHandle } from "../../../ui/Modal";
-import { currentRef } from "../../../util";
-import { COMMON_ROLES } from "../../../util/roles";
-import { Acl, AclSelector, knownRolesFragment } from "../../../ui/Access";
-import { useNavBlocker } from "../../util";
+import { Acl, AclSelector, AclEditButtons, knownRolesFragment } from "../../../ui/Access";
 import {
     AccessKnownRolesData$data,
     AccessKnownRolesData$key,
@@ -23,6 +18,7 @@ import {
 import { ManageRoute } from "..";
 import { ManageVideosRoute } from ".";
 import { ManageVideoDetailsRoute } from "./Details";
+import { READ_WRITE_ACTIONS } from "../../../util/permissionLevels";
 
 
 export const ManageVideoAccessRoute = makeManageVideoRoute(
@@ -109,112 +105,24 @@ const AccessUI: React.FC<AccessUIProps> = ({ event, knownRoles }) => {
                 flexDirection: "column",
                 width: "100%",
             }}>
-                <AclSelector acl={selections} onChange={setSelections} knownRoles={knownRoles} />
-                <ButtonWrapper {...{ selections, setSelections, initialAcl }} />
+                <AclSelector
+                    acl={selections}
+                    onChange={setSelections}
+                    knownRoles={knownRoles}
+                    permissionLevels={READ_WRITE_ACTIONS}
+                >
+                </AclSelector>
+                <AclEditButtons
+                    {...{ selections, setSelections, initialAcl }}
+                    kind="write"
+                    onSubmit={async (acl: Acl) => {
+                        // TODO: Actually save new ACL.
+                        // eslint-disable-next-line no-console
+                        console.log(acl);
+                    }}
+                />
             </div>
         </div>
     );
-};
-
-type ButtonWrapperProps = {
-    selections: Acl;
-    setSelections: Dispatch<SetStateAction<Acl>>;
-    initialAcl: Acl;
-}
-
-const ButtonWrapper: React.FC<ButtonWrapperProps> = ({ selections, setSelections, initialAcl }) => {
-    const { t } = useTranslation();
-    const user = useUser();
-    const saveModalRef = useRef<ModalHandle>(null);
-    const resetModalRef = useRef<ModalHandle>(null);
-
-    const containsUser = (acl: Acl) => isRealUser(user)
-        && user.roles.some(r => r === COMMON_ROLES.ADMIN || acl.get(r)?.actions.has("write"));
-
-    const areSetsEqual = (a: Set<string>, b: Set<string>) =>
-        a.size === b.size && [...a].every((str => b.has(str)));
-    const selectionIsInitial = selections.size === initialAcl.size
-        && [...selections].every(([role, info]) => {
-            const other = initialAcl.get(role);
-            return other && areSetsEqual(other.actions, info.actions);
-        });
-
-    const submit = async (acl: Acl) => {
-        // TODO: Actually save new ACL.
-        // eslint-disable-next-line no-console
-        console.log(acl);
-    };
-
-    useNavBlocker(!selectionIsInitial);
-
-    return <div css={{ display: "flex", gap: 8, alignSelf: "flex-start", marginTop: 40 }}>
-        {/* Reset button */}
-        <ButtonWithModal
-            buttonKind="danger"
-            modalRef={resetModalRef}
-            label={t("manage.access.reset-modal.label")}
-            title={t("manage.access.reset-modal.title")}
-            body={t("manage.access.reset-modal.body")}
-            confirmationLabel={t("manage.access.reset-modal.label")}
-            handleClick={() => currentRef(resetModalRef).open()}
-            onConfirm={() => setSelections(initialAcl)}
-            disabled={selectionIsInitial}
-        />
-        {/* Save button */}
-        <ButtonWithModal
-            buttonKind="happy"
-            modalRef={saveModalRef}
-            label={t("general.action.save")}
-            title={t("manage.access.save-modal.title")}
-            body={t("manage.access.save-modal.body")}
-            confirmationLabel={t("manage.access.save-modal.confirm")}
-            handleClick={() => !containsUser(selections)
-                ? currentRef(saveModalRef).open()
-                : submit(selections)}
-            onConfirm={() => submit(selections)}
-            disabled={selectionIsInitial}
-        />
-    </div>;
-};
-
-type ButtonWithModalProps = {
-    buttonKind: ButtonKind;
-    modalRef: RefObject<ModalHandle>;
-    label: string;
-    title: string;
-    body: string;
-    confirmationLabel: string;
-    handleClick: () => void;
-    onConfirm: () => void;
-    disabled?: boolean;
-}
-
-const ButtonWithModal: React.FC<ButtonWithModalProps> = ({ ...props }) => {
-    const { t } = useTranslation();
-    return <>
-        <Button
-            kind={props.buttonKind}
-            onClick={props.handleClick}
-            disabled={props.disabled}
-        >{props.label}</Button>
-        <Modal ref={props.modalRef} title={props.title}>
-            <p>{props.body}</p>
-            <div css={{
-                display: "flex",
-                gap: 12,
-                justifyContent: "center",
-                flexWrap: "wrap",
-                marginTop: 32,
-            }}>
-                <Button onClick={() => currentRef(props.modalRef).close?.()}>
-                    {t("general.action.cancel")}
-                </Button>
-                <Button kind="danger" onClick={() => {
-                    props.onConfirm();
-                    currentRef(props.modalRef).close?.();
-                }}>{props.confirmationLabel}</Button>
-            </div>
-        </Modal>
-    </>;
 };
 

--- a/frontend/src/routes/manage/Video/Access.tsx
+++ b/frontend/src/routes/manage/Video/Access.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { WithTooltip } from "@opencast/appkit";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { LuInfo } from "react-icons/lu";
 import { useFragment } from "react-relay";
 
@@ -19,6 +19,7 @@ import { ManageRoute } from "..";
 import { ManageVideosRoute } from ".";
 import { ManageVideoDetailsRoute } from "./Details";
 import { READ_WRITE_ACTIONS } from "../../../util/permissionLevels";
+import { ConfirmationModalHandle } from "../../../ui/Modal";
 
 
 export const ManageVideoAccessRoute = makeManageVideoRoute(
@@ -88,6 +89,7 @@ type AccessUIProps = {
 }
 
 const AccessUI: React.FC<AccessUIProps> = ({ event, knownRoles }) => {
+    const saveModalRef = useRef<ConfirmationModalHandle>(null);
 
     const initialAcl: Acl = new Map(
         event.acl.map(item => [item.role, {
@@ -110,10 +112,9 @@ const AccessUI: React.FC<AccessUIProps> = ({ event, knownRoles }) => {
                     onChange={setSelections}
                     knownRoles={knownRoles}
                     permissionLevels={READ_WRITE_ACTIONS}
-                >
-                </AclSelector>
+                />
                 <AclEditButtons
-                    {...{ selections, setSelections, initialAcl }}
+                    {...{ selections, setSelections, initialAcl, saveModalRef }}
                     kind="write"
                     onSubmit={async (acl: Acl) => {
                         // TODO: Actually save new ACL.

--- a/frontend/src/routes/manage/Video/Access.tsx
+++ b/frontend/src/routes/manage/Video/Access.tsx
@@ -14,7 +14,7 @@ import { NotAuthorized } from "../../../ui/error";
 import { Modal, ModalHandle } from "../../../ui/Modal";
 import { currentRef } from "../../../util";
 import { COMMON_ROLES } from "../../../util/roles";
-import { Acl, AclSelector, knownRolesFragement } from "../../../ui/Access";
+import { Acl, AclSelector, knownRolesFragment } from "../../../ui/Access";
 import { useNavBlocker } from "../../util";
 import {
     AccessKnownRolesData$data,
@@ -44,7 +44,7 @@ const AclPage: React.FC<AclPageProps> = ({ event, data }) => {
         return <NotAuthorized />;
     }
 
-    const knownRoles = useFragment(knownRolesFragement, data);
+    const knownRoles = useFragment(knownRolesFragment, data);
 
     const breadcrumbs = [
         { label: t("user.manage-content"), link: ManageRoute.url },

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -341,7 +341,7 @@ type Realm implements Node {
   """
     Returns the combined acl of this realm's parent, which effectively contains
     the acl and inherited acl of each ancestor realm. This is used to display
-    these roles in the permissions UI, where we don't want to show that realm's onw
+    these roles in the permissions UI, where we don't want to show that realm's own
     flattened acl since that also contains the realm's "regular", i.e. non-inherited
     acl.
   """
@@ -368,7 +368,17 @@ type Realm implements Node {
     (excluding this one). Returns a number ≥ 0.
   """
   numberOfDescendants: Int!
-  canCurrentUserEdit: Boolean!
+  """
+    Returns whether the current user has the rights to add sub-pages, edit realm content,
+    and edit settings including changing the realm path, deleting the realm and editing
+    the realm's acl.
+  """
+  currentUserIsPageAdmin: Boolean!
+  """
+    Returns whether the current user has the rights to add sub-pages and edit realm content
+    and non-critical settings.
+  """
+  canCurrentUserModerate: Boolean!
   """
     Returns `true` if this realm somehow references the given node via
     blocks. Currently, the following rules are used:

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -192,6 +192,11 @@ interface Block {
 
 union KnownUsersSearchOutcome = SearchUnavailable | KnownUserSearchResults
 
+input UpdatedPermissions {
+  moderatorRoles: [String!]
+  adminRoles: [String!]
+}
+
 type NotAllowed {
   """
     Unused dummy field for this marker type. GraphQL requires all objects to
@@ -328,6 +333,19 @@ type Realm implements Node {
     `null` is returned.
   """
   ownerDisplayName: String
+  """
+    Returns the acl of this realm, combining moderator and admin roles and assigns
+    the respective actions that are necessary for UI purposes.
+  """
+  ownAcl: [AclItem!]!
+  """
+    Returns the combined acl of this realm's parent, which effectively contains
+    the acl and inherited acl of each ancestor realm. This is used to display
+    these roles in the permissions UI, where we don't want to show that realm's onw
+    flattened acl since that also contains the realm's "regular", i.e. non-inherited
+    acl.
+  """
+  inheritedAcl: [AclItem!]!
   "Returns the immediate parent of this realm."
   parent: Realm
   """
@@ -404,6 +422,8 @@ type Mutation {
   setChildOrder(parent: ID!, childOrder: RealmOrder!, childIndices: [ChildIndex!] = null): Realm!
   "Changes the name of a realm."
   renameRealm(id: ID!, name: UpdatedRealmName!): Realm!
+  "Changes the moderator and/or admin roles of a realm."
+  updatePermissions(id: ID!, permissions: UpdatedPermissions!): Realm!
   "Updates a realm's data."
   updateRealm(id: ID!, set: UpdateRealm!): Realm!
   "Remove a realm from the tree."

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -328,7 +328,7 @@ type Realm implements Node {
   """
   path: String!
   """
-    This is only returns a value for root user realms, in which case it is
+    This only returns a value for root user realms, in which case it is
     the display name of the user who owns this realm. For all other realms,
     `null` is returned.
   """
@@ -373,7 +373,7 @@ type Realm implements Node {
     and edit settings including changing the realm path, deleting the realm and editing
     the realm's acl.
   """
-  currentUserIsPageAdmin: Boolean!
+  isCurrentUserPageAdmin: Boolean!
   """
     Returns whether the current user has the rights to add sub-pages and edit realm content
     and non-critical settings.

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -771,6 +771,7 @@ type AclEditButtonsProps = {
     inheritedAcl?: Acl;
     userIsOwner?: boolean;
     kind: "write" | "admin";
+    saveModalRef: React.RefObject<ConfirmationModalHandle>;
 }
 
 export const AclEditButtons: React.FC<AclEditButtonsProps> = (
@@ -783,13 +784,13 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = (
         inFlight,
         inheritedAcl,
         userIsOwner,
+        saveModalRef,
         kind,
     }
 ) => {
     const { t } = useTranslation();
     const user = useUser();
     const resetModalRef = useRef<ModalHandle>(null);
-    const saveModalRef = useRef<ConfirmationModalHandle>(null);
 
     const containsUser = (acl: Acl) => isRealUser(user) && (userIsOwner || user.roles.some(r =>
         r === COMMON_ROLES.ADMIN

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -122,7 +122,7 @@ export const AclSelector: React.FC<AclSelectorProps> = (
 type RoleKind = "Group" | "User";
 
 
-export const knownRolesFragement = graphql`
+export const knownRolesFragment = graphql`
     fragment AccessKnownRolesData on Query {
         knownGroups { role label implies large }
     }

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -336,10 +336,12 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                                 }
 
                                 setError(null);
-                                callback(users.items.map(item => ({
-                                    role: item.userRole,
-                                    label: item.displayName,
-                                })));
+                                callback(users.items
+                                    .filter(item => item.displayName !== ownerDisplayName)
+                                    .map(item => ({
+                                        role: item.userRole,
+                                        label: item.displayName,
+                                    })));
                             },
                             start: () => {},
                             error: (error: Error) => setError(<ErrorDisplay error={error} />),

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -94,6 +94,7 @@ type AclSelectorProps = {
     knownRoles: AccessKnownRolesData$data;
     ownerDisplayName?: string | null;
     permissionLevels: PermissionLevels;
+    addAnonymous?: boolean;
 }
 
 export const AclSelector: React.FC<AclSelectorProps> = (
@@ -105,12 +106,13 @@ export const AclSelector: React.FC<AclSelectorProps> = (
         knownRoles,
         ownerDisplayName = "",
         permissionLevels,
+        addAnonymous = true,
     }
 ) => {
     const { i18n } = useTranslation();
     const knownGroups = [...knownRoles.knownGroups];
-    insertBuiltinRoleInfo(acl, knownGroups, i18n);
-    insertBuiltinRoleInfo(inheritedAcl, knownGroups, i18n);
+    [acl, inheritedAcl].forEach(list =>
+        insertBuiltinRoleInfo(list, knownGroups, i18n, addAnonymous));
     const [groupAcl, userAcl] = splitAcl(acl);
     const [inheritedGroupAcl, inheritedUserAcl] = splitAcl(inheritedAcl);
 
@@ -912,6 +914,7 @@ const insertBuiltinRoleInfo = (
     acl: Acl,
     knownGroups: AccessKnownRolesData$data["knownGroups"][number][],
     i18n: i18n,
+    addAnonymous: boolean,
 ) => {
     const keyToTranslatedString = (key: ParseKeys): TranslatedLabel => Object.fromEntries(
         i18n.languages
@@ -939,7 +942,9 @@ const insertBuiltinRoleInfo = (
         user.info = userInfo;
     }
 
-    knownGroups.push({ role: COMMON_ROLES.ANONYMOUS, ...anonymousInfo });
+    if (addAnonymous) {
+        knownGroups.push({ role: COMMON_ROLES.ANONYMOUS, ...anonymousInfo });
+    }
     knownGroups.push({ role: COMMON_ROLES.USER, ...userInfo });
 };
 

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -215,6 +215,10 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
         });
     }
 
+    const showAdminEntry = kind === "group"
+        && !entries.some(e => e.role === COMMON_ROLES.ADMIN)
+        && userIsAdmin;
+
     const remove = (item: Entry) => change(prev => prev.delete(item.role));
 
     const handleCreate = (inputValue: string) => change(prev => {
@@ -343,7 +347,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                 },
             }}>
                 <colgroup>
-                    <col css={{ }} />
+                    <col />
                     <col css={{ width: i18n.resolvedLanguage === "en" ? 190 : 224 }} />
                     <col css={{ width: 42 }} />
                 </colgroup>
@@ -359,7 +363,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                 </thead>
                 <tbody>
                     {/* Placeholder if there are no entries */}
-                    {entries.length === 0 && !userIsAdmin && <tr>
+                    {entries.length === 0 && !showAdminEntry && <tr>
                         <td colSpan={3} css={{ textAlign: "center", fontStyle: "italic" }}>
                             {t("acl.no-entries")}
                         </td>
@@ -370,19 +374,13 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, kind }) => {
                     }
 
                     {/*
-                    The ACLs usually don't explicitly include admins, but showing that
-                    entry makes sense if the user is admin.
+                        The ACLs usually don't explicitly include admins, but showing that
+                        entry makes sense if the user is admin.
                     */}
-                    {(
-                        kind === "group"
-                        && !entries.some(e => e.role === COMMON_ROLES.ADMIN)
-                        && userIsAdmin
-                    ) && (
-                        <TableRow
-                            labelCol={<>{t("acl.groups.admins")}</>}
-                            actionCol={<UnchangeableAllActions />}
-                        />
-                    )}
+                    {showAdminEntry && <TableRow
+                        labelCol={<>{t("acl.groups.admins")}</>}
+                        actionCol={<UnchangeableAllActions />}
+                    />}
                 </tbody>
             </table>
         </div>

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -49,7 +49,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     useImperativeHandle(ref, () => ({
         isOpen: () => isOpen,
         open: () => setOpen(true),
-        close: closable ? (() => setOpen(false)) : undefined,
+        close: () => setOpen(false),
     }), [isOpen, closable]);
 
     useEffect(() => {

--- a/frontend/src/util/permissionLevels.tsx
+++ b/frontend/src/util/permissionLevels.tsx
@@ -17,3 +17,12 @@ export const READ_WRITE_ACTIONS: PermissionLevels = {
     highest: "write",
 };
 
+export const MODERATE_ADMIN_ACTIONS: PermissionLevels = {
+    all: {
+        "moderate": { actions: new Set(["moderate"]) },
+        "admin": { actions: new Set(["moderate", "admin"]) },
+    },
+    default: "moderate",
+    highest: "admin",
+};
+

--- a/frontend/src/util/permissionLevels.tsx
+++ b/frontend/src/util/permissionLevels.tsx
@@ -1,0 +1,19 @@
+export type PermissionLevel = "read" | "write" | "moderate" | "admin" | "unknown";
+export type PermissionLevels = {
+    /** Must include the below `default` and `highest` values. */
+    all: Partial<Record<PermissionLevel, { actions: Set<PermissionLevel> }>>;
+    /** Default action for new entries. */
+    default: PermissionLevel;
+    /** Most privileged action, usually includes every other action. */
+    highest: PermissionLevel;
+}
+
+export const READ_WRITE_ACTIONS: PermissionLevels = {
+    all: {
+        "read": { actions: new Set(["read"]) },
+        "write": { actions: new Set(["read", "write"]) },
+    },
+    default: "read",
+    highest: "write",
+};
+


### PR DESCRIPTION
This allows restricting editing permissions to users and groups of users as discussed in #1049.
There are two "levels" of access:
- `moderate`: Users can add subpages and edit content and page settings (excluding permissions and so called "danger zone" things like deleting the page or renaming its path)
- `admin`: Everything a moderator can do, but including editing permissions and danger zone things

Permissions are inherited down to every subrealm of a specific realm but can be expanded on in these subrealms. It is however not possible to remove or "downgrade" the access level of an inherited entry, so any user included in a parent realm's access list has **at least** the same access level for that parent realm's children.

Closes #1049
(Can be reviewed commit by commit)
