### PR TITLE
Fix docs about "listed" behavior

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -230,13 +230,11 @@ impl AuthorizedEvent {
                 where realm = realms.id \
                 and ( \
                     type = 'video' and video = $1 \
-                    or type = 'series' and series = ( \
-                        select series from events where id = $1 \
-                    ) \
+                    or type = 'series' and series = $2 \
                 ) \
             ) \
         ");
-        context.db.query_mapped(&query, dbargs![&self.key], |row| Realm::from_row_start(&row))
+        context.db.query_mapped(&query, dbargs![&self.key, &self.series], |row| Realm::from_row_start(&row))
             .await?
             .pipe(Ok)
     }
@@ -261,11 +259,11 @@ impl AuthorizedEvent {
             where realms.full_path = $1 \
                 and ( \
                     blocks.video = $2 or \
-                    blocks.series = (select series from events where id = $2) \
+                    blocks.series = $3 \
                 )\
             )\
         ";
-        context.db.query_one(&query, &[&path.trim_end_matches('/'), &self.key])
+        context.db.query_one(&query, &[&path.trim_end_matches('/'), &self.key, &self.series])
             .await?
             .get::<_, bool>(0)
             .pipe(Ok)

--- a/docs/docs/semantics.md
+++ b/docs/docs/semantics.md
@@ -89,16 +89,23 @@ The values `in this style` are the URL paths, e.g. what the browser will show af
 
 ## "Listed" and being findable via search
 
-User pages *cannot* be found via search.
-Non-user content pages *can* be found via search.
-For videos and series, it gets more complicated.
+Entities like pages, videos and series are either "listed" or "unlisted".
+This is a derived property and not something that can be toggled individually.
+Only listed entities can be found via search.
+Of course, for videos, the ACLs determine whether someone can see the video at all.
+So if the ACLs don't allow someone to see a video, they won't be able to find it via search, even if it's "listed".
+A video must be readable *and* listed to be found via search.
 
-The findability for both depends on whether they are included in a *content page*.
-Included means that a content block (the things you can put on a *content page*) refers to them.
-A video is "included in a content page" if that content page has a video block with that video, or a series block with that video's series.
-Similarly, a series is included in a content page, if a series block refers to it or if a video block refers to any of its videos.
+User pages can never be found via search.
+Non-user content pages can always be found via search.
 
-If and only if a video/series is included in any non-user content page, it is findable via search.
+A series is considered "listed", if a series-block of that series exists on at least one non-user page.
+
+A video is considered "listed", if *any* of the following blocks exists on at least one non-user page:
+- a video-block of that video, or
+- a series-block of that video's series, or
+- a playlist-block of a playlist containing that video.
+
 
 ## Permissions in Tobira
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -360,8 +360,7 @@ manage:
     unlisted:
         note: Dieses Video ist ungelistet.
         explanation: >
-          Ungelistete Videos sind nur über ihren direkten Link aufrufbar.
-          Dies ist equivalent zu einem Passwortschutz.
+          Ein ungelistetes Video ist nur über seinen direkten Link oder seine Serie aufrufbar.
     reset-modal:
       label: Zurücksetzen
       title: Änderungen zurücksetzen?

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -345,7 +345,7 @@ manage:
     unlisted:
       note: This video is unlisted.
       explanation: >
-        Unlisted videos can only be found by sharing its direct link. This is equivalent to a password protection.
+        An unlisted video can only be found by sharing its direct link or via its series.
     reset-modal:
       label: Reset
       title: Reset changes?


### PR DESCRIPTION
Text copied from the second commit:

---

Our docs described a behavior that was implemented differently. This
commit fixes this inconsistency. We discussed this in detail internally
and believe the suggested behavior (which already happened to be
implemented) is the most useful one for Tobira. An explanation of the
three most discuss-worthy points:

(1) Series do NOT become listed via a video-block of their videos:

It is fine that only the event is findable, especially since "series
title" is part of the event data in the search index, so you can find
that event via the series title. And then the series is only one click
away. So why not make the series findable directly as well? It's not
necessary for UX, and would be a lot more complicated
implementation-wise.

(2) Events do NOT become listed via video-blocks of other videos in
their series:

For one, that might be unexpected to some users, especially because
spooky action at a distance. But it also leads to user confusion
elsewhere: if it were findable, then the "manage my events" page for
that event should better also list the page responsible for that
under "referencing pages", but then users might only see another event
on that page, being confused. However, even if these events are not
findable via search, they are "reachable", namely by finding another
video in the series, and then clicking a couple of times. For that
reason we adjusted the phrasing of our "unlisted" note (which is still
hidden behind the experimental feature flag, so no user ever saw it
yet). The new phrasing promises a bit less.

(3) Events DO become listed via playlist-blocks of a playlist containing
them:

At first this seems like a bad idea as every user can add every event to
all playlists they have write access to (for example: their own). So
can every user make any event listed then? No: the playlist block still
needs to be added to a non-user page, which requires a privilege that
likely only few trusted users have. And if they have that privilege,
they can just as easily add a video block with that video directly, so
no one gets any additional powers for mischief. But wait: what if
someone has write access to a playlist that is already mounted on a
non-user page and they add a video there? Yes that is the other option
on how to make the video listed, however: they also need access to such
a playlist first. And note: even if we don't make the event findable
via a playlist block: the event could still be reached by clicking
around in the non-user pages! So it is already not hidden anymore. And
finally: to add a video to a playlist, that person needs to have the
ID (or a link) to that video in the first place. If they had malicious
intends of making the video public, they might as well just e-mail the
link around or something like that.

So in summary: while it first sounds a bit dangerous, thinking it
through shows that there are basically no way in which we give untrusted
users more power to do unintended things.

On the other hand, there are a few advantages of making events findable
via playlist block. To users, a playlist block looks basically like a
series block: the video with its thumbnail "is clearly on this page".
Having different behavior for both could be confusing. Further, we would
like to allow "video in context" pages, i.e. `/path/to/realm/v/<id>` for
videos only mentioned via playlist in that realm. We also want to show
a realm with a playlist block as a "referncing realm" in the "my videos"
section, and we shouldn't show the "unlisted" note in case a playlist
block exists for a video. With that, it's most consistent and easiest
to explain if playlist blocks make events findable.

---

Also, this is already the behavior in code! Only the docs were wrong
about this. So this change isn't even breaking, it's just a doc fix.