### PR TITLE
Ignore `build` and `node_modules` folder for `webpack --watch`

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -29,6 +29,10 @@ const config: CallableOption = (_env, argv) => ({
         },
     },
 
+    watchOptions: {
+        ignored: [OUT_PATH, "**/node_modules"],
+    },
+
     resolve: {
         extensions: [".ts", ".tsx", ".js", ".json"],
         // For local appkit development, see this for more details:


### PR DESCRIPTION
Before, the page was reloaded two additional times, uselessly, as webpack was triggered by changes in `build`.