### PR TITLE
Adjust paella progress bar color

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -213,6 +213,9 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
                 "& .progress-indicator-remaining": {
                     backgroundColor: "#9e9e9e !important",
                 },
+                "& .progress-indicator-content": {
+                    opacity: "unset",
+                },
 
                 '& button[name="es.upv.paella.backwardButtonPlugin"] div': {
                     marginTop: "-4px !important",


### PR DESCRIPTION
Paella uses `opacity: 0.8` on the progress bar, making that color slightly different than the volume indicator.
This overrides the opacity rule so the colors are exactly the same.

Closes #1039