### PR TITLE
Make font configurable, improve asset handling and use basic frontend bundle splitting

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -40,6 +40,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +252,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -314,6 +356,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
 
 [[package]]
 name = "chrono"
@@ -917,6 +965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "graphql-parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,7 +1329,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "ring 0.16.20",
  "serde",
  "serde_json",
@@ -1702,7 +1756,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -1821,7 +1875,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2031,15 +2085,17 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reinda"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c40f549743a9e98c5eb0013e759b777ad02f460d45b23efc13c7bf11b959e4"
+checksum = "12312d1d8208b396c947429ff83f92c6da671c0bbb51971df2fcc3d1417f2316"
 dependencies = [
  "ahash",
- "base64",
+ "aho-corasick",
+ "base64 0.22.1",
+ "brotli",
  "bytes",
- "flate2",
- "reinda-core",
+ "cfg_aliases",
+ "glob",
  "reinda-macros",
  "sha2",
  "thiserror",
@@ -2047,28 +2103,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "reinda-core"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b71eed785c3da132d82e7f0977ee325c2afc0c4b41d6ba32bc12b7cdba91a3"
-dependencies = [
- "bytes",
- "memchr",
- "thiserror",
-]
-
-[[package]]
 name = "reinda-macros"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0feecec02328c959f0753e65686c158adacc04f97d80c103c5844852244d9825"
+checksum = "8b117146cd5ea075441f690927fe5fa64cde4b71010dde6bf5f02e4b6b92fc5a"
 dependencies = [
- "bytes",
- "flate2",
+ "brotli",
+ "cfg_aliases",
+ "glob",
+ "litrs 0.4.1",
  "proc-macro2",
  "quote",
- "reinda-core",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2163,7 +2208,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c333bb734fcdedcea57de1602543590f545f127dc8b533324318fd492c5c70b"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -2585,7 +2630,7 @@ name = "tobira"
 version = "2.9.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bincode",
  "bstr",
  "built",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,7 +13,7 @@ description = "Backend of the Tobira video portal for Opencast"
 
 
 [features]
-embed-in-debug = ["reinda/debug-is-prod"]
+embed-in-debug = ["reinda/always-prod"]
 
 
 [dependencies]
@@ -59,7 +59,7 @@ postgres-types = { version = "0.2.2", features = ["derive", "array-impls"] }
 prometheus-client = "0.22.1"
 rand = "0.8.4"
 regex = "1.7.1"
-reinda = "0.2"
+reinda = "0.3"
 ring = "0.17.8"
 rustls = "0.22.4"
 rustls-native-certs = "0.7.0"

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -108,6 +108,8 @@ async fn check_referenced_files(config: &Config) -> Result<()> {
     files.extend(config.theme.logo.small.as_ref().map(|l| &l.path));
     files.extend(config.theme.logo.large_dark.as_ref().map(|l| &l.path));
     files.extend(config.theme.logo.small_dark.as_ref().map(|l| &l.path));
+    files.extend(&config.theme.font.files);
+    files.extend(&config.theme.font.extra_css);
     files.extend(config.auth.jwt.secret_key.as_ref());
 
     for path in files {

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -179,6 +179,12 @@ impl Config {
             fix_path(&base, &mut logo.path);
         }
         fix_path(&base, &mut self.theme.favicon);
+        if let Some(p) = &mut self.theme.font.extra_css {
+            fix_path(&base, p);
+        }
+        for font_path in &mut self.theme.font.files {
+            fix_path(&base, font_path);
+        }
         if let Some(jwt_key) = &mut self.auth.jwt.secret_key {
             fix_path(&base, jwt_key);
         }

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -20,7 +20,7 @@ mod upload;
 
 pub(crate) use self::{
     translated_string::TranslatedString,
-    theme::ThemeConfig,
+    theme::{ThemeConfig, LogoDef},
     matomo::MatomoConfig,
     opencast::OpencastConfig,
     player::PlayerConfig,

--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -47,13 +47,13 @@ pub(crate) struct LogoConfig {
     pub(crate) small_dark: Option<LogoDef>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct LogoDef {
     pub(crate) path: PathBuf,
     pub(crate) resolution: LogoResolution,
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct LogoResolution(pub(crate) [u32; 2]);
 
 impl fmt::Debug for LogoResolution {

--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -22,6 +22,9 @@ pub(crate) struct ThemeConfig {
     /// Colors used in the UI. Specified in sRGB.
     #[config(nested)]
     pub(crate) color: ColorConfig,
+
+    #[config(nested)]
+    pub(crate) font: FontConfig,
 }
 
 
@@ -61,6 +64,26 @@ impl fmt::Debug for LogoResolution {
         let [w, h] = self.0;
         write!(f, "{}x{}", w, h)
     }
+}
+
+#[derive(Debug, confique::Config)]
+pub(crate) struct FontConfig {
+    /// The main font family to use in Tobira. Needs to be a valid CSS value for
+    /// `font-family`.
+    #[config(default = "'Open Sans'")]
+    pub(crate) main_family: String,
+
+    /// Path to a CSS file with extra `@font-face` declarations. If you want to
+    /// refer to files included via `font_files` (see below), be sure to to
+    /// include the full path, e.g. `/~assets/fonts/vollkorn-400.woff2`. That's
+    /// required as the font files are served with a hashed filename for
+    /// caching and Tobira needs to fix up the path in your CSS.
+    pub(crate) extra_css: Option<PathBuf>,
+
+    /// Additional font files to serve under `/~assets/fonts/`. Prefer using the
+    /// WOFF 2.0 format: it has excellent browser support and great compression.
+    #[config(default = [])]
+    pub(crate) files: Vec<PathBuf>,
 }
 
 impl ThemeConfig {

--- a/backend/src/config/translated_string.rs
+++ b/backend/src/config/translated_string.rs
@@ -10,11 +10,6 @@ pub(crate) struct TranslatedString(HashMap<String, String>);
 impl TranslatedString {
     pub(crate) const LANGUAGES: &'static [&'static str] = &["en", "de"];
 
-    pub(crate) fn to_json(&self) -> String {
-        serde_json::to_string(&self.0)
-            .expect("serialization of translated string failed")
-    }
-
     pub(crate) fn en(&self) -> &str {
         &self.0["en"]
     }

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -108,7 +108,7 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
             let asset_path = &path[ASSET_PREFIX.len()..];
             match ctx.assets.serve(asset_path).await {
                 Some(r) => r,
-                None => reply_404(&ctx, &method, path).await,
+                None => response::not_found(),
             }
         }
 
@@ -168,21 +168,6 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
     let response_time = time_incoming.elapsed();
     ctx.metrics.observe_response_time(category, response_time);
     response
-}
-
-/// Replies with a 404 Not Found.
-pub(super) async fn reply_404(ctx: &Context, method: &Method, path: &str) -> Response {
-    debug!(?method, path, "Responding with 404");
-
-    // We simply send the normal index and let the frontend router determinate
-    // this is a 404. That way, our 404 page looks like the main page and users
-    // are not confused. And it's easier to return to the normal page.
-    //
-    // TODO: I am somewhat uneasy about this code assuming the router of the
-    // frontend is the same as the backend router. Maybe we want to indicate to
-    // the frontend explicitly to show a 404 page? However, without redirecting
-    // to like `/404` because that's annoying for users.
-    ctx.assets.serve_index(StatusCode::NOT_FOUND, &ctx.config).await
 }
 
 async fn handle_rss_request(path: &str, ctx: &Arc<Context>) -> Result<Response, Response> {

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -553,6 +553,27 @@
 #happy =
 
 
+[theme.font]
+# The main font family to use in Tobira. Needs to be a valid CSS value for
+# `font-family`.
+#
+# Default value: "'Open Sans'"
+#main_family = "'Open Sans'"
+
+# Path to a CSS file with extra `@font-face` declarations. If you want to
+# refer to files included via `font_files` (see below), be sure to to
+# include the full path, e.g. `/~assets/fonts/vollkorn-400.woff2`. That's
+# required as the font files are served with a hashed filename for
+# caching and Tobira needs to fix up the path in your CSS.
+#extra_css =
+
+# Additional font files to serve under `/~assets/fonts/`. Prefer using the
+# WOFF 2.0 format: it has excellent browser support and great compression.
+#
+# Default value: []
+#files = []
+
+
 [upload]
 # Whether specifying a series is required when uploading.
 #

--- a/docs/docs/setup/theme.md
+++ b/docs/docs/setup/theme.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# Theme: Logo & Colors
+# Theme: Logo, Font & Colors
 
 This document will explain how to best adjust the `[theme]` configuration.
 If you have no experience in UI design and are not familiar with your organization's CI, you usually want to talk to such a person and do this part of the configuration together.
@@ -35,6 +35,70 @@ You should also test if the logo is  properly configured for dark mode:
 
 The favicon is a single SVG file, that's usually a simplified version of your logo.
 It is shown as tiny image in browser tabs, the browser's history or a bookmark list.
+
+## Font
+
+You can change the main font used by Tobira.
+The relevant config section is `theme.font` – see the comments there for specifics on the individual values.
+The following goes over three different ways of changing the font.
+
+If you want to use a font that you expect most of your users to already have installed on their devices, you can just set `font.main_family`.
+For example: `font.main_family = "Arial"` (please don't actually use Arial though).
+The `main_family` value is used as the value for the CSS `font-family` declaration, which has two consequences.
+For one, you have to quote font names with spaces, e.g. `font.main_family = "'Noto Sans'"`.
+More importantly, you can use multiple values to let the browser choose the first one that's available, for example:
+`font.main_family = "Papyrus, Helvetica, 'Noto Sans'"`.
+Tobira will always add `sans-serif` at the very end as a fallback.
+
+But you cannot assume anything about the fonts installed on a user's device.
+So to be sure a particular font is used, it has to be provided.
+Tobira always provides "Open Sans", its default font. So you can just mention `'Open Sans'` in `main_family` to be sure that that is used as a fallback.
+But you can also provide your own fonts by specifying `font.extra_css`, a CSS file that is expected to contain `@font-face` declarations.
+As examples, you can look at the Google Font files, e.g. [this for Montserrat](https://fonts.googleapis.com/css2?family=Montserrat:wght@100..900&display=swap).
+You could download that CSS file from Google (this is not legal advice) and specify it as `extra_css`, then set `main_family = "Montserrat"` and be sure that the user's browser can display that font.
+
+But said CSS file refers to Google Font servers via `url()`.
+You likely don't want that, so you can also instruct Tobira to host font files for you.
+These you have to specify as `font.files`.
+Tobira will serve them under `/~assets/fonts/`.
+So you can then just use links to the Tobira hosted files in your CSS file.
+Try encoding your fonts in the WOFF2 format, as this is widely supported and well compressed.
+
+Finally, here is a full example of self-hosted custom fonts:
+
+```toml title=config.toml
+[theme.font]
+main_family = "'My Fancy Font', 'Open Sans'"
+extra_css = "font.css"
+files = [
+    "font/MyFancyFont-Regular.woff2",
+    "font/MyFancyFont-Bold.woff2",
+]
+```
+
+```css title=font.css
+@font-face {
+  font-family: 'My Fancy Font';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(/~assets/fonts/MyFancyFont-Regular.woff2) format('woff2');
+}
+@font-face {
+  font-family: 'My Fancy Font';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(/~assets/fonts/MyFancyFont-Bold.woff2) format('woff2');
+}
+```
+
+**Note**:
+Tobira is developed with Open Sans in mind and optimized for it.
+Other fonts might have different glyph heights and positioning metrics, making them look off in Tobira.
+To make your font look good, use CSS properties such as `size-adjust` and `ascent-override` inside your `@font-face` declaration.
+Simply compare your configured font to the default Open Sans to see if letter height, baseline and other metrics fit.
+See [these docs about `@font-face`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) to see what you can adjust.
 
 
 ## Colors

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-react": "^7.34.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "fork-ts-checker-webpack-plugin": "^6.5.3",
+        "html-webpack-plugin": "^5.6.0",
         "postgres": "^3.4.3",
         "schema-dts": "^1.1.2",
         "ts-node": "^10.9.2",
@@ -2538,6 +2539,12 @@
         "@types/unist": "^2"
       }
     },
+    "node_modules/@types/html-minifier-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+      "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3853,6 +3860,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -3955,6 +3972,27 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/clean-webpack-plugin": {
@@ -4398,6 +4436,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "dev": true,
+      "dependencies": {
+        "utila": "~0.4"
       }
     },
     "node_modules/dom-helpers": {
@@ -5737,6 +5784,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hls.js": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.7.tgz",
@@ -5750,12 +5806,154 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-minifier-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "^5.2.2",
+        "commander": "^8.3.0",
+        "he": "^1.2.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.10.0"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-webpack-plugin": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier-terser": "^6.0.0",
+        "html-minifier-terser": "^6.0.2",
+        "lodash": "^4.17.21",
+        "pretty-error": "^4.0.0",
+        "tapable": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/html-webpack-plugin"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.20.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/i18next": {
@@ -6602,6 +6800,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -7516,6 +7720,16 @@
         "paella-core": "^1.41.0"
       }
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7542,6 +7756,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -7778,6 +8002,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.20",
+        "renderkid": "^3.0.0"
       }
     },
     "node_modules/promise": {
@@ -8186,6 +8420,15 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/relay-compiler": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-16.2.0.tgz",
@@ -8305,6 +8548,87 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/renderkid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "node_modules/renderkid/node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/renderkid/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/require-from-string": {
@@ -9380,6 +9704,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
+      "dev": true
     },
     "node_modules/uvu": {
       "version": "0.5.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "fork-ts-checker-webpack-plugin": "^6.5.3",
+    "html-webpack-plugin": "^5.6.0",
     "postgres": "^3.4.3",
     "schema-dts": "^1.1.2",
     "ts-node": "^10.9.2",

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -62,9 +62,9 @@ type AuthConfig = {
 
 type LogoConfig = {
     large: SingleLogoConfig;
-    small: SingleLogoConfig;
-    largeDark: SingleLogoConfig & { invert: boolean };
-    smallDark: SingleLogoConfig & { invert: boolean };
+    small: SingleLogoConfig | null;
+    largeDark: SingleLogoConfig | null;
+    smallDark: SingleLogoConfig | null;
 };
 
 type SingleLogoConfig = {

--- a/frontend/src/fonts.css
+++ b/frontend/src/fonts.css
@@ -1,5 +1,5 @@
 :root {
-    --main-font: 'Open Sans';
+    --main-font: {{ main_family }};
 }
 
 /* Open Sans is licensed under the Apache-2.0 license. */
@@ -8,7 +8,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/cyrillic-ext-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/cyrillic-ext-i400.woff2) format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 @font-face {
@@ -16,7 +16,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/cyrillic-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/cyrillic-i400.woff2) format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 @font-face {
@@ -24,7 +24,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/greek-ext-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/greek-ext-i400.woff2) format('woff2');
     unicode-range: U+1F00-1FFF;
 }
 @font-face {
@@ -32,7 +32,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/greek-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/greek-i400.woff2) format('woff2');
     unicode-range: U+0370-03FF;
 }
 @font-face {
@@ -40,7 +40,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/vietnamese-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/vietnamese-i400.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 @font-face {
@@ -48,7 +48,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/latin-ext-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/latin-ext-i400.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -56,7 +56,7 @@
     font-style: italic;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/{{: path:fonts/latin-i400.woff2 :}}) format('woff2');
+    src: local('Open Sans Italic'), local('OpenSans-Italic'), url(/~assets/fonts/open-sans/latin-i400.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -64,7 +64,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/cyrillic-ext-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/cyrillic-ext-i700.woff2) format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 @font-face {
@@ -72,7 +72,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/cyrillic-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/cyrillic-i700.woff2) format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 @font-face {
@@ -80,7 +80,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/greek-ext-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/greek-ext-i700.woff2) format('woff2');
     unicode-range: U+1F00-1FFF;
 }
 @font-face {
@@ -88,7 +88,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/greek-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/greek-i700.woff2) format('woff2');
     unicode-range: U+0370-03FF;
 }
 @font-face {
@@ -96,7 +96,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/vietnamese-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/vietnamese-i700.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 @font-face {
@@ -104,7 +104,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/latin-ext-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/latin-ext-i700.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -112,7 +112,7 @@
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/{{: path:fonts/latin-i700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'), url(/~assets/fonts/open-sans/latin-i700.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -120,7 +120,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/cyrillic-ext-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/cyrillic-ext-400.woff2) format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 @font-face {
@@ -128,7 +128,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/cyrillic-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/cyrillic-400.woff2) format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 @font-face {
@@ -136,7 +136,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/greek-ext-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/greek-ext-400.woff2) format('woff2');
     unicode-range: U+1F00-1FFF;
 }
 @font-face {
@@ -144,7 +144,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/greek-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/greek-400.woff2) format('woff2');
     unicode-range: U+0370-03FF;
 }
 @font-face {
@@ -152,7 +152,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/vietnamese-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/vietnamese-400.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 @font-face {
@@ -160,7 +160,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/latin-ext-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/latin-ext-400.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -168,7 +168,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/{{: path:fonts/latin-400.woff2 :}}) format('woff2');
+    src: local('Open Sans'), local('Open Sans Regular'), local('OpenSans-Regular'), url(/~assets/fonts/open-sans/latin-400.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -176,7 +176,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/cyrillic-ext-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/cyrillic-ext-700.woff2) format('woff2');
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 @font-face {
@@ -184,7 +184,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/cyrillic-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/cyrillic-700.woff2) format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 @font-face {
@@ -192,7 +192,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/greek-ext-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/greek-ext-700.woff2) format('woff2');
     unicode-range: U+1F00-1FFF;
 }
 @font-face {
@@ -200,7 +200,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/greek-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/greek-700.woff2) format('woff2');
     unicode-range: U+0370-03FF;
 }
 @font-face {
@@ -208,7 +208,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/vietnamese-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/vietnamese-700.woff2) format('woff2');
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 @font-face {
@@ -216,7 +216,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/latin-ext-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/latin-ext-700.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -224,6 +224,6 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/{{: path:fonts/latin-700.woff2 :}}) format('woff2');
+    src: local('Open Sans Bold'), local('OpenSans-Bold'), url(/~assets/fonts/open-sans/latin-700.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,52 +1,15 @@
 <!DOCTYPE html>
 <html data-tobira-style-nonce="{{ nonce }}">
   <head>
-    <title>{{: var:html-title :}}</title>
+    <title>{{ htmlTitle }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" href="/~assets/{{: path:favicon.svg :}}" sizes="any" type="image/svg+xml">
-    <link rel="stylesheet" href="/~assets/{{: path:fonts.css :}}">
+    <link rel="icon" href="/~assets/{{ faviconPath }}" sizes="any" type="image/svg+xml">
+    <link rel="stylesheet" href="/~assets/{{ fontCssPath }}">
     <style nonce="{{ nonce }}">
-      {{: var:global-style :}}
+      {{ globalStyle }}
     </style>
     <script id="tobira-frontend-config" type="application/json">
-      {
-        "version": {{: var:version :}},
-        "auth": {{: var:auth :}},
-        "upload": {{: var:upload :}},
-        "siteTitle": {{: var:site-title :}},
-        "initialConsent": {{: var:initial-consent :}},
-        "showDownloadButton": {{: var:show-download-button :}},
-        "usersSearchable": {{: var:users-searchable :}},
-        "footerLinks": {{: var:footer-links :}},
-        "metadataLabels": {{: var:metadata-labels :}},
-        "paellaPluginConfig": {{: var:paella-plugin-config :}},
-        "opencast": {
-          "presentationNode": "{{: var:presentation-node :}}",
-          "uploadNode": "{{: var:upload-node :}}",
-          "studioUrl": "{{: var:studio-url :}}",
-          "editorUrl": "{{: var:editor-url :}}"
-        },
-        "logo": {
-          "large": {
-            "path": "/~assets/{{: path:logo-large.svg :}}",
-            "resolution": {{: var:large-logo-resolution :}}
-          },
-          "small": {
-            "path": "/~assets/{{: path:logo-small.svg :}}",
-            "resolution": {{: var:small-logo-resolution :}}
-          },
-          "largeDark": {
-            "path": "/~assets/{{: path:logo-large-dark.svg :}}",
-            "resolution": {{: var:large-dark-logo-resolution :}},
-            "invert": {{: var:invertLargeDarkLogo :}}
-          },
-          "smallDark": {
-            "path": "/~assets/{{: path:logo-small-dark.svg :}}",
-            "resolution": {{: var:small-dark-logo-resolution :}},
-            "invert": {{: var:invertSmallDarkLogo :}}
-          }
-        }
-      }
+      {{ frontendConfig }}
     </script>
     <script nonce="{{ nonce }}">
       // Read dark mode preference. This code is inlined here to run it as soon
@@ -55,10 +18,10 @@
       document.documentElement.dataset.colorScheme = (scheme === "dark" || scheme === "light")
         ? scheme
         : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-      {{: var:matomo-code :}}
+      {{ matomoCode }}
     </script>
   </head>
   <body>
-    <script src="/~assets/{{: path:main.bundle.js :}}"></script>
+    <script src="/~assets/{{ bundlePath }}"></script>
   </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -21,7 +21,5 @@
       {{ matomoCode }}
     </script>
   </head>
-  <body>
-    <script src="/~assets/{{ bundlePath }}"></script>
-  </body>
+  <body></body>
 </html>

--- a/frontend/src/layout/header/Logo.tsx
+++ b/frontend/src/layout/header/Logo.tsx
@@ -32,7 +32,18 @@ export const Logo: React.FC = () => {
     // The solution is to calculate the correct `flex-basis` for the `<a>`
     // element manually.
 
-    const { small, large, smallDark, largeDark } = CONFIG.logo;
+    const large = CONFIG.logo.large;
+    const small = CONFIG.logo.small ?? CONFIG.logo.large;
+    const largeDark = CONFIG.logo.largeDark ?? CONFIG.logo.large;
+    const smallDark = CONFIG.logo.smallDark
+        ?? CONFIG.logo.largeDark
+        ?? CONFIG.logo.small
+        ?? CONFIG.logo.large;
+
+    // If the dark logos are not specified, we default to the white ones but
+    // inverting them.
+    const invertLargeDark = CONFIG.logo.largeDark === null;
+    const invertSmallDark = CONFIG.logo.smallDark === null && CONFIG.logo.largeDark === null;
 
     const alt = t("general.logo-alt", { title: translatedConfig(CONFIG.siteTitle, i18n) });
     const invertCss = {
@@ -60,7 +71,7 @@ export const Logo: React.FC = () => {
                 src={(isDark ? largeDark : large).path}
                 alt={alt}
                 css={{
-                    ...isDark && largeDark.invert && invertCss,
+                    ...isDark && invertLargeDark && invertCss,
                     [screenWidthAtMost(BREAKPOINT_SMALL)]: {
                         display: "none",
                     },
@@ -72,7 +83,7 @@ export const Logo: React.FC = () => {
                 src={(isDark ? smallDark : small).path}
                 alt={alt}
                 css={{
-                    ...isDark && smallDark.invert && invertCss,
+                    ...isDark && invertSmallDark && invertCss,
                     [screenWidthAbove(BREAKPOINT_SMALL)]: {
                         display: "none",
                     },

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HiOutlineSearch } from "react-icons/hi";
+import { ProtoButton, screenWidthAtMost } from "@opencast/appkit";
 import { LuX } from "react-icons/lu";
+
 import { useRouter } from "../../router";
 import {
     handleNavigation,
@@ -12,10 +14,9 @@ import {
 import { focusStyle } from "../../ui";
 import { Spinner } from "../../ui/Spinner";
 import { currentRef, useDebounce } from "../../util";
-
 import { BREAKPOINT as NAV_BREAKPOINT } from "../Navigation";
 import { COLORS } from "../../color";
-import { ProtoButton, screenWidthAtMost } from "@opencast/appkit";
+import { useUser } from "../../User";
 
 
 type SearchFieldProps = {
@@ -27,6 +28,12 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
     const router = useRouter();
     const ref = useRef<HTMLInputElement>(null);
     const { debounce } = useDebounce();
+
+    // If the user is unknown, then we are still in the initial loading phase.
+    // We don't want users to input anything into the search field in that
+    // state, as their input would be ignored and discarded as soon as the
+    // initial-loading phase is done.
+    const disabled = useUser() === "unknown";
 
     // Register global shortcut to focus search bar
     useEffect(() => {
@@ -115,6 +122,7 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                     <input
                         ref={ref}
                         type="text"
+                        disabled={disabled}
                         placeholder={t("search.input-label")}
                         defaultValue={defaultValue}
                         // The `onSearchRoute` part of this is a hacky fix to the search

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -10,7 +10,6 @@ import { ExtraMetadata, useForceRerender } from "../../util";
 import { getEventTimeInfo } from "../../util/video";
 import { Spinner } from "../Spinner";
 import { RelativeDate } from "../time";
-import PaellaPlayer from "./Paella";
 import { COLORS } from "../../color";
 
 
@@ -197,7 +196,7 @@ export const getPlayerAspectRatio = (tracks: readonly Track[]): [number, number]
 };
 
 
-const LoadPaellaPlayer = PaellaPlayer;
+const LoadPaellaPlayer = React.lazy(() => import(/* webpackChunkName: "paella" */ "./Paella"));
 
 /**
  * Suspense fallback while the player JS files are still loading. This is

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -4,6 +4,7 @@ import YAML from "yaml";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 import * as fs from "fs";
 
 const APP_PATH = path.join(__dirname, "src");
@@ -90,7 +91,6 @@ const config: CallableOption = (_env, argv) => ({
         }),
         new CopyPlugin({
             patterns: [
-                { from: path.join(APP_PATH, "index.html"), to: path.join(OUT_PATH) },
                 { from: path.join(APP_PATH, "fonts.css"), to: path.join(OUT_PATH) },
                 { from: path.join(__dirname, "static"), to: OUT_PATH },
                 { from: PAELLA_SKIN_PATH, to: path.join(OUT_PATH, "paella") },
@@ -111,6 +111,9 @@ const config: CallableOption = (_env, argv) => ({
                 fs.writeFileSync(outPath, out);
             });
         },
+        new HtmlWebpackPlugin({
+            template: path.join(APP_PATH, "index.html"),
+        }),
     ],
 
     devtool: "source-map",

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -15,7 +15,7 @@ const config: CallableOption = (_env, argv) => ({
     context: __dirname,
 
     output: {
-        filename: "[name].bundle.js",
+        filename: "bundle.[name].[contenthash].js",
         path: OUT_PATH,
         publicPath: "/~assets/",
     },
@@ -113,7 +113,7 @@ const config: CallableOption = (_env, argv) => ({
         },
     ],
 
-    devtool: "hidden-source-map",
+    devtool: "source-map",
 });
 
 const fontDecl = `@font-face {


### PR DESCRIPTION
Fixes #287 
Fixes #362
First steps towards #257 

<details>
<summary>Historical background pretty irrelevant for users of Tobira</summary>

This was on my radar for years already, and we always talked about making fonts configurable and splitting the frontend. Both were blocked by us using `reinda` as a library to manage assets, which had some limitations (mainly: not being able to include wildcards). I tried tackling this a couple of time, but never succeeded. This time I wanted to finally make it work, since we needed configurable fonts. 

And boy, it was a lot more complex than I thought. This seems very simple on the surface but the complexity comes from the two different modes: in release mode we want to embed most assets into the executable, but in debug mode we want to load everything dynamically for faster development speed. Neither of these things are really up for debate. Combine that with the need to have hashes in file names, which means that references to assets need to be fixed, and you have a very complex system. I'm convinced this would have been at most marginally easier when doing that all inside Tobira, instead of having that logic live in an external library. So yeah, as far as I see this was just a hard task. I am probably only writing this here so that I don't feel so bad for taking such a long time :sob: 

Anyway, I am happy with the result, both the library and how it works in Tobira. It also gets rid of this terrible frontend config mess we had before. Now it's mostly just one `json!{}` call and easy to read.

</details>

The user/admin-facing change in this PR is configurable font. Admins can specify a font-family, custom CSS (with `@font-face` declarations) and a list of font files in the config. The font files are served as static files, the CSS and font-family is included. This should be plenty flexible! The default Open Sans font is still always included, I don't think that hurts.

See the changes in `config.toml` for more information.

![image](https://github.com/elan-ev/tobira/assets/7419664/8b33f5ab-1831-4ea0-b0b7-8da917797275)

---

The other change, which is only indirectly user-facing is that I started code splitting. This was just to verify it's possible with the new `reinda`, it's absolutely not perfect yet. I just split the biggest dependency in our bundle (Paella) into its own file. This reduces the JS size required to render the main site considerably (3.0MB -> 1.3MB). 

Since the new reinda also uses `brotli` instead of `flate2`, the Tobira binary size might have shrunk a bit. EDIT: nope, not considerably: 34.8MB -> 34.6MB. For the record: size of embedded assets is 2.4MiB in total (13.9MiB when uncompressed).

Finally: `reinda` is not yet released. I wanted to wait for this PR to get reviewed before doing that. Once I get a thumbs up, I will release reinda, adjust `Cargo.toml` and then this PR can be merged.

(PR can be reviewed commit by commit)
