### PR TITLE
Add delete button to "video details"

### DIFF
--- a/backend/src/api/context.rs
+++ b/backend/src/api/context.rs
@@ -6,6 +6,7 @@ use crate::{
     config::Config,
     db::Transaction,
     search,
+    sync::OcClient,
     prelude::*,
 };
 
@@ -17,6 +18,7 @@ pub(crate) struct Context {
     pub(crate) config: Arc<Config>,
     pub(crate) jwt: Arc<JwtContext>,
     pub(crate) search: Arc<search::Client>,
+    pub(crate) oc_client: Arc<OcClient>,
 }
 
 impl juniper::Context for Context {}

--- a/backend/src/api/err.rs
+++ b/backend/src/api/err.rs
@@ -30,6 +30,9 @@ pub(crate) enum ApiErrorKind {
 
     /// Some server error out of control of the API user.
     InternalServerError,
+
+    /// Communication error with Opencast.
+    OpencastUnavailable,
 }
 
 impl ApiErrorKind {
@@ -39,6 +42,7 @@ impl ApiErrorKind {
             Self::InvalidInput => "INVALID_INPUT",
             Self::NotAuthorized => "NOT_AUTHORIZED",
             Self::InternalServerError => "INTERNAL_SERVER_ERROR",
+            Self::OpencastUnavailable => "OPENCAST_UNAVAILABLE",
         }
     }
 
@@ -47,6 +51,7 @@ impl ApiErrorKind {
             Self::InvalidInput => "Invalid input",
             Self::NotAuthorized => "Not authorized",
             Self::InternalServerError => "Internal server error",
+            Self::OpencastUnavailable => "Opencast unavailable",
         }
     }
 }
@@ -130,9 +135,14 @@ macro_rules! not_authorized {
     ($($t:tt)+) => { $crate::api::err::api_err!(NotAuthorized, $($t)*) };
 }
 
+macro_rules! opencast_unavailable {
+    ($($t:tt)+) => { $crate::api::err::api_err!(OpencastUnavailable, $($t)*) };
+}
+
 pub(crate) use api_err;
 pub(crate) use invalid_input;
 pub(crate) use not_authorized;
+pub(crate) use opencast_unavailable;
 
 
 // ===== Helper macro to inspect DbError ==================================================

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -65,7 +65,9 @@ impl User {
     }
 
     /// Returns all events that somehow "belong" to the user, i.e. that appear
-    /// on the "my videos" page.
+    /// on the "my videos" page. This also returns events that have been marked
+    /// as deleted (meaning their deletion in Opencast has been requested but they
+    /// are not yet removed from Tobira's database).
     ///
     /// Exactly one of `first` and `last` must be set!
     #[graphql(arguments(order(default = Default::default())))]

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -366,4 +366,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     31: "series-metadata",
     32: "custom-actions",
     33: "event-slide-text-and-segments",
+    34: "event-view-and-deletion-timestamp",
 ];

--- a/backend/src/db/migrations/34-event-view-and-deletion-timestamp.sql
+++ b/backend/src/db/migrations/34-event-view-and-deletion-timestamp.sql
@@ -1,0 +1,17 @@
+-- This adds a 'tobira_deletion_timestamp' column to events to mark videos
+-- that have been deleted but are either waiting for sync or still present
+-- in Opencast due to a failed deletion on that end. It can be used to
+-- detect these failed deletions by comparing it to the current time.
+
+-- Furthermore, the 'events' table is renamed to 'all_events', and a new view
+-- called 'events' is created to show all non-deleted records from 'all_events'.
+-- This view practically replaces the former 'events' table and removes the
+-- need to adjust all queries to check it an event has been deleted.
+
+alter table events
+    add column tobira_deletion_timestamp timestamp with time zone;
+
+alter table events rename to all_events;
+
+create view events as
+    select * from all_events where tobira_deletion_timestamp is null;

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -292,6 +292,9 @@ fn frontend_config(config: &Config) -> serde_json::Value {
             "small": config.theme.logo.small.as_ref().map(logo_obj),
             "largeDark": config.theme.logo.large_dark.as_ref().map(logo_obj),
             "smallDark": config.theme.logo.small_dark.as_ref().map(logo_obj),
-        }
+        },
+        "sync": {
+            "pollPeriod": config.sync.poll_period.as_secs_f64(),
+        },
     })
 }

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -303,6 +303,7 @@ async fn handle_api(req: Request<Incoming>, ctx: &Context) -> Result<Response, R
         config: ctx.config.clone(),
         jwt: ctx.jwt.clone(),
         search: ctx.search.clone(),
