### PR TITLE
Enables i18ned footer links

### DIFF
--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -49,11 +49,14 @@ pub(crate) struct GeneralConfig {
     /// By overwriting this default value, you can remove the default links and
     /// add custom ones. Note that these two default links are special and can
     /// be specified with only the shown string. To add custom ones, you need
-    /// to define a label and a link. Example:
+    /// to define a label and a link. The link is either the same for every language
+    /// or can be specified for each language in the same manner as the label. 
+    /// Example:
     ///
     /// ```
     /// footer_links = [
-    ///     { label = { en = "Example" }, link = { en = "https://example.com/en" } },
+    ///     { label = { en = "Example 1" }, link = "https://example.com" },
+    ///     { label = { en = "Example 2" }, link = { en = "https://example.com/en" } },
     ///     "about",
     /// ]
     /// ```

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -53,7 +53,7 @@ pub(crate) struct GeneralConfig {
     ///
     /// ```
     /// footer_links = [
-    ///     { label = { en = "Example" }, link = "https://example.com" },
+    ///     { label = { en = "Example" }, link = { en = "https://example.com/en" } },
     ///     "about",
     /// ]
     /// ```
@@ -131,7 +131,7 @@ pub(crate) enum FooterLink {
     GraphiQL,
     Custom {
         label: TranslatedString,
-        link: String,
+        link: TranslatedString,
     }
 }
 

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -124,6 +124,14 @@ impl GeneralConfig {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
+pub(crate) enum StringOrTranslatedString {
+    Simple(String),
+    Translated(TranslatedString),
+}
+
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
 pub(crate) enum FooterLink {
     #[serde(with = "serde_about_footer")]
     About,
@@ -131,7 +139,7 @@ pub(crate) enum FooterLink {
     GraphiQL,
     Custom {
         label: TranslatedString,
-        link: TranslatedString,
+        link: StringOrTranslatedString,
     }
 }
 

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -66,7 +66,7 @@
 #
 # ```
 # footer_links = [
-#     { label = { en = "Example" }, link = "https://example.com" },
+#     { label = { en = "Example" }, link = { en = "https://example.com/en/" } },
 #     "about",
 # ]
 # ```

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -62,11 +62,14 @@
 # By overwriting this default value, you can remove the default links and
 # add custom ones. Note that these two default links are special and can
 # be specified with only the shown string. To add custom ones, you need
-# to define a label and a link. Example:
+# to define a label and a link. The link is either the same for every language
+# or can be specified for each language in the same manner as the label. 
+# Example:
 #
 # ```
 # footer_links = [
-#     { label = { en = "Example" }, link = { en = "https://example.com/en" } },
+#     { label = { en = "Example 1" }, link = "https://example.com" },
+#     { label = { en = "Example 2" }, link = { en = "https://example.com/en" } },
 #     "about",
 # ]
 # ```

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -66,7 +66,7 @@
 #
 # ```
 # footer_links = [
-#     { label = { en = "Example" }, link = { en = "https://example.com/en/" } },
+#     { label = { en = "Example" }, link = { en = "https://example.com/en" } },
 #     "about",
 # ]
 # ```

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -38,7 +38,7 @@ type Config = {
 
 type FooterLink = "about" | "graphiql" | {
     label: TranslatedString;
-    link: string;
+    link: TranslatedString;
 };
 
 type InitialConsent = {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -38,7 +38,7 @@ type Config = {
 
 type FooterLink = "about" | "graphiql" | {
     label: TranslatedString;
-    link: TranslatedString;
+    link: TranslatedString | string;
 };
 
 type InitialConsent = {

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -44,7 +44,11 @@ export const Footer: React.FC = () => {
                         </li>;
                     } else {
                         return <li key={i}>
-                            <Link to={translatedConfig(entry.link, i18n)}>
+                            <Link to={
+                                typeof entry.link === "string"
+                                    ? entry.link
+                                    : translatedConfig(entry.link, i18n)
+                            }>
                                 {translatedConfig(entry.label, i18n)}
                             </Link>
                         </li>;

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -44,7 +44,9 @@ export const Footer: React.FC = () => {
                         </li>;
                     } else {
                         return <li key={i}>
-                            <Link to={entry.link}>{translatedConfig(entry.label, i18n)}</Link>
+                            <Link to={translatedConfig(entry.link, i18n)}>
+                                {translatedConfig(entry.label, i18n)}
+                            </Link>
                         </li>;
                     }
                 })}


### PR DESCRIPTION
This changes the footer custom link type from `string` to `TranslatedString`, enabling links to resources, especially documents like PDFs, in different languages with just one link.

