### PR TITLE
Replace actual ETH test server URL in docs with dummy URL

### DIFF
--- a/docs/docs/setup/matomo.md
+++ b/docs/docs/setup/matomo.md
@@ -26,7 +26,7 @@ First, you have to tell Tobira about your Matomo server so that the correct trac
 
 ```toml
 [matomo]
-server = "https://matomo.test.tobira.ethz.ch/matomo/"
+server = "https://matomo.my-university.edu/matomo/"
 site_id = "1"
 ```
 


### PR DESCRIPTION
Woops, that wasn't really intended to ever land in the docs. It's not too bad, no secrets were leaked, but yeah, lets rather use a dummy URL here.