### PR TITLE
Improve logging: switch to `tracing` & make filters more powerful

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -38,7 +38,7 @@ signing_algorithm = "ES256"
 secret_key = "/opt/tobira/secret-jwt-key.pem"
 
 [log]
-file = "/var/log/tobira/{{ id }}.log"
+file = "/var/log/tobira/{{ id }}-${cmd}.log"
 
 [opencast]
 host = "https://oc.tobira.ethz.ch"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1397,9 +1397,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "match_cfg"
@@ -1515,6 +1512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1608,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -2312,6 +2325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,9 +2611,9 @@ dependencies = [
  "isahc",
  "juniper",
  "libz-sys",
- "log",
  "meilisearch-sdk",
  "mime_guess",
+ "nu-ansi-term",
  "ogrim",
  "once_cell",
  "p256",
@@ -2615,6 +2647,8 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -2779,6 +2813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -2789,6 +2824,31 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2897,6 +2957,12 @@ checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2614,6 +2614,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "tracing",
  "url",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,6 +77,7 @@ tokio = { version = "1.36", features = ["fs", "rt-multi-thread", "macros", "time
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.11.1"
 url = "2.4.1"
+tracing = { version = "0.1.40", features = ["log"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.16.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,9 +43,9 @@ hyper-util = { version = "0.1.3", features = ["client", "server", "http1", "http
 isahc = { version = "1", features = ["static-ssl"] }
 juniper = { version = "0.15.10", default-features = false, features = ["chrono", "schema-language"] }
 libz-sys = { version = "1", features = ["static"] }
-log = { version = "0.4", features = ["serde", "std"] }
 meilisearch-sdk = "0.24.3"
 mime_guess = { version = "2", default-features = false }
+nu-ansi-term = "0.46.0"
 ogrim = "0.1.1"
 once_cell = "1.5"
 p256 = { version = "0.13.2", features = ["jwk"] }
@@ -78,6 +78,8 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_j
 tokio-postgres-rustls = "0.11.1"
 url = "2.4.1"
 tracing = { version = "0.1.40", features = ["log"] }
+tracing-log = "0.2.0"
+tracing-subscriber = "0.3.18"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.16.0"

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -345,6 +345,7 @@ impl BlockValue {
                 &[&realm.key, &index],
             )
             .await?;
+        info!(?block_id, realm.path = realm.full_path, "Removed block");
 
         Ok(RemovedBlock { id, realm })
     }

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -92,19 +92,19 @@ impl Block for RealmNameSourceBlockValue {
 
 pub(crate) struct Realm {
     pub(crate) key: Key,
-    parent_key: Option<Key>,
-    plain_name: Option<String>,
-    resolved_name: Option<String>,
-    name_from_block: Option<Key>,
-    path_segment: String,
-    full_path: String,
-    index: i32,
-    child_order: RealmOrder,
-    owner_display_name: Option<String>,
-    moderator_roles: Vec<String>,
-    admin_roles: Vec<String>,
-    flattened_moderator_roles: Vec<String>,
-    flattened_admin_roles: Vec<String>,
+    pub(crate) parent_key: Option<Key>,
+    pub(crate) plain_name: Option<String>,
+    pub(crate) resolved_name: Option<String>,
+    pub(crate) name_from_block: Option<Key>,
+    pub(crate) path_segment: String,
+    pub(crate) full_path: String,
+    pub(crate) index: i32,
+    pub(crate) child_order: RealmOrder,
+    pub(crate) owner_display_name: Option<String>,
+    pub(crate) moderator_roles: Vec<String>,
+    pub(crate) admin_roles: Vec<String>,
+    pub(crate) flattened_moderator_roles: Vec<String>,
+    pub(crate) flattened_admin_roles: Vec<String>,
 }
 
 impl_from_db!(

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -48,7 +48,7 @@ impl Realm {
 
         Self::load_by_key(key, context).await.map(Option::unwrap).inspect_(|realm| {
             let Self { key, full_path, resolved_name, .. } = realm;
-            info!("Realm added: {key:?} '{full_path}' {resolved_name:?}");
+            info!(path = full_path, ?key, ?resolved_name, "Created realm");
         })
     }
 
@@ -83,9 +83,10 @@ impl Realm {
 
         Self::load_by_key(key, context).await.map(Option::unwrap).inspect_(|_| {
             info!(
-                "Root user realm added for user '{}' ({}): {key:?}",
-                user.username,
-                user.display_name,
+                username = user.username,
+                display_name = user.display_name,
+                ?key,
+                "Created root user realm",
             );
         })
     }
@@ -335,7 +336,7 @@ impl Realm {
             None => None,
         };
 
-        info!("Removed realm {id:?} ({})", realm.full_path);
+        info!(%id, path = realm.full_path, "Removed realm");
         Ok(RemovedRealm { parent })
     }
 }

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -16,7 +16,7 @@ use crate::{
 
 
 pub(crate) async fn run(shared: &args::Shared, args: &Args) -> Result<()> {
-    let config = load_config_and_init_logger(shared, args)
+    let config = load_config_and_init_logger(shared, args, "cli")
         .context("failed to load config: cannot proceed with `check` command")?;
 
 

--- a/backend/src/db/tx.rs
+++ b/backend/src/db/tx.rs
@@ -46,7 +46,7 @@ impl Transaction {
         query: &str,
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error> {
-        trace!("Executing SQL query: \"{}\" with {:?}", query, params);
+        trace!(query, ?params, "Executing SQL query");
         let statement = self.inner.prepare_cached(query).await?;
         self.increase_num_queries();
         self.inner.query_one(&statement, params).await
@@ -57,7 +57,7 @@ impl Transaction {
         query: &str,
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error> {
-        trace!("Executing SQL query: \"{}\" with {:?}", query, params);
+        trace!(query, ?params, "Executing SQL query");
         let statement = self.inner.prepare_cached(query).await?;
         self.increase_num_queries();
         self.inner.query_opt(&statement, params).await
@@ -69,7 +69,7 @@ impl Transaction {
         I: IntoIterator<Item = P> + std::fmt::Debug,
         I::IntoIter: ExactSizeIterator,
     {
-        trace!("Executing SQL query: \"{}\" with {:?}", query, params);
+        trace!(query, ?params, "Executing SQL query");
         let statement = self.inner.prepare_cached(query).await?;
         self.increase_num_queries();
         self.inner.query_raw(&statement, params).await
@@ -97,7 +97,7 @@ impl Transaction {
         query: &str,
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<u64, Error> {
-        trace!("Executing SQL query: \"{}\" with {:?}", query, params);
+        trace!(query, ?params, "Executing SQL query");
         let statement = self.inner.prepare_cached(query).await?;
         self.increase_num_queries();
         self.inner.execute(&statement, params).await

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -31,9 +31,9 @@ use super::{Context, Response, response};
 pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Response {
     let time_incoming = Instant::now();
     trace!(
-        "Incoming HTTP {:?} request to '{}'",
-        req.method(),
-        req.uri().path_and_query().map_or("", |pq| pq.as_str()),
+        method = ?req.method(),
+        path = req.uri().path_and_query().map_or("", |pq| pq.as_str()),
+        "Incoming HTTP request",
     );
     if ctx.config.log.log_http_headers {
         let mut out = String::new();
@@ -80,7 +80,7 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
         // will result in 404.
         _ if method != Method::GET && method != Method::HEAD => {
             register_req!(HttpReqCategory::Other);
-            debug!("Responding 405 Method not allowed to {method:?} {path}");
+            debug!(?method, path, "Responding 405 Method not allowed");
             Response::builder()
                 .status(StatusCode::METHOD_NOT_ALLOWED)
                 .header("Content-Type", "text/plain; charset=UTF-8")
@@ -172,7 +172,7 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
 
 /// Replies with a 404 Not Found.
 pub(super) async fn reply_404(ctx: &Context, method: &Method, path: &str) -> Response {
-    debug!("Responding with 404 to {:?} '{}'", method, path);
+    debug!(?method, path, "Responding with 404");
 
     // We simply send the normal index and let the frontend router determinate
     // this is a 404. That way, our 404 page looks like the main page and users

--- a/backend/src/logger.rs
+++ b/backend/src/logger.rs
@@ -1,10 +1,18 @@
-use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::{
-    fs::{File, OpenOptions},
+    fs::OpenOptions,
     path::PathBuf,
-    sync::Mutex,
 };
-use termcolor::{NoColor, StandardStream, WriteColor};
+use nu_ansi_term::{Color, Style};
+use serde::Deserialize;
+use termcolor::ColorChoice;
+use tracing::{field::Visit, Level};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::{
+    filter::{FilterFn, LevelFilter},
+    fmt::FormatEvent,
+    prelude::*,
+};
+
 
 use crate::{prelude::*, args::Args};
 
@@ -14,8 +22,8 @@ pub(crate) struct LogConfig {
     /// Determines how many messages are logged. Log messages below
     /// this level are not emitted. Possible values: "trace", "debug",
     /// "info", "warn", "error" and "off".
-    #[config(default = "debug")]
-    pub(crate) level: log::LevelFilter,
+    #[config(default = "debug", deserialize_with = deserialize_level)]
+    pub(crate) level: LevelFilter,
 
     /// If this is set, log messages are also written to this file.
     /// Example: "/var/log/tobira.log".
@@ -31,22 +39,52 @@ pub(crate) struct LogConfig {
     pub(crate) log_http_headers: bool,
 }
 
+fn deserialize_level<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_level_filter(&s).map_err(|msg| <D::Error as serde::de::Error>::custom(msg))
+}
 
-/// Our own `Log` implementation.
-struct Logger {
-    level_filter: LevelFilter,
-    file: Option<Mutex<File>>,
-    stdout: Option<Mutex<StandardStream>>,
+fn parse_level_filter(s: &str) -> Result<LevelFilter, String> {
+    match s {
+        "off" => Ok(LevelFilter::OFF),
+        "trace" => Ok(LevelFilter::TRACE),
+        "debug" => Ok(LevelFilter::DEBUG),
+        "info" => Ok(LevelFilter::INFO),
+        "warn" => Ok(LevelFilter::WARN),
+        "error" => Ok(LevelFilter::ERROR),
+        other => Err(format!("invalid log level '{other}'")),
+    }
 }
 
 /// Installs our own logger globally. Must only be called once!
 pub(crate) fn init(config: &LogConfig, args: &Args) -> Result<()> {
-    let stdout = match config.stdout {
-        true => Some(Mutex::new(StandardStream::stdout(args.stdout_color()))),
-        false => None,
+    let filter = {
+        let level = config.level;
+        let filter = FilterFn::new(move |metadata| {
+            metadata.target().starts_with("tobira")
+                && metadata.level() <= &level
+        });
+        filter.with_max_level_hint(level)
     };
 
-    let file = config.file.as_ref()
+    macro_rules! subscriber {
+        ($writer:expr) => {
+            tracing_subscriber::fmt::layer()
+                .event_format(EventFormatter(args.color))
+                .with_writer($writer)
+        };
+    }
+
+    let stdout_output = if config.stdout {
+        Some(subscriber!(std::io::stdout))
+    } else {
+        None
+    };
+
+    let file_output = config.file.as_ref()
         .map(|path| {
             OpenOptions::new()
                 .append(true)
@@ -55,101 +93,273 @@ pub(crate) fn init(config: &LogConfig, args: &Args) -> Result<()> {
                 .with_context(|| format!("failed to open/create log file '{}'", path.display()))
         })
         .transpose()?
-        .map(Mutex::new);
+        .map(|file| subscriber!(file).with_ansi(args.color == ColorChoice::Always));
 
-    let logger = Logger {
-        level_filter: config.level,
-        file,
-        stdout,
-    };
-
-    log::set_boxed_logger(Box::new(logger)).expect("`logger::init` called twice");
-    log::set_max_level(config.level);
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(file_output)
+        .with(stdout_output)
+        .init();
 
     Ok(())
 }
 
-impl Log for Logger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.target().starts_with("tobira")
-            && metadata.level() <= self.level_filter
+type TracingWriter<'a> = tracing_subscriber::fmt::format::Writer<'a>;
+
+#[derive(Clone, Copy)]
+struct EventFormatter(ColorChoice);
+
+impl<S, N> FormatEvent<S, N> for EventFormatter
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        // TODO: maybe print infos about the span
+        _ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: TracingWriter<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        // Helper macros to conditionally emit ANSI control codes
+        let use_ansi = self.0 == ColorChoice::Always
+            || (writer.has_ansi_escapes() && self.0 != ColorChoice::Never);
+        macro_rules! wr {
+            ($style:expr, $fmt:literal $($args:tt)*) => {{
+                with_style(&mut writer, use_ansi, $style, |w| {
+                    write!(w, $fmt $($args)*)
+                })?;
+            }};
+        }
+
+        // Normalize metadata of log events
+        let normalized_metadata = event.normalized_metadata();
+        let metadata = normalized_metadata.as_ref().unwrap_or(event.metadata());
+
+        // Determine styles/colors
+        let dim_style = Style::new().dimmed();
+        let level_style = match *metadata.level() {
+            Level::ERROR => Style::new().fg(Color::Red).bold(),
+            Level::WARN => Style::new().fg(Color::Yellow).bold(),
+            Level::INFO => Style::new().fg(Color::Green),
+            Level::DEBUG => Style::new().fg(Color::Blue),
+            Level::TRACE => Style::new().fg(Color::Magenta),
+        };
+        let body_style = match *metadata.level() {
+            Level::ERROR => Style::new().fg(Color::Red),
+            Level::WARN => Style::new().fg(Color::Yellow),
+            Level::INFO => Style::new(),
+            Level::DEBUG => Style::new().dimmed(),
+            Level::TRACE => Style::new().fg(Color::DarkGray),
+        };
+
+
+        // Print time, level and target.
+        wr!(dim_style, "{} ", chrono::Local::now().format("%Y-%m-%d %H:%M:%S.%3f"));
+        wr!(level_style, "{:5}", metadata.level());
+        wr!(dim_style, " {} >  ", metadata.target());
+
+
+        // ---- Print message & all fields ------------------------------------
+        // `tracing-subscriber` intends this part to be done by the
+        // `FormatFields` trait, but this doesn't work for us since we want to
+        // have pretty multi-line printing. For that we need to switch between
+        // dimmed_style and body_style. The latter depends on the level which is
+        // inaccessible in `FieldFormatter`. So we do all of that here.
+
+        fn ignore_field(name: &str) -> bool {
+            name == "message" || name.starts_with("log.") || name.starts_with("tobira.")
+        }
+
+        // We first visit all fields to gather some information on how to print
+        // them. We also remember the `message` field. This is always the first
+        // field in my tests and other code seems to rely on it, but I haven't
+        // seen it guaranteed anywhere. And we need to allocate an intermediate
+        // string anyway.
+        #[derive(Debug)]
+        struct ProbeVisitor {
+            message: Option<String>,
+            // Print each field on its own line.
+            multiline: bool,
+            num_fields: u32,
+        }
+
+        impl Visit for ProbeVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if !ignore_field(field.name()) {
+                    self.num_fields += 1;
+                }
+
+                if field.name() == "message" {
+                    self.message = Some(format!("{value:?}"));
+                }
+            }
+
+            fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+                if !ignore_field(field.name()) {
+                    self.num_fields += 1;
+                }
+
+                // "tobira.multiline" is a special flag that we can set to print
+                //  each variable on its own line.
+                match field.name() {
+                    "tobira.multiline" => self.multiline = value,
+                    _ => {}
+                }
+            }
+        }
+
+        let mut probe = ProbeVisitor {
+            message: None,
+            multiline: false,
+            num_fields: 0,
+        };
+        event.record(&mut probe);
+
+
+        struct PrintContext<'a> {
+            prefix: &'a str,
+            use_ansi: bool,
+            body_style: Style,
+        }
+
+        fn print_multiline(
+            s: &str,
+            out: &mut TracingWriter<'_>,
+            ctx: &PrintContext<'_>,
+        ) -> std::fmt::Result {
+            macro_rules! with_style {
+                ($style:expr, |$arg:ident| $body:tt) => {
+                    with_style(out, ctx.use_ansi, $style, |$arg| $body)?;
+                };
+            }
+
+            let mut lines = s.lines();
+
+            // First line
+            with_style!(ctx.body_style, |out| {
+                write!(out, "{}", lines.next().unwrap_or(""))
+            });
+
+            for line in lines {
+                write!(out, "{}", ctx.prefix)?;
+                with_style!(ctx.body_style, |out| { write!(out, "{line}") });
+            }
+
+            Ok(())
+        }
+
+        // Print all other fields
+        struct Printer<'a, 'w> {
+            buffer: String,
+            ctx: PrintContext<'a>,
+            multiline: bool,
+            separator: &'a str,
+            needs_separator: bool,
+            out: TracingWriter<'w>,
+        }
+
+        impl Visit for Printer<'_, '_> {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                // Ignore some fields
+                let name = field.name();
+                if name == "message" || name.starts_with("log.") || name.starts_with("tobira.") {
+                    return;
+                }
+
+                let _ = (|| -> std::fmt::Result {
+                    use std::fmt::Write;
+
+                    self.buffer.clear();
+                    write!(self.buffer, "{value:?}").unwrap();
+
+                    if self.needs_separator {
+                        write!(self.out, "{}", self.separator)?;
+                    }
+
+                    let key_style = self.ctx.body_style.italic();
+                    with_style(&mut self.out, self.ctx.use_ansi, key_style, |out| {
+                        write!(out, "{}", field.name())
+                    })?;
+                    with_style(&mut self.out, self.ctx.use_ansi, self.ctx.body_style, |out| {
+                        write!(out, "{}", if self.multiline { " = " } else { "=" })
+                    })?;
+
+                    if self.multiline {
+                        print_multiline(&self.buffer, &mut self.out, &self.ctx)?;
+                    } else {
+                        with_style(&mut self.out, self.ctx.use_ansi, self.ctx.body_style, |out| {
+                            write!(out, "{}", self.buffer)
+                        })?;
+                    }
+                    self.needs_separator = true;
+
+                    Ok(())
+                })();
+            }
+        }
+
+
+
+        // The padded prefix to make the message nicely aligned. I know this
+        // only works if the target is ASCII, but that's a fair assumption.
+        let prefix = {
+            let padding = "2021-05-04 19:40:18.270 DEBUG ".len() + 2 + metadata.target().len();
+            format!(
+                "\n{:padding$}{prefix}>{suffix}  ",
+                "",
+                padding = padding - 1,
+                prefix = if use_ansi { dim_style.prefix() } else { Style::new().prefix() },
+                suffix = if use_ansi { dim_style.suffix() } else { Style::new().suffix() },
+            )
+        };
+
+        let print_ctx = PrintContext {
+            prefix: &prefix,
+            use_ansi,
+            body_style,
+        };
+
+        // Print main message
+        if let Some(msg) = &probe.message {
+            print_multiline(msg, &mut writer, &print_ctx)?;
+        }
+
+        // Print fields
+        if probe.num_fields > 0 {
+            if probe.message.is_some() {
+                wr!(level_style, " ~~ ");
+            }
+            let mut printer = Printer {
+                separator: if probe.multiline { &prefix } else { " " },
+                needs_separator: probe.multiline && probe.message.is_some(),
+                ctx: print_ctx,
+                multiline: probe.multiline,
+                out: writer.by_ref(),
+                // Reuse the string from before as scratch buffer
+                buffer: probe.message.unwrap_or_default(),
+            };
+            event.record(&mut printer);
+        }
+
+        writeln!(writer, "{}", if use_ansi { nu_ansi_term::ansi::RESET } else { "" })?;
+
+        Ok(())
     }
-
-    fn log(&self, record: &Record) {
-        if !self.enabled(record.metadata()) {
-            return;
-        }
-
-        if let Some(stdout) = &self.stdout {
-            // We ignore a poisoned mutex. The stdout handle doesn't contain
-            // any "state" that other threads could have tainted. The worst
-            // that could happen is slightly weird formatting.
-            //
-            // We also ignore possible errors writing to `stdout`. Because...
-            // what are we supposed to do? It's better the server keeps running
-            // without logs than the server going down, right?
-            let mut stdout = stdout.lock().unwrap_or_else(|e| e.into_inner());
-            let _ = write(record, &mut *stdout);
-        }
-
-        if let Some(file) = &self.file {
-            // See comment above about stdout.
-            let mut file = file.lock().unwrap_or_else(|e| e.into_inner());
-            let _ = write(record, &mut NoColor::new(&mut *file));
-        }
-    }
-
-    fn flush(&self) {}
 }
 
-fn write(record: &Record, out: &mut impl WriteColor) -> Result<()> {
-    // Figure out styles/colors for the parts of the message.
-    let dim_style = bunt::style!("dimmed");
-    let level_style = match record.level() {
-        Level::Error => bunt::style!("red+bold"),
-        Level::Warn => bunt::style!("yellow+bold"),
-        Level::Info => bunt::style!("green"),
-        Level::Debug => bunt::style!("blue"),
-        Level::Trace => bunt::style!("magenta"),
-    };
-    let body_style = match record.level() {
-        Level::Error => bunt::style!("red"),
-        Level::Warn => bunt::style!("yellow"),
-        Level::Info => bunt::style!(""),
-        Level::Debug => bunt::style!("dimmed"),
-        Level::Trace => bunt::style!("black+intense"),
-    };
-
-    // Print time, level and target.
-    out.set_color(&dim_style)?;
-    write!(out, "{} ", chrono::Local::now().format("%Y-%m-%d %H:%M:%S.%3f"))?;
-    out.set_color(&level_style)?;
-    write!(out, "{:5}", record.level())?;
-    out.set_color(&dim_style)?;
-    write!(out, " {} >", record.target())?;
-
-    // Print actual message
-    let msg = record.args().to_string();
-    let mut lines = msg.lines();
-
-    // First line
-    out.set_color(&body_style)?;
-    write!(out, "  {}", lines.next().unwrap_or(""))?;
-    out.reset()?;
-    writeln!(out)?;
-
-    // Print remaining lines with a padding such that the message is
-    // nicely aligned. I know this only works if the target is ASCII,
-    // but that's a fair assumption.
-    let padding = "2021-05-04 19:40:18.270 DEBUG ".len() + 2 + record.target().len();
-    for line in lines {
-        out.set_color(&dim_style)?;
-        write!(out, "{:padding$}>", "", padding = padding - 1)?;
-        out.set_color(&body_style)?;
-        write!(out, "  {msg}", msg = line)?;
-        out.reset()?;
-        writeln!(out)?;
+fn with_style(
+    out: &mut TracingWriter<'_>,
+    use_ansi: bool,
+    style: Style,
+    f: impl FnOnce(&mut TracingWriter<'_>) -> std::fmt::Result,
+) -> std::fmt::Result {
+    if use_ansi {
+        write!(out, "{}", style.prefix())?;
     }
-
+    f(out)?;
+    if use_ansi {
+        write!(out, "{}", style.suffix())?;
+    }
     Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -183,7 +183,7 @@ fn load_config_and_init_logger(shared: &args::Shared, args: &Args) -> Result<Con
     // Initialize logger. Unfortunately, we can only do this here
     // after reading the config.
     logger::init(&config.log, args)?;
-    info!("Loaded config from '{}'", path.display());
+    info!(source_file = ?path.display(), "Loaded config");
 
     // Call validate again, as some of the checks will only print warnings.
     config.validate()?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -185,7 +185,9 @@ fn load_config_and_init_logger(shared: &args::Shared, args: &Args, cmd: &str) ->
     // Initialize logger. Unfortunately, we can only do this here
     // after reading the config.
     logger::init(&config.log, args, cmd)?;
+    info!(cli_args = ?std::env::args().collect::<Vec<_>>(), "Starting Tobira");
     info!(source_file = ?path.display(), "Loaded config");
+    debug!(cmd, "Initialized logger");
 
     // Call validate again, as some of the checks will only print warnings.
     config.validate()?;

--- a/backend/src/prelude.rs
+++ b/backend/src/prelude.rs
@@ -2,7 +2,7 @@
 //! commonly used symbols are easily available.
 
 pub(crate) use anyhow::{anyhow, bail, Context as _, Result};
-pub(crate) use log::{error, warn, info, debug, trace, log};
+pub(crate) use tracing::{error, warn, info, debug, trace};
 pub(crate) use futures::{FutureExt as _, TryStreamExt as _};
 pub(crate) use tap::Pipe;
 

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -32,6 +32,12 @@ pub(crate) enum SearchIndexCommand {
     },
 }
 
+impl SearchIndexCommand {
+    pub(crate) fn is_long_running(&self) -> bool {
+        matches!(self, Self::Update { daemon: true })
+    }
+}
+
 /// Entry point for `search-index` commands.
 pub(crate) async fn run(cmd: &SearchIndexCommand, config: &Config) -> Result<()> {
     let meili = config.meili.connect().await?;

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -299,9 +299,11 @@ pub(crate) async fn rebuild_if_necessary(
 ) -> Result<()> {
     let state = IndexState::fetch(&meili.meta_index).await?;
     if state.needs_rebuild() {
-        info!("Search index schema incompatible -> will rebuild search index\n\
-            Search index state: {state:?}\n\
-            Expected version: {VERSION}");
+        info!(
+            search_index_state = ?state,
+            expected_version = VERSION,
+            "Search index schema incompatible -> will rebuild search index",
+        );
 
         meili.meta_index.add_or_replace(&[meta::Meta::current_dirty()], None).await
             .context("failed to update index version document (dirty)")?;

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -105,14 +105,22 @@ impl OcClient {
             .with_context(|| format!("Harvest request failed (to '{uri}')"))?;
 
         let (out, body_len) = self.deserialize_response::<HarvestResponse>(response, &uri).await?;
-        log!(
-            if out.items.len() > 0 { log::Level::Debug } else { log::Level::Trace },
-            "Received {} KiB ({} items) from the harvest API (in {:.2?}, since = {:?})",
-            body_len / 1024,
-            out.items.len(),
-            before.elapsed(),
-            since,
-        );
+
+        if out.items.len() > 0 {
+            debug!(
+                "Received {} KiB ({} items) from the harvest API (in {:.2?}, since = {:?})",
+                body_len / 1024,
+                out.items.len(),
+                before.elapsed(),
+                since,
+            );
+        } else {
+            trace!(
+                "Received 0 items from harvest API (in {:.2?}, since = {:?})",
+                before.elapsed(),
+                since,
+            );
+        }
 
         Ok(out)
     }

--- a/backend/src/sync/cmd.rs
+++ b/backend/src/sync/cmd.rs
@@ -33,6 +33,12 @@ pub(crate) enum SyncCommand {
     },
 }
 
+impl Args {
+    pub(crate) fn is_long_running(&self) -> bool {
+        matches!(self.cmd, SyncCommand::Run { daemon: true })
+    }
+}
+
 /// Entry point for `search-index` commands.
 pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
     info!("Starting Tobira <-> Opencast synchronization ...");

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -328,12 +328,29 @@
 
 
 [log]
-# Determines how many messages are logged. Log messages below
-# this level are not emitted. Possible values: "trace", "debug",
-# "info", "warn", "error" and "off".
+# Specifies what log messages to emit, based on the module path and log level.
 #
-# Default value: "debug"
-#level = "debug"
+# This is a map where the key specifies a module path prefix, and the
+# value specifies a minimum log level. For each log message, the map
+# entry with the longest prefix matching the log's module path is chosen.
+# If no such entry exists, the log is not emitted. Otherwise, that
+# entry's level is used to check whether the log message should be
+# emitted.
+#
+# Take the following example: the following config only allows ≥"info"
+# logs from Tobira generally, but also ≥"trace" messages from the `db`
+# submodule. But it completely disables all logs from `tobira::db::tx`.
+# Finally, it also enabled ≥"debug" messages from one of Tobira's
+# dependencies, the HTTP library `hyper`.
+#
+#    [log]
+#    filters.tobira = "info"
+#    filters."tobira::db" = "trace"
+#    filters."tobira::db::tx" = "off"
+#    filters.hyper = "debug"
+#
+# Default value: { tobira = "debug" }
+#filters = { tobira = "debug" }
 
 # If this is set, log messages are also written to this file.
 # Example: "/var/log/tobira.log".

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -352,8 +352,10 @@
 # Default value: { tobira = "debug" }
 #filters = { tobira = "debug" }
 
-# If this is set, log messages are also written to this file.
-# Example: "/var/log/tobira.log".
+# If this is set, log messages are also written to this file. The string
+# `${cmd}` in this value is replaced by the subcommand name of the Tobira
+# process, e.g. `serve`, `worker` or `other` (for less important
+# commands). Example: "/var/log/tobira-${job}.log".
 #file =
 
 # If this is set to `false`, log messages are not written to stdout.

--- a/frontend/tests/util/isolation.ts
+++ b/frontend/tests/util/isolation.ts
@@ -127,9 +127,6 @@ const tobiraConfig = ({ index, port, dbName, rootPath }: {
     index_prefix = "tobira_ui_test_${index}"
     key = "tobira"
 
-    [log]
-    level = "debug"
-
     [auth]
     source = "tobira-session"
     session.from_login_credentials = "login-callback:http://localhost:3091"

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -20,7 +20,7 @@ tls_mode = "off"
 key = "tobira"
 
 [log]
-level = "debug"
+filters.tobira = "debug"
 
 [auth]
 source = "tobira-session"


### PR DESCRIPTION
This does two main things:

- **Switch from `log` to `tracing`**: the new library is more powerful mostly due to two features: spans and structured logging. Spans can attach contexts to log messages and describe time spans instead of a single point in time. We don't use that feature yet. The structured logging feature refers to the ability to specify arbitrary fields alongside the log message. While currently these fields are always formatted back into text, their raw form is available. This allows us to write them to JSON files or ingest them into other systems, allowing the logs to be analyzed a lot better.

- **Make filtering logic more powerful**: the previous system of having a single `level` field to specify what log messages to emit was replaced. This has two major advantages: admins can specify different log levels for different modules and log output of Tobira's dependencies can be enabled. This change is a breaking one, as the config changed.


There are two things that I decided not to include in this PR:

- Converting all our log statements into structured logging. This can be done later and the non-structured logging statements don't really hurt. I already converted a number of them. And some don't really have any use for structured logging anyway (e.g. "Starting Tobira backend...").
- Configure additional sinks that can take benefit of structured logging: currently, Tobira only logs to stdout or the file, as before. So the structured logging is not really used yet. In the future we can add logging to JSON files or other integrations like OpenTelemetry. But that's really not important right now.

One thing I still try to do in this PR, or at least think about (therefore draft):

- [x] Improve `tobira serve` and `tobira worker` writing into the same log file. This proved annoying in practice. Either they should both log into different log files (maybe sth like `log_file = "/var/log/tobira-${job}.log"`?) or there should be a clear prefix in each line showing from which process the output is. Not sure yet what I prefer. Or if there are better solutions.

---

Can be reviewed commit by commit. 