### PR TITLE
Update paella-core

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "i18next": "^23.10.0",
         "i18next-browser-languagedetector": "^7.2.0",
         "paella-basic-plugins": "1.44.10",
-        "paella-core": "1.48.1",
+        "paella-core": "1.49.4",
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.0",
         "paella-slide-plugins": "^1.41.6",
@@ -7699,9 +7699,9 @@
       }
     },
     "node_modules/paella-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.48.1.tgz",
-      "integrity": "sha512-5cQsuWpnUCD5Sbuxz5Gjwv7qhJhbWjoGesMjTbXvHWRZzw0/hnqBfjyhaB2WAUsmIlJYzsGBaN7lb5jJXH3hOw==",
+      "version": "1.49.4",
+      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.49.4.tgz",
+      "integrity": "sha512-lF/imiFSIrmeKVclig0f7WJnr1KPWlC4XjHhe16E1z6gwszUui/TE2e1xyoxjAUgtWCFyR8HPiww04vWzuNk6A==",
       "dependencies": {
         "core-js": "^3.8.2",
         "hls.js": "^1.0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "i18next": "^23.10.0",
     "i18next-browser-languagedetector": "^7.2.0",
     "paella-basic-plugins": "1.44.10",
-    "paella-core": "1.48.1",
+    "paella-core": "1.49.4",
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.0",
     "paella-slide-plugins": "^1.41.6",


### PR DESCRIPTION
Updates paella-core to 1.49.4 to fix floating/scrolling pop-up menus.