### PR TITLE
Future proof harvest sync code for new items

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2204,18 +2204,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -64,7 +64,7 @@ rustls = { version = "0.21.0", features = ["dangerous_configuration"] }
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "1.0.0"
 secrecy = { version = "0.8", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.21"
 static_assertions = "1"

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -256,6 +256,11 @@ async fn store_in_db(
                 check_affected_rows_removed(rows_affected, "series", &opencast_id);
                 removed_series += 1;
             }
+
+            HarvestItem::Unknown { kind, .. } => {
+                warn!("Unknown item of kind '{kind}' in harvest response. \
+                    You might need to update Tobira.");
+            }
         }
     }
 

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -66,6 +66,13 @@ pub(crate) enum HarvestItem {
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
     },
+
+    #[serde(untagged)]
+    Unknown {
+        kind: String,
+        #[serde(with = "chrono::serde::ts_milliseconds")]
+        updated: DateTime<Utc>,
+    },
 }
 
 impl HarvestItem {
@@ -75,6 +82,7 @@ impl HarvestItem {
             Self::EventDeleted { updated, .. } =>  updated,
             Self::Series { updated, .. } => updated,
             Self::SeriesDeleted { updated, .. } => updated,
+            Self::Unknown { updated, .. } => updated,
         }
     }
 }


### PR DESCRIPTION
Before this commit, when the harvest API would have returned an item with a `kind` not known to Tobira, harvest would fail. It is expected that a new kind, namely playlists, will be added with Opencast 16. We will of course extend the harvest code to properly store playlists then. This commit just makes sure that Tobira can also deal with these future APIs without breaking.