### PR TITLE
Improve config docs for `general.initial_consent`

### DIFF
--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -29,10 +29,9 @@ pub(crate) struct GeneralConfig {
     /// Example:
     /// 
     /// ```
-    /// [general.initial_consent]
-    /// title.en = "Terms & Conditions"
-    /// button.en = "Agree"
-    /// text.en = """
+    /// initial_consent.title.en = "Terms & Conditions"
+    /// initial_consent.button.en = "Agree"
+    /// initial_consent.text.en = """
     /// To use Tobira, you need to agree to our terms and conditions:
     /// - [Terms](https://www.our-terms.de)
     /// - [Conditions](https://www.our-conditions.de)

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -41,10 +41,9 @@
 # Example:
 # 
 # ```
-# [general.initial_consent]
-# title.en = "Terms & Conditions"
-# button.en = "Agree"
-# text.en = """
+# initial_consent.title.en = "Terms & Conditions"
+# initial_consent.button.en = "Agree"
+# initial_consent.text.en = """
 # To use Tobira, you need to agree to our terms and conditions:
 # - [Terms](https://www.our-terms.de)
 # - [Conditions](https://www.our-conditions.de)


### PR DESCRIPTION
The suggested code there would open a new section, making all values below it belong to that section. And since those are unknown and none are required, they are silently ignored.