### PR TITLE
Add prompt to consent to terms and conditions on first use

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -3,6 +3,17 @@ site_title.en = "Tobira Test Deployment"
 tobira_url = "https://{% if id != 'master' %}{{id}}.{% endif %}tobira.opencast.org"
 users_searchable = true
 
+[general.initial_consent]
+title.en = "Terms & Conditions"
+button.en = "Agree"
+text.en = """
+By using this video portal, you agree to our terms and conditions.
+
+For more information, see:
+- [Our terms](https://www.our.terms)
+- [Our conditions](https://www.our.conditions)
+"""
+
 [general.metadata]
 dcterms.source = "builtin:source"
 dcterms.license = "builtin:license"

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -18,6 +18,29 @@ pub(crate) struct GeneralConfig {
     /// Example: "https://tobira.my-uni.edu".
     pub(crate) tobira_url: HttpHost,
 
+    /// Terms and conditions that a user has to agree to in order to use Tobira.
+    /// This consists of a title, a markdown rendered text explaining what a user
+    /// is agreeing to, and a button label for confirmation.
+    /// These can be specified in multiple languages.
+    /// Consent is prompted upon first use and only if this is configured. It is
+    /// re-prompted when any of these values change.
+    /// 
+    /// We recommend not to configure this unless absolutely necessary,
+    /// in order to not degrade the user experience needlessly.
+    /// 
+    /// Example:
+    /// 
+    /// ```
+    /// [general.initial_consent]
+    /// title.en = "Terms & Conditions"
+    /// button_label.en = "Agree"
+    /// text.en = """
+    /// To use Tobira, you need to agree to our terms and conditions:
+    /// - [Terms](https://www.our-terms.de)
+    /// - [Conditions](https://www.our-conditions.de)
+    /// """
+    /// ```
+    pub initial_consent: Option<InitialConsent>,
 
     /// Whether or not to show a download button on the video page.
     #[config(default = true)]
@@ -155,3 +178,10 @@ pub(crate) enum MetadataLabel {
 
 make_fixed_string_deserializer!(serde_metadata_license, "builtin:license");
 make_fixed_string_deserializer!(serde_metadata_source, "builtin:source");
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct InitialConsent {
+    title: TranslatedString,
+    button: TranslatedString,
+    text: TranslatedString,
+}

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -143,6 +143,7 @@ impl Assets {
 
         variables.insert("html-title".into(), config.general.site_title.en().into());
         variables.insert("site-title".into(), config.general.site_title.to_json());
+        variables.insert("initial-consent".into(), json!(config.general.initial_consent).to_string());
         variables.insert("show-download-button".into(), json!(config.general.show_download_button).to_string());
         variables.insert("users-searchable".into(), json!(config.general.users_searchable).to_string());
         variables.insert("footer-links".into(), json!(config.general.footer_links).to_string());

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -28,6 +28,30 @@
 # Required! This value must be specified.
 #tobira_url =
 
+# Terms and conditions that a user has to agree to in order to use Tobira.
+# This consists of a title, a markdown rendered text explaining what a user
+# is agreeing to, and a button label for confirmation.
+# These can be specified in multiple languages.
+# Consent is prompted upon first use and only if this is configured. It is
+# re-prompted when any of these values change.
+# 
+# We recommend not to configure this unless absolutely necessary,
+# in order to not degrade the user experience needlessly.
+# 
+# Example:
+# 
+# ```
+# [general.initial_consent]
+# title.en = "Terms & Conditions"
+# button_label.en = "Agree"
+# text.en = """
+# To use Tobira, you need to agree to our terms and conditions:
+# - [Terms](https://www.our-terms.de)
+# - [Conditions](https://www.our-conditions.de)
+# """
+# ```
+#initial_consent =
+
 # Whether or not to show a download button on the video page.
 #
 # Default value: true

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -24,6 +24,7 @@ type Config = {
     version: VersionInfo;
     auth: AuthConfig;
     siteTitle: TranslatedString;
+    initialConsent: InitialConsent | null;
     showDownloadButton: boolean;
     usersSearchable: boolean;
     opencast: OpencastConfig;
@@ -38,6 +39,12 @@ type FooterLink = "about" | "graphiql" | {
     label: TranslatedString;
     link: string;
 };
+
+type InitialConsent = {
+    title: TranslatedString;
+    button: TranslatedString;
+    text: TranslatedString;
+}
 
 type AuthConfig = {
     loginLink: string | null;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,6 +14,7 @@
         "auth": {{: var:auth :}},
         "upload": {{: var:upload :}},
         "siteTitle": {{: var:site-title :}},
+        "initialConsent": {{: var:initial-consent :}},
         "showDownloadButton": {{: var:show-download-button :}},
         "usersSearchable": {{: var:users-searchable :}},
         "footerLinks": {{: var:footer-links :}},

--- a/frontend/src/layout/Root.tsx
+++ b/frontend/src/layout/Root.tsx
@@ -32,7 +32,9 @@ export const Root: React.FC<Props> = ({ nav, children }) => {
 
     return (
         <Outer disableScrolling={menu.state === "burger"}>
-            <InitialConsent />
+            <Suspense fallback={<div css={{ backgroundColor: "red" }}>fallback</div>}>
+                <InitialConsent />
+            </Suspense>
             <Header hideNavIcon={!navExists} />
             {menu.state === "burger" && navExists && (
                 <BurgerMenu items={navElements} hide={() => menu.close()} />

--- a/frontend/src/layout/Root.tsx
+++ b/frontend/src/layout/Root.tsx
@@ -15,6 +15,7 @@ import { OperationType } from "relay-runtime";
 import { UserData$key } from "../__generated__/UserData.graphql";
 import { useNoindexTag } from "../util";
 import { screenWidthAtMost } from "@opencast/appkit";
+import { InitialConsent } from "../ui/InitialConsent";
 
 
 export const MAIN_PADDING = 16;
@@ -31,6 +32,7 @@ export const Root: React.FC<Props> = ({ nav, children }) => {
 
     return (
         <Outer disableScrolling={menu.state === "burger"}>
+            <InitialConsent />
             <Header hideNavIcon={!navExists} />
             {menu.state === "burger" && navExists && (
                 <BurgerMenu items={navElements} hide={() => menu.close()} />

--- a/frontend/src/ui/InitialConsent.tsx
+++ b/frontend/src/ui/InitialConsent.tsx
@@ -1,38 +1,55 @@
-import { useEffect, useRef, useState } from "react";
-import CONFIG from "../config";
+import { useRef, useState } from "react";
+import CONFIG, { TranslatedString } from "../config";
 import { currentRef, useTranslatedConfig } from "../util";
 import { Modal, ModalHandle } from "./Modal";
 import { Button } from "./Button";
 import { TextBlock } from "./Blocks/Text";
+import { useTranslation } from "react-i18next";
+import { notNullish } from "@opencast/appkit";
 
 
-const USER_CONSENT = "tobiraUserConsent";
+const LOCAL_STORAGE_KEY = "tobiraUserConsent";
 
 export const InitialConsent: React.FC = () => {
     if (!CONFIG.initialConsent) {
         return null;
     }
-    const [hash, setHash] = useState("");
-    const userConsent = localStorage.getItem(USER_CONSENT);
+    const { i18n } = useTranslation();
+    const [consentGiven, setConsentGiven] = useState<boolean | null>(null);
     const modalRef = useRef<ModalHandle>(null);
     const title = useTranslatedConfig(CONFIG.initialConsent.title);
     const text = useTranslatedConfig(CONFIG.initialConsent.text);
     const buttonLabel = useTranslatedConfig(CONFIG.initialConsent.button);
+    const currentLanguage = i18n.resolvedLanguage ?? "en";
 
-    useEffect(() => {
-        const makeHash = async () => {
-            const msgUint8 = new TextEncoder().encode(JSON.stringify(CONFIG.initialConsent));
-            const hashBuffer = await crypto.subtle.digest("SHA-256", msgUint8);
-            const hashArray = Array.from(new Uint8Array(hashBuffer));
-            const hashHex = hashArray
-                .map(b => b.toString(16).padStart(2, "0"))
-                .join("");
-            setHash(hashHex);
-        };
-        makeHash();
-    }, []);
+    const calcHash = async (language: string): Promise<string> => {
+        const getTranslated = (s: TranslatedString) => (
+            language in s ? s[language as keyof TranslatedString] : undefined) ?? s.en;
+        const conditions = notNullish(CONFIG.initialConsent);
 
-    return hash === userConsent ? null : (
+        const data = getTranslated(conditions.title)
+            + "\0" + getTranslated(conditions.button)
+            + "\0" + getTranslated(conditions.text);
+        const msg = new TextEncoder().encode(data);
+        const hashBuffer = await crypto.subtle.digest("SHA-256", msg);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
+    };
+
+    if (consentGiven === null) {
+        throw (async () => {
+            const stored = localStorage.get(LOCAL_STORAGE_KEY);
+            if (!stored) {
+                setConsentGiven(false);
+            }
+
+            const storedLang = stored.split(":")[0];
+            const hash = await calcHash(storedLang);
+            setConsentGiven(hash === stored.split(":")[1]);
+        })();
+    }
+
+    return consentGiven ? null : (
         <Modal
             open
             ref={modalRef}
@@ -42,8 +59,9 @@ export const InitialConsent: React.FC = () => {
         >
             <TextBlock content={text} />
             <div css={{ display: "flex" }}>
-                <Button css={{ marginTop: 20, marginLeft: "auto" }} onClick={() => {
-                    localStorage.setItem(USER_CONSENT, hash);
+                <Button css={{ marginTop: 20, marginLeft: "auto" }} onClick={async () => {
+                    await calcHash(currentLanguage).then(hash =>
+                        localStorage.setItem(LOCAL_STORAGE_KEY, hash));
                     currentRef(modalRef).close?.();
                 }}>{buttonLabel}</Button>
             </div>

--- a/frontend/src/ui/InitialConsent.tsx
+++ b/frontend/src/ui/InitialConsent.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from "react";
+import CONFIG from "../config";
+import { currentRef, useTranslatedConfig } from "../util";
+import { Modal, ModalHandle } from "./Modal";
+import { Button } from "./Button";
+import { TextBlock } from "./Blocks/Text";
+
+
+const USER_CONSENT = "tobiraUserConsent";
+
+export const InitialConsent: React.FC = () => {
+    if (!CONFIG.initialConsent) {
+        return null;
+    }
+    const [hash, setHash] = useState("");
+    const userConsent = localStorage.getItem(USER_CONSENT);
+    const modalRef = useRef<ModalHandle>(null);
+    const title = useTranslatedConfig(CONFIG.initialConsent.title);
+    const text = useTranslatedConfig(CONFIG.initialConsent.text);
+    const buttonLabel = useTranslatedConfig(CONFIG.initialConsent.button);
+
+    useEffect(() => {
+        const makeHash = async () => {
+            const msgUint8 = new TextEncoder().encode(JSON.stringify(CONFIG.initialConsent));
+            const hashBuffer = await crypto.subtle.digest("SHA-256", msgUint8);
+            const hashArray = Array.from(new Uint8Array(hashBuffer));
+            const hashHex = hashArray
+                .map(b => b.toString(16).padStart(2, "0"))
+                .join("");
+            setHash(hashHex);
+        };
+        makeHash();
+    }, []);
+
+    return hash === userConsent ? null : (
+        <Modal
+            open
+            ref={modalRef}
+            title={title}
+            closable={false}
+            initialFocus={false}
+        >
+            <TextBlock content={text} />
+            <div css={{ display: "flex" }}>
+                <Button css={{ marginTop: 20, marginLeft: "auto" }} onClick={() => {
+                    localStorage.setItem(USER_CONSENT, hash);
+                    currentRef(modalRef).close?.();
+                }}>{buttonLabel}</Button>
+            </div>
+        </Modal>
+    );
+};
+

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -27,6 +27,8 @@ type ModalProps = {
     closable?: boolean;
     className?: string;
     closeOnOutsideClick?: boolean;
+    open?: boolean;
+    initialFocus?: false;
 };
 
 export type ModalHandle = {
@@ -41,16 +43,18 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     children,
     className,
     closeOnOutsideClick = false,
+    open = false,
+    initialFocus,
 }, ref) => {
     const { t } = useTranslation();
-    const [isOpen, setOpen] = useState(false);
+    const [isOpen, setOpen] = useState(open);
     const isDark = useColorScheme().scheme === "dark";
 
     useImperativeHandle(ref, () => ({
         isOpen: () => isOpen,
         open: () => setOpen(true),
         close: () => setOpen(false),
-    }), [isOpen, closable]);
+    }), [isOpen]);
 
     useEffect(() => {
         const handleEscape = (event: KeyboardEvent) => {
@@ -63,7 +67,7 @@ export const Modal = forwardRef<ModalHandle, PropsWithChildren<ModalProps>>(({
     }, [closable]);
 
     return ReactDOM.createPortal(
-        isOpen && <FocusTrap>
+        isOpen && <FocusTrap focusTrapOptions={{ initialFocus }}>
             <div
                 {...(closable && closeOnOutsideClick && { onClick: e => {
                     if (e.target === e.currentTarget) {

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -6,6 +6,17 @@ site_title.en = "Tobira Videoportal"
 tobira_url = "http://localhost:8030"
 users_searchable = true
 
+[general.initial_consent]
+title.en = "Terms & Conditions"
+button.en = "Agree"
+text.en = """
+By using this video portal, you agree to our terms and conditions.
+
+For more information, see:
+- [Our terms](https://www.our.terms)
+- [Our conditions](https://www.our.conditions)
+"""
+
 [http]
 # To make our Docker based development setup work, Tobira needs to listen
 # on every interface. This is an unfortunate side effect of us trying to avoid


### PR DESCRIPTION
Closes #1023 

This adds a simple modal asking the user to agree to configurable terms and conditions.
The modal can only be closed by agreeing. So if a user doesn't agree, they cannot use Tobira.

Right now this is only done when a user first visits Tobira prior to logging in, so it doesn't store any
user information per se. This means consent is given per device/browser and not per user.

Still subject to change or be expanded with additional consent needed after logging in.

I'm marking this as a draft, since that is what it is, but I would still appreciate a review and feedback.

Edit: Tests need to be rewritten for this. I'd definitely want to wait for @LukasKalbertodt playwright changes.