### PR TITLE
Embedding videos using Opencast IDs

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,7 +13,7 @@ import { ManageVideosRoute } from "./routes/manage/Video";
 import { UploadRoute } from "./routes/Upload";
 import { SearchRoute } from "./routes/Search";
 import { InvalidUrlRoute } from "./routes/InvalidUrl";
-import { BlockEmbedRoute, EmbedVideoRoute } from "./routes/Embed";
+import { BlockEmbedRoute, EmbedOpencastVideoRoute, EmbedVideoRoute } from "./routes/Embed";
 import { ManageVideoDetailsRoute } from "./routes/manage/Video/Details";
 import { ManageVideoTechnicalDetailsRoute } from "./routes/manage/Video/TechnicalDetails";
 import React from "react";
@@ -52,6 +52,7 @@ const {
         AddChildRoute,
         ManageRealmContentRoute,
         EmbedVideoRoute,
+        EmbedOpencastVideoRoute,
     ],
 });
 


### PR DESCRIPTION
Previously, embedding videos was only possible using the Tobira ID. This change introduces the ability to embed videos with Opencast IDs using the same embedding format (`/~embed/!v/:<opencast-id>`). This enhancement improves flexibility and consistency in video embedding options.