### PR TITLE
Add return link to editor, open studio and editor in current context

### DIFF
--- a/frontend/src/relay/auth.tsx
+++ b/frontend/src/relay/auth.tsx
@@ -76,7 +76,7 @@ export const ExternalLink = React.forwardRef<HTMLButtonElement, ExternalLinkProp
         form.submit();
     };
 
-    return <form action={redirect.toString()} method="POST" target="_blank" onSubmit={onSubmit}>
+    return <form action={redirect.toString()} method="POST" onSubmit={onSubmit}>
         <input type="hidden" name="target" value={target.toString()} />
         <input type="hidden" name="jwt" />
 

--- a/frontend/src/relay/auth.tsx
+++ b/frontend/src/relay/auth.tsx
@@ -30,7 +30,9 @@ export type ExternalLinkProps = PropsWithChildren<{
 } | {
     service: "EDITOR";
     params: {
-        mediaPackageId: string;
+        id: string;
+        callbackUrl: string;
+        callbackSystem: string;
     };
 })>;
 

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -14,10 +14,11 @@ import { AuthorizedEvent, makeManageVideoRoute, PAGE_WIDTH } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
 import { buttonStyle } from "../../../ui/Button";
 import { COLORS } from "../../../color";
-import { secondsToTimeString } from "../../../util";
+import { secondsToTimeString, translatedConfig } from "../../../util";
 import { DirectVideoRoute, VideoRoute } from "../../Video";
 import { ManageRoute } from "..";
 import { ManageVideosRoute } from ".";
+import CONFIG from "../../../config";
 
 
 export const ManageVideoDetailsRoute = makeManageVideoRoute(
@@ -31,7 +32,7 @@ type Props = {
 };
 
 const Page: React.FC<Props> = ({ event }) => {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
 
     const breadcrumbs = [
         { label: t("user.manage-content"), link: ManageRoute.url },
@@ -56,7 +57,11 @@ const Page: React.FC<Props> = ({ event }) => {
                 {user.canUseEditor && !event.isLive && event.canWrite && (
                     <ExternalLink
                         service="EDITOR"
-                        params={{ mediaPackageId: event.opencastId }}
+                        params={{
+                            id: event.opencastId,
+                            callbackUrl: document.location.href,
+                            callbackSystem: translatedConfig(CONFIG.siteTitle, i18n),
+                        }}
                         fallback="button"
                         css={{
                             marginBottom: 16,


### PR DESCRIPTION
This adds parameters to the editor link that are used to display a return-to-tobira link in editor. Furthermore studio and editor will now open in the same context (tab) instead of a new one.