### PR TITLE
Add playlist blocks

### DIFF
--- a/.deployment/files/realms.yaml
+++ b/.deployment/files/realms.yaml
@@ -23,16 +23,19 @@ blocks:
       test data, mostly consisting of all CC-licensed videos and the page
       structure from [ETHZ's old video portal](https://video.ethz.ch/).
 
-  - series:
-      series: { by_uuid: 94ecfeed-aa7d-4a5c-912b-58b5891543f4 }
+  - video_list:
+      ty: series
+      id: { by_uuid: 94ecfeed-aa7d-4a5c-912b-58b5891543f4 }
       show_title: true
       show_description: true
-  - series:
-      series: { by_uuid: 8a430c59-7e04-4e4b-b532-b2fcad8de8d4 }
+  - video_list:
+      ty: series
+      id: { by_uuid: 8a430c59-7e04-4e4b-b532-b2fcad8de8d4 }
       show_title: true
       show_description: false
-  - series:
-      series: { by_uuid: 9d2f81a2-aa03-4684-948b-28c145df4960 }
+  - video_list:
+      ty: playlist
+      id: { by_uuid: ee39bb7b-7022-458b-ab54-570e81f4730d }
       show_title: true
       show_description: true
   - title: More useful videos
@@ -74,8 +77,9 @@ children:
 
           And of course there is **bold** and *cursive* text.
 
-      - series:
-          series: { by_uuid: 3e586498-d00a-48c6-9c65-63c61acfc64a }
+      - video_list:
+          ty: series
+          id: { by_uuid: 3e586498-d00a-48c6-9c65-63c61acfc64a }
           show_title: true
           show_description: true
 
@@ -5141,8 +5145,9 @@ children:
     blocks:
       - text: |
           Here are some never ending live streams!
-      - series:
-          series: { by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b }
+      - video_list:
+          ty: series
+          id: { by_uuid: 089944f4-e69c-4eb6-81fd-44b8b9924f0b }
           show_title: true
           show_description: false
     children:

--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -6,12 +6,19 @@ use crate::{
         Id,
         Context,
         err::{self, ApiResult},
-        model::{event::AuthorizedEvent, series::Series, realm::Realm, search::SearchSeriesExtended},
+        model::{
+            event::AuthorizedEvent, 
+            series::Series, 
+            realm::Realm, 
+            search::SearchSeriesExtended,
+            playlist::AuthorizedPlaylist,
+        },
     },
     prelude::*,
     search::Event as SearchEvent,
     search::Realm as SearchRealm,
     search::Series as SearchSeries,
+    search::Playlist as SearchPlaylist,
     db::types::ExtraMetadata,
 };
 
