### PR TITLE
Adjust spacing of forwards and backwards button text

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -215,15 +215,17 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
                 },
 
                 '& button[name="es.upv.paella.backwardButtonPlugin"] div': {
-                    marginTop: "-4px !important",
+                    marginTop: "-7px !important",
                     "svg text": {
-                        transform: "translate(1px, -2px)",
+                        transform: "translate(0px, -1px)",
+                        fontFamily: "var(--main-font) !important",
                     },
                 },
                 '& button[name="es.upv.paella.forwardButtonPlugin"] div': {
-                    marginTop: "-4px !important",
+                    marginTop: "-7px !important",
                     "svg text": {
-                        transform: "translate(1px, -2px)",
+                        transform: "translate(2px, -1px)",
+                        fontFamily: "var(--main-font) !important",
                     },
                 },
 


### PR DESCRIPTION
Since these are basically mirrored (not completely because the number 10 is obv not), the x-offset of the number does not necessarily need to be the same. It's kinda hard to tell, so I tried around a bit with different values and also increased the y-offset of both by one pixel. I might have ended up with an improved balancing. Though that is still somewhat subjective of course, so feedback is still welcome.

Closes #1086