+        oc_client: ctx.oc_client.clone(),
     });
     let gql_result = juniper::execute(
         &gql_request.query,

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     metrics,
     prelude::*,
     search,
+    sync::OcClient,
     util::{self, ByteBody, HttpsClient, UdxHttpClient},
 };
 use self::{
@@ -78,6 +79,7 @@ pub(crate) struct Context {
     pub(crate) auth_caches: auth::Caches,
     pub(crate) http_client: HttpsClient<ByteBody>,
     pub(crate) uds_http_client: UdxHttpClient<ByteBody>,
+    pub(crate) oc_client: Arc<OcClient>,
 }
 
 
@@ -96,12 +98,13 @@ pub(crate) async fn serve(
         db_pool: db,
         assets,
         jwt: Arc::new(JwtContext::new(&config.auth.jwt)?),
-        config: Arc::new(config),
         search: Arc::new(search),
         metrics: Arc::new(metrics::Metrics::new()),
         auth_caches: auth::Caches::new(),
         http_client: util::http_client().context("failed to create HTTP client")?,
         uds_http_client: UdxHttpClient::unix(),
+        oc_client: Arc::new(OcClient::new(&config).context("Failed to create Opencast client")?),
+        config: Arc::new(config),
     });
 
     let ctx_clone = ctx.clone();

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -136,6 +136,16 @@ impl OcClient {
         self.http_client.request(req).await.map_err(Into::into)
     }
 
