### PR TITLE
Add series to search results

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -10,6 +10,7 @@ use crate::{
     prelude::*,
     search::Event as SearchEvent,
     search::Realm as SearchRealm,
+    search::Series as SearchSeries,
     db::types::ExtraMetadata,
 };
 
@@ -17,7 +18,7 @@ use crate::{
 /// A node with a globally unique ID. Mostly useful for relay.
 #[juniper::graphql_interface(
     Context = Context,
-    for = [AuthorizedEvent, Realm, Series, SearchEvent, SearchRealm]
+    for = [AuthorizedEvent, Realm, Series, SearchEvent, SearchRealm, SearchSeries]
 )]
 pub(crate) trait Node {
     fn id(&self) -> Id;

--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     api::{
-        Id, Context,
+        Id,
+        Context,
         err::{self, ApiResult},
-        model::{event::AuthorizedEvent, series::Series, realm::Realm},
+        model::{event::AuthorizedEvent, series::Series, realm::Realm, search::SearchSeriesExtended},
     },
     prelude::*,
     search::Event as SearchEvent,
@@ -18,7 +19,7 @@ use crate::{
 /// A node with a globally unique ID. Mostly useful for relay.
 #[juniper::graphql_interface(
     Context = Context,
-    for = [AuthorizedEvent, Realm, Series, SearchEvent, SearchRealm, SearchSeries]
+    for = [AuthorizedEvent, Realm, Series, SearchEvent, SearchRealm, SearchSeries, SearchSeriesExtended]
 )]
 pub(crate) trait Node {
     fn id(&self) -> Id;

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -1,15 +1,20 @@
 use chrono::{DateTime, Utc};
+use juniper::GraphQLObject;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::{fmt, borrow::Cow};
+use std::{borrow::Cow, collections::HashMap, fmt, future};
 
 use crate::{
     api::{
-        Context, NodeValue,
         err::ApiResult,
         util::impl_object_with_dummy_field,
+        Context,
+        Id,
+        Node,
+        NodeValue
     },
     auth::HasRoles,
+    db::{types::Key, util::select},
     prelude::*,
     search,
 };
@@ -84,6 +89,29 @@ pub(crate) struct Filters {
     start: Option<DateTime<Utc>>,
     end: Option<DateTime<Utc>>,
 }
+
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct ThumbnailInfo {
+    pub(crate) thumbnail: Option<String>,
+    pub(crate) is_live: bool,
+    pub(crate) audio_only: bool,
+}
+
+#[derive(Debug, GraphQLObject)]
+#[graphql(context = Context, impl = NodeValue)]
+pub(crate) struct SearchSeriesExtended {
+    pub(crate) id: Id,
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) thumbnail_info: Vec<ThumbnailInfo>,
+}
+
+impl Node for SearchSeriesExtended {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
 
 macro_rules! handle_search_result {
     ($res:expr, $return_type:ty) => {{
@@ -202,6 +230,44 @@ pub(crate) async fn perform(
     );
     let (event_results, series_results, realm_results) = handle_search_result!(res, SearchOutcome);
 
+    // Get thumbnails for series
+    let ids = series_results.hits.iter()
+        .map(|r| r.result.id.0)
+        .collect::<Vec<_>>();
+
+    let (selection, mapping) = select!(series, is_live, audio_only, thumbnail);
+    let thumbnail_info_query = format!("\
+        select {selection} \
+        from ( \
+            select e.series, e.is_live, e.thumbnail, \
+                not exists ( \
+                    select 1 from unnest(e.tracks) as t where t.resolution is not null \
+                ) as audio_only, \
+                row_number() over ( \
+                    partition by e.series order by e.created desc \
+                ) as row_num \
+            from events e \
+            where e.series = any($1) and (read_roles || 'ROLE_ADMIN'::text) && $2 \
+            and (e.start_time <= current_timestamp or e.start_time is null) \
+        ) as ranked \
+        where row_num <= 3");
+
+    let mut thumbnail_info = HashMap::new();
+    context.db
+        .query_raw(&thumbnail_info_query, dbargs![&ids, &context.auth.roles_vec()])
+        .await?
+        .try_for_each(|row| {
+            let value = ThumbnailInfo {
+                thumbnail: mapping.thumbnail.of(&row),
+                is_live: mapping.is_live.of(&row),
+                audio_only: mapping.audio_only.of(&row),
+            };
+            let key = mapping.series.of::<Key>(&row);
+            thumbnail_info.entry(key).or_insert(vec![]).push(value);
+            future::ready(Ok(()))
+        })
+        .await?;
+
     // Merge results according to Meilis score.
     //
     // TODO: Comparing scores of different indices is not well defined right now.
@@ -211,7 +277,16 @@ pub(crate) async fn perform(
     let events = event_results.hits.into_iter()
         .map(|result| (NodeValue::from(result.result), result.ranking_score));
     let series = series_results.hits.into_iter()
-        .map(|result| (NodeValue::from(result.result), result.ranking_score));
+        .map(|result| {
+            let series = SearchSeriesExtended {
+                id: Id::search_series(result.result.id.0),
+                title: result.result.title,
+                description: result.result.description,
+                thumbnail_info: thumbnail_info.remove(&result.result.id.0).unwrap_or_default(),
+            };
+            (NodeValue::from(series), result.ranking_score)
+        } 
+    );
     let realms = realm_results.hits.into_iter()
         .map(|result| (NodeValue::from(result.result), result.ranking_score));
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -178,6 +178,7 @@ series:
   deleted-series-block: Die hier referenzierte Serie wurde gelöscht.
   no-events: Diese Serie enthält keine Videos oder Sie sind nicht berechtigt, diese zu sehen.
   upcoming-live-streams: "Anstehende Livestreams ({{count}})"
+  entry-of-series-thumbnail: "Vorschlaubild für Teil von „{{series}}“"
   videos:
     heading: Videos
   not-ready:

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -233,9 +233,11 @@ search:
   no-results: Keine Ergebnisse
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
   unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.
-  filter-all: Alle
-  filter-event: Videos
-  filter-realm: Seiten
+  filter:
+    all: Alle
+    event: Videos
+    realm: Seiten
+    series: Serien
   select-time-frame: Zeitraum auswählen
   clear-time-frame: Zeitraum zurücksetzen
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -231,9 +231,11 @@ search:
   no-results: No results
   too-few-characters: Please type more characters to start the search.
   unavailable: The search is currently unavailable. Try again later.
-  filter-all: All
-  filter-event: Videos
-  filter-realm: Pages
+  filter:
+    all: All
+    event: Videos
+    realm: Pages
+    series: Series
   select-time-frame: Select time frame
   clear-time-frame: Clear time frame
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -175,6 +175,7 @@ series:
   deleted-series-block: The series referenced here was deleted.
   no-events: This series does not contain any events, or you might not be authorized to see them.
   upcoming-live-streams: "Upcoming live streams ({{count}})"
+  entry-of-series-thumbnail: "Thumbnail for entry of “{{series}}”"
   videos:
     heading: Videos
   not-ready:

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,6 +1,13 @@
 import { Trans, useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { LuCalendarRange, LuLayout, LuLibrary, LuPlayCircle, LuX } from "react-icons/lu";
+import {
+    LuCalendarRange,
+    LuLayout,
+    LuLibrary,
+    LuPlayCircle,
+    LuRadio,
+    LuX,
+} from "react-icons/lu";
 import { IconType } from "react-icons";
 import { ReactNode, RefObject, useEffect, useRef } from "react";
 import {
@@ -10,6 +17,7 @@ import {
     ProtoButton,
     screenWidthAtMost,
     unreachable,
+    useColorScheme,
 } from "@opencast/appkit";
 
 import { RootLoader } from "../layout/Root";
@@ -21,7 +29,14 @@ import {
 import { RouterControl, makeRoute } from "../rauta";
 import { loadQuery } from "../relay";
 import { Link, useRouter } from "../router";
-import { Creators, Thumbnail } from "../ui/Video";
+import {
+    Creators,
+    Thumbnail,
+    ThumbnailImg,
+    ThumbnailOverlay,
+    ThumbnailOverlayContainer,
+    ThumbnailReplacement,
+} from "../ui/Video";
 import { SmallDescription } from "../ui/metadata";
 import { Card } from "../ui/Card";
 import { Breadcrumbs, BreadcrumbsContainer, BreadcrumbSeparator } from "../ui/Breadcrumbs";
@@ -83,7 +98,7 @@ export const SearchRoute = makeRoute({
     },
 });
 
-const itemTypes: ItemType[] = ["EVENT", "REALM"];
+const itemTypes: ItemType[] = ["EVENT", "REALM", "SERIES"];
 export const isValidSearchItemType = (value: string | null | undefined) =>
     value && (itemTypes as string[]).includes(value)
         ? value as ItemType
@@ -128,10 +143,10 @@ const query = graphql`
                         created
                         hostRealms { path }
                     }
-                    ... on SearchSeries {
+                    ... on SearchSeriesExtended {
                         title
                         description
-                        hostRealms { path }
+                        thumbnailInfo { thumbnail isLive audioOnly }
                     }
                     ... on SearchRealm { name path ancestorNames }
                 }
@@ -367,12 +382,12 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                     endTime: unwrapUndefined(item.endTime),
                     hostRealms: unwrapUndefined(item.hostRealms),
                 }} />;
-            } else if (item.__typename === "SearchSeries") {
+            } else if (item.__typename === "SearchSeriesExtended") {
                 return <SearchSeries key={item.id} {...{
                     id: item.id,
                     title: unwrapUndefined(item.title),
                     description: unwrapUndefined(item.description),
-                    hostRealms: unwrapUndefined(item.hostRealms),
+                    thumbnailInfo: unwrapUndefined(item.thumbnailInfo),
                 }} />;
             } else if (item.__typename === "SearchRealm") {
                 return <SearchRealm key={item.id} {...{
@@ -392,10 +407,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
 
 type WithIconProps = React.PropsWithChildren<{
     Icon: IconType;
+    iconSize?: number;
     hideIconOnMobile?: boolean;
 }>;
 
-const WithIcon: React.FC<WithIconProps> = ({ Icon, children, hideIconOnMobile }) => (
+const WithIcon: React.FC<WithIconProps> = ({ Icon, iconSize = 30, children, hideIconOnMobile }) => (
     <div css={{
         display: "flex",
         flexDirection: "row",
@@ -412,7 +428,7 @@ const WithIcon: React.FC<WithIconProps> = ({ Icon, children, hideIconOnMobile })
             },
         },
     }}>
-        <Icon size={30} css={{
+        <Icon size={iconSize} css={{
             flexShrink: 0,
             color: COLORS.primary0,
             strokeWidth: 1.5,
@@ -513,7 +529,7 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                             borderRadius: 4,
                             outlineOffset: 1,
                             position: "relative",
-                            zIndex: 1,
+                            zIndex: 4,
                         }}>{seriesTitle}</Link>
                     </div>}
                 </div>
@@ -531,40 +547,43 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                         audioOnly,
                     },
                 }}
-                css={{
-                    outline: `1px solid ${COLORS.neutral15}`,
-                    minWidth: 270,
-                    width: 270,
-                    marginLeft: "auto",
-                    [screenWidthAtMost(800)]: {
-                        minWidth: 240,
-                        width: 240,
-                    },
-                    [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-                        maxWidth: 400,
-                        margin: "0 auto",
-                    },
-                }}
+                css={thumbnailCss}
             />
         </Item>
     );
 };
 
+const thumbnailCss = {
+    outline: `1px solid ${COLORS.neutral15}`,
+    minWidth: 270,
+    width: 270,
+    marginLeft: "auto",
+    [screenWidthAtMost(800)]: {
+        minWidth: 240,
+        width: 240,
+    },
+    [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+        maxWidth: 400,
+        margin: "0 auto",
+    },
+};
 
+
+type ThumbnailInfo = {
+    readonly audioOnly: boolean;
+    readonly isLive: boolean;
+    readonly thumbnail: string | null | undefined;
+}
 type SearchSeriesProps = {
     id: string;
     title: string;
     description: string | null;
-    hostRealms: readonly {
-        readonly path: string;
-    }[];
+    thumbnailInfo: readonly ThumbnailInfo[] | undefined;
 }
 
-const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, hostRealms }) => {
-    const _dum = "";
-
-    return <Item key={id} link={DirectSeriesRoute.url({ seriesId: id })}>
-        <WithIcon Icon={LuLibrary} hideIconOnMobile>
+const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, thumbnailInfo }) =>
+    <Item key={id} link={DirectSeriesRoute.url({ seriesId: id })}>
+        <WithIcon Icon={LuLibrary} iconSize={28} hideIconOnMobile>
             <div css={{
                 color: COLORS.neutral90,
                 marginRight: "clamp(12px, 4vw - 13px, 40px)",
@@ -585,7 +604,76 @@ const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, hos
                 />}
             </div>
         </WithIcon>
-    </Item>;
+        <ThumbnailStack {...{ thumbnailInfo, title }} />
+    </Item>
+;
+
+type ThumbnailStackProps = Pick<SearchSeriesProps, "title" | "thumbnailInfo">
+
+const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnailInfo, title }) => (
+    <div css={{
+        ...thumbnailCss,
+        outline: 0,
+        display: "grid",
+        gridAutoColumns: "1fr",
+        "> div": {
+            outline: `1px solid ${COLORS.neutral10}`,
+            borderRadius: 8,
+        },
+        "> div:not(:last-child)": {
+            boxShadow: "3px -2px 6px rgba(0, 0, 0, 40%)",
+        },
+        "> div:nth-child(1)": {
+            zIndex: 3,
+            gridColumn: "1 / span 10",
+            gridRow: "3 / span 10",
+        },
+        "> div:nth-child(2)": {
+            zIndex: 2,
+            gridColumn: "2 / span 10",
+            gridRow: "2 / span 10",
+        },
+        "> div:nth-child(3)": {
+            zIndex: 1,
+            gridColumn: "3 / span 10",
+            gridRow: "1 / span 10",
+        },
+    }}>
+        {thumbnailInfo?.map((info, idx) => <div key={idx}>
+            <SeriesThumbnail {...{ info, title }} />
+        </div>)}
+    </div>
+);
+
+type SeriesThumbnailProps = {
+    info: ThumbnailInfo;
+    title: string;
+}
+
+const SeriesThumbnail: React.FC<SeriesThumbnailProps> = ({ info, title }) => {
+    const { t } = useTranslation();
+    const isDark = useColorScheme().scheme === "dark";
+
+    let inner;
+    if (info.thumbnail != null) {
+        // We have a proper thumbnail.
+        inner = <ThumbnailImg
+            src={info.thumbnail}
+            alt={t("series.entry-of-series-thumbnail", { series: title })}
+        />;
+    } else {
+        inner = <ThumbnailReplacement audioOnly={info.audioOnly} {...{ isDark }} />;
+    }
+
+    const overlay = <ThumbnailOverlay backgroundColor="rgba(200, 0, 0, 0.9)">
+        <LuRadio css={{ fontSize: 19, strokeWidth: 1.4 }} />
+        {t("video.live")}
+    </ThumbnailOverlay>;
+
+    return <ThumbnailOverlayContainer>
+        {inner}
+        {info.isLive && overlay}
+    </ThumbnailOverlayContainer>;
 };
 
 type SearchRealmProps = {
@@ -641,7 +729,7 @@ const Item: React.FC<ItemProps> = ({ link, children }) => (
         <Link to={link} css={{
             position: "absolute",
             inset: 0,
-            zIndex: 1,
+            zIndex: 4,
             borderRadius: 16,
         }}/>
         {children}

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { LuCalendarRange, LuLayout, LuPlayCircle, LuX } from "react-icons/lu";
+import { LuCalendarRange, LuLayout, LuLibrary, LuPlayCircle, LuX } from "react-icons/lu";
 import { IconType } from "react-icons";
 import { ReactNode, RefObject, useEffect, useRef } from "react";
 import {
@@ -32,6 +32,7 @@ import { BREAKPOINT_MEDIUM, BREAKPOINT_SMALL } from "../GlobalStyle";
 import { isExperimentalFlagSet, keyOfId } from "../util";
 import { Button } from "../ui/Button";
 import { DirectVideoRoute, VideoRoute } from "./Video";
+import { DirectSeriesRoute } from "./Series";
 
 
 export const isSearchActive = (): boolean => document.location.pathname === "/~search";
@@ -125,6 +126,11 @@ const query = graphql`
                         startTime
                         endTime
                         created
+                        hostRealms { path }
+                    }
+                    ... on SearchSeries {
+                        title
+                        description
                         hostRealms { path }
                     }
                     ... on SearchRealm { name path ancestorNames }
@@ -322,7 +328,7 @@ const FilterButton: React.FC<FilterButtonProps> = ({ type, router }) => {
                 border: `1px solid ${COLORS.neutral90}`,
             },
         }}
-    >{t(`search.filter-${translationKey}`)}</Button>;
+    >{t(`search.filter.${translationKey}`)}</Button>;
 };
 
 const CenteredNote: React.FC<{ children: ReactNode }> = ({ children }) => (
@@ -360,7 +366,14 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                     startTime: unwrapUndefined(item.startTime),
                     endTime: unwrapUndefined(item.endTime),
                     hostRealms: unwrapUndefined(item.hostRealms),
-                }}/>;
+                }} />;
+            } else if (item.__typename === "SearchSeries") {
+                return <SearchSeries key={item.id} {...{
+                    id: item.id,
+                    title: unwrapUndefined(item.title),
+                    description: unwrapUndefined(item.description),
+                    hostRealms: unwrapUndefined(item.hostRealms),
+                }} />;
             } else if (item.__typename === "SearchRealm") {
                 return <SearchRealm key={item.id} {...{
                     id: item.id,
@@ -535,6 +548,44 @@ const SearchEvent: React.FC<SearchEventProps> = ({
             />
         </Item>
     );
+};
+
+
+type SearchSeriesProps = {
+    id: string;
+    title: string;
+    description: string | null;
+    hostRealms: readonly {
+        readonly path: string;
+    }[];
+}
+
+const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, hostRealms }) => {
+    const _dum = "";
+
+    return <Item key={id} link={DirectSeriesRoute.url({ seriesId: id })}>
+        <WithIcon Icon={LuLibrary} hideIconOnMobile>
+            <div css={{
+                color: COLORS.neutral90,
+                marginRight: "clamp(12px, 4vw - 13px, 40px)",
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+            }}>
+                <h3 css={{
+                    color: COLORS.primary0,
+                    marginBottom: 6,
+                    fontSize: 17,
+                    lineHeight: 1.3,
+                    ...ellipsisOverflowCss(2),
+                }}>{title}</h3>
+                {description && <SmallDescription
+                    text={description}
+                    lines={3}
+                />}
+            </div>
+        </WithIcon>
+    </Item>;
 };
 
 type SearchRealmProps = {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -109,6 +109,27 @@ type EventConnection {
   totalCount: Int!
 }
 
+"Some extra information we know about a role."
+type RoleInfo {
+  """
+    A user-facing label for this role (group or person). If the label does
+    not depend on the language (e.g. a name), `{ "_": "Peter" }` is
+    returned.
+  """
+  label: TranslatedString!
+  """
+    For user roles this is `null`. For groups, it defines a list of other
+    group roles that this role implies. I.e. a user with this role always
+    also has these other roles.
+  """
+  implies: [String!]
+  """
+    Is `true` if this role represents a large group. Used to warn users
+    accidentally giving write access to large groups.
+  """
+  large: Boolean!
+}
+
 "A simple realm name: a fixed string."
 type PlainRealmName {
   name: String!
@@ -136,27 +157,6 @@ type Series {
   syncedData: SyncedSeriesData
   hostRealms: [Realm!]!
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!
-}
-
-"Some extra information we know about a role."
-type RoleInfo {
-  """
-    A user-facing label for this role (group or person). If the label does
-    not depend on the language (e.g. a name), `{ "_": "Peter" }` is
-    returned.
-  """
-  label: TranslatedString!
-  """
-    For user roles this is `null`. For groups, it defines a list of other
-    group roles that this role implies. I.e. a user with this role always
-    also has these other roles.
-  """
-  implies: [String!]
-  """
-    Is `true` if this role represents a large group. Used to warn users
-    accidentally giving write access to large groups.
-  """
-  large: Boolean!
 }
 
 union EventSearchOutcome = SearchUnavailable | EventSearchResults
@@ -654,6 +654,19 @@ type SearchSeries implements Node {
   title: String!
   description: String
   hostRealms: [SearchRealm!]!
+}
+
+type ThumbnailInfo {
+  thumbnail: String
+  isLive: Boolean!
+  audioOnly: Boolean!
+}
+
+type SearchSeriesExtended implements Node {
+  id: ID!
+  title: String!
+  description: String
+  thumbnailInfo: [ThumbnailInfo!]!
 }
 
 type User {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -630,6 +630,7 @@ input UpdateTitleBlock {
 
 enum ItemType {
   EVENT
+  SERIES
   REALM
 }
 

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuAlertTriangle, LuFilm, LuRadio, LuUserCircle, LuVolume2 } from "react-icons/lu";
 import { useColorScheme } from "@opencast/appkit";
@@ -54,48 +54,9 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({
             alt={t("video.thumbnail-for", { video: event.title })}
         />;
     } else {
-        // We have no thumbnail. If the resolution is `null` as well, we are
-        // dealing with an audio-only event and show an appropriate icon.
-        // Otherwise we use a generic icon.
-        const icon = audioOnly ? <LuVolume2 /> : <LuFilm />;
-
-        inner = (
-            <div css={{
-                display: "flex",
-                height: "100%",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: 40,
-                background: "linear-gradient(135deg, #33333380 50%, transparent 0),"
-                    + "linear-gradient(-135deg, #33333380 50%, transparent 0)",
-                backgroundSize: "17px 17px",
-                color: "#dbdbdb",
-                backgroundColor: "#292929",
-                ...isDark && {
-                    backgroundColor: isUpcoming ? "#3c3b3b" : "#313131",
-                    background: isUpcoming
-                        ? "linear-gradient(135deg, #48484880 50%, transparent 0),"
-                            + "linear-gradient(-135deg, #48484880 50%, transparent 0)"
-                        : "linear-gradient(135deg, #3e3e3e80 50%, transparent 0),"
-                            + "linear-gradient(-135deg, #3e3e3e80 50%, transparent 0)",
-                },
-            }}>{icon}</div>
-        );
+        inner = <ThumbnailReplacement {...{ audioOnly, isUpcoming, isDark }} />;
     }
 
-    const overlayBaseCss = {
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 6,
-        position: "absolute",
-        right: 6,
-        bottom: 6,
-        borderRadius: 4,
-        padding: "1px 5px",
-        fontSize: 14,
-        backgroundColor: "hsla(0, 0%, 0%, 0.75)",
-        color: "white",
-    } as const;
     let overlay;
     if (event.isLive) {
         // TODO: we might want to have a better "is currently live" detection.
@@ -118,36 +79,104 @@ export const Thumbnail: React.FC<ThumbnailProps> = ({
             innerOverlay = t("video.upcoming");
         }
 
-        overlay = <div css={{
-            ...overlayBaseCss,
-            ...currentlyLive ? { backgroundColor: "rgba(200, 0, 0, 0.9)" } : {},
-        }}>
+        const backgroundColor = currentlyLive ? "rgba(200, 0, 0, 0.9)" : "hsla(0, 0%, 0%, 0.75)";
+
+        overlay = <ThumbnailOverlay {...{ backgroundColor }}>
             {innerOverlay}
-        </div>;
+        </ThumbnailOverlay>;
     } else if (event.syncedData) {
-        overlay = <div css={overlayBaseCss}>{formatDuration(event.syncedData.duration)}</div>;
+        overlay = <ThumbnailOverlay backgroundColor="hsla(0, 0%, 0%, 0.75)">
+            {formatDuration(event.syncedData.duration)}
+        </ThumbnailOverlay>;
     }
 
-    return (
-        <div css={{
-            position: "relative",
-            transition: "0.2s box-shadow",
-            overflow: "hidden",
-            height: "fit-content",
-            borderRadius: 8,
-            aspectRatio: "16 / 9",
-            ...isDark && {
-                img: {
-                    filter: "brightness(90%)",
-                    transition: "0.1s filter",
-                },
+    return <ThumbnailOverlayContainer {...rest}>
+        {inner}
+        {active && <ActiveIndicator />}
+        {overlay}
+    </ThumbnailOverlayContainer>;
+};
+
+type ThumbnailReplacementProps = {
+    audioOnly: boolean;
+    isDark: boolean;
+    isUpcoming?: boolean;
+}
+export const ThumbnailReplacement: React.FC<ThumbnailReplacementProps> = (
+    { audioOnly, isDark, isUpcoming }
+) => {
+    // We have no thumbnail. If the resolution is `null` as well, we are
+    // dealing with an audio-only event and show an appropriate icon.
+    // Otherwise we use a generic icon.
+    const icon = audioOnly ? <LuVolume2 /> : <LuFilm />;
+
+    return <div css={{
+        display: "flex",
+        height: "100%",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 40,
+        background: "linear-gradient(135deg, #33333380 50%, transparent 0),"
+            + "linear-gradient(-135deg, #33333380 50%, transparent 0)",
+        backgroundSize: "17px 17px",
+        color: "#dbdbdb",
+        backgroundColor: "#292929",
+        ...isDark && {
+            backgroundColor: "#313131",
+            background: isUpcoming
+                ? "linear-gradient(135deg, #48484880 50%, transparent 0),"
+                    + "linear-gradient(-135deg, #48484880 50%, transparent 0)"
+                : "linear-gradient(135deg, #3e3e3e80 50%, transparent 0),"
+                    + "linear-gradient(-135deg, #3e3e3e80 50%, transparent 0)",
+        },
+    }}>{icon}</div>;
+};
+
+type ThumbnailOverlayProps = PropsWithChildren<{
+    backgroundColor: string;
+}>;
+export const ThumbnailOverlay: React.FC<ThumbnailOverlayProps> = (
+    { children, backgroundColor }
+) => (
+    <div css={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        position: "absolute",
+        right: 6,
+        bottom: 6,
+        borderRadius: 4,
+        padding: "1px 5px",
+        fontSize: 14,
+        backgroundColor,
+        color: "white",
+    }}>
+        {children}
+    </div>
+);
+
+type ThumbnailOverlayContainerProps = JSX.IntrinsicElements["div"];
+export const ThumbnailOverlayContainer: React.FC<ThumbnailOverlayContainerProps> = (
+    { children, ...rest }
+) => {
+    const isDark = useColorScheme().scheme === "dark";
+
+    return <div css={{
+        position: "relative",
+        transition: "0.2s box-shadow",
+        overflow: "hidden",
+        height: "fit-content",
+        borderRadius: 8,
+        aspectRatio: "16 / 9",
+        ...isDark && {
+            img: {
+                filter: "brightness(90%)",
+                transition: "0.1s filter",
             },
-        }} {...rest}>
-            {inner}
-            {active && <ActiveIndicator />}
-            {overlay}
-        </div>
-    );
+        },
+    }} {...rest}>
+        {children}
+    </div>;
 };
 
 const ActiveIndicator = () => (
@@ -188,7 +217,7 @@ export const isPastLiveEvent = (endTime: string | null, isLive: boolean): boolea
 export const isUpcomingLiveEvent = (startingTime: string | null, isLive: boolean): boolean =>
     isLive && startingTime != null && new Date(startingTime) > new Date();
 
-const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
+export const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
     const { t } = useTranslation();
     const [loadError, setLoadError] = useState(false);
 

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -20,7 +20,7 @@ test("Search", async ({ page, standardData, activeSearchIndex }) => {
     });
 
     await test.step("Should show breadcrumbs", async () => {
-        await expect(page.getByText("Search results for cat (4 hits)")).toBeVisible();
+        await expect(page.getByText("Search results for cat (6 hits)")).toBeVisible();
     });
 
     for (const videoTitle of ["Video of a Tabby Cat", "Dual Stream Cats"]) {
@@ -52,7 +52,7 @@ test("Search", async ({ page, standardData, activeSearchIndex }) => {
     });
 
     await test.step("Should show realm 'Fabulous Cats'", async () => {
-        const realm = page.getByRole("heading", { name: "Fabulous Cats" });
+        const realm = page.getByRole("heading", { name: "Fabulous Cats" }).nth(1);
         await expect(realm).toBeVisible();
         await realm.click({ force: true });
         await expect(page).toHaveURL("/love");


### PR DESCRIPTION
This adds series to search results.

Couple of notes:
- I don't really like the icon chosen for this, but the one I would prefer is not yet included in the icon package used in Tobira.
- The box shadow for the thumbnails is also debatable. I left it in so you can play around with it and see if you can find a nicer looking one.
- The series entries look samewhat empty when there is no description, but we discussed adding some metadata like a (potentially shortened) list of creators of events in that series and maybe also/alternatively direct links to the first few events, but this is tbd in another PR.

Closes #360 