### PR TITLE
Make video routes work with Opencast Ids

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,7 +7,12 @@ import { AddChildRoute } from "./routes/manage/Realm/AddChild";
 import { ManageRealmContentRoute } from "./routes/manage/Realm/Content";
 import { NotFoundRoute } from "./routes/NotFound";
 import { RealmRoute } from "./routes/Realm";
-import { DirectOpencastVideoRoute, DirectVideoRoute, VideoRoute } from "./routes/Video";
+import {
+    DirectOpencastVideoRoute,
+    DirectVideoRoute,
+    OpencastVideoRoute,
+    VideoRoute,
+} from "./routes/Video";
 import { DirectSeriesOCRoute, DirectSeriesRoute } from "./routes/Series";
 import { ManageVideosRoute } from "./routes/manage/Video";
 import { UploadRoute } from "./routes/Upload";
@@ -37,6 +42,7 @@ const {
         LoginRoute,
         RealmRoute,
         SearchRoute,
+        OpencastVideoRoute,
         VideoRoute,
         DirectVideoRoute,
         DirectOpencastVideoRoute,

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -138,6 +138,11 @@ type Series {
   syncedData: SyncedSeriesData
   hostRealms: [Realm!]!
   events(order: EventSortOrder = {column: "CREATED", direction: "DESCENDING"}): [AuthorizedEvent!]!
+  """
+    Returns `true` if the realm has a series block with this series.
+    Otherwise, `false` is returned.
+  """
+  isReferencedByRealm(path: String!): Boolean!
 }
 
 "Some extra information we know about a role."
@@ -259,6 +264,12 @@ type AuthorizedEvent implements Node {
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!
   acl: [AclItem!]!
+  """
+    Returns `true` if the realm has a video block with this video
+    OR if the realm has a series block with this event's series.
+    Otherwise, `false` is returned.
+  """
+  isReferencedByRealm(path: String!): Boolean!
 }
 
 "A block just showing some title."
@@ -389,18 +400,6 @@ type Realm implements Node {
     and non-critical settings.
   """
   canCurrentUserModerate: Boolean!
-  """
-    Returns `true` if this realm somehow references the given node via
-    blocks. Currently, the following rules are used:
-
-    - If `id` refers to a series: returns `true` if the realm has a series
-      block with that series.
-    - If `id` refers to an event: returns `true` if the realm has a video
-      block with that video OR if the realm has a series block with that
-      event's series.
-    - Otherwise, `false` is returned.
-  """
-  references(id: ID!): Boolean!
 }
 
 "A role being granted permission to perform certain actions."


### PR DESCRIPTION
This helps with making paths from the old ETH video portal work in Tobira by letting video links work with Opencast Ids as well as Tobira's internally used Ids.
Meaning URLs like `/speakers/introductory-lectures/v/PYhD7DtIL9c` and `/speakers/introductory-lectures/v/774b3a56-c9c7-46c4-be00-9b55eb15b940` can be used interchangeably.

In conjunction with https://gitlab.elan-ev.de/opencast/eth/tobira-opencast-ansible/-/merge_requests/1, this closes #1185 