### PR TITLE
Fix deadlock in auth cache (solves Tobira freezing problem)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -538,19 +538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deadpool"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "scc"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d29c0ce204821e0453e158e6f7ec8ba23cf930af1f06600818a4106f04589f9"
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,7 +2563,6 @@ dependencies = [
  "clap",
  "confique",
  "cookie",
- "dashmap",
  "deadpool",
  "deadpool-postgres",
  "elliptic-curve",
@@ -2609,6 +2601,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
+ "scc",
  "secrecy",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,7 +27,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde", "std"
 clap = { version = "4.2.2", features = ["derive", "string"] }
 confique = { version = "0.2.0", default-features = false, features = ["toml"] }
 cookie = "0.18.0"
-dashmap = "5.5.3"
 deadpool = { version = "0.10.0", default-features = false, features = ["managed", "rt_tokio_1"] }
 deadpool-postgres = { version = "0.12.1", default-features = false, features = ["rt_tokio_1"] }
 elliptic-curve = { version = "0.13.4", features = ["jwk", "sec1"] }
@@ -65,6 +64,7 @@ ring = "0.17.8"
 rustls = "0.22.2"
 rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.1.0"
+scc = "2.0.17"
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1"

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -255,7 +255,7 @@ impl User {
         if !ctx.config.auth.callback.cache_duration.is_zero() {
             header_copy = Some(req.headers().clone());
             let callback_config = &ctx.config.auth.callback;
-            if let Some(user) = ctx.auth_caches.callback.get(req.headers(), callback_config) {
+            if let Some(user) = ctx.auth_caches.callback.get(req.headers(), &callback_config).await {
                 return Ok(user);
             }
         }
@@ -265,7 +265,7 @@ impl User {
 
         // Insert into cache
         if !ctx.config.auth.callback.cache_duration.is_zero() {
-            ctx.auth_caches.callback.insert(header_copy.unwrap(), out.clone());
+            ctx.auth_caches.callback.insert(header_copy.unwrap(), out.clone()).await;
         }
 
         Ok(out)

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -23,6 +23,7 @@ mod handlers;
 mod session_id;
 mod jwt;
 
+use self::config::CallbackCacheDuration;
 pub(crate) use self::{
     cache::Caches,
     config::{AuthConfig, AuthSource, CallbackUri},
@@ -252,10 +253,9 @@ impl User {
 
         // Check cache.
         let mut header_copy = None;
-        if !ctx.config.auth.callback.cache_duration.is_zero() {
+        if let CallbackCacheDuration::Enabled(duration) = ctx.config.auth.callback.cache_duration {
             header_copy = Some(req.headers().clone());
-            let callback_config = &ctx.config.auth.callback;
-            if let Some(user) = ctx.auth_caches.callback.get(req.headers(), &callback_config).await {
+            if let Some(user) = ctx.auth_caches.callback.get(req.headers(), duration).await {
                 return Ok(user);
             }
         }
@@ -264,7 +264,7 @@ impl User {
         let out = Self::from_callback_impl(req, callback_url, ctx).await?;
 
         // Insert into cache
-        if !ctx.config.auth.callback.cache_duration.is_zero() {
+        if let CallbackCacheDuration::Enabled(_) = ctx.config.auth.callback.cache_duration {
             ctx.auth_caches.callback.insert(header_copy.unwrap(), out.clone()).await;
         }
 


### PR DESCRIPTION
Fixes #1129

See first commit description for the technical details on how this was caused. But the gist is: I incorrectly used `DashMap`, holding locks across await points. This causes a deadlock if the timing is right and two specific tasks are scheduled to run in the same thread. I could have fixed the code around the await point, but since this is a very easy and subtle mistake to make, I decided to use a different concurrent hashmap that can better deal with these scenarios. 

The second commit also fixes the cache dealing with a 0 cache duration (which is supposed to disable the cache). See commits for more details. 

On the ETH test system I deployed v2.6 plus this patch and verified that the freeze is not happening anymore in the only situation where I could reliably reproduce it before: starting Tobira and immediately making an authenticated request. Since the cache_duration was set to 0, the timing somehow worked out most of the time. Doing that does not freeze Tobira anymore with this patch (I tried several times).

---

<details>
<summary>Some additional tests/details</summary>

The `scc` hashmap has no problem when a lock is held on the same thread that `retain` is called. I tested it like this:

```rust
#[tokio::main(flavor = "current_thread")]
async fn main() {
    let start = Instant::now();

    let map = HashMap::new();
    let _ = map.insert_async("foo", 4).await;
    let _ = map.insert_async("bar", 27).await;
    let map = Arc::new(map);

    {
        let map = Arc::clone(&map);
        tokio::spawn(async move {
            println!("--- {:.2?} calling entry", start.elapsed());
            let e = map.entry_async("foo").await;
            println!("--- {:.2?} acquired entry", start.elapsed());
            tokio::time::sleep(Duration::from_millis(3000)).await;
            *e.or_insert(6).get_mut() *= 2;
            println!("--- {:.2?} done with entry", start.elapsed());
        });
    }

    {
        let map = Arc::clone(&map);
        tokio::spawn(async move {
            tokio::time::sleep(Duration::from_millis(1500)).await;
            println!("--- {:.2?} calling entry 2", start.elapsed());
            let e = map.entry_async("foo").await;
            println!("--- {:.2?} acquired entry 2", start.elapsed());
            tokio::time::sleep(Duration::from_millis(3000)).await;
            *e.or_insert(6).get_mut() *= 2;
            println!("--- {:.2?} done with entry 2", start.elapsed());
        });
    }

    tokio::time::sleep(Duration::from_millis(1000)).await;
    println!("--- {:.2?} calling retain", start.elapsed());
    map.retain_async(|_, v| *v % 2 != 0).await;
    println!("--- {:.2?} done retain", start.elapsed());
}
```

This outputs:

```
--- 31.88µs calling entry
--- 38.91µs acquired entry
--- 1.00s calling retain
--- 1.50s calling entry 2
--- 3.00s done with entry
--- 3.00s acquired entry 2
--- 6.00s done with entry 2
--- 6.00s done retain
```

Of course a single test doesn't guarantee that this is supported by the library, but all docs indicate as well that the library can deal with these situations. "async" is used everywhere and these kinds of situations regularly occur in async code.

Edit: thinking about it more, I suppose the key feature here is that `retain_async` can yield, whereas the `retain` from dashmap could only block when it couldn't make any progress.

</details>