### PR TITLE
Hide editor link on live videos

### DIFF
--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -53,7 +53,7 @@ const Page: React.FC<Props> = ({ event }) => {
         }}>
             <UpdatedCreatedInfo event={event} />
             <div css={{ margin: "8px 2px", flex: "1 0 auto" }}>
-                {user.canUseEditor && event.canWrite && (
+                {user.canUseEditor && !event.isLive && event.canWrite && (
                     <ExternalLink
                         service="EDITOR"
                         params={{ mediaPackageId: event.opencastId }}


### PR DESCRIPTION
Adds a check to conditionally hide the editor link from "video details" if the video is live (live videos can't be edited).

Closes #1177 