### PR TITLE
Hide child list in "change order" UI if sorted alphabetically

### DIFF
--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -141,9 +141,9 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
                 order="BY_INDEX"
             />
 
-            <ChildList disabled={sortOrder !== "BY_INDEX"} swap={swap}>
+            {sortOrder === "BY_INDEX" && <ChildList swap={swap}>
                 {sortedChildren}
-            </ChildList>
+            </ChildList>}
 
             <div css={{ display: "flex", alignItems: "center" }}>
                 <Button onClick={save} disabled={!anyChange}>{t("general.action.save")}</Button>
@@ -158,18 +158,10 @@ export const ChildOrder: React.FC<Props> = ({ fragRef }) => {
 type ChildListProps = {
     children: readonly Child[];
     swap: (index: number) => void;
-    disabled: boolean;
 };
 
-const ChildList: React.FC<ChildListProps> = ({ disabled, children, swap }) => (
-    <ol css={{
-        maxWidth: 900,
-        padding: 0,
-        ...disabled && {
-            pointerEvents: "none",
-            opacity: 0.5,
-        },
-    }}>
+const ChildList: React.FC<ChildListProps> = ({ children, swap }) => (
+    <ol css={{ maxWidth: 900, padding: 0 }}>
         {children.map((child, i) => <ChildEntry
             key={child.id}
             index={i}


### PR DESCRIPTION
I really dislike that this section pushes other sections further down, especially so because almost all page use alphabetical ordering anyway. Yes, with this change you cannot preview the order anymore when switching between the two alphabetical orderings. But I think that's really not a big problem.

---

I don't expect this to get merged necessarily. This is just a personal proposal and I could understand if people argue for the status quo. So yeah, feedback welcome.