### PR TITLE
Refine notes for missing videos in series and playlist blocks

### DIFF
--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -17,6 +17,8 @@ use crate::{
     prelude::*,
 };
 
+use super::playlist::VideoListEntry;
+
 
 pub(crate) struct Series {
     pub(crate) key: Key,
@@ -145,7 +147,7 @@ impl Series {
             .pipe(Ok)
     }
 
-    async fn events(&self, context: &Context) -> ApiResult<Vec<AuthorizedEvent>> {
+    async fn entries(&self, context: &Context) -> ApiResult<Vec<VideoListEntry>> {
         AuthorizedEvent::load_for_series(self.key, context).await
     }
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -45,6 +45,7 @@ errors:
   not-authorized: Sie sind nicht autorisiert.
   not-authorized-to-view-page: Sie sind nicht dazu autorisiert, diese Seite aufzurufen.
   might-need-to-login: Sie müssen sich möglicherweise einloggen.
+  might-need-to-login-link: Sie müssen sich möglicherweise <1>einloggen</1>.
   invalid-input: Ungültige Eingabe.
   opencast-unavailable: Opencast ist momentan nicht erreichbar.
   internal-server-error: Interner Server-Fehler (es ist ein Problem mit dem Server aufgetreten).

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -196,10 +196,13 @@ series:
 videolist-block:
   upcoming-live-streams: "Anstehende Livestreams ({{count}})"
   missing-video: Video nicht gefunden
+  no-videos: Keine Videos
   unauthorized: Fehlende Berechtigung
-  hidden-items_one: 'Ein Video wurde nicht gefunden oder Sie haben keinen Zugriff darauf.'
-  hidden-items_other: '{{count}} Videos wurden nicht gefunden oder Sie haben keinen Zugriff darauf.'
-  no-videos: Keine videos
+  hidden-items:
+    unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte. 
+    unauthorized_other: 'Für {{count}} Videos fehlen Ihnen die Zugriffsrechte.'
+    missing_one: Ein Video wurde nicht gefunden.
+    missing_other: '{{count}} Videos wurden nicht gefunden.'
   videos:
     heading: Videos
   settings:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -193,10 +193,13 @@ series:
 videolist-block:
   upcoming-live-streams: "Upcoming live streams ({{count}})"
   missing-video: Video not found
-  unauthorized: Missing permissions
-  hidden-items_one: 'One video is missing or requires additional permissions to view.'
-  hidden-items_other: '{{count}} videos are missing or require additional permissions to view.'
   no-videos: No videos
+  unauthorized: Missing permissions
+  hidden-items:
+    unauthorized_one: One video requires additional permissions to view. 
+    unauthorized_other: '{{count}} videos require additional permissions to view.'
+    missing_one: One video is missing.
+    missing_other: '{{count}} videos are missing.'
   videos:
     heading: Videos
   settings:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -44,6 +44,7 @@ errors:
   not-authorized: You are not authorized.
   not-authorized-to-view-page: You are not authorized to view this page.
   might-need-to-login: You might need to login.
+  might-need-to-login-link: You might need to <1>login</1>.
   invalid-input: Invalid input.
   opencast-unavailable: Opencast is currently not available.
   internal-server-error: Internal server error (something is wrong with the server).

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -17,7 +17,6 @@ import { User, useUser } from "../../User";
 import { ActionIcon, ICON_STYLE } from "./ui";
 import CONFIG from "../../config";
 import { Spinner } from "@opencast/appkit";
-import { LoginRoute, REDIRECT_STORAGE_KEY } from "../../routes/Login";
 import { focusStyle } from "../../ui";
 import { ExternalLink } from "../../relay/auth";
 import { COLORS } from "../../color";
@@ -25,6 +24,7 @@ import { translatedConfig } from "../../util";
 import { UploadRoute } from "../../routes/Upload";
 import { ManageRoute } from "../../routes/manage";
 import { ManageVideosRoute } from "../../routes/manage/Video";
+import { LoginLink } from "../../routes/util";
 
 
 
@@ -65,13 +65,7 @@ const LoggedOut: React.FC = () => {
     const { t } = useTranslation();
 
     return (
-        <Link
-            to={CONFIG.auth.loginLink ?? LoginRoute.url}
-            onClick={() => {
-                // Store a redirect link in session storage.
-                window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, window.location.href);
-            }}
-            htmlLink={!!CONFIG.auth.loginLink}
+        <LoginLink
             css={{
                 /* Show labelled button on larger screens. */
                 [screenWidthAbove(BREAKPOINT_MEDIUM)]: {
@@ -101,7 +95,7 @@ const LoggedOut: React.FC = () => {
         >
             <LuLogIn />
             <span>{t("user.login")}</span>
-        </Link>
+        </LoginLink>
     );
 };
 

--- a/frontend/src/routes/util.tsx
+++ b/frontend/src/routes/util.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from "react";
+import { PropsWithChildren, useEffect } from "react";
 import { useBeforeunload } from "react-beforeunload";
 import { useTranslation } from "react-i18next";
 import { match } from "@opencast/appkit";
 
-import { useRouter } from "../router";
+import { Link, useRouter } from "../router";
+import CONFIG from "../config";
+import { LoginRoute, REDIRECT_STORAGE_KEY } from "./Login";
 
 
 export const b64regex = "[a-zA-Z0-9\\-_]";
@@ -77,3 +79,19 @@ export const useNavBlocker = (shouldBlock: boolean | (() => boolean)) => {
         ))
     ));
 };
+
+type LoginLinkProps = PropsWithChildren & {
+    className?: string;
+}
+
+export const LoginLink: React.FC<LoginLinkProps> = ({ className, children }) => (
+    <Link
+        to={CONFIG.auth.loginLink ?? LoginRoute.url}
+        onClick={() => {
+            // Store a redirect link in session storage.
+            window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, window.location.href);
+        }}
+        htmlLink={!!CONFIG.auth.loginLink}
+        {...{ className }}
+    >{children}</Link>
+);

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -114,7 +114,7 @@ type AuthorizedPlaylist {
   opencastId: String!
   title: String!
   description: String
-  entries: [PlaylistEntry!]!
+  entries: [VideoListEntry!]!
 }
 
 type SyncedSeriesData {
@@ -164,15 +164,13 @@ type Series {
   metadata: ExtraMetadata
   syncedData: SyncedSeriesData
   hostRealms: [Realm!]!
-  events: [AuthorizedEvent!]!
+  entries: [VideoListEntry!]!
   """
     Returns `true` if the realm has a series block with this series.
     Otherwise, `false` is returned.
   """
   isReferencedByRealm(path: String!): Boolean!
 }
-
-union PlaylistEntry = AuthorizedEvent | NotAllowed | Missing
 
 "A block just showing the list of videos in an Opencast series"
 type SeriesBlock implements Block & RealmNameSourceBlock {
@@ -199,6 +197,14 @@ type KnownGroup {
   large: Boolean!
 }
 
+input NewPlaylistBlock {
+  playlist: ID!
+  showTitle: Boolean!
+  showMetadata: Boolean!
+  order: VideoListOrder!
+  layout: VideoListLayout!
+}
+
 type SyncedEventData implements Node {
   updated: DateTimeUtc!
   startTime: DateTimeUtc
@@ -209,14 +215,6 @@ type SyncedEventData implements Node {
   thumbnail: String
   captions: [Caption!]!
   segments: [Segment!]!
-}
-
-input NewPlaylistBlock {
-  playlist: ID!
-  showTitle: Boolean!
-  showMetadata: Boolean!
-  order: VideoListOrder!
-  layout: VideoListLayout!
 }
 
 input NewVideoBlock {
@@ -477,13 +475,9 @@ type AclItem {
   info: RoleInfo
 }
 
-union SeriesSearchOutcome = SearchUnavailable | SeriesSearchResults
+union VideoListEntry = AuthorizedEvent | NotAllowed | Missing
 
-"Exactly one of `plain` or `block` has to be non-null."
-input UpdatedRealmName {
-  plain: String
-  block: ID
-}
+union SeriesSearchOutcome = SearchUnavailable | SeriesSearchResults
 
 type Mutation {
   "Adds a new realm."
@@ -570,6 +564,12 @@ type Mutation {
     and adds a block with the given series at the leaf.
   """
   mountSeries(series: NewSeries!, parentRealmPath: String!, newRealms: [RealmSpecifier!]!): Realm!
+}
+
+"Exactly one of `plain` or `block` has to be non-null."
+input UpdatedRealmName {
+  plain: String
+  block: ID
 }
 
 input NewSeries {

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -1,12 +1,11 @@
-import { graphql, readInlineData, useFragment } from "react-relay";
+import { graphql, useFragment } from "react-relay";
 import { Fields } from "../../relay";
 import { useTranslation } from "react-i18next";
 import {
     PlaylistBlockData$data,
     PlaylistBlockData$key,
 } from "./__generated__/PlaylistBlockData.graphql";
-import { VideoListEventData$key } from "./__generated__/VideoListEventData.graphql";
-import { VideoListBlock, VideoListBlockContainer, videoListEventFragment } from "./VideoList";
+import { VideoListBlock, VideoListBlockContainer } from "./VideoList";
 import {
     PlaylistBlockPlaylistData$data,
     PlaylistBlockPlaylistData$key,
@@ -99,19 +98,6 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
         return unreachable();
     }
 
-    const items = playlist.entries.map(entry => {
-        if (entry.__typename === "AuthorizedEvent") {
-            const out = readInlineData<VideoListEventData$key>(videoListEventFragment, entry);
-            return out;
-        } else if (entry.__typename === "Missing") {
-            return "missing";
-        } else if (entry.__typename === "NotAllowed") {
-            return "unauthorized";
-        } else {
-            return unreachable();
-        }
-    });
-
     const title = props.showTitle
         ? (props.moreOfTitle ? t("video.more-from-playlist", { playlist: playlist.title })
             : playlist.title)
@@ -123,12 +109,12 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
             (props.order === "%future added value" ? undefined : props.order) ?? "ORIGINAL"
         }
         allowOriginalOrder
-        {...{ title, items }}
+        {...{ title }}
         description={(props.showMetadata && playlist.description) || undefined}
         activeEventId={props.activeEventId}
         basePath={props.basePath}
-        items={items}
         isPlaylist
         listId={playlist.id}
+        listEntries={playlist.entries}
     />;
 };

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -8,7 +8,7 @@ import React, {
     useRef,
     useState,
 } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import type { i18n } from "i18next";
 import {
     match, unreachable, ProtoButton, screenWidthAtMost, screenWidthAbove,
@@ -38,6 +38,9 @@ import { CollapsibleDescription, SmallDescription } from "../metadata";
 import { darkModeBoxShadow, ellipsisOverflowCss, focusStyle } from "..";
 import { COLORS } from "../../color";
 import { FloatingBaseMenu } from "../FloatingBaseMenu";
+import { isRealUser, useUser } from "../../User";
+import { LoginLink } from "../../routes/util";
+
 
 
 
@@ -114,6 +117,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
 }) => {
     const { t, i18n } = useTranslation();
     const [eventOrder, setEventOrder] = useState<Order>(initialOrder);
+    const user = useUser();
 
     const items = listEntries.map(entry => {
         if (entry.__typename === "AuthorizedEvent") {
@@ -172,7 +176,17 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
                     {t("videolist-block.hidden-items.missing", { count: missingItems })}
                 </HiddenItemsInfo>}
                 {unauthorizedItems > 0 && <HiddenItemsInfo>
-                    {t("videolist-block.hidden-items.unauthorized", { count: unauthorizedItems })}
+                    <span>
+                        {t("videolist-block.hidden-items.unauthorized", {
+                            count: unauthorizedItems,
+                        })}
+                        &nbsp;
+                        {!isRealUser(user) && <>
+                            <Trans i18nKey="errors.might-need-to-login-link">
+                                You might need to <LoginLink />
+                            </Trans>
+                        </>}
+                    </span>
                 </HiddenItemsInfo>}
             </div>}
         </VideoListBlockContainer>

--- a/frontend/tests/util/user.ts
+++ b/frontend/tests/util/user.ts
@@ -19,7 +19,7 @@ export type UserId = keyof typeof USERS;
  */
 export const login = async (page: Page, username: UserId) => {
     const prevUrl = page.url();
-    await page.getByRole("link", { name: "Login" }).click({ });
+    await page.getByRole("link", { name: "Login", exact: true }).click({ });
     await expect(page).toHaveURL("~login");
     await page.getByLabel("User ID").fill(username);
     await page.getByLabel("Password").fill("tobira");
@@ -37,5 +37,5 @@ export const login = async (page: Page, username: UserId) => {
 export const logout = async (page: Page, username: UserId) => {
     await page.getByRole("button", { name: USERS[username] }).click();
     await page.getByRole("button", { name: "Log out" }).click();
-    await expect(page.getByRole("link", { name: "Login" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Login", exact: true })).toBeVisible();
 };


### PR DESCRIPTION
This will now show the exact number of missing and authorization-lacking videos.

Closes #1197

Edit: I am planning to create some series and playlists for this PR so you can see this in action. For now here are some screenshots:
- Series with a video that is missing authorization:
<img width="1117" alt="Bildschirmfoto 2024-07-17 um 18 07 57" src="https://github.com/user-attachments/assets/caf95692-3667-4d3e-bc1d-5956e2c107b8">

- Playlist with videos that couldn't be found and videos that are missing authorization:
<img width="1121" alt="Bildschirmfoto 2024-07-17 um 18 09 25" src="https://github.com/user-attachments/assets/43c5b96e-bf2f-4f77-8d64-db46512ee8db">

And a question: Do we even want to show the "No videos" line if there are some hidden videos?
