### PR TITLE
Remove obsolete `version` field from `docker-compose` files

### DIFF
--- a/util/containers/docker-compose.yml
+++ b/util/containers/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   # The server handling login callback requests.
   tobira-login-handler:


### PR DESCRIPTION
My Docker warns me by now:

> ```
> WARN[0000] [redacted]/util/containers/docker-compose.yml: `version` is obsolete
> ```

cf. https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md#version-top-level-element-obsolete