### PR TITLE
Add slide segments and extracted text to harvesting and DB, enable paella slide previews

### DIFF
--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -139,7 +139,7 @@ macro_rules! handle_search_result {
             // rebuilt yet. We also show "search unavailable" for this case.
             Err(MsError::ParseError(e)) if e.is_data() => {
                 error!("Failed to deserialize search results (missing rebuild after update?): {e} \
-                    (=> replying 'search uavailable')");
+                    (=> replying 'search unavailable')");
                 return Ok(<$return_type>::SearchUnavailable(SearchUnavailable));
             }
 

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -365,4 +365,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     30: "realm-permissions",
     31: "series-metadata",
     32: "custom-actions",
+    33: "event-slide-text",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -365,5 +365,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     30: "realm-permissions",
     31: "series-metadata",
     32: "custom-actions",
-    33: "event-slide-text",
+    33: "event-slide-text-and-segments",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -298,7 +298,7 @@ pub(crate) async fn unsafe_overwrite_migrations(db: &mut Db) -> Result<()> {
 }
 
 
-// Helper macro to include migrations in the `migations` folder and add them to
+// Helper macro to include migrations in the `migrations` folder and add them to
 // a map. The `assert!` and `panic!` in there should ideally be compile errors,
 // but panics are fine for now.
 macro_rules! include_migrations {

--- a/backend/src/db/migrations/33-event-slide-text-and-segments.sql
+++ b/backend/src/db/migrations/33-event-slide-text-and-segments.sql
@@ -1,0 +1,30 @@
+-- Adds two new fields to `events`:
+-- `slide_text` which holds a url pointing to the extracted slide text
+-- generated in Opencast,
+-- and `segments`, which holds a list of frames with their respective
+-- starting time, and is needed for slide previews in paella.
+-- Also creates the appropriate type for the segments and adjusts
+-- the constraints. Basically an adjusted copy of `14-event-captions`.
+
+create type event_segment as (
+    uri text,
+    start_time bigint -- in ms
+);
+
+alter table events
+    add column slide_text text,
+    add column segments event_segment[]
+        default '{}'
+        constraint no_null_segment_items check (array_position(segments, null) is null);
+
+alter table events
+    -- The default above was just for all existing records. New records should
+    -- require this to be set.
+    alter column segments drop default,
+    drop constraint ready_event_has_fields,
+    add constraint ready_event_has_fields check (state <> 'ready' or (
+        duration is not null
+        and tracks is not null and array_length(tracks, 1) > 0
+        and captions is not null
+        and segments is not null
+    ));

--- a/backend/src/db/migrations/33-event-slide-text.sql
+++ b/backend/src/db/migrations/33-event-slide-text.sql
@@ -1,0 +1,5 @@
+-- Adds a `slide_text` field to `events` which holds an url pointing 
+-- to the extracted slide text generated in Opencast.
+
+alter table events
+    add column slide_text text;

--- a/backend/src/db/migrations/33-event-slide-text.sql
+++ b/backend/src/db/migrations/33-event-slide-text.sql
@@ -1,5 +1,0 @@
--- Adds a `slide_text` field to `events` which holds an url pointing 
--- to the extracted slide text generated in Opencast.
-
-alter table events
-    add column slide_text text;

--- a/backend/src/db/tests/util.rs
+++ b/backend/src/db/tests/util.rs
@@ -89,7 +89,7 @@ impl TestDb {
     ) -> Result<Key> {
         let sql = "insert into events
             (state, opencast_id, title, series, is_live, read_roles, write_roles, created,
-                updated, metadata, duration, tracks, captions)
+                updated, metadata, duration, tracks, captions, segments)
             values
             ('ready', $1, $2, $3, false, '{ROLE_ANONYMOUS}', '{ROLE_ANONYMOUS}',
                 now(), now(), '{}', $4,
@@ -100,7 +100,7 @@ impl TestDb {
                     '{1280, 720}',
                     true
                 )]::event_track[],
-             '{}'
+             '{}', '{}'
             )
             returning id";
 

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -59,6 +59,13 @@ pub struct EventTrack {
     pub resolution: Option<[i32; 2]>,
     pub is_master: Option<bool>,
 }
+/// Represents the `event_segment` type defined in `33-event-slide-text-and-segments.sql`.
+#[derive(Debug, FromSql, ToSql)]
+#[postgres(name = "event_segment")]
+pub struct EventSegment {
+    pub uri: String,
+    pub start_time: i64,
+}
 
 /// Represents the `event_caption` type defined in `14-event-captions.sql`.
 #[derive(Debug, FromSql, ToSql)]

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -128,7 +128,7 @@ pub(crate) async fn serve(
                         }))
                         .await;
                     if let Err(e) = res {
-                        warn!("Error serving connectiion: {e:#}");
+                        warn!("Error serving connection: {e:#}");
                     }
                 });
             }

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -162,6 +162,7 @@ async fn store_in_db(
                 is_live,
                 metadata,
                 updated,
+                slide_text,
             } => {
                 let series_id = match &part_of {
                     None => None,
@@ -206,6 +207,7 @@ async fn store_in_db(
                     ("custom_action_roles", &acl.custom_actions),
                     ("tracks", &tracks),
                     ("captions", &captions),
+                    ("slide_text", &slide_text),
                 ]).await?;
 
                 trace!("Inserted or updated event {} ({})", opencast_id, title);

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -8,7 +8,7 @@ use tokio_postgres::types::ToSql;
 use crate::{
     auth::ROLE_ADMIN,
     config::Config,
-    db::{types::{EventTrack, EventState, SeriesState, EventCaption}, DbConnection},
+    db::{types::{EventCaption, EventSegment, EventState, EventTrack, SeriesState}, DbConnection},
     prelude::*,
 };
 use super::{status::SyncStatus, OcClient};
@@ -162,6 +162,7 @@ async fn store_in_db(
                 is_live,
                 metadata,
                 updated,
+                segments,
                 slide_text,
             } => {
                 let series_id = match &part_of {
@@ -184,6 +185,7 @@ async fn store_in_db(
 
                 let tracks = tracks.into_iter().map(Into::into).collect::<Vec<EventTrack>>();
                 let captions = captions.into_iter().map(Into::into).collect::<Vec<EventCaption>>();
+                let segments = segments.into_iter().map(Into::into).collect::<Vec<EventSegment>>();
 
                 // We upsert the event data.
                 upsert(db, "events", "opencast_id", &[
@@ -207,6 +209,7 @@ async fn store_in_db(
                     ("custom_action_roles", &acl.custom_actions),
                     ("tracks", &tracks),
                     ("captions", &captions),
+                    ("segments", &segments),
                     ("slide_text", &slide_text),
                 ]).await?;
 

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -25,7 +25,7 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(5 * 60);
 
 
-/// Continuiously fetches from the harvesting API and writes new data into our
+/// Continuously fetches from the harvesting API and writes new data into our
 /// database.
 pub(crate) async fn run(
     daemon: bool,

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -41,6 +41,7 @@ pub(crate) enum HarvestItem {
         end_time: Option<DateTime<Utc>>,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
+        slide_text: Option<String>,
     },
 
     #[serde(rename_all = "camelCase")]

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::db::types::{CustomActions, EventCaption, EventTrack, ExtraMetadata};
+use crate::db::types::{CustomActions, EventCaption, EventTrack, EventSegment, ExtraMetadata};
 
 
 /// What the harvesting API returns.
@@ -41,6 +41,7 @@ pub(crate) enum HarvestItem {
         end_time: Option<DateTime<Utc>>,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
+        segments: Vec<Segment>,
         slide_text: Option<String>,
     },
 
@@ -125,6 +126,22 @@ impl Into<EventCaption> for Caption {
         EventCaption {
             uri: self.uri,
             lang: self.lang,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Segment {
+    uri: String,
+    start_time: i64
+}
+
+impl Into<EventSegment> for Segment {
+    fn into(self) -> EventSegment {
+        EventSegment {
+            uri: self.uri,
+            start_time: self.start_time,
         }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "paella-core": "1.48.1",
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.0",
+        "paella-slide-plugins": "^1.41.6",
         "paella-user-tracking": "1.42.1",
         "paella-zoom-plugin": "1.41.3",
         "qrcode.react": "^3.1.0",
@@ -7703,6 +7704,14 @@
       "version": "1.48.0",
       "resolved": "https://registry.npmjs.org/paella-skins/-/paella-skins-1.48.0.tgz",
       "integrity": "sha512-ABnRvt95adrg20TBmWNoUlSVCJEzGOnKJqrmNabxilF2/dulWs4STdrShBE8EsdxHDonQqC/fGei5lg9IarCxQ=="
+    },
+    "node_modules/paella-slide-plugins": {
+      "version": "1.41.6",
+      "resolved": "https://registry.npmjs.org/paella-slide-plugins/-/paella-slide-plugins-1.41.6.tgz",
+      "integrity": "sha512-oNZQWG/yMCqLH7e7lNPoU2FcJixqRImo0P9Qr7iv/tyEvOM7gvGiVXF4bkg7+efaIJXP6yRNp3nrplvW/w3q0A==",
+      "dependencies": {
+        "paella-core": "^1.44.2"
+      }
     },
     "node_modules/paella-user-tracking": {
       "version": "1.42.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "paella-core": "1.48.1",
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.0",
+    "paella-slide-plugins": "^1.41.6",
     "paella-user-tracking": "1.42.1",
     "paella-zoom-plugin": "1.41.3",
     "qrcode.react": "^3.1.0",

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -38,6 +38,7 @@ const query = graphql`
                     thumbnail
                     tracks { uri flavor mimetype resolution isMaster }
                     captions { uri lang }
+                    segments { uri startTime }
                 }
             }
         }

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -261,6 +261,7 @@ const eventFragment = graphql`
                 endTime
                 tracks { uri flavor mimetype resolution isMaster }
                 captions { uri lang }
+                segments { uri startTime }
             }
             series {
                 id

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -109,27 +109,6 @@ type EventConnection {
   totalCount: Int!
 }
 
-"Some extra information we know about a role."
-type RoleInfo {
-  """
-    A user-facing label for this role (group or person). If the label does
-    not depend on the language (e.g. a name), `{ "_": "Peter" }` is
-    returned.
-  """
-  label: TranslatedString!
-  """
-    For user roles this is `null`. For groups, it defines a list of other
-    group roles that this role implies. I.e. a user with this role always
-    also has these other roles.
-  """
-  implies: [String!]
-  """
-    Is `true` if this role represents a large group. Used to warn users
-    accidentally giving write access to large groups.
-  """
-  large: Boolean!
-}
-
 "A simple realm name: a fixed string."
 type PlainRealmName {
   name: String!
@@ -161,6 +140,27 @@ type Series {
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!
 }
 
+"Some extra information we know about a role."
+type RoleInfo {
+  """
+    A user-facing label for this role (group or person). If the label does
+    not depend on the language (e.g. a name), `{ "_": "Peter" }` is
+    returned.
+  """
+  label: TranslatedString!
+  """
+    For user roles this is `null`. For groups, it defines a list of other
+    group roles that this role implies. I.e. a user with this role always
+    also has these other roles.
+  """
+  implies: [String!]
+  """
+    Is `true` if this role represents a large group. Used to warn users
+    accidentally giving write access to large groups.
+  """
+  large: Boolean!
+}
+
 union EventSearchOutcome = SearchUnavailable | EventSearchResults
 
 """
@@ -189,6 +189,7 @@ type SyncedEventData implements Node {
   tracks: [Track!]!
   thumbnail: String
   captions: [Caption!]!
+  segments: [Segment!]!
 }
 
 "A `Block`: a UI element that belongs to a realm."
@@ -711,6 +712,11 @@ input NewRealm {
   parent: ID!
   name: String!
   pathSegment: String!
+}
+
+type Segment {
+  uri: String!
+  startTime: Float!
 }
 
 enum SortDirection {

--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -95,7 +95,16 @@ declare module "paella-core" {
 
         captions: Caption[];
 
-        // TODO: `frameList`
+        frameList: Frame[];
+    }
+
+    // https://github.com/polimediaupv/paella-core/blob/main/doc/video_manifest.md#frame-list
+    export interface Frame {
+        id: string;
+        mimetype: "image/jpeg";
+        time: number;
+        url: string;
+        thumb: string;
     }
 
     export interface Stream {

--- a/frontend/src/typings/paella-slide-plugins.d.ts
+++ b/frontend/src/typings/paella-slide-plugins.d.ts
@@ -1,0 +1,3 @@
+declare module "paella-slide-plugins" {
+    export default function (): __WebpackModuleApi.RequireContext;
+}

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -42,6 +42,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
                         thumbnail
                         tracks { uri flavor mimetype resolution isMaster }
                         captions { uri lang }
+                        segments { uri startTime }
                     }
                 }
             }

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -4,6 +4,7 @@ import getBasicPluginsContext from "paella-basic-plugins";
 import getZoomPluginContext from "paella-zoom-plugin";
 import getMP4MultiQualityContext from "paella-mp4multiquality-plugin";
 import getUserTrackingPluginsContext from "paella-user-tracking";
+import getSlidePluginsContext from "paella-slide-plugins";
 import { Global } from "@emotion/react";
 import { useTranslation } from "react-i18next";
 
@@ -96,6 +97,16 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
                         + (lang ? ` (${lang})` : "")
                         + (event.syncedData.captions.length > 1 ? ` [${index + 1}]` : ""),
                 })),
+                frameList: event.syncedData.segments.map(segment => {
+                    const time = segment.startTime / 1000;
+                    return {
+                        id: "frame_" + time,
+                        mimetype: "image/jpeg",
+                        time,
+                        url: segment.uri,
+                        thumb: segment.uri,
+                    };
+                }),
             };
 
             // If there are no presenter tracks (and there is more than one
@@ -126,6 +137,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
                     getZoomPluginContext(),
                     getUserTrackingPluginsContext(),
                     getMP4MultiQualityContext(),
+                    getSlidePluginsContext(),
                 ],
             });
 
@@ -469,6 +481,22 @@ const PAELLA_CONFIG = {
             side: "right",
             order: 9,
             tabIndex: 9,
+        },
+        "es.upv.paella.frameControlButtonPlugin": {
+            enabled: true,
+            side: "right",
+            order: 10,
+            tabIndex: 10,
+        },
+
+        "es.upv.paella.slideMapProgressBarPlugin": {
+            enabled: true,
+            markColor: {
+                mouseOut: "#0A0A0A",
+                mouseHover: "#A9A9A9",
+            },
+            markWidth: 3,
+            drawBackground: false,
         },
 
         // Data plugin

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -42,6 +42,7 @@ export type PlayerEvent = {
         tracks: readonly Track[];
         captions: readonly Caption[];
         thumbnail?: string | null;
+        segments: readonly Segment[];
     };
 };
 
@@ -57,6 +58,11 @@ export type Caption = {
     uri: string;
     lang?: string | null;
 };
+
+export type Segment = {
+    uri: string;
+    startTime: number;
+}
 
 /**
  * Video player.

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -203,6 +203,9 @@ export const isExperimentalFlagSet = () => (
     window.localStorage.getItem("tobiraExperimentalFeatures") === "true"
 );
 
+/**
+ * Converts a time string used in URL params like "01h30m49s" to seconds.
+ */
 export const timeStringToSeconds = (timeString: string): number => {
     const timeSplit = /((\d+)h)?((\d+)m)?((\d+)s)?/.exec(timeString);
     const hours = timeSplit && timeSplit[2] ? parseInt(timeSplit[2]) * 60 * 60 : 0;

--- a/frontend/tests/fixtures/standard.sql
+++ b/frontend/tests/fixtures/standard.sql
@@ -37,7 +37,7 @@ values ('waiting', '2b814c02-c849-4553-b5f5-f4e9e69fd74f', null, null, '-infinit
 -- player should only use videos where it fits.
 
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', 'aaa12fa0-95f8-4722-84d7-4fac5e59a572', 'Video of a Tabby Cat',
     'A nice cat captured with a narrow depth of field.\n\nKindly uploaded by Gustavo Belemmi with a very permissive license.',
     '{"Gustavo Belemmi"}',
@@ -53,11 +53,12 @@ values ('ready', 'aaa12fa0-95f8-4722-84d7-4fac5e59a572', 'Video of a Tabby Cat',
         row('http://localhost:38456/cat-bokeh-no-audio-x264-240p.mp4',
             'presenter/preview', 'video/mp4', '{432, 240}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '2784521d-d10a-4a27-a77c-cd3f557259c2', 'Black Cat (protected)',
     'Secret kitty hihi',
     '{"klimkin"}',
@@ -73,12 +74,13 @@ values ('ready', '2784521d-d10a-4a27-a77c-cd3f557259c2', 'Black Cat (protected)'
         row('http://localhost:38456/cat-black-x264-240p.mp4',
             'presentation/preview', 'video/mp4', '{432, 240}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Dual stream public
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '172d4ec3-4e58-48b4-bdf0-85909a32439d', 'Dual Stream Cats',
     null,
     '{"Gustavo Belemmi", "klimkin"}',
@@ -98,12 +100,13 @@ values ('ready', '172d4ec3-4e58-48b4-bdf0-85909a32439d', 'Dual Stream Cats',
         row('http://localhost:38456/cat-black-x264-240p.mp4',
             'presentation/preview', 'video/mp4', '{432, 240}', false)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Planned event
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '9dc41ccb-4a54-498f-98cf-98ca455f708c', 'Far in the Future',
     null,
     '{"Peter Lustig"}',
@@ -119,12 +122,13 @@ values ('ready', '9dc41ccb-4a54-498f-98cf-98ca455f708c', 'Far in the Future',
         row('http://localhost:38456/cat-black-x264-240p.mp4',
             'presentation/preview', 'video/mp4', '{432, 240}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Live event
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', 'b5d4533f-0ddd-4dd2-aa64-de24d3b20d72', 'Currently live!!',
     null,
     '{"Die Maus"}',
@@ -138,12 +142,13 @@ values ('ready', 'b5d4533f-0ddd-4dd2-aa64-de24d3b20d72', 'Currently live!!',
         row('http://localhost:38456/cat-black-x264-144p.mp4',
             'presentation/preview', 'video/mp4', '{256, 144}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Past Live event
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', 'd5af7441-e9a3-4a1f-a58d-1116b899c693', 'Past live event',
     null,
     '{"Hubert"}',
@@ -157,12 +162,13 @@ values ('ready', 'd5af7441-e9a3-4a1f-a58d-1116b899c693', 'Past live event',
         row('http://localhost:38456/cat-black-x264-144p.mp4',
             'presentation/preview', 'video/mp4', '{256, 144}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Private video
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '7205a608-08bc-44fc-af8d-65578697c625', 'Very secret private video',
     null,
     '{"Anon"}',
@@ -176,12 +182,13 @@ values ('ready', '7205a608-08bc-44fc-af8d-65578697c625', 'Very secret private vi
         row('http://localhost:38456/scifi-tunnel-no-audio-x264-144p.mp4',
             'presentation/preview', 'video/mp4', '{256, 144}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- Portrait video
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '2e5b56da-695d-4be8-b557-7f0fba51ca24', 'Portait video of a train',
     null,
     '{"Joachim Rübe"}',
@@ -195,12 +202,13 @@ values ('ready', '2e5b56da-695d-4be8-b557-7f0fba51ca24', 'Portait video of a tra
         row('http://localhost:38456/train-portrait-x264.mp4',
             'presentation/preview', 'video/mp4', '{256, 144}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- 1h+ video
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '1c5d5e89-76b7-4d81-a316-ef62b470e13d', 'Long boy',
     null,
     '{"Joachim Rübe"}',
@@ -214,11 +222,12 @@ values ('ready', '1c5d5e89-76b7-4d81-a316-ef62b470e13d', 'Long boy',
         row('http://localhost:38456/train-portrait-x264.mp4',
             'presentation/preview', 'video/mp4', '{256, 144}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 insert into events (state, opencast_id, title, description, creators, metadata, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '0637a85a-c360-450b-900d-81f423cb21f3', 'Unlisted video without series',
     'Unlisted video being alone',
     '{"Stanley"}',
@@ -233,11 +242,12 @@ values ('ready', '0637a85a-c360-450b-900d-81f423cb21f3', 'Unlisted video without
         row('http://localhost:38456/cat-black-x264-240p.mp4',
             'presentation/preview', 'video/mp4', '{432, 240}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 insert into events (state, opencast_id, title, description, creators, metadata, series, part_of, duration, is_live,
-    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions)
+    created, updated, start_time, end_time, read_roles, write_roles, thumbnail, tracks, captions, segments)
 values ('ready', '06a71e43-94cd-472d-a345-952979489e88', 'Unlisted video in series',
     'Cheesecake is yummy',
     '{"klimkin"}',
@@ -253,11 +263,13 @@ values ('ready', '06a71e43-94cd-472d-a345-952979489e88', 'Unlisted video in seri
         row('http://localhost:38456/cat-black-x264-240p.mp4',
             'presentation/preview', 'video/mp4', '{432, 240}', true)
     ]::event_track[],
+    '{}',
     '{}'
 );
 
 -- TODO:
 -- Video with subtitles -> array[row('https://...', 'en')]::event_caption[]
+-- Video with slide segments?
 
 
 -- ----- Realms ---------------------------------------------------------------

--- a/util/fixtures.sql
+++ b/util/fixtures.sql
@@ -22,9 +22,9 @@ begin
     insert into series (opencast_id, state, title, read_roles, write_roles, updated)
         values ('event-tests', 'ready', 'Different event states', '{"ROLE_ANONYMOUS"}', '{"ROLE_ADMIN"}', now())
         returning id into series_event_tests;
-    insert into events (opencast_id, state, updated, is_live, read_roles, write_roles, title, created, metadata, series, captions)
-        values ('waiting', 'waiting', '-infinity', false, '{"ROLE_ANONYMOUS"}', '{"ROLE_USER_SABINE"}', 'Waiting event', now(), '{}', series_event_tests, '{}');
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (opencast_id, state, updated, is_live, read_roles, write_roles, title, created, metadata, series, captions, segments)
+        values ('waiting', 'waiting', '-infinity', false, '{"ROLE_ANONYMOUS"}', '{"ROLE_USER_SABINE"}', 'Waiting event', now(), '{}', series_event_tests, '{}', '{}');
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
             'ready',
             'restricted',
@@ -45,9 +45,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, captions, segments)
         values (
             'ready',
             'live-future',
@@ -69,9 +70,10 @@ begin
             '{}',
             true,
             '9999-01-01',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, end_time, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, end_time, captions, segments)
         values (
             'ready',
             'live-present',
@@ -94,9 +96,10 @@ begin
             true,
             'epoch',
             '9999-01-01',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, end_time, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, series, created, updated, read_roles, write_roles, metadata, is_live, start_time, end_time, captions, segments)
         values (
             'ready',
             'live-past',
@@ -119,6 +122,7 @@ begin
             true,
             'epoch',
             '2000-01-01',
+            '{}',
             '{}'
         );
 
@@ -149,7 +153,7 @@ begin
 
 
     -- Add a bunch of events/videos
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
             'ready',
             'bbb',
@@ -173,9 +177,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'cosmos-laundromat',
@@ -199,9 +204,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'spring',
@@ -225,10 +231,11 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
 
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'bee',
@@ -252,10 +259,11 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
 
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'nasa',
@@ -279,10 +287,11 @@ begin
             '{}',
             false,
             '{}',
-            array[row('https://tobira-test-oc.ethz.ch/static/mh_default_org/moontour_narrated.en_US.vtt', 'en')]::event_caption[]
+            array[row('https://tobira-test-oc.ethz.ch/static/mh_default_org/moontour_narrated.en_US.vtt', 'en')]::event_caption[],
+            '{}'
         );
 
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'pir-introduction',
@@ -306,9 +315,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'pir-modules',
@@ -332,9 +342,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'pir-stack-heap',
@@ -358,9 +369,10 @@ begin
             '{}',
             false,
             '{}',
+            '{}',
             '{}'
         );
-    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions)
+    insert into events (state, opencast_id, title, tracks, thumbnail, duration, description, series, part_of, creators, created, updated, read_roles, write_roles, is_live, metadata, captions, segments)
         values (
         'ready',
             'pir-performance',
@@ -383,6 +395,7 @@ begin
             '{"ROLE_ANONYMOUS"}',
             '{}',
             false,
+            '{}',
             '{}',
             '{}'
         );


### PR DESCRIPTION
This adds the ocr'd slide texts as well as a list of timestamped frames to the harvesting sync code and stores them in the DB.
In order the show the slide previews, `paella-slide-plugins` was added and configured to use the timestamped frames.

Needs https://github.com/opencast/opencast/pull/5757 to work. Once that is merged, released and used on our test Opencast, the changes can be tested with fresh uploads. We'll still need some mechanism to apply segmentation and ocr (and speech-to-text as well) to existing videos.

(Can be reviewed commit by commit, though note that the migration from the second commit was extended in the third)