### PR TITLE
Fix overflowing videos

### DIFF
--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -174,6 +174,7 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
             maxHeight: "calc(100vh - var(--header-height) - 18px - 16px - 38px - 60px)",
             minHeight: `min(320px, (100vw - 32px) / (${aspectRatio[0]} / ${aspectRatio[1]}))`,
             width: controlsFit ? "unset" : "100%",
+            maxWidth: "100%",
             aspectRatio: `${aspectRatio[0]} / ${aspectRatio[1]}`,
 
             // If the player gets too small, the controls are pretty crammed, so
@@ -181,6 +182,7 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
             [screenWidthAtMost(380)]: {
                 margin: `0 -${MAIN_PADDING}px`,
                 width: `calc(100% + ${2 * MAIN_PADDING}px)`,
+                maxWidth: `calc(100% + ${2 * MAIN_PADDING}px)`,
             },
         }}>
             <Player {...{ event, ...playerProps }} />


### PR DESCRIPTION
The video container width is set to `unset` when there is enough space for the control elements. I know this had a good-ish reason, I just don't remember it.
On that note, I should start writing better commit messages, or at least try to explain things like that so I can later remember it.

So anyway, this unset width can lead to situations were videos with weird aspect ratios like 15/4 or sth would overflow on smaller (but larger than mobile) screens. To fix that without removing or further complicating the `unset` rule, this commit introduced a `maxWidth` of 100%. BUT that also needs to be overwritten on mobile screens to preserve current sizing behaviour on these.

Closes #1173 