@@ -19,7 +26,17 @@ use crate::{
 /// A node with a globally unique ID. Mostly useful for relay.
 #[juniper::graphql_interface(
     Context = Context,
-    for = [AuthorizedEvent, Realm, Series, SearchEvent, SearchRealm, SearchSeries, SearchSeriesExtended]
+    for = [
+        AuthorizedEvent,
+        AuthorizedPlaylist,
+        Realm,
+        Series,
+        SearchEvent,
+        SearchRealm,
+        SearchSeries,
+        SearchSeriesExtended,
+        SearchPlaylist,
+    ]
 )]
 pub(crate) trait Node {
     fn id(&self) -> Id;

--- a/backend/src/api/id.rs
+++ b/backend/src/api/id.rs
@@ -87,6 +87,7 @@ define_kinds![
     search_realm = b"rs",
     search_event = b"es",
     search_series = b"ss",
+    search_playlist = b"ps",
 ];
 
 

--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -63,7 +63,7 @@ impl_from_db!(
 
 impl Playlist {
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> ApiResult<Option<Self>> {
-        if let Some(key) = id.key_for(Id::SERIES_KIND) {
+        if let Some(key) = id.key_for(Id::PLAYLIST_KIND) {
             Self::load_by_key(key, context).await
         } else {
             Ok(None)

--- a/backend/src/api/model/search/playlist.rs
+++ b/backend/src/api/model/search/playlist.rs
@@ -1,0 +1,34 @@
+use crate::{
+    api::{Context, Node, Id, NodeValue},
+    search,
+};
+
+
+impl Node for search::Playlist {
+    fn id(&self) -> Id {
+        Id::search_playlist(self.id.0)
+    }
+}
+
+#[juniper::graphql_object(Context = Context, impl = NodeValue, name = "SearchPlaylist")]
+impl search::Playlist {
+    fn id(&self) -> Id {
+        Node::id(self)
+    }
+
+    fn opencast_id(&self) -> &str {
+        &self.opencast_id
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    fn host_realms(&self) -> &[search::Realm] {
+        &self.host_realms
+    }
+}

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -27,10 +27,12 @@ use super::{
             NewTitleBlock,
             NewTextBlock,
             NewSeriesBlock,
+            NewPlaylistBlock,
             NewVideoBlock,
             UpdateTitleBlock,
             UpdateTextBlock,
             UpdateSeriesBlock,
+            UpdatePlaylistBlock,
             UpdateVideoBlock,
             RemovedBlock,
             VideoListOrder,
@@ -146,6 +148,18 @@ impl Mutation {
         BlockValue::add_series(realm, index, block, context).await
     }
 
+    /// Adds a playlist block to a realm.
+    ///
+    /// See `addTitleBlock` for more details.
+    async fn add_playlist_block(
+        realm: Id,
+        index: i32,
+        block: NewPlaylistBlock,
+        context: &Context,
+    ) -> ApiResult<Realm> {
+        BlockValue::add_playlist(realm, index, block, context).await
+    }
+
     /// Adds a video block to a realm.
     ///
     /// See `addTitleBlock` for more details.
@@ -193,6 +207,15 @@ impl Mutation {
         context: &Context,
     ) -> ApiResult<BlockValue> {
         BlockValue::update_series(id, set, context).await
+    }
+
+    /// Update a playlist block's data.
+    async fn update_playlist_block(
+        id: Id,
+        set: UpdatePlaylistBlock,
+        context: &Context,
+    ) -> ApiResult<BlockValue> {
+        BlockValue::update_playlist(id, set, context).await
     }
 
     /// Update a video block's data.

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -11,7 +11,14 @@ use super::{
         known_roles::{self, KnownGroup, KnownUsersSearchOutcome},
         playlist::Playlist,
         realm::Realm,
-        search::{self, EventSearchOutcome, Filters, SearchOutcome, SeriesSearchOutcome},
+        search::{
+            self,
+            EventSearchOutcome,
+            Filters,
+            SearchOutcome,
+            SeriesSearchOutcome,
+            PlaylistSearchOutcome
+        },
         series::Series,
     },
     Context,
@@ -133,6 +140,20 @@ impl Query {
         context: &Context,
     ) -> ApiResult<SeriesSearchOutcome> {
         search::all_series(&query, writable_only, context).await
+    }
+
+    /// Searches through playlists. Results may include:
+    ///
+    /// - Playlists that the user has write access to (listed & unlisted).
+    /// - If `writable_only` is false, this also searches through listed playlists.
+    ///   If the user has the privilege to find unlisted playlists, all playlists are
+    ///   searched.
+    async fn search_all_playlists(
+        query: String,
+        writable_only: bool,
+        context: &Context,
+    ) -> ApiResult<PlaylistSearchOutcome> {
+        search::all_playlists(&query, writable_only, context).await
     }
 
     /// Searches through all known users. The behavior of this depends on the

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -368,4 +368,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     33: "event-slide-text-and-segments",
     34: "event-view-and-deletion-timestamp",
     35: "playlists",
+    36: "playlist-blocks",
 ];

--- a/backend/src/db/migrations/35-playlists.sql
+++ b/backend/src/db/migrations/35-playlists.sql
@@ -39,8 +39,11 @@ create table playlists (
 -- to list all playlists that a user has write access to.
 create index idx_playlists_write_roles on playlists using gin (write_roles);
 
--- Extend enum types to allow for playlist blocks and playlist items in search index queue.
+-- Extend enum types to allow for playlist blocks, playlist items in search index queue
+-- and to remember deleted playlists.
 -- This needs to be done prior to their usage in the next migration since they can't be used
 -- in the same migration they were added.
 alter type block_type add value 'playlist';
 alter type search_index_item_kind add value 'playlist';
+alter type opencast_item_kind add value 'playlist';
+

--- a/backend/src/db/migrations/35-playlists.sql
+++ b/backend/src/db/migrations/35-playlists.sql
@@ -6,7 +6,7 @@ create type playlist_entry_type as enum ('event');
 -- All fields should never be null.
 create type playlist_entry as (
     -- The Opencast ID of this entry. Not a UUID.
-    opencast_id bigint,
+    entry_id bigint,
 
     type playlist_entry_type,
 

--- a/backend/src/db/migrations/35-playlists.sql
+++ b/backend/src/db/migrations/35-playlists.sql
@@ -39,7 +39,8 @@ create table playlists (
 -- to list all playlists that a user has write access to.
 create index idx_playlists_write_roles on playlists using gin (write_roles);
 
-
--- Search index ---------------------------------------------------------------
-
--- TODO
+-- Extend enum types to allow for playlist blocks and playlist items in search index queue.
+-- This needs to be done prior to their usage in the next migration since they can't be used
+-- in the same migration they were added.
+alter type block_type add value 'playlist';
+alter type search_index_item_kind add value 'playlist';

--- a/backend/src/db/migrations/36-playlist-blocks.sql
+++ b/backend/src/db/migrations/36-playlist-blocks.sql
@@ -106,3 +106,16 @@ as $$
         )
     select * from the_events union all select * from the_series union all select * from the_playlists
 $$;
+
+-- Triggers to remember and reuse deleted playlists.
+create trigger remember_deleted_opencast_playlists
+after delete
+on playlists
+for each row
+execute procedure remember_deleted_opencast_items('playlist');
+
+create trigger reuse_existing_id_on_playlist_insert
+before insert
+on playlists
+for each row
+execute procedure reuse_existing_id_on_insert('playlist');

--- a/backend/src/db/migrations/36-playlist-blocks.sql
+++ b/backend/src/db/migrations/36-playlist-blocks.sql
@@ -1,0 +1,108 @@
+-- This adds the necessary type, column and constraints for playlist blocks.
+alter table blocks
+    add column playlist bigint references playlists on delete set null,
+    add constraint playlist_block_has_fields check (type <> 'playlist' or (
+        videolist_order is not null and
+        videolist_layout is not null and
+        show_title is not null and
+        show_metadata is not null
+    ));
+
+alter type video_list_order add value 'original';
+
+create index idx_block_playlist on blocks (playlist);
+
+
+-- All of this is the preparation to store playlists in the search index.
+-- The procedure for playlists is very similar to the one for series, and
+-- is adapted from `19-series-search-view` and `20-fix-queue-triggers`
+-- (this includes some of the comments).
+
+-- Add view for playlist data that we put into the search index.
+create view search_playlists as
+    select
+        playlists.id, playlists.opencast_id,
+        playlists.read_roles, playlists.write_roles,
+        playlists.title, playlists.description, playlists.creator,
+        coalesce(
+            array_agg((
+                -- Using a nested query here improves the overall performance
+                -- for the main use case: 'where id = any(...)'. If we would
+                -- use a join instead, the runtime would be the same with or
+                -- without the 'where id' (roughly 300ms on my machine).
+                select row(search_realms.*)::search_realms
+                from search_realms
+                where search_realms.id = blocks.realm
+            )) filter(where blocks.realm is not null),
+            '{}'
+        ) as host_realms
+    from playlists
+    left join blocks on type = 'playlist' and blocks.playlist = playlists.id
+    group by playlists.id;
+
+-- Add a trigger to automatically add a playlist to the queue whenever it's changed
+-- somehow.
+create function queue_playlist_for_reindex(playlist playlists) returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    values (playlist.id, 'playlist')
+    on conflict do nothing
+$$;
+
+create function queue_touched_playlist_for_reindex()
+returns trigger
+   language plpgsql
+as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_playlist_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_playlist_for_reindex(new);
+    end if;
+    return null;
+end;
+$$;
+
+create trigger queue_touched_playlist_for_reindex
+after insert or delete or update
+on playlists
+for each row
+execute procedure queue_touched_playlist_for_reindex();
+
+-- Returns all series, events and playlists that are hosted by the given realm.
+-- They are returned in the form that can be directly inserted into
+-- `search_index_queue`.
+-- In theory this should be renamed to reflect the fact that this now also
+-- includes playlists. But since this is used in another function
+-- (`queue_touched_realm_for_reindex()`), it's easier to stick with the
+-- existing name.
+create or replace function hosted_series_and_events(realm_id bigint)
+    returns table (id bigint, kind search_index_item_kind)
+    language 'sql'
+as $$
+    with
+        the_blocks as (
+            select *
+            from blocks
+            where blocks.realm = realm_id
+        ),
+        the_events as (
+            select events.id, 'event'::search_index_item_kind
+            from the_blocks
+            inner join events on (
+                type = 'series' and the_blocks.series = events.series
+                or type = 'video' and the_blocks.video = events.id
+            )
+        ),
+        the_series as (
+            select series.id, 'series'::search_index_item_kind
+            from the_blocks
+            inner join series on type = 'series' and the_blocks.series = series.id
+        ),
+        the_playlists as (
+            select playlists.id, 'playlist'::search_index_item_kind
+            from the_blocks
+            inner join playlists on type = 'playlist' and the_blocks.playlist = playlists.id
+        )
+    select * from the_events union all select * from the_series union all select * from the_playlists
+$$;

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -109,7 +109,7 @@ pub enum PlaylistEntryType {
 #[derive(Debug, FromSql, ToSql, Clone)]
 #[postgres(name = "playlist_entry")]
 pub struct PlaylistEntry {
-    pub opencast_id: i64,
+    pub entry_id: i64,
     #[postgres(name = "type")]
     pub ty: PlaylistEntryType,
     pub content_id: String,

--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -194,6 +194,8 @@ async fn status(meili: &Client) -> Result<()> {
     println!();
     index_status("user", &meili.user_index, meili.config.user_index_name()).await?;
     println!();
+    index_status("playlist", &meili.playlist_index, meili.config.playlist_index_name()).await?;
+    println!();
 
     Ok(())
 }

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -43,7 +43,7 @@ pub(crate) struct Event {
     pub(crate) read_roles: Vec<String>,
     pub(crate) write_roles: Vec<String>,
 
-    // The `listed` field is always `!host_realms.is_empty()`, but we need to
+    // The `listed` field is always derived from `host_realms`, but we need to
     // store it explicitly to filter for this condition in Meili.
     pub(crate) listed: bool,
     pub(crate) host_realms: Vec<Realm>,

--- a/backend/src/search/playlist.rs
+++ b/backend/src/search/playlist.rs
@@ -1,0 +1,89 @@
+use meilisearch_sdk::indexes::Index;
+use serde::{Serialize, Deserialize};
+use tokio_postgres::GenericClient;
+
+use crate::{
+    prelude::*,
+    db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
+};
+
+use super::{realm::Realm, SearchId, IndexItem, IndexItemKind, util};
+
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Playlist {
+    pub(crate) id: SearchId,
+    pub(crate) opencast_id: String,
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) creator: String,
+
+    // See `search::Event::*_roles` for notes that also apply here.
+    pub(crate) read_roles: Vec<String>,
+    pub(crate) write_roles: Vec<String>,
+
+    pub(crate) host_realms: Vec<Realm>,
+}
+
+impl IndexItem for Playlist {
+    const KIND: IndexItemKind = IndexItemKind::Playlist;
+    fn id(&self) -> SearchId {
+        self.id
+    }
+}
+
+impl_from_db!(
+    Playlist,
+    select: {
+        search_playlists.{
+            id, opencast_id,
+            title, description, creator,
+            read_roles, write_roles,
+            host_realms,
+        },
+    },
+    |row| {
+        let host_realms = row.host_realms::<Vec<Realm>>();
+        Self {
+            id: row.id(),
+            opencast_id: row.opencast_id(),
+            title: row.title(),
+            description: row.description(),
+            creator: row.creator(),
+            read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
+            write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
+            host_realms,
+        }
+    }
+);
+
+impl Playlist {
+    pub(crate) async fn load_by_ids(db: &impl GenericClient, ids: &[Key]) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from search_playlists \
+            where id = any($1)");
+        let rows = db.query_raw(&query, dbargs![&ids]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load playlists from DB")
+    }
+
+    pub(crate) async fn load_all(db: &impl GenericClient) -> Result<Vec<Self>> {
+        let selection = Self::select();
+        let query = format!("select {selection} from search_playlists");
+        let rows = db.query_raw(&query, dbargs![]);
+        collect_rows_mapped(rows, |row| Self::from_row_start(&row))
+            .await
+            .context("failed to load playlists from DB")
+    }
+}
+
+pub(super) async fn prepare_index(index: &Index) -> Result<()> {
+    util::lazy_set_special_attributes(
+        index,
+        "playlist",
+        &["title", "description"],
+        &["read_roles", "write_roles"],
+    ).await
+}

--- a/backend/src/search/playlist.rs
+++ b/backend/src/search/playlist.rs
@@ -23,6 +23,9 @@ pub(crate) struct Playlist {
     pub(crate) read_roles: Vec<String>,
     pub(crate) write_roles: Vec<String>,
 
+    // The `listed` field is always derived from `host_realms`, but we need to
+    // store it explicitly to filter for this condition in Meili.
+    pub(crate) listed: bool,
     pub(crate) host_realms: Vec<Realm>,
 }
 
@@ -53,6 +56,7 @@ impl_from_db!(
             creator: row.creator(),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
+            listed: host_realms.iter().any(|realm| !realm.is_user_realm()),
             host_realms,
         }
     }

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -22,7 +22,7 @@ pub(crate) struct Series {
     pub(crate) read_roles: Vec<String>,
     pub(crate) write_roles: Vec<String>,
 
-    // The `listed` field is always `!host_realms.is_empty()`, but we need to
+    // The `listed` field is always derived from `host_realms`, but we need to
     // store it explicitly to filter for this condition in Meili.
     pub(crate) listed: bool,
     pub(crate) host_realms: Vec<Realm>,

--- a/backend/src/sync/harvest/mod.rs
+++ b/backend/src/sync/harvest/mod.rs
@@ -303,7 +303,7 @@ async fn store_in_db(
                     };
 
                     Some(db::types::PlaylistEntry {
-                        opencast_id: e.id,
+                        entry_id: e.id,
                         ty,
                         content_id: e.content_id,
                     })

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -177,13 +177,15 @@ video:
     rss: RSS
     show-qr-code: QR Code anzeigen
 
+playlist:
+  deleted-playlist-block: Die hier referenzierte Playlist wurde gelöscht.
+  not-allowed-playlist-block: Sie sind nicht autorisiert, die hier eingebettete Playlist zu sehen.
+
 series:
   series: Serie
   deleted: Gelöschte Serie
   deleted-series-block: Die hier referenzierte Serie wurde gelöscht.
   entry-of-series-thumbnail: "Vorschlaubild für Teil von „{{series}}“"
-  videos:
-    heading: Videos
   not-ready:
     title: Serie noch nicht synchronisiert
     text: >
@@ -196,6 +198,9 @@ videolist-block:
   unauthorized: Fehlende Berechtigung
   hidden-items_one: 'Ein Video wurde nicht gefunden oder Sie haben keinen Zugriff darauf.'
   hidden-items_other: '{{count}} Videos wurden nicht gefunden oder Sie haben keinen Zugriff darauf.'
+  no-videos: Keine videos
+  videos:
+    heading: Videos
   settings:
     order: Reihenfolge
     order-label: Video Reihenfolge auswählen
@@ -530,6 +535,7 @@ manage:
       add-text: Text
       add-series: Serie
       add-video: Video
+      add-playlist: Playlist
 
       move-down: Block nach unten verschieben
       move-up: Block nach oben verschieben
@@ -555,6 +561,16 @@ manage:
           invalid: Bitte eine Serie auswählen
           findable-series-note: >
             Sie können hier nur Serien wählen, die gelistet sind oder auf die
+            Sie Schreibzugriff haben.
+        metadata:
+          heading: Metadaten
+
+      playlist:
+        playlist:
+          heading: Playlist
+          invalid: Bitte eine Playlist auswählen
+          findable-playlist-note: >
+            Sie können hier nur Playlisten wählen, die gelistet sind oder auf die
             Sie Schreibzugriff haben.
         metadata:
           heading: Metadaten

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -129,6 +129,7 @@ video:
   link: Zur Videoseite
   part-of-series: Teil der Serie
   more-from-series: Mehr von „{{series}}“
+  more-from-playlist: Mehr von “{{playlist}}”
   deleted-video-block: Das hier referenzierte Video wurde gelöscht.
   not-allowed-video-block: Sie sind nicht autorisiert, das hier eingebettete Video zu sehen.
   not-ready:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -127,6 +127,7 @@ video:
   link: Go to video page
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
+  more-from-playlist: More from “{{playlist}}”
   deleted-video-block: The video referenced here was deleted.
   not-allowed-video-block: You are not allowed to view the video embedded here.
   not-ready:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -174,13 +174,15 @@ video:
     rss: RSS
     show-qr-code: Show QR code
 
+playlist:
+  deleted-playlist-block: The playlist referenced here was deleted.
+  not-allowed-playlist-block: You are not allowed to view the playlist embedded here.
+
 series:
   series: Series
   deleted: Deleted series
   deleted-series-block: The series referenced here was deleted.
   entry-of-series-thumbnail: "Thumbnail for entry of “{{series}}”"
-  videos:
-    heading: Videos
   not-ready:
     title: Series not synchronized yet
     text: >
@@ -194,6 +196,8 @@ videolist-block:
   hidden-items_one: 'One video is missing or requires additional permissions to view.'
   hidden-items_other: '{{count}} videos are missing or require additional permissions to view.'
   no-videos: No videos
+  videos:
+    heading: Videos
   settings:
     order: Order
     order-label: Choose video order
@@ -507,6 +511,7 @@ manage:
       add-text: Text
       add-series: Series
       add-video: Video
+      add-playlist: Playlist
 
       move-down: Move block down
       move-up: Move block up
@@ -532,6 +537,15 @@ manage:
           invalid: Please select a series
           findable-series-note: >
             You can only select series here which are listed or which you have write-access to.
+        metadata:
+          heading: Metadata
+
+      playlist:
+        playlist:
+          heading: Playlist
+          invalid: Please select a playlist
+          findable-playlist-note: >
+            You can only select playlists here which are listed or which you have write-access to.
         metadata:
           heading: Metadata
 

--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -1,4 +1,4 @@
-import { graphql, readInlineData, useFragment } from "react-relay";
+import { graphql, useFragment } from "react-relay";
 import { useTranslation } from "react-i18next";
 import { unreachable } from "@opencast/appkit";
 
@@ -15,8 +15,7 @@ import { PlaylistByOpencastIdQuery } from "./__generated__/PlaylistByOpencastIdQ
 import { PlaylistRouteData$key } from "./__generated__/PlaylistRouteData.graphql";
 import { PlaylistByIdQuery } from "./__generated__/PlaylistByIdQuery.graphql";
 import { ErrorPage } from "../ui/error";
-import { VideoListBlock, videoListEventFragment } from "../ui/Blocks/VideoList";
-import { VideoListEventData$key } from "../ui/Blocks/__generated__/VideoListEventData.graphql";
+import { PlaylistBlockFromPlaylist } from "../ui/Blocks/Playlist";
 
 
 export const DirectPlaylistOCRoute = makeRoute({
@@ -92,6 +91,7 @@ const fragment = graphql`
         __typename
         ... on NotAllowed { dummy } # workaround
         ... on AuthorizedPlaylist {
+            id
             title
             description
             entries {
@@ -101,6 +101,7 @@ const fragment = graphql`
                 ...on NotAllowed { dummy }
             }
         }
+        ... PlaylistBlockPlaylistData
     }
 `;
 
@@ -123,30 +124,20 @@ const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag }) => {
         return unreachable();
     }
 
-    const items = playlist.entries.map(entry => {
-        if (entry.__typename === "AuthorizedEvent") {
-            const out = readInlineData<VideoListEventData$key>(videoListEventFragment, entry);
-            return out;
-        } else if (entry.__typename === "Missing") {
-            return "missing";
-        } else if (entry.__typename === "NotAllowed") {
-            return "unauthorized";
-        } else {
-            return unreachable();
-        }
-    });
-
     return <div css={{ display: "flex", flexDirection: "column" }}>
-        <Breadcrumbs path={[]} tail={playlist.title} />
-        <PageTitle title={playlist.title} />
+        {/*
+            `playlist.title` is actually never undefined,
+            but the following assertions are necessary to work around
+            some graphql weirdness.
+        */}
+        <Breadcrumbs path={[]} tail={playlist.title ?? ""} />
+        <PageTitle title={playlist.title ?? ""} />
         <p css={{ maxWidth: "90ch" }}>{playlist.description}</p>
         <div css={{ marginTop: 12 }}>
-            <VideoListBlock
-                allowOriginalOrder={true}
-                initialOrder="ORIGINAL"
+            <PlaylistBlockFromPlaylist
                 title={t("videolist-block.videos.heading")}
                 basePath="/!v"
-                items={items}
+                fragRef={playlist}
             />
         </div>
     </div>;

--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -144,7 +144,7 @@ const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag }) => {
             <VideoListBlock
                 allowOriginalOrder={true}
                 initialOrder="ORIGINAL"
-                title={t("series.videos.heading")}
+                title={t("videolist-block.videos.heading")}
                 basePath="/!v"
                 items={items}
             />

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -43,10 +43,11 @@ import { MissingRealmName } from "./util";
 import { ellipsisOverflowCss, focusStyle } from "../ui";
 import { COLORS } from "../color";
 import { BREAKPOINT_MEDIUM, BREAKPOINT_SMALL } from "../GlobalStyle";
-import { isExperimentalFlagSet, keyOfId } from "../util";
+import { isExperimentalFlagSet } from "../util";
 import { Button, Card } from "@opencast/appkit";
 import { DirectVideoRoute, VideoRoute } from "./Video";
 import { DirectSeriesRoute } from "./Series";
+import { PartOfSeriesLink } from "../ui/Blocks/VideoList";
 
 
 export const isSearchActive = (): boolean => document.location.pathname === "/~search";
@@ -474,8 +475,6 @@ const SearchEvent: React.FC<SearchEventProps> = ({
     endTime,
     hostRealms,
 }) => {
-    const { t } = useTranslation();
-
     // TODO: decide what to do in the case of more than two host realms. Direct
     // link should be avoided.
     const link = hostRealms.length !== 1
@@ -514,23 +513,7 @@ const SearchEvent: React.FC<SearchEventProps> = ({
                         text={description}
                         lines={3}
                     />}
-                    {seriesTitle && seriesId && <div css={{
-                        fontSize: 14,
-                        marginTop: "auto",
-                        paddingTop: 8,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        padding: 3,
-                    }}>
-                        {t("video.part-of-series") + ": "}
-                        <Link to={`/!s/${keyOfId(seriesId)}`} css={{
-                            borderRadius: 4,
-                            outlineOffset: 1,
-                            position: "relative",
-                            zIndex: 4,
-                        }}>{seriesTitle}</Link>
-                    </div>}
+                    {seriesTitle && seriesId && <PartOfSeriesLink {...{ seriesTitle, seriesId }} />}
                 </div>
             </WithIcon>
             <Thumbnail

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -118,7 +118,7 @@ const SeriesPage: React.FC<SeriesPageProps> = ({ seriesFrag }) => {
         <p css={{ maxWidth: "90ch" }}>{series.syncedData.description}</p>
         <div css={{ marginTop: 12 }}>
             <SeriesBlockFromSeries
-                title={t("series.videos.heading")}
+                title={t("videolist-block.videos.heading")}
                 basePath="/!v"
                 fragRef={series}
             />

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -23,7 +23,7 @@ import { FieldIsRequiredNote, InputContainer, TitleLabel } from "../ui/metadata"
 import { PageTitle } from "../layout/header/ui";
 import { useRouter } from "../router";
 import { getJwt } from "../relay/auth";
-import { SeriesSelector } from "../ui/SearchableSelect";
+import { VideoListSelector } from "../ui/SearchableSelect";
 import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { ManageNav, ManageRoute } from "./manage";
 import { COLORS } from "../color";
@@ -765,7 +765,8 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
                         <span><LuInfo tabIndex={0} /></span>
                     </WithTooltip>
                 </label>
-                <SeriesSelector
+                <VideoListSelector
+                    type="series"
                     inputId={seriesFieldId}
                     writableOnly
                     menuPlacement="top"

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -460,6 +460,7 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, basePath 
                 moreOfTitle
                 basePath={basePath}
                 fragRef={playlistRef}
+                activeEventId={event.id}
             />
             : event.series && <SeriesBlockFromSeries
                 basePath={basePath}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -32,6 +32,7 @@ import {
     secondsToTimeString,
     eventId,
     keyOfId,
+    playlistId,
 } from "../util";
 import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
 import { LinkButton } from "../ui/LinkButton";
@@ -54,6 +55,9 @@ import {
 import { UserData$key } from "../__generated__/UserData.graphql";
 import { NavigationData$key } from "../layout/__generated__/NavigationData.graphql";
 import { VideoPageByOcIdInRealmQuery } from "./__generated__/VideoPageByOcIdInRealmQuery.graphql";
+import {
+    PlaylistBlockPlaylistData$key,
+} from "../ui/Blocks/__generated__/PlaylistBlockPlaylistData.graphql";
 import { getEventTimeInfo } from "../util/video";
 import { formatDuration } from "../ui/Video";
 import { ellipsisOverflowCss, focusStyle } from "../ui";
@@ -67,6 +71,7 @@ import { CollapsibleDescription } from "../ui/metadata";
 import { DirectSeriesRoute } from "./Series";
 import { EmbedVideoRoute } from "./Embed";
 import { ManageVideoDetailsRoute } from "./manage/Video/Details";
+import { PlaylistBlockFromPlaylist } from "../ui/Blocks/Playlist";
 
 
 // ===========================================================================================
@@ -82,10 +87,10 @@ export const VideoRoute = makeRoute({
         if (params === null) {
             return null;
         }
-        const [realmPath, videoId] = params;
+        const { realmPath, videoId, listId } = params;
 
         const query = graphql`
-            query VideoPageInRealmQuery($id: ID!, $realmPath: String!) {
+            query VideoPageInRealmQuery($id: ID!, $realmPath: String!, $listId: ID!) {
                 ... UserData
                 event: eventById(id: $id) {
                     ... VideoPageEventData
@@ -97,19 +102,21 @@ export const VideoRoute = makeRoute({
                     ... VideoPageRealmData
                     ... NavigationData
                 }
+                playlist: playlistById(id: $listId) { ...PlaylistBlockPlaylistData }
             }
         `;
 
         const queryRef = loadQuery<VideoPageInRealmQuery>(query, {
             id: eventId(videoId),
             realmPath,
+            listId,
         });
 
         return {
             render: () => <RootLoader
                 {... { query, queryRef }}
                 nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
-                render={({ event, realm }) => {
+                render={({ event, realm, playlist }) => {
                     if (!event) {
                         return <NotFound kind="video" />;
                     }
@@ -121,6 +128,7 @@ export const VideoRoute = makeRoute({
                     return <VideoPage
                         eventRef={event}
                         realmRef={realm}
+                        playlistRef={playlist ?? null}
                         basePath={realmPath.replace(/\/$/u, "") + "/v"}
                     />;
                 }}
@@ -140,11 +148,11 @@ export const OpencastVideoRoute = makeRoute({
             return null;
         }
 
-        const [realmPath, id] = params;
-        const videoId = id.substring(1);
+        const { realmPath, videoId, listId } = params;
+        const id = videoId.substring(1);
 
         const query = graphql`
-            query VideoPageByOcIdInRealmQuery($id: String!, $realmPath: String!) {
+            query VideoPageByOcIdInRealmQuery($id: String!, $realmPath: String!, $listId: ID!) {
                 ... UserData
                 event: eventByOpencastId(id: $id) {
                     ... VideoPageEventData
@@ -156,30 +164,33 @@ export const OpencastVideoRoute = makeRoute({
                     ... VideoPageRealmData
                     ... NavigationData
                 }
+                playlist: playlistById(id: $listId) { ...PlaylistBlockPlaylistData }
             }
         `;
 
         const queryRef = loadQuery<VideoPageByOcIdInRealmQuery>(query, {
-            id: videoId,
+            id,
             realmPath,
+            listId,
         });
 
         return {
             render: () => <RootLoader
                 {... { query, queryRef }}
                 nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
-                render={({ event, realm }) => {
+                render={({ event, realm, playlist }) => {
                     if (!event) {
                         return <NotFound kind="video" />;
                     }
 
                     if (!realm || !event.isReferencedByRealm) {
-                        return <ForwardToDirectOcRoute ocID={videoId} />;
+                        return <ForwardToDirectOcRoute ocID={id} />;
                     }
 
                     return <VideoPage
                         eventRef={event}
                         realmRef={realm}
+                        playlistRef={playlist ?? null}
                         basePath={realmPath.replace(/\/$/u, "") + "/v"}
                     />;
                 }}
@@ -189,8 +200,15 @@ export const OpencastVideoRoute = makeRoute({
     },
 });
 
-const getVideoDetailsFromUrl = (url: URL, regEx: string) => {
+type VideoParams = {
+    realmPath: string;
+    videoId: string;
+    listId: string;
+} | null;
+
+const getVideoDetailsFromUrl = (url: URL, regEx: string): VideoParams => {
     const urlPath = url.pathname.replace(/^\/|\/$/g, "");
+    const listId = makeListId(url.searchParams.get("list"));
     const parts = urlPath.split("/").map(decodeURIComponent);
     if (parts.length < 2) {
         return null;
@@ -210,8 +228,10 @@ const getVideoDetailsFromUrl = (url: URL, regEx: string) => {
 
     const realmPath = "/" + realmPathParts.join("/");
 
-    return [realmPath, videoId];
+    return { realmPath, videoId, listId };
 };
+
+const makeListId = (id: string | null) => id ? playlistId(id) : "";
 
 const ForwardToDirectRoute: React.FC<{ videoId: string }> = ({ videoId }) => {
     const router = useRouter();
@@ -236,17 +256,21 @@ export const DirectVideoRoute = makeRoute({
         }
 
         const query = graphql`
-            query VideoPageDirectLinkQuery($id: ID!) {
+            query VideoPageDirectLinkQuery($id: ID!, $listId: ID!) {
                 ... UserData
                 event: eventById(id: $id) { ... VideoPageEventData }
                 realm: rootRealm {
                     ... VideoPageRealmData
                     ... NavigationData
                 }
+                playlist: playlistById(id: $listId) { ...PlaylistBlockPlaylistData }
             }
         `;
         const videoId = decodeURIComponent(params[1]);
-        const queryRef = loadQuery<VideoPageDirectLinkQuery>(query, { id: eventId(videoId) });
+        const queryRef = loadQuery<VideoPageDirectLinkQuery>(query, {
+            id: eventId(videoId),
+            listId: makeListId(url.searchParams.get("list")),
+        });
 
         return matchedDirectRoute(query, queryRef);
     },
@@ -263,17 +287,21 @@ export const DirectOpencastVideoRoute = makeRoute({
         }
 
         const query = graphql`
-            query VideoPageDirectOpencastLinkQuery($id: String!) {
+            query VideoPageDirectOpencastLinkQuery($id: String!, $listId: ID!) {
                 ... UserData
                 event: eventByOpencastId(id: $id) { ... VideoPageEventData }
                 realm: rootRealm {
                     ... VideoPageRealmData
                     ... NavigationData
                 }
+                playlist: playlistById(id: $listId) { ...PlaylistBlockPlaylistData }
             }
         `;
         const videoId = decodeURIComponent(matches[1]);
-        const queryRef = loadQuery<VideoPageDirectOpencastLinkQuery>(query, { id: videoId });
+        const queryRef = loadQuery<VideoPageDirectOpencastLinkQuery>(query, {
+            id: videoId,
+            listId: makeListId(url.searchParams.get("list")),
+        });
 
         return matchedDirectRoute(query, queryRef);
     },
@@ -284,6 +312,7 @@ interface DirectRouteQuery extends OperationType {
     response: UserData$key & {
         realm: VideoPageRealmData$key & NavigationData$key;
         event?: VideoPageEventData$key | null;
+        playlist?: PlaylistBlockPlaylistData$key | null;
     };
 }
 
@@ -296,11 +325,12 @@ const matchedDirectRoute = (
         {... { query, queryRef }}
         noindex
         nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
-        render={({ event, realm }) => !event
+        render={({ event, realm, playlist }) => !event
             ? <NotFound kind="video" />
             : <VideoPage
                 eventRef={event}
                 realmRef={realm ?? unreachable("root realm doesn't exist")}
+                playlistRef={playlist ?? null}
                 basePath="/!v"
             />}
     />,
@@ -356,6 +386,7 @@ const eventFragment = graphql`
 `;
 
 
+
 // ===========================================================================================
 // ===== Components
 // ===========================================================================================
@@ -363,10 +394,11 @@ const eventFragment = graphql`
 type Props = {
     eventRef: NonNullable<VideoPageEventData$key>;
     realmRef: NonNullable<VideoPageRealmData$key>;
+    playlistRef: PlaylistBlockPlaylistData$key | null;
     basePath: string;
 };
 
-const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
+const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, basePath }) => {
     const { t } = useTranslation();
     const rerender = useForceRerender();
     const event = useFragment(eventFragment, eventRef);
@@ -423,12 +455,19 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, basePath }) => {
 
         <div css={{ height: 80 }} />
 
-        {event.series && <SeriesBlockFromSeries
-            basePath={basePath}
-            fragRef={event.series}
-            title={t("video.more-from-series", { series: event.series.title })}
-            activeEventId={event.id}
-        />}
+        {playlistRef
+            ? <PlaylistBlockFromPlaylist
+                moreOfTitle
+                basePath={basePath}
+                fragRef={playlistRef}
+            />
+            : event.series && <SeriesBlockFromSeries
+                basePath={basePath}
+                fragRef={event.series}
+                title={t("video.more-from-series", { series: event.series.title })}
+                activeEventId={event.id}
+            />
+        }
     </>;
 };
 

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -2,7 +2,7 @@ import React, { RefObject, useId, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, commitLocalUpdate, useRelayEnvironment } from "react-relay";
 import type { RecordProxy, RecordSourceProxy } from "relay-runtime";
-import { LuPlus, LuHash, LuType, LuFilm, LuLayoutGrid } from "react-icons/lu";
+import { LuPlus, LuHash, LuType, LuFilm, LuLayoutGrid, LuListVideo } from "react-icons/lu";
 import {
     ProtoButton, bug, useColorScheme, Floating, FloatingContainer,
     FloatingHandle, FloatingTrigger, WithTooltip, useFloatingItemProps,
@@ -110,7 +110,7 @@ const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}>
         });
     };
 
-    type Block = "title" | "text" | "series" | "video";
+    type Block = "title" | "text" | "series" | "video" | "playlist";
     const buttonProps: [IconType, Block, () => void][] = [
         [LuHash, "title", () => addBlock("Title")],
         [LuType, "text", () => addBlock("Text")],
@@ -123,6 +123,12 @@ const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}>
         [LuFilm, "video", () => addBlock("Video", (_store, block) => {
             block.setValue(true, "showTitle");
             block.setValue(true, "showLink");
+        })],
+        [LuListVideo, "playlist", () => addBlock("Playlist", (_store, block) => {
+            block.setValue("ORIGINAL", "order");
+            block.setValue("GALLERY", "layout");
+            block.setValue(true, "showTitle");
+            block.setValue(false, "showMetadata");
         })],
     ];
 

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Playlist.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Playlist.tsx
@@ -1,0 +1,114 @@
+import { graphql, useFragment, useMutation } from "react-relay";
+import {
+    PlaylistEditModeBlockData$key,
+    VideoListLayout,
+    VideoListOrder,
+} from "./__generated__/PlaylistEditModeBlockData.graphql";
+import { PlaylistEditSaveMutation } from "./__generated__/PlaylistEditSaveMutation.graphql";
+import { PlaylistEditCreateMutation } from "./__generated__/PlaylistEditCreateMutation.graphql";
+import { useTranslation } from "react-i18next";
+import { isRealUser, useUser } from "../../../../../../User";
+import { useController, useFormContext } from "react-hook-form";
+import { EditModeForm } from ".";
+import { Heading, VideoListFormFields } from "./util";
+import { VideoListSelector } from "../../../../../../ui/SearchableSelect";
+import { InfoTooltip } from "../../../../../../ui";
+import { Card } from "@opencast/appkit";
+
+type PlaylistFormData = {
+    playlist: string;
+    order: VideoListOrder;
+    layout: VideoListLayout;
+    showTitle: boolean;
+    showMetadata: boolean;
+};
+
+type EditPlaylistBlockProps = {
+    block: PlaylistEditModeBlockData$key;
+}
+
+export const EditPlaylistBlock: React.FC<EditPlaylistBlockProps> = ({ block: blockRef }) => {
+    const { playlist, showTitle, showMetadata, order, layout } = useFragment(graphql`
+        fragment PlaylistEditModeBlockData on PlaylistBlock {
+            playlist {
+                __typename
+                ...on NotAllowed { dummy }
+                ...on AuthorizedPlaylist {
+                    id
+                    opencastId
+                    title
+                    description
+                }
+            }
+            showTitle
+            showMetadata
+            order
+            layout
+        }
+    `, blockRef);
+
+    const [save] = useMutation<PlaylistEditSaveMutation>(graphql`
+        mutation PlaylistEditSaveMutation($id: ID!, $set: UpdatePlaylistBlock!) {
+            updatePlaylistBlock(id: $id, set: $set) {
+                ... BlocksBlockData
+                ... EditBlockUpdateRealmNameData
+            }
+        }
+    `);
+
+    const [create] = useMutation<PlaylistEditCreateMutation>(graphql`
+        mutation PlaylistEditCreateMutation($realm: ID!, $index: Int!, $block: NewPlaylistBlock!) {
+            addPlaylistBlock(realm: $realm, index: $index, block: $block) {
+                ... ContentManageRealmData
+            }
+        }
+    `);
+
+    const { t } = useTranslation();
+    const user = useUser();
+
+    if (playlist != null && playlist.__typename !== "AuthorizedPlaylist") {
+        return t("playlist.not-allowed-playlist-block");
+    }
+
+    const form = useFormContext<PlaylistFormData>();
+    const { formState: { errors }, control } = form;
+    const { field: playlistField } = useController({
+        defaultValue: playlist?.id,
+        name: "playlist",
+        control,
+        rules: { required: true },
+    });
+
+
+    return <EditModeForm create={create} save={save} map={(data: PlaylistFormData) => data}>
+        <Heading>
+            {t("manage.realm.content.playlist.playlist.heading")}
+            {isRealUser(user) && !user.canFindUnlisted && <InfoTooltip
+                info={t("manage.realm.content.playlist.playlist.findable-playlist-note")}
+            />}
+        </Heading>
+        {"playlist" in errors && <div css={{ margin: "8px 0" }}>
+            <Card kind="error">{t("manage.realm.content.playlist.playlist.invalid")}</Card>
+        </div>}
+        <VideoListSelector
+            type="playlist"
+            defaultValue={playlist == null ? undefined : {
+                ...playlist,
+                description: playlist.description ?? null,
+            }}
+            onChange={data => playlistField.onChange(data?.id)}
+            onBlur={playlistField.onBlur}
+            autoFocus
+        />
+        <VideoListFormFields allowOriginalOrder {...{
+            form,
+            order,
+            layout,
+            showMetadata,
+            showTitle,
+        }} />
+    </EditModeForm>;
+};
+
+

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -1,10 +1,10 @@
-import React, { useId } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
 import { useController, useFormContext } from "react-hook-form";
 
 import { EditModeForm } from ".";
-import { Heading } from "./util";
+import { Heading, VideoListFormFields } from "./util";
 import type {
     VideoListOrder,
     VideoListLayout,
@@ -16,10 +16,8 @@ import {
 import {
     SeriesEditCreateMutation,
 } from "./__generated__/SeriesEditCreateMutation.graphql";
-import { SeriesSelector } from "../../../../../../ui/SearchableSelect";
-import { DisplayOptionGroup } from "../../../../../../ui/Input";
-import { Card, screenWidthAtMost } from "@opencast/appkit";
-import { BREAKPOINT_SMALL } from "../../../../../../GlobalStyle";
+import { Card } from "@opencast/appkit";
+import { VideoListSelector } from "../../../../../../ui/SearchableSelect";
 import { InfoTooltip } from "../../../../../../ui";
 import { isRealUser, useUser } from "../../../../../../User";
 
@@ -84,8 +82,6 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
         rules: { required: true },
     });
 
-    const headingId = useId();
-
     return <EditModeForm create={create} save={save} map={(data: SeriesFormData) => data}>
         <Heading>
             {t("manage.realm.content.series.series.heading")}
@@ -96,7 +92,8 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
         {"series" in errors && <div css={{ margin: "8px 0" }}>
             <Card kind="error">{t("manage.realm.content.series.series.invalid")}</Card>
         </div>}
-        <SeriesSelector
+        <VideoListSelector
+            type="series"
             defaultValue={series == null ? undefined : {
                 ...series,
                 description: series.syncedData?.description ?? null,
@@ -105,102 +102,6 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
             onBlur={seriesField.onBlur}
             autoFocus
         />
-        <div
-            css={{
-                display: "flex",
-                flexDirection: "row",
-                flexWrap: "wrap",
-                marginTop: 12,
-                justifyContent: "start",
-                rowGap: 24,
-                columnGap: 96,
-                [screenWidthAtMost(1000)]: {
-                    columnGap: 48,
-                },
-                [screenWidthAtMost(BREAKPOINT_SMALL)]: {
-                    flexDirection: "column",
-                    gap: 12,
-                },
-            }}
-        >
-            <div
-                role="group"
-                aria-labelledby={headingId + "-order"}
-            >
-                <Heading id={headingId + "-order"}>{t("videolist-block.settings.order")}</Heading>
-                <DisplayOptionGroup type="radio" {...{ form }} optionProps={[
-                    {
-                        option: "order",
-                        title: t("videolist-block.settings.new-to-old"),
-                        checked: order === "NEW_TO_OLD",
-                        value: "NEW_TO_OLD",
-                    },
-                    {
-                        option: "order",
-                        title: t("videolist-block.settings.old-to-new"),
-                        checked: order === "OLD_TO_NEW",
-                        value: "OLD_TO_NEW",
-                    },
-                    {
-                        option: "order",
-                        title: t("videolist-block.settings.a-z"),
-                        checked: order === "AZ",
-                        value: "AZ",
-                    },
-                    {
-                        option: "order",
-                        title: t("videolist-block.settings.z-a"),
-                        checked: order === "ZA",
-                        value: "ZA",
-                    },
-                ]} />
-            </div>
-            <div
-                role="group"
-                aria-labelledby={headingId + "-view"}
-            >
-                <Heading id={headingId + "-view"}>{t("videolist-block.settings.layout")}</Heading>
-                <DisplayOptionGroup type="radio" {...{ form }} optionProps={[
-                    {
-                        option: "layout",
-                        title: t("videolist-block.settings.slider"),
-                        checked: layout === "SLIDER",
-                        value: "SLIDER",
-                    },
-                    {
-                        option: "layout",
-                        title: t("videolist-block.settings.gallery"),
-                        checked: layout === "GALLERY",
-                        value: "GALLERY",
-                    },
-                    {
-                        option: "layout",
-                        title: t("videolist-block.settings.list"),
-                        checked: layout === "LIST",
-                        value: "LIST",
-                    },
-                ]} />
-            </div>
-            <div
-                role="group"
-                aria-labelledby={headingId + "-metadata"}
-            >
-                <Heading id={headingId + "-metadata"}>
-                    {t("manage.realm.content.series.metadata.heading")}
-                </Heading>
-                <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
-                    {
-                        option: "showTitle",
-                        title: t("manage.realm.content.show-title"),
-                        checked: showTitle,
-                    },
-                    {
-                        option: "showMetadata",
-                        title: t("manage.realm.content.show-description"),
-                        checked: showMetadata,
-                    },
-                ]} />
-            </div>
-        </div>
+        <VideoListFormFields {...{ form, order, layout, showMetadata, showTitle }} />
     </EditModeForm>;
 };

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -14,6 +14,7 @@ import { EditTextBlock } from "./Text";
 import { EditSeriesBlock } from "./Series";
 import { EditVideoBlock } from "./Video";
 import FocusTrap from "focus-trap-react";
+import { EditPlaylistBlock } from "./Playlist";
 
 
 type EditModeProps = {
@@ -42,6 +43,7 @@ export const EditMode: React.FC<EditModeProps> = props => {
                 ... on TextBlock { ...TextEditModeBlockData }
                 ... on SeriesBlock { ...SeriesEditModeBlockData }
                 ... on VideoBlock { ...VideoEditModeBlockData }
+                ... on PlaylistBlock { ...PlaylistEditModeBlockData }
             }
             ...EditModeFormRealmData
         }
@@ -58,6 +60,7 @@ export const EditMode: React.FC<EditModeProps> = props => {
                 TextBlock: () => <EditTextBlock block={block} />,
                 SeriesBlock: () => <EditSeriesBlock block={block} />,
                 VideoBlock: () => <EditVideoBlock block={block} />,
+                PlaylistBlock: () => <EditPlaylistBlock block={block} />,
             }, () => bug("unknown block type"))}
         </FormProvider>
     </EditModeFormContext.Provider>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
@@ -1,6 +1,14 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useId } from "react";
 import { COLORS } from "../../../../../../color";
 import { screenWidthAbove, screenWidthAtMost } from "@opencast/appkit";
+import { BREAKPOINT_SMALL } from "../../../../../../GlobalStyle";
+import { DisplayOptionGroup } from "../../../../../../ui/Input";
+import { useTranslation } from "react-i18next";
+import { FieldValues, UseFormReturn } from "react-hook-form";
+import {
+    VideoListLayout,
+    VideoListOrder,
+} from "../../../../../../ui/Blocks/__generated__/SeriesBlockData.graphql";
 
 
 export const Heading: React.FC<{ id?: string; children: ReactNode }> = ({ id, children }) =>
@@ -89,3 +97,134 @@ export const NiceRadioOption = React.forwardRef<HTMLInputElement, NiceRadioOptio
         </label>
     ),
 );
+
+type VideoListFormFieldProps<TFieldValues extends FieldValues> = {
+    form: UseFormReturn<TFieldValues>;
+    order: VideoListOrder;
+    layout: VideoListLayout;
+    showTitle: boolean;
+    showMetadata: boolean;
+    allowOriginalOrder?: boolean;
+}
+
+export function VideoListFormFields<TFieldValues extends FieldValues>({
+    form,
+    order,
+    layout,
+    showTitle,
+    showMetadata,
+    allowOriginalOrder,
+}: VideoListFormFieldProps<TFieldValues>) {
+    const { t } = useTranslation();
+    const headingId = useId();
+    const optionProps = [
+        {
+            option: "order",
+            title: t("videolist-block.settings.new-to-old"),
+            checked: order === "NEW_TO_OLD",
+            value: "NEW_TO_OLD",
+        },
+        {
+            option: "order",
+            title: t("videolist-block.settings.old-to-new"),
+            checked: order === "OLD_TO_NEW",
+            value: "OLD_TO_NEW",
+        },
+        {
+            option: "order",
+            title: t("videolist-block.settings.a-z"),
+            checked: order === "AZ",
+            value: "AZ",
+        },
+        {
+            option: "order",
+            title: t("videolist-block.settings.z-a"),
+            checked: order === "ZA",
+            value: "ZA",
+        },
+    ];
+    if (allowOriginalOrder) {
+        optionProps.unshift({
+            option: "order",
+            title: t("videolist-block.settings.original"),
+            checked: order === "ORIGINAL",
+            value: "ORIGINAL",
+        });
+    }
+
+    return (
+        <div
+            css={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                marginTop: 12,
+                justifyContent: "start",
+                rowGap: 24,
+                columnGap: 96,
+                [screenWidthAtMost(1000)]: {
+                    columnGap: 48,
+                },
+                [screenWidthAtMost(BREAKPOINT_SMALL)]: {
+                    flexDirection: "column",
+                    gap: 12,
+                },
+            }}
+        >
+            <div
+                role="group"
+                aria-labelledby={headingId + "-order"}
+            >
+                <Heading id={headingId + "-order"}>{t("videolist-block.settings.order")}</Heading>
+                <DisplayOptionGroup type="radio" {...{ form, optionProps }} />
+            </div>
+            <div
+                role="group"
+                aria-labelledby={headingId + "-view"}
+            >
+                <Heading id={headingId + "-view"}>{t("videolist-block.settings.layout")}</Heading>
+                <DisplayOptionGroup type="radio" {...{ form }} optionProps={[
+                    {
+                        option: "layout",
+                        title: t("videolist-block.settings.slider"),
+                        checked: layout === "SLIDER",
+                        value: "SLIDER",
+                    },
+                    {
+                        option: "layout",
+                        title: t("videolist-block.settings.gallery"),
+                        checked: layout === "GALLERY",
+                        value: "GALLERY",
+                    },
+                    {
+                        option: "layout",
+                        title: t("videolist-block.settings.list"),
+                        checked: layout === "LIST",
+                        value: "LIST",
+                    },
+                ]} />
+            </div>
+            <div
+                role="group"
+                aria-labelledby={headingId + "-metadata"}
+            >
+                <Heading id={headingId + "-metadata"}>
+                    {t("manage.realm.content.series.metadata.heading")}
+                </Heading>
+                <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
+                    {
+                        option: "showTitle",
+                        title: t("manage.realm.content.show-title"),
+                        checked: showTitle,
+                    },
+                    {
+                        option: "showMetadata",
+                        title: t("manage.realm.content.show-description"),
+                        checked: showMetadata,
+                    },
+                ]} />
+            </div>
+        </div>
+    );
+}
+

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -32,12 +32,6 @@ type Missing {
   dummy: Boolean
 }
 
-input Filters {
-  itemType: ItemType
-  start: DateTimeUtc
-  end: DateTimeUtc
-}
-
 "Arbitrary metadata for events/series. Serialized as JSON object."
 scalar ExtraMetadata
 
@@ -46,6 +40,13 @@ enum VideoListOrder {
   OLD_TO_NEW
   AZ
   ZA
+  ORIGINAL
+}
+
+input Filters {
+  itemType: ItemType
+  start: DateTimeUtc
+  end: DateTimeUtc
 }
 
 "A block just showing some text."
@@ -107,10 +108,6 @@ input NewTextBlock {
   content: String!
 }
 
-type SyncedSeriesData {
-  description: String
-}
-
 "Represents an Opencast series."
 type AuthorizedPlaylist {
   id: ID!
@@ -118,6 +115,10 @@ type AuthorizedPlaylist {
   title: String!
   description: String
   entries: [PlaylistEntry!]!
+}
+
+type SyncedSeriesData {
+  description: String
 }
 
 type EventConnection {
@@ -132,35 +133,6 @@ type PlainRealmName {
 }
 
 union RealmNameSource = PlainRealmName | RealmNameFromBlock
-
-"A block just showing the list of videos in an Opencast series"
-type SeriesBlock implements Block & RealmNameSourceBlock {
-  series: Series
-  showTitle: Boolean!
-  showMetadata: Boolean!
-  order: VideoListOrder!
-  layout: VideoListLayout!
-  id: ID!
-  index: Int!
-  realm: Realm!
-}
-
-"Represents an Opencast series."
-type Series {
-  id: ID!
-  opencastId: String!
-  title: String!
-  created: DateTimeUtc
-  metadata: ExtraMetadata
-  syncedData: SyncedSeriesData
-  hostRealms: [Realm!]!
-  events: [AuthorizedEvent!]!
-  """
-    Returns `true` if the realm has a series block with this series.
-    Otherwise, `false` is returned.
-  """
-  isReferencedByRealm(path: String!): Boolean!
-}
 
 "Some extra information we know about a role."
 type RoleInfo {
@@ -183,7 +155,36 @@ type RoleInfo {
   large: Boolean!
 }
 
+"Represents an Opencast series."
+type Series {
+  id: ID!
+  opencastId: String!
+  title: String!
+  created: DateTimeUtc
+  metadata: ExtraMetadata
+  syncedData: SyncedSeriesData
+  hostRealms: [Realm!]!
+  events: [AuthorizedEvent!]!
+  """
+    Returns `true` if the realm has a series block with this series.
+    Otherwise, `false` is returned.
+  """
+  isReferencedByRealm(path: String!): Boolean!
+}
+
 union PlaylistEntry = AuthorizedEvent | NotAllowed | Missing
+
+"A block just showing the list of videos in an Opencast series"
+type SeriesBlock implements Block & RealmNameSourceBlock {
+  series: Series
+  showTitle: Boolean!
+  showMetadata: Boolean!
+  order: VideoListOrder!
+  layout: VideoListLayout!
+  id: ID!
+  index: Int!
+  realm: Realm!
+}
 
 union EventSearchOutcome = SearchUnavailable | EventSearchResults
 
@@ -210,6 +211,14 @@ type SyncedEventData implements Node {
   segments: [Segment!]!
 }
 
+input NewPlaylistBlock {
+  playlist: ID!
+  showTitle: Boolean!
+  showMetadata: Boolean!
+  order: VideoListOrder!
+  layout: VideoListLayout!
+}
+
 input NewVideoBlock {
   event: ID!
   showTitle: Boolean!
@@ -221,6 +230,14 @@ interface Block {
   id: ID!
   index: Int!
   realm: Realm!
+}
+
+type SearchPlaylist implements Node {
+  id: ID!
+  opencastId: String!
+  title: String!
+  description: String
+  hostRealms: [SearchRealm!]!
 }
 
 union KnownUsersSearchOutcome = SearchUnavailable | KnownUserSearchResults
@@ -260,6 +277,14 @@ type SearchUnavailable {
     have at least one field. Always returns `null`.
   """
   dummy: Boolean
+}
+
+input UpdatePlaylistBlock {
+  playlist: ID
+  showTitle: Boolean
+  showMetadata: Boolean
+  order: VideoListOrder
+  layout: VideoListLayout
 }
 
 type AuthorizedEvent implements Node {
@@ -423,6 +448,18 @@ type Realm implements Node {
   canCurrentUserModerate: Boolean!
 }
 
+"A block just showing the list of videos in an Opencast playlist"
+type PlaylistBlock implements Block & RealmNameSourceBlock {
+  playlist: Playlist
+  showTitle: Boolean!
+  showMetadata: Boolean!
+  order: VideoListOrder!
+  layout: VideoListLayout!
+  id: ID!
+  index: Int!
+  realm: Realm!
+}
+
 "A role being granted permission to perform certain actions."
 type AclItem {
   "Role. In arrays of AclItems, no two items have the same `role`."
@@ -502,6 +539,12 @@ type Mutation {
   """
   addSeriesBlock(realm: ID!, index: Int!, block: NewSeriesBlock!): Realm!
   """
+    Adds a playlist block to a realm.
+
+    See `addTitleBlock` for more details.
+  """
+  addPlaylistBlock(realm: ID!, index: Int!, block: NewPlaylistBlock!): Realm!
+  """
     Adds a video block to a realm.
 
     See `addTitleBlock` for more details.
@@ -515,6 +558,8 @@ type Mutation {
   updateTextBlock(id: ID!, set: UpdateTextBlock!): Block!
   "Update a series block's data."
   updateSeriesBlock(id: ID!, set: UpdateSeriesBlock!): Block!
+  "Update a playlist block's data."
+  updatePlaylistBlock(id: ID!, set: UpdatePlaylistBlock!): Block!
   "Update a video block's data."
   updateVideoBlock(id: ID!, set: UpdateVideoBlock!): Block!
   "Remove a block from a realm."
@@ -606,6 +651,15 @@ type Query {
   """
   searchAllSeries(query: String!, writableOnly: Boolean!): SeriesSearchOutcome!
   """
+    Searches through playlists. Results may include:
+
+    - Playlists that the user has write access to (listed & unlisted).
+    - If `writable_only` is false, this also searches through listed playlists.
+      If the user has the privilege to find unlisted playlists, all playlists are
+      searched.
+  """
+  searchAllPlaylists(query: String!, writableOnly: Boolean!): PlaylistSearchOutcome!
+  """
     Searches through all known users. The behavior of this depends on the
     `general.users_searchable` config value. If it is `false`, this returns
     only users that have an exact match with the input query. The number of
@@ -634,8 +688,14 @@ type EmptyQuery {
   dummy: Boolean
 }
 
+union PlaylistSearchOutcome = SearchUnavailable | PlaylistSearchResults
+
 "A string in different languages"
 scalar TranslatedString
+
+type PlaylistSearchResults {
+  items: [SearchPlaylist!]!
+}
 
 input UpdateSeriesBlock {
   series: ID

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -310,7 +310,7 @@ type AuthorizedEvent implements Node {
   acl: [AclItem!]!
   """
     Returns `true` if the realm has a video block with this video
-    OR if the realm has a series block with this event's series.
+    OR if the realm has a series or playlist block including this video.
     Otherwise, `false` is returned.
   """
   isReferencedByRealm(path: String!): Boolean!

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -63,6 +63,7 @@ type BlockProps = Partial<Omit<Fields<PlaylistBlockData$data>, "playlist">>;
 
 type SharedFromPlaylistProps = SharedProps & BlockProps & {
     title?: string;
+    activeEventId?: string;
 };
 
 type FromPlaylistProps = SharedFromPlaylistProps & {
@@ -124,6 +125,7 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
         allowOriginalOrder
         {...{ title, items }}
         description={(props.showMetadata && playlist.description) || undefined}
+        activeEventId={props.activeEventId}
         basePath={props.basePath}
         items={items}
         isPlaylist

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -72,5 +72,6 @@ export const PlaylistBlock: React.FC<PlaylistProps> = ({ fragRef, basePath }) =>
         description={(showMetadata && playlist.description) || undefined}
         basePath={basePath}
         items={items}
+        isPlaylist
     />;
 };

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -1,0 +1,76 @@
+import { graphql, readInlineData, useFragment } from "react-relay";
+import { PlaylistBlockData$key } from "./__generated__/PlaylistBlockData.graphql";
+import { useTranslation } from "react-i18next";
+import { VideoListEventData$key } from "./__generated__/VideoListEventData.graphql";
+import { VideoListBlock, VideoListBlockContainer, videoListEventFragment } from "./VideoList";
+import { unreachable } from "@opencast/appkit";
+
+
+type PlaylistProps = {
+    fragRef: PlaylistBlockData$key;
+    basePath: string;
+}
+
+export const PlaylistBlock: React.FC<PlaylistProps> = ({ fragRef, basePath }) => {
+    const { t } = useTranslation();
+    const { playlist, showTitle, showMetadata, layout, order } = useFragment(graphql`
+        fragment PlaylistBlockData on PlaylistBlock {
+            playlist {
+                __typename
+                ... on NotAllowed { dummy } # workaround
+                ... on AuthorizedPlaylist {
+                    title
+                    description
+                    entries {
+                        __typename
+                        ... on AuthorizedEvent { id, ...VideoListEventData }
+                        ... on Missing { dummy }
+                        ... on NotAllowed { dummy }
+                    }
+                }
+            }
+            showTitle
+            showMetadata
+            order
+            layout
+        }
+    `, fragRef);
+
+    if (!playlist) {
+        return <VideoListBlockContainer showViewOptions={false}>
+            {t("playlist.deleted-playlist-block")}
+        </VideoListBlockContainer>;
+    }
+
+    if (playlist.__typename === "NotAllowed") {
+        return <VideoListBlockContainer showViewOptions={false}>
+            {t("playlist.not-allowed-playlist-block")}
+        </VideoListBlockContainer>;
+    }
+    if (playlist.__typename !== "AuthorizedPlaylist") {
+        return unreachable();
+    }
+
+    const items = playlist.entries.map(entry => {
+        if (entry.__typename === "AuthorizedEvent") {
+            const out = readInlineData<VideoListEventData$key>(videoListEventFragment, entry);
+            return out;
+        } else if (entry.__typename === "Missing") {
+            return "missing";
+        } else if (entry.__typename === "NotAllowed") {
+            return "unauthorized";
+        } else {
+            return unreachable();
+        }
+    });
+
+    return <VideoListBlock
+        initialLayout={layout}
+        initialOrder={(order === "%future added value" ? undefined : order) ?? "ORIGINAL"}
+        allowOriginalOrder
+        title={playlist.title ?? (showTitle ? playlist.title : undefined)}
+        description={(showMetadata && playlist.description) || undefined}
+        basePath={basePath}
+        items={items}
+    />;
+};

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -874,7 +874,10 @@ const Item: React.FC<ItemProps> = ({
     })();
 
     const inner = <>
-        <div css={{ position: "relative" }}>{thumbnail}</div>
+        <div css={{
+            position: "relative",
+            borderRadius: 8,
+        }}>{thumbnail}</div>
         <div css={{
             margin: "0px 4px",
             marginTop: 12,

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -10,6 +10,7 @@ import { TextBlockByQuery } from "./Text";
 import { SeriesBlockFromBlock } from "./Series";
 import { VideoBlock } from "./Video";
 import { PlayerGroupProvider } from "../player/PlayerGroupContext";
+import { PlaylistBlock } from "./Playlist";
 
 
 type BlocksProps = {
@@ -63,6 +64,7 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             ... on TextBlock { ... TextBlockData }
             ... on SeriesBlock { ... SeriesBlockData }
             ... on VideoBlock { ... VideoBlockData }
+            ... on PlaylistBlock { ... PlaylistBlockData }
         }
     `, blockRef);
     const { __typename } = block;
@@ -74,6 +76,7 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             "TextBlock": () => <TextBlockByQuery fragRef={block} />,
             "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} basePath={basePath} />,
             "VideoBlock": () => <VideoBlock fragRef={block} basePath={basePath} />,
+            "PlaylistBlock": () => <PlaylistBlock fragRef={block} basePath={basePath} />,
         })}
     </div>;
 };

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -10,7 +10,7 @@ import { TextBlockByQuery } from "./Text";
 import { SeriesBlockFromBlock } from "./Series";
 import { VideoBlock } from "./Video";
 import { PlayerGroupProvider } from "../player/PlayerGroupContext";
-import { PlaylistBlock } from "./Playlist";
+import { PlaylistBlockFromBlock } from "./Playlist";
 
 
 type BlocksProps = {
@@ -76,7 +76,7 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             "TextBlock": () => <TextBlockByQuery fragRef={block} />,
             "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} basePath={basePath} />,
             "VideoBlock": () => <VideoBlock fragRef={block} basePath={basePath} />,
-            "PlaylistBlock": () => <PlaylistBlock fragRef={block} basePath={basePath} />,
+            "PlaylistBlock": () => <PlaylistBlockFromBlock fragRef={block} basePath={basePath} />,
         })}
     </div>;
 };

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -299,7 +299,7 @@ type DisplayOptionGroup<TFieldValues extends FieldValues> = {
     form: UseFormReturn<TFieldValues>;
     type: "radio" | "checkbox";
     optionProps: {
-        option: Path<TFieldValues>;
+        option: string;
         title: string;
         checked?: boolean;
         value?: string;
@@ -318,7 +318,7 @@ export function DisplayOptionGroup<TFieldValues extends FieldValues>(
                 <input
                     {...{ type, value }}
                     defaultChecked={checked}
-                    {...form.register(option)}
+                    {...form.register(option as Path<TFieldValues>)}
                     style={{ marginRight: 6 }}
                 />
                 {title}

--- a/frontend/tests/videoPage.spec.ts
+++ b/frontend/tests/videoPage.spec.ts
@@ -8,7 +8,11 @@ test("Video page", async ({ page, standardData, browserName }) => {
 
     await test.step("Setup", async () => {
         await page.goto("/");
-        await page.getByRole("img", { name: "Video of a Tabby Cat" }).first().click();
+        await page
+            .locator("div")
+            .filter({ hasText: /^0:12Video of a Tabby CatGustavo Belemmi2 years ago$/ })
+            .getByRole("link")
+            .click();
         await page.waitForSelector("nav");
     });
 
@@ -57,7 +61,10 @@ test("Video page", async ({ page, standardData, browserName }) => {
         });
 
         await test.step("Block contains sibling event tile", async () => {
-            const siblingEvent = page.getByRole("link", { name: "Thumbnail" }).first();
+            const siblingEvent = page
+                .locator("div")
+                .filter({ hasText: /^0:12Dual Stream CatsGustavo Belemmi, klimkin2 years ago$/ })
+                .getByRole("link");
             await test.step("Tile links to event", async () => {
                 const siblingId = await siblingEvent.getAttribute("href") as string;
                 await siblingEvent.click();

--- a/util/dummy-realms.yaml
+++ b/util/dummy-realms.yaml
@@ -16,18 +16,20 @@ blocks:
       containing a bunch of dummy data. All text and videos you can see here are just for
       testing.
 
-  - series:
-      series: { by_title: "Cats" }
+  - video_list:
+      ty: playlist
+      id: { by_uuid: ee39bb7b-7022-458b-ab54-570e81f4730d }
       show_title: true
-      show_description: false
+      show_description: true
 
 children:
   - path: campus
     name: Campus
     blocks:
       - text: Videos about life on the campus, the canteen and more.
-      - series:
-          series: { by_title: "SciFi Chicken" }
+      - video_list:
+          ty: series
+          id: { by_title: "SciFi Chicken" }
           show_title: true
           show_description: false
 


### PR DESCRIPTION
This builds on #1159 to add the necessary components and adjustments in both back- and frontend to allow creating and editing playlist **blocks**.
These are already a lot of changes, so in order to limit the scope of this PR and make it somewhat reviewable, a feature _still_ missing is a management area to create, delete and edit playlists themselves (i.e. adding and removing videos).