### PR TITLE
Adjust sync code for series metadata

### DIFF
--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -363,4 +363,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     28: "user-index-queue-triggers",
     29: "extend-series-block",
     30: "realm-permissions",
+    31: "series-metadata",
 ];

--- a/backend/src/db/migrations/31-series-metadata.sql
+++ b/backend/src/db/migrations/31-series-metadata.sql
@@ -1,0 +1,68 @@
+-- Adds `metadata` and `created` fields to `series`. Also adjusts the
+-- `check_metadata_format` function from `events` to be usable in both
+-- contexts, and adds new triggers.
+
+alter table series
+    add column created timestamp with time zone,
+    add column metadata jsonb;
+
+drop trigger check_metadata_format_on_insert on events;
+drop function check_metadata_format;
+
+-- The following function makes sure that the extra JSON metadata is always in a
+-- predefined format. It is identical to the function defined in `05-events.sql`,
+-- with the addition of a mandatory argument to declare which table is checked.
+-- This can be either `events` or `series`, but can in theory be any table whose
+-- entries include a `metadata` field.
+create or replace function check_metadata_format() returns trigger as $$
+declare
+    col text := tg_argv[0] || '.metadata';
+    namespace record;
+    field record;
+    element jsonb;
+begin
+    if jsonb_typeof(new.metadata) <> 'object' then
+        raise exception '% is %, but should be a JSON object', col, jsonb_typeof(new.metadata);
+    end if;
+
+    for namespace in select * from jsonb_each(new.metadata) loop
+        if jsonb_typeof(namespace.value) <> 'object' then
+            raise exception '%: type of top level field "%" is %, but should be object',
+                col,
+                namespace.key,
+                jsonb_typeof(namespace.value);
+        end if;
+
+        for field in select * from jsonb_each(namespace.value) loop
+            if jsonb_typeof(field.value) <> 'array' then
+                raise exception '%: type of field "%.%" is %, but should be array',
+                    col,
+                    namespace.key,
+                    field.key,
+                    jsonb_typeof(field.value);
+            end if;
+
+            for element in select * from jsonb_array_elements(field.value) loop
+                if jsonb_typeof(element) <> 'string' then
+                    raise exception '%: found non-string element "%" in "%.%", but that field should be a string array',
+                        col,
+                        element,
+                        namespace.key,
+                        field.key;
+                end if;
+            end loop;
+        end loop;
+    end loop;
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger check_event_metadata_format_on_upsert
+    before insert or update on events
+    for each row
+    execute procedure check_metadata_format('events');
+
+create trigger check_series_metadata_format_on_upsert
+    before insert or update on series
+    for each row
+    execute procedure check_metadata_format('series');

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -215,7 +215,15 @@ async fn store_in_db(
                 removed_events += 1;
             }
 
-            HarvestItem::Series { id: opencast_id, title, description, updated, acl } => {
+            HarvestItem::Series {
+                id: opencast_id,
+                title,
+                description,
+                updated,
+                acl,
+                created,
+                metadata
+            } => {
                 // We first simply upsert the series.
                 let new_id = upsert(db, "series", "opencast_id", &[
                     ("opencast_id", &opencast_id),
@@ -225,6 +233,8 @@ async fn store_in_db(
                     ("read_roles", &acl.read),
                     ("write_roles", &acl.write),
                     ("updated", &updated),
+                    ("created", &created),
+                    ("metadata", &metadata),
                 ]).await?;
 
                 // But now we have to fix the foreign key for any events that

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -58,6 +58,9 @@ pub(crate) enum HarvestItem {
         acl: Acl,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
+        #[serde(with = "chrono::serde::ts_milliseconds")]
+        created: DateTime<Utc>,
+        metadata: ExtraMetadata,
     },
 
     #[serde(rename_all = "camelCase")]

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -154,6 +154,8 @@ type Series {
   id: ID!
   opencastId: String!
   title: String!
+  created: DateTimeUtc
+  metadata: ExtraMetadata
   syncedData: SyncedSeriesData
   hostRealms: [Realm!]!
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!


### PR DESCRIPTION
This repurposes the code from the events migration, since series metadata is using the same format. With this, extended metadata and date of creation is now harvested and stored in db series entries.

Note: This is only the backend part. We don't display any metadata for series yet (so technically `changelog:user` is incorrect, but it isn't really a `dev` change either).