### PR TITLE
Revise download menu listitems

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -154,8 +154,8 @@ video:
   caption: Untertitel
   download:
     title: Download
-    presenter: Kamera
-    slides: Präsentation
+    presenter: Video (Sprecher:in)
+    slides: Video (Präsentation)
     info: >
       Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen 
       (Rechtsklick - Speichern unter).
@@ -393,6 +393,8 @@ manage:
     technical-details:
       title: Technische Details
       tracks: Video-/Audiospuren
+      video: Video
+      audio: Audio
       unknown-mimetype: Unbekannter MIME-Type
       opencast-id: Opencast-ID
       copy-oc-id-to-clipboard: Opencast-ID in Zwischenablage kopieren

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -152,8 +152,8 @@ video:
   caption: Caption
   download:
     title: Download
-    presenter: Presenter
-    slides: Presentation
+    presenter: Video (speaker)
+    slides: Video (presentation)
     info: > 
       Here you can download the video(s) in different formats/qualities (Right click - Save as).
   manage: Manage
@@ -373,6 +373,8 @@ manage:
     technical-details:
       title: Technical details
       tracks: Video/audio tracks
+      video: Video
+      audio: Audio
       unknown-mimetype: Unknown MIME type
       opencast-id: Opencast ID
       copy-oc-id-to-clipboard: Copy Opencast-ID to clipboard

--- a/frontend/src/routes/manage/Video/TechnicalDetails.tsx
+++ b/frontend/src/routes/manage/Video/TechnicalDetails.tsx
@@ -94,6 +94,7 @@ export const TrackInfo: React.FC<TrackInfoProps> = (
         return null;
     }
 
+
     const flavorTranslation = (flavor: string) => {
         if (flavor.startsWith("presenter")) {
             return t("video.download.presenter");
@@ -115,35 +116,50 @@ export const TrackInfo: React.FC<TrackInfoProps> = (
         tracks.push({ resolution, mimetype, uri });
     }
 
+    const isSingleFlavor = flavors.size === 1;
+
     return <section css={className}>
         <h2>{t("manage.my-videos.technical-details.tracks")}</h2>
         <ul css={{ fontSize: 15, marginTop: 8, paddingLeft: 24 }}>
-            {Array.from(flavors, ([flavor, tracks]) => <li key={flavor}>
-                {translateFlavors ? flavorTranslation(flavor) : <code>{flavor}</code>}
-                <ul>{tracks
+            {Array.from(flavors, ([flavor, tracks]) => {
+                const trackItems = tracks
                     .sort((a, b) => (a.resolution?.[0] ?? 0) - (b.resolution?.[0] ?? 0))
-                    .map((track, i) => <TrackItem key={i} {...track} />)
-                }</ul>
-            </li>)}
+                    .map((track, i) => <TrackItem key={i} {...track} />);
+                const flavorLabel = translateFlavors
+                    ? flavorTranslation(flavor)
+                    : <code>{flavor}</code>;
+                const flat = isSingleFlavor && translateFlavors;
+
+                return <li key={flavor}>
+                    {flat ? trackItems : <>{flavorLabel}<ul>{trackItems}</ul></>}
+                </li>;
+            })}
         </ul>
     </section>;
 };
 
+
 const TrackItem: React.FC<SingleTrackInfo> = ({ mimetype, resolution, uri }) => {
     const { t } = useTranslation();
+    const type = mimetype && mimetype.split("/")[0];
+    const subtype = mimetype && mimetype.split("/")[1];
+    const typeTranslation = (type === "audio" || type === "video")
+        ? t(`manage.my-videos.technical-details.${type}`)
+        : type;
+
+    const resolutionString = (type && " ")
+        + "("
+        + [subtype, resolution?.join(" × ")].filter(Boolean).join(", ")
+        + ")";
 
     return (
         <li css={{ marginBottom: 4 }}>
             <a href={uri}>
-                {mimetype == null
-                    ? <i>{t("manage.my-videos.technical-details.unknown-mimetype")}</i>
-                    : <code>{mimetype}</code>}
-                {resolution && <span css={{
-                    backgroundColor: COLORS.neutral10,
-                    marginLeft: 8,
-                    padding: "2px 4px",
-                    borderRadius: 4,
-                }}>{resolution.join(" × ")}</span>}
+                {type
+                    ? <>{typeTranslation}</>
+                    : <i>{t("manage.my-videos.technical-details.unknown-mimetype")}</i>
+                }
+                {(resolution || subtype) && resolutionString}
             </a>
         </li>
     );


### PR DESCRIPTION
- Removes label if media is single stream
- Renames labels for dual streams
- Adjusts formatting of mimetype/resolution

closes #1095 