### PR TITLE
Fix login page redirect when `login_link` is not configured

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import "./i18n";
 import { matchInitialRoute } from "./router";
 import { LoginRoute, REDIRECT_STORAGE_KEY } from "./routes/Login";
 import { checkInitialConsent } from "./ui/InitialConsent";
+import CONFIG from "./config";
 
 
 const redirect = (target: string) => {
@@ -44,7 +45,7 @@ const redirect = (target: string) => {
     // a component to trigger a redirect. In fact, that approach would break in
     // `StrictMode`.
     const target = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
-    if (window.location.pathname === LoginRoute.url && target) {
+    if (window.location.pathname === LoginRoute.url && target && CONFIG.auth.loginLink) {
         // eslint-disable-next-line no-console
         console.debug(`Requested login page after login: redirecting to previous page ${target}`);
         redirect(target);


### PR DESCRIPTION
When no login link is set, the "on load" redirect does not make sense. Before this commit, refreshing the login page would redirect you to the previous page, which is not intended.