+    pub async fn delete_event(&self, oc_id: &String) -> Result<Response<Incoming>> {
+        let pq = format!("/api/events/{}", oc_id);
+        let req = self.req_builder(&pq)
+            .method(http::Method::DELETE)
+            .body(RequestBody::empty())
+            .expect("failed to build request");
+
+        self.http_client.request(req).await.map_err(Into::into)
+    }
+
     fn build_req(&self, path_and_query: &str) -> (Uri, Request<RequestBody>) {
         let req = self.req_builder(path_and_query)
             .body(RequestBody::empty())

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -188,7 +188,7 @@ async fn store_in_db(
                 let segments = segments.into_iter().map(Into::into).collect::<Vec<EventSegment>>();
 
                 // We upsert the event data.
-                upsert(db, "events", "opencast_id", &[
+                upsert(db, "all_events", "opencast_id", &[
                     ("opencast_id", &opencast_id),
                     ("state", &EventState::Ready),
                     ("series", &series_id),
@@ -219,7 +219,7 @@ async fn store_in_db(
 
             HarvestItem::EventDeleted { id: opencast_id, .. } => {
                 let rows_affected = db
-                    .execute("delete from events where opencast_id = $1", &[&opencast_id])
+                    .execute("delete from all_events where opencast_id = $1", &[&opencast_id])
                     .await?;
                 check_affected_rows_removed(rows_affected, "event", &opencast_id);
                 removed_events += 1;

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -68,7 +68,7 @@ pub(crate) struct SyncConfig {
     /// The duration to wait after a "no new data" reply from Opencast. Only
     /// relevant in `--daemon` mode.
     #[config(default = "30s", deserialize_with = crate::config::deserialize_duration)]
-    poll_period: Duration,
+    pub(crate) poll_period: Duration,
 }
 
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -34,6 +34,7 @@ type Config = {
     plyr: PlyrConfig;
     upload: UploadConfig;
     paellaPluginConfig: object;
+    sync: SyncConfig;
 };
 
 type FooterLink = "about" | "graphiql" | {
@@ -94,6 +95,10 @@ type VersionInfo = {
 
 type UploadConfig = {
     requireSeries: boolean;
+};
+
+type SyncConfig = {
+    pollPeriod: number;
 };
 
 type MetadataLabel = "builtin:license" | "builtin:source" | TranslatedString;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -411,6 +411,16 @@ manage:
         confirm: Video löschen?
         cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
         failed: Löschen fehlgeschlagen.
+        failed-maybe: Löschen möglicherweise fehlgeschlagen.
+        pending: Löschvorgang ausstehend.
+        tooltip:
+          failed: >
+            Der Löschvorgang für dieses Video wurde {{time}} angesetzt, ist aber bisher nicht erfolgt
+            und daher möglicherweise fehlgeschlagen.
+          pending: >
+            Der Löschvorgang dieses Videos in Opencast wurde angesetzt und es wird
+            nach dessen Erfolg hier entfernt.
+
     acl:
       title: Zugriffsrechte
     technical-details:

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -406,6 +406,11 @@ manage:
       referencing-pages: Referenzierende Seiten
       referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'
       no-referencing-pages: Dieses Video wird von keiner Seite referenziert.
+      delete:
+        title: Video löschen
+        confirm: Video löschen?
+        cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
+        failed: Löschen fehlgeschlagen.
     acl:
       title: Zugriffsrechte
     technical-details:

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -46,6 +46,7 @@ errors:
   not-authorized-to-view-page: Sie sind nicht dazu autorisiert, diese Seite aufzurufen.
   might-need-to-login: Sie müssen sich möglicherweise einloggen.
   invalid-input: Ungültige Eingabe.
+  opencast-unavailable: Opencast ist momentan nicht erreichbar.
   internal-server-error: Interner Server-Fehler (es ist ein Problem mit dem Server aufgetreten).
   are-you-connected-to-internet: Sind Sie mit dem Internet verbunden?
   unknown: Unbekannter Fehler.
@@ -597,6 +598,10 @@ api-remote-errors:
       Ihr Nutzername '{{username}}' enthält Zeichen, die nicht in Seitenpfaden erlaubt sind.
       Daher können Sie sich keine persönliche Seite anlegen.
       Kontaktieren Sie einen Systemadministrator für weitere Unterstützung.
+  event:
+    delete:
+      not-found: Das zu löschende Video existiert nicht. Möglicherweise wurde es bereits entfernt.
+      not-allowed: Sie haben nicht die Berechtigung, dieses Video zu löschen.
 
 embed:
   not-supported: Diese Seite kann nicht eingebettet werden.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -45,6 +45,7 @@ errors:
   not-authorized-to-view-page: You are not authorized to view this page.
   might-need-to-login: You might need to login.
   invalid-input: Invalid input.
+  opencast-unavailable: Opencast is currently not available.
   internal-server-error: Internal server error (something is wrong with the server).
   are-you-connected-to-internet: Are you connected to the internet?
   unknown: Unknown error.
@@ -571,6 +572,12 @@ api-remote-errors:
       Your username '{{username}}' contains characters that are not allowed in page paths,
       thus you cannot create your own page. Contact a system administrator for
       further assistance.
+  event:
+    delete:
+      not-found: >
+        The video you are trying to delete does not exist.
+        It might have been removed already.
+      not-allowed: You are not allowed to delete this video.
 
 embed:
   not-supported: This page can't be embedded.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -391,6 +391,15 @@ manage:
         confirm: Delete Video?
         cannot-be-undone: This action <strong>cannot</strong> be undone!
         failed: Deleting the video failed.
+        failed-maybe: Deleting the video possibly failed.
+        pending: Deletion is pending.
+        tooltip:
+          failed: >
+            The deletion was requested {{time}} but still has not happened, so it might have failed.
+          pending: >
+            The deletion of this video was requested in Opencast
+            and it will be removed from this list upon success.
+
     acl:
       title: Access policy
     technical-details:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -386,6 +386,11 @@ manage:
       referencing-pages: Referencing pages
       referencing-pages-explanation: 'This video is referenced on the following pages:'
       no-referencing-pages: No pages reference this video.
+      delete:
+        title: Delete Video
+        confirm: Delete Video?
+        cannot-be-undone: This action <strong>cannot</strong> be undone!
+        failed: Deleting the video failed.
     acl:
       title: Access policy
     technical-details:

--- a/frontend/src/relay/errors.ts
+++ b/frontend/src/relay/errors.ts
@@ -111,4 +111,8 @@ export type ApiError = {
  *
  * This has to be kept in sync with the `ApiErrorKind` in `api/err.rs`!
  */
-export type ErrorKind = "INVALID_INPUT" | "NOT_AUTHORIZED" | "INTERNAL_SERVER_ERROR";
+export type ErrorKind = "INVALID_INPUT"
+    | "NOT_AUTHORIZED"
+    | "INTERNAL_SERVER_ERROR"
+    | "OPENCAST_UNAVAILABLE"
+;

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -254,6 +254,7 @@ type AuthorizedEvent implements Node {
   syncedData: SyncedEventData
   "Whether the current user has write access to this event."
   canWrite: Boolean!
+  tobiraDeletionTimestamp: DateTimeUtc
   series: Series
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!
@@ -716,7 +717,9 @@ type User {
   canFindUnlisted: Boolean!
   """
     Returns all events that somehow "belong" to the user, i.e. that appear
-    on the "my videos" page.
+    on the "my videos" page. This also returns events that have been marked
+    as deleted (meaning their deletion in Opencast has been requested but they
+    are not yet removed from Tobira's database).
 
     Exactly one of `first` and `last` must be set!
   """

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -433,6 +433,17 @@ type Mutation {
   "Creates the current users realm. Errors if it already exists."
   createMyUserRealm: Realm!
   """
+    Deletes the given event. Meaning: a deletion request is sent to Opencast, the event
+    is marked as "deletion pending" in Tobira, and fully removed once Opencast
+    finished deleting the event.
+
+    Returns the deletion timestamp in case of success and errors otherwise.
+    Note that "success" in this case only means the request was successfully sent
+    and accepted, not that the deletion itself succeeded, which is instead checked
+    in subsequent harvesting results.
+  """
+  deleteVideo(id: ID!): RemovedEvent!
+  """
     Sets the order of all children of a specific realm.
 
     `childIndices` must contain at least one element, i.e. do not call this
@@ -620,6 +631,10 @@ type SearchRealm implements Node {
 input EventSortOrder {
   column: EventSortColumn!
   direction: SortDirection!
+}
+
+type RemovedEvent {
+  id: ID!
 }
 
 input UpdateRealm {

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -1,7 +1,6 @@
 import {
     useColorScheme,
     ProtoButton,
-    WithTooltip,
     FloatingHandle,
     Floating,
     bug,
@@ -19,14 +18,14 @@ import {
     PropsWithChildren,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { LuX, LuAlertTriangle, LuInfo } from "react-icons/lu";
+import { LuX } from "react-icons/lu";
 import { MultiValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import AsyncCreatableSelect from "react-select/async-creatable";
 import { fetchQuery, graphql } from "react-relay";
 import { i18n, ParseKeys } from "i18next";
 
-import { focusStyle } from ".";
+import { InfoWithTooltip, focusStyle } from ".";
 import { useUser, isRealUser } from "../User";
 import { COLORS } from "../color";
 import { COMMON_ROLES } from "../util/roles";
@@ -636,24 +635,6 @@ const TableRow: React.FC<TableRowProps> = (
             </ProtoButton>}
         </td>
     </tr>
-);
-
-
-type InfoWithTooltipProps = {
-    tooltip: string;
-    mode: "info" | "warning";
-}
-
-const InfoWithTooltip: React.FC<InfoWithTooltipProps> = ({ tooltip, mode }) => (
-    <WithTooltip
-        {...{ tooltip }}
-        css={{ display: "flex", fontWeight: "normal" }}
-        tooltipCss={{ width: "min(85vw, 460px)" }}
-    >
-        <span css={{ marginLeft: 6, display: "flex", alignItems: "center" }}>
-            {mode === "info" ? <LuInfo /> : <LuAlertTriangle css={{ color: COLORS.danger0 }}/>}
-        </span>
-    </WithTooltip>
 );
 
 const UnchangeableAllActions: React.FC<{ permission?: PermissionLevel }> = ({ permission }) => {

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -1,5 +1,5 @@
 import { match, WithTooltip, screenWidthAbove, useColorScheme } from "@opencast/appkit";
-import { LuInfo } from "react-icons/lu";
+import { LuAlertTriangle, LuInfo } from "react-icons/lu";
 import { ReactNode } from "react";
 import { CSSObject } from "@emotion/react";
 
@@ -189,5 +189,22 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({ info }) => (
         }}
     >
         <span><LuInfo tabIndex={0} /></span>
+    </WithTooltip>
+);
+
+type InfoWithTooltipProps = {
+    tooltip: string;
+    mode: "info" | "warning";
+}
+
+export const InfoWithTooltip: React.FC<InfoWithTooltipProps> = ({ tooltip, mode }) => (
+    <WithTooltip
+        {...{ tooltip }}
+        css={{ display: "flex", fontWeight: "normal" }}
+        tooltipCss={{ width: "min(85vw, 460px)" }}
+    >
+        <span css={{ marginLeft: 6, display: "flex", alignItems: "center" }}>
+            {mode === "info" ? <LuInfo /> : <LuAlertTriangle css={{ color: COLORS.danger0 }}/>}
+        </span>
     </WithTooltip>
 );

--- a/frontend/src/ui/time.tsx
+++ b/frontend/src/ui/time.tsx
@@ -1,7 +1,49 @@
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { WithTooltip } from "@opencast/appkit";
+import { useTranslation } from "react-i18next";
+import i18n from "../i18n";
 
+
+/**
+ * Calculates the time difference between a given date and a moment
+ * (which is typically the current time).
+ * Returns both the time as number (i.e. 2.1234...)
+ * and formatted string (i.e. "2 days ago").
+ */
+export const relativeDate = (date: Date, moment: number): [number, string] => {
+    const secsAgo = Math.floor((moment - date.getTime()) / 1000);
+    const secsDiff = Math.abs(secsAgo);
+
+    const MINUTE = 60;
+    const HOUR = 60 * MINUTE;
+    const DAY = 24 * HOUR;
+    const WEEK = 7 * DAY;
+    const MONTH = 30.5 * DAY;
+    const YEAR = 365.25 * DAY;
+
+    let timeAndUnit: [number, Intl.RelativeTimeFormatUnit];
+    if (secsDiff <= 55) {
+        timeAndUnit = [secsAgo, "second"];
+    } else if (secsDiff <= 55 * MINUTE) {
+        timeAndUnit = [secsAgo / MINUTE, "minute"];
+    } else if (secsDiff <= 23 * HOUR) {
+        timeAndUnit = [secsAgo / HOUR, "hour"];
+    } else if (secsDiff <= 6 * DAY) {
+        timeAndUnit = [secsAgo / DAY, "day"];
+    } else if (secsDiff <= 3.5 * WEEK) {
+        timeAndUnit = [secsAgo / WEEK, "week"];
+    } else if (secsDiff <= 11 * MONTH) {
+        timeAndUnit = [secsAgo / MONTH, "month"];
+    } else {
+        timeAndUnit = [secsAgo / YEAR, "year"];
+    }
+
+    const [time, unit] = timeAndUnit;
+    const intl = new Intl.RelativeTimeFormat(i18n.language);
+    const relative = intl.format(Math.round(-time), unit);
+
+    return [time, relative];
+};
 
 type RelativeDateProps = {
     date: Date;
@@ -14,11 +56,9 @@ type RelativeDateProps = {
  * or "Started 3 days ago" in case of live events.
  */
 export const RelativeDate: React.FC<RelativeDateProps> = ({ date, isLive, noTooltip = false }) => {
-    const { i18n } = useTranslation();
+    const { t, i18n } = useTranslation();
     const [now, setNow] = useState(Date.now());
     const secsAgo = Math.floor((now - date.getTime()) / 1000);
-    const secsDiff = Math.abs(secsAgo);
-    const { t } = useTranslation();
 
     // We rerender this component regularly so that it's basically always up to
     // date. Most dates are more than a couple minutes in the past, and for
@@ -29,38 +69,10 @@ export const RelativeDate: React.FC<RelativeDateProps> = ({ date, isLive, noTool
         return () => clearInterval(interval);
     });
 
+    const [time, relative] = relativeDate(date, now);
+    const prefix = time < 0 ? "video.starts-in" : "video.started-when";
 
-    const MINUTE = 60;
-    const HOUR = 60 * MINUTE;
-    const DAY = 24 * HOUR;
-    const WEEK = 7 * DAY;
-    const MONTH = 30.5 * DAY;
-    const YEAR = 365.25 * DAY;
-
-    const prettyDate = (() => {
-        const intl = new Intl.RelativeTimeFormat(i18n.language);
-        let timeAndUnit: [number, Intl.RelativeTimeFormatUnit];
-        if (secsDiff <= 55) {
-            timeAndUnit = [secsAgo, "second"];
-        } else if (secsDiff <= 55 * MINUTE) {
-            timeAndUnit = [secsAgo / MINUTE, "minute"];
-        } else if (secsDiff <= 23 * HOUR) {
-            timeAndUnit = [secsAgo / HOUR, "hour"];
-        } else if (secsDiff <= 6 * DAY) {
-            timeAndUnit = [secsAgo / DAY, "day"];
-        } else if (secsDiff <= 3.5 * WEEK) {
-            timeAndUnit = [secsAgo / WEEK, "week"];
-        } else if (secsDiff <= 11 * MONTH) {
-            timeAndUnit = [secsAgo / MONTH, "month"];
-        } else {
-            timeAndUnit = [secsAgo / YEAR, "year"];
-        }
-        const [time, unit] = timeAndUnit;
-        const prefix = time < 0 ? "video.starts-in" : "video.started-when";
-        const relative = intl.format(Math.round(-time), unit);
-        return isLive ? t(prefix, { duration: relative }) : relative;
-    })();
-
+    const prettyDate = isLive ? t(prefix, { duration: relative }) : relative;
     const preciseDate = date.toLocaleString(i18n.language);
 
     return noTooltip

--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -101,6 +101,10 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
                     },
                     INVALID_INPUT: () => t("errors.invalid-input"),
                     NOT_AUTHORIZED: () => t("errors.not-authorized"),
+                    OPENCAST_UNAVAILABLE: () => {
+                        notOurFault = false;
+                        return t("errors.opencast-unavailable");
+                    },
                 });
                 causes.add(msg);
             }


### PR DESCRIPTION
This adds a "delete" button to the "Video details" page which will remove that event in Tobira and send a `delete` request to Opencast. While that operation is pending and when it fails on Opencast side, the event will still be visible on the "My Videos" page marked respectively, but only there and only as long as it is still present in Opencast. Tobira's sync code will pick up if it gets eventually deleted, and then the "pending/ deletion failed" event will be removed completely.

See commits for more technical details.
Should be fine to review commit by commit.

Closes #806 
