### PR TITLE
Fix "listed" logic, rewrite all search index trigger logic & some other improvements

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -10,7 +10,6 @@ use crate::{
             event::AuthorizedEvent, 
             series::Series, 
             realm::Realm, 
-            search::SearchSeriesExtended,
             playlist::AuthorizedPlaylist,
         },
     },
@@ -34,7 +33,6 @@ use crate::{
         SearchEvent,
         SearchRealm,
         SearchSeries,
-        SearchSeriesExtended,
         SearchPlaylist,
     ]
 )]

--- a/backend/src/api/model/search/series.rs
+++ b/backend/src/api/model/search/series.rs
@@ -1,7 +1,9 @@
 use crate::{
-    api::{Context, Node, Id, NodeValue},
-    search,
+    api::{Context, Id, Node, NodeValue},
+    search, HasRoles,
 };
+
+use super::ThumbnailInfo;
 
 
 impl Node for search::Series {
@@ -30,5 +32,17 @@ impl search::Series {
 
     fn host_realms(&self) -> &[search::Realm] {
         &self.host_realms
+    }
+
+    fn thumbnails(&self, context: &Context) -> Vec<ThumbnailInfo> {
+        self.thumbnails.iter()
+            .filter(|info| context.auth.overlaps_roles(&info.read_roles))
+            .map(|info| ThumbnailInfo {
+                thumbnail: info.url.clone(),
+                audio_only: info.audio_only,
+                is_live: info.live,
+            })
+            .take(3)
+            .collect()
     }
 }

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -369,4 +369,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     34: "event-view-and-deletion-timestamp",
     35: "playlists",
     36: "playlist-blocks",
+    37: "redo-search-triggers-and-listed",
 ];

--- a/backend/src/db/migrations/36-playlist-blocks.sql
+++ b/backend/src/db/migrations/36-playlist-blocks.sql
@@ -13,29 +13,6 @@ alter type video_list_order add value 'original';
 create index idx_block_playlist on blocks (playlist);
 
 
--- Add view for playlist data that we put into the search index.
-create view search_playlists as
-    select
-        playlists.id, playlists.opencast_id,
-        playlists.read_roles, playlists.write_roles,
-        playlists.title, playlists.description, playlists.creator,
-        coalesce(
-            array_agg((
-                -- Using a nested query here improves the overall performance
-                -- for the main use case: 'where id = any(...)'. If we would
-                -- use a join instead, the runtime would be the same with or
-                -- without the 'where id' (roughly 300ms on my machine).
-                select row(search_realms.*)::search_realms
-                from search_realms
-                where search_realms.id = blocks.realm
-            )) filter(where blocks.realm is not null),
-            '{}'
-        ) as host_realms
-    from playlists
-    left join blocks on type = 'playlist' and blocks.playlist = playlists.id
-    group by playlists.id;
-
-
 -- Triggers to remember and reuse deleted playlists.
 create trigger remember_deleted_opencast_playlists
 after delete
@@ -49,5 +26,5 @@ on playlists
 for each row
 execute procedure reuse_existing_id_on_insert('playlist');
 
--- Everything related to queuing playlists for search indexing is done in the
+-- Everything related to playlists in the search index is done in the
 -- next migration.

--- a/backend/src/db/migrations/36-playlist-blocks.sql
+++ b/backend/src/db/migrations/36-playlist-blocks.sql
@@ -13,11 +13,6 @@ alter type video_list_order add value 'original';
 create index idx_block_playlist on blocks (playlist);
 
 
--- All of this is the preparation to store playlists in the search index.
--- The procedure for playlists is very similar to the one for series, and
--- is adapted from `19-series-search-view` and `20-fix-queue-triggers`
--- (this includes some of the comments).
-
 -- Add view for playlist data that we put into the search index.
 create view search_playlists as
     select
@@ -40,72 +35,6 @@ create view search_playlists as
     left join blocks on type = 'playlist' and blocks.playlist = playlists.id
     group by playlists.id;
 
--- Add a trigger to automatically add a playlist to the queue whenever it's changed
--- somehow.
-create function queue_playlist_for_reindex(playlist playlists) returns void language sql as $$
-    insert into search_index_queue (item_id, kind)
-    values (playlist.id, 'playlist')
-    on conflict do nothing
-$$;
-
-create function queue_touched_playlist_for_reindex()
-returns trigger
-   language plpgsql
-as $$
-begin
-    if tg_op <> 'INSERT' then
-        perform queue_playlist_for_reindex(old);
-    end if;
-    if tg_op <> 'DELETE' then
-        perform queue_playlist_for_reindex(new);
-    end if;
-    return null;
-end;
-$$;
-
-create trigger queue_touched_playlist_for_reindex
-after insert or delete or update
-on playlists
-for each row
-execute procedure queue_touched_playlist_for_reindex();
-
--- Returns all series, events and playlists that are hosted by the given realm.
--- They are returned in the form that can be directly inserted into
--- `search_index_queue`.
--- In theory this should be renamed to reflect the fact that this now also
--- includes playlists. But since this is used in another function
--- (`queue_touched_realm_for_reindex()`), it's easier to stick with the
--- existing name.
-create or replace function hosted_series_and_events(realm_id bigint)
-    returns table (id bigint, kind search_index_item_kind)
-    language 'sql'
-as $$
-    with
-        the_blocks as (
-            select *
-            from blocks
-            where blocks.realm = realm_id
-        ),
-        the_events as (
-            select events.id, 'event'::search_index_item_kind
-            from the_blocks
-            inner join events on (
-                type = 'series' and the_blocks.series = events.series
-                or type = 'video' and the_blocks.video = events.id
-            )
-        ),
-        the_series as (
-            select series.id, 'series'::search_index_item_kind
-            from the_blocks
-            inner join series on type = 'series' and the_blocks.series = series.id
-        ),
-        the_playlists as (
-            select playlists.id, 'playlist'::search_index_item_kind
-            from the_blocks
-            inner join playlists on type = 'playlist' and the_blocks.playlist = playlists.id
-        )
-    select * from the_events union all select * from the_series union all select * from the_playlists
-$$;
 
 -- Triggers to remember and reuse deleted playlists.
 create trigger remember_deleted_opencast_playlists
@@ -119,3 +48,6 @@ before insert
 on playlists
 for each row
 execute procedure reuse_existing_id_on_insert('playlist');
+
+-- Everything related to queuing playlists for search indexing is done in the
+-- next migration.

--- a/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
+++ b/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
@@ -1,0 +1,458 @@
+-- This migration recreates all triggers related to queuing items for the search
+-- index (with the exceptions of users, see migration 28). This is done for multiple reasons:
+--
+-- * Triggers were adjusted in many migrations, making it difficult to see the
+--   whole trigger situation at once.
+-- * There were still bugs.
+-- * Add additional triggers, for example to allow storing series/playlist
+--   thumbnails in the index, or include text block content in the realm search
+--   index.
+--
+-- Generally, these triggers are a bit looser and err on the side of "queue too
+-- much", as that's the semantically correct thing to do and allows us to be
+-- more flexible in the future, without having to change triggers every time.
+-- However, there shouldn't be any triggers that queue a crazy amount of
+-- unnecessary items.
+--
+-- Finally, by this migration also changes/fixes the "listed" logic. The
+-- behavior was defined in PR #1211 and the DB still needed some adjustments,
+-- in particular after adding playlist blocks.
+
+---------- Cleanup -------------------------------------------------------------------------------
+-- Drop all old triggers and functions used by those triggers
+drop trigger queue_blocks_for_reindex on blocks;
+drop trigger queue_touched_realm_for_reindex on realms;
+drop trigger queue_realm_on_updated_series_title on series;
+drop trigger queue_realm_on_updated_event_title on all_events;
+drop trigger queue_touched_event_for_reindex on all_events;
+drop trigger queue_all_events_of_touched_series_for_reindex on series;
+drop trigger queue_touched_series_for_reindex on series;
+
+drop function queue_blocks_for_reindex;
+drop function queue_block_for_reindex;
+drop function queue_touched_realm_for_reindex;
+drop function queue_realm_for_reindex;
+drop function queue_realm_on_updated_title;
+drop function queue_touched_event_for_reindex;
+drop function queue_all_events_of_touched_series_for_reindex;
+drop function queue_touched_series_for_reindex;
+drop function hosted_series_and_events;
+drop function queue_all_events_of_series_for_reindex;
+drop function queue_event_for_reindex;
+drop function queue_series_for_reindex;
+
+
+
+---------- Adjust views --------------------------------------------------------------------------
+
+-- Adjust `search_events` to also include realms as host realms that include an
+-- event via playlist. Last version in 26-more-event-search-data.sql. It also
+-- adds `opencast_id` (because why not, we might want that in the future) and
+-- `containing_playlists` (which also might be useful in the future).
+drop view search_events;
+create view search_events as
+    select
+        events.id, events.opencast_id, events.state,
+        events.series, series.title as series_title,
+        events.title, events.description, events.creators,
+        events.thumbnail, events.duration,
+        events.is_live, events.created, events.start_time, events.end_time,
+        events.read_roles, events.write_roles,
+        coalesce(
+            array_agg(
+                distinct
+                row(search_realms.*)::search_realms
+            ) filter(where search_realms.id is not null),
+            '{}'
+        ) as host_realms,
+        not exists (
+            select from unnest(events.tracks) as t where t.resolution is not null
+        ) as audio_only,
+        coalesce(
+            array_agg(playlists.id)
+                filter(where playlists.id is not null),
+            '{}'
+        ) as containing_playlists
+    from all_events as events
+    left join series on events.series = series.id
+    -- This syntax instead of `foo = any(...)` to use the index, which is not
+    -- otherwise used.
+    left join playlists on array[events.opencast_id] <@ event_entry_ids(entries)
+    left join blocks on (
+        type = 'series' and blocks.series = events.series
+        or type = 'video' and blocks.video = events.id
+        or type = 'playlist' and blocks.playlist = playlists.id
+    )
+    left join search_realms on search_realms.id = blocks.realm
+    group by events.id, series.id;
+
+
+
+
+---------- Utility functions ---------------------------------------------------------------------
+
+-- Returns all series, events and playlists that are hosted by the given realm.
+-- They are returned in the form that can be directly inserted into
+-- `search_index_queue`.
+create or replace function search_items_hosted_by_realm(realm_id bigint)
+    returns table (id bigint, kind search_index_item_kind)
+    language 'sql'
+as $$
+    with
+        the_blocks as (
+            select *
+            from blocks
+            where blocks.realm = realm_id
+        ),
+        the_events as (
+            select events.id, 'event'::search_index_item_kind
+            from the_blocks
+            left join playlists on (type = 'playlist' and the_blocks.playlist = playlists.id)
+            inner join events on (
+                events.opencast_id = any(event_entry_ids(entries))
+                or type = 'video' and the_blocks.video = events.id
+                or type = 'series' and the_blocks.series = events.series
+            )
+        ),
+        the_series as (
+            select series.id, 'series'::search_index_item_kind
+            from the_blocks
+            inner join series on type = 'series' and the_blocks.series = series.id
+        ),
+        the_playlists as (
+            select playlists.id, 'playlist'::search_index_item_kind
+            from the_blocks
+            inner join playlists on type = 'playlist' and the_blocks.playlist = playlists.id
+        )
+    select * from the_events
+        union all select * from the_series
+        union all select * from the_playlists
+$$;
+
+-- Returns all realms in the realm-subtree which root has `root_full_path`,
+-- including the root itself.
+create function realm_subtree_of(root_full_path text)
+returns setof realms
+language sql
+as $$
+    select * from realms
+        where full_path = root_full_path
+            -- All children (notice the '/'). It would be nicer to use
+            -- `starts_with`, but currently, only `like` will use our index. So
+            -- we need to escape for usage in `like`. Luckily, backslash and
+            -- percent are disallowed in realm paths anyway.
+            or full_path like replace(root_full_path, '_', '\\_') || '/%';
+$$;
+
+-- This function queues a full realm-subtree (including all hosted items). This
+-- is necessary whenever a resolved realm name changes.
+create function queue_subtree_on_realm_name_change(r realms)
+returns void language plpgsql as $$
+begin
+    -- Queue all realms in the subtree, as well as all items hosted by any of those realms.
+    insert into search_index_queue (item_id, kind)
+    select id, 'realm' from realm_subtree_of(r.full_path)
+    union all
+    select h.* from realm_subtree_of(r.full_path) t, search_items_hosted_by_realm(t.id) as h
+    on conflict do nothing;
+end;
+$$;
+
+-- Queues a specific realm and all its directly hosted items.
+create function queue_realm_and_hosted_items(realm_id bigint)
+returns void language plpgsql as $$
+begin
+    perform queue_single_item_for_reindex(realm_id, 'realm');
+
+    insert into search_index_queue (item_id, kind)
+    select * from search_items_hosted_by_realm(realm_id)
+    on conflict do nothing;
+end;
+$$;
+
+-- Returns all realms that derive their names from the item with the given ID.
+create function realms_deriving_name_from(item_id bigint, ty block_type)
+returns setof realms
+language sql
+as $$
+    select realms.*
+    from blocks
+    inner join realms on realms.name_from_block = blocks.id
+    where blocks.type = ty and (
+        blocks.video = item_id
+        or blocks.series = item_id
+        or blocks.playlist = item_id
+    )
+$$;
+
+-- Calls `queue_subtree_on_realm_name_change` on all realms returned by
+-- `realms_deriving_name_from`.
+create function queue_subtrees_for_derived_realm_names(item_id bigint, ty block_type)
+returns void language plpgsql as $$
+declare
+    deriving_realm realms;
+begin
+    for deriving_realm in select * from realms_deriving_name_from(item_id, ty) loop
+        perform queue_subtree_on_realm_name_change(deriving_realm);
+    end loop;
+end;
+$$;
+
+
+-- Just a convenience function.
+create function queue_single_item_for_reindex(id bigint, kind search_index_item_kind)
+returns void language sql as $$
+    insert into search_index_queue (item_id, kind)
+    values (id, kind)
+    on conflict do nothing
+$$;
+
+
+
+---------- Install triggers ----------------------------------------------------------------------
+
+------- On event change ------------------------------------------------------
+--
+-- Requires queuing:
+-- * the event itself
+-- * the series (due to it using event thumbnails)
+-- * all playlists containing the event (due to them using event thumbnails)
+-- * on title change: propagate realm name change
+
+create function queue_event_related_items_for_reindex(e all_events)
+returns void language plpgsql as $$
+begin
+    -- Queue event itself
+    perform queue_single_item_for_reindex(e.id, 'event');
+
+    -- Queue its series
+    if e.series is not null then
+        perform queue_single_item_for_reindex(e.series, 'series');
+    end if;
+
+    -- Queue all playlists containing it
+    insert into search_index_queue (item_id, kind)
+    select id, 'playlist' from playlists where array[e.opencast_id] <@ event_entry_ids(entries)
+    on conflict do nothing;
+end;
+$$;
+
+create function queue_event_related_items_for_reindex_on_change()
+returns trigger language plpgsql as $$
+begin
+    -- Queue event itself
+    if tg_op <> 'INSERT' then
+        perform queue_event_related_items_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_event_related_items_for_reindex(new);
+    end if;
+
+    -- On title change -> handle potentially derived name changes. We can
+    -- ignore "inserts" as at that point, this cannot be a name source.
+    if tg_op = 'DELETE' or (tg_op = 'UPDATE' and new.title is distinct from old.title) then
+        perform queue_subtrees_for_derived_realm_names(old.id, 'video');
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger queue_related_items_for_reindex_on_change
+after insert or delete or update
+on all_events
+for each row
+execute procedure queue_event_related_items_for_reindex_on_change();
+
+
+------- On series change -----------------------------------------------------
+--
+-- Requires queuing:
+-- * the series itself
+-- * all its events (they use the series title)
+-- * on title change: propagate realm name change
+
+create function queue_series_related_items_for_reindex(s series)
+returns void language plpgsql as $$
+begin
+    -- Queue series itself
+    perform queue_single_item_for_reindex(s.id, 'series');
+
+    -- Queue all its events
+    insert into search_index_queue (item_id, kind)
+    select id, 'event' from events where events.series = s.id
+    on conflict do nothing;
+end;
+$$;
+
+create function queue_series_related_items_for_reindex_on_change()
+returns trigger language plpgsql as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_series_related_items_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_series_related_items_for_reindex(new);
+    end if;
+
+    -- On title change -> handle potentially derived name changes. We can
+    -- ignore "inserts" as at that point, this cannot be a name source.
+    if tg_op = 'DELETE' or (tg_op = 'UPDATE' and new.title is distinct from old.title) then
+        perform queue_subtrees_for_derived_realm_names(old.id, 'series');
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger queue_related_items_for_reindex_on_change
+after insert or delete or update
+on series
+for each row
+execute procedure queue_series_related_items_for_reindex_on_change();
+
+
+------- On playlist change ---------------------------------------------------
+--
+-- Requires queuing:
+-- * the playlist itself
+-- * the its events (affects host_realms of the event)
+-- * on title change: propagate realm name change
+
+create function queue_playlist_related_items_for_reindex(p playlists)
+returns void language plpgsql as $$
+begin
+    -- Queue playlist itself
+    perform queue_single_item_for_reindex(p.id, 'playlist');
+
+    -- Queue all its events
+    insert into search_index_queue (item_id, kind)
+    select id, 'event' from events where events.opencast_id = any(event_entry_ids(p.entries))
+    on conflict do nothing;
+end;
+$$;
+
+create function queue_playlist_related_items_for_reindex_on_change()
+returns trigger language plpgsql as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_playlist_related_items_for_reindex(old);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_playlist_related_items_for_reindex(new);
+    end if;
+
+    -- On title change -> handle potentially derived name changes. We can
+    -- ignore "inserts" as at that point, this cannot be a name source.
+    if tg_op = 'DELETE' or (tg_op = 'UPDATE' and new.title is distinct from old.title) then
+        perform queue_subtrees_for_derived_realm_names(old.id, 'playlist');
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger queue_related_items_for_reindex_on_change
+after insert or delete or update
+on playlists
+for each row
+execute procedure queue_playlist_related_items_for_reindex_on_change();
+
+
+------- On realm change ------------------------------------------------------
+--
+-- Requires queuing:
+-- * the realm itself
+-- * all its hosted items
+-- * on resolved name change: whole subtree including hosted items
+
+create function queue_realm_related_items_for_reindex_on_change()
+returns trigger language plpgsql as $$
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_realm_and_hosted_items(old.id);
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_realm_and_hosted_items(new.id);
+    end if;
+
+    -- If the resolved name changed, we have to queue the whole subtree. INSERTs
+    -- can be ignored as they don't have children, DELETEs can be ignored as
+    -- all children will be automatically deleted as well.
+    if tg_op = 'UPDATE' and (
+        old.name is distinct from new.name
+            or old.name_from_block is distinct from new.name_from_block
+    ) then
+        perform queue_subtree_on_realm_name_change(new);
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger queue_related_items_for_reindex_on_change
+after insert or delete or update
+on realms
+for each row
+execute procedure queue_realm_related_items_for_reindex_on_change();
+
+
+------- On block change ------------------------------------------------------
+--
+-- Requires queuing:
+-- * The block's realm
+-- * All hosted items of the block's realm (currently a bit overkill)
+-- * If used as name source: full realm subtree and all hosted items
+
+create function queue_block_related_items_for_reindex_on_change()
+returns trigger language plpgsql as $$
+declare
+    r realms;
+begin
+    if tg_op <> 'INSERT' then
+        perform queue_realm_and_hosted_items(old.realm);
+
+        -- Queue the previously referenced items
+        insert into search_index_queue (item_id, kind)
+            -- The directly referenced items
+            select *
+                from (values
+                    (old.video, 'event'::search_index_item_kind),
+                    (old.series, 'series'::search_index_item_kind),
+                    (old.playlist, 'playlist'::search_index_item_kind)
+                ) as t (id, kind)
+                where id is not null
+        union all
+            -- All events of series
+            select id, 'event' from events where events.series = old.series
+        union all
+            -- All events of playlist
+            select id, 'event' from events where events.opencast_id = any(event_entry_ids(
+                (select entries from playlists where id = old.playlist)
+            ))
+        on conflict do nothing;
+    end if;
+    if tg_op <> 'DELETE' then
+        perform queue_realm_and_hosted_items(new.realm);
+    end if;
+
+    -- If this block is used as a name source, we queue the whole subtree of its
+    -- realm. We only care about UPDATEs as on inserts, the block cannot be
+    -- used as name source yet, and deletes are not allowed for name-source
+    -- blocks.
+    r := (select row(realms.*) from realms where id = new.realm);
+    if tg_op = 'UPDATE' and r.name_from_block = new.id then
+        perform queue_subtree_on_realm_name_change(r);
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger queue_related_items_for_reindex_on_change
+after insert or delete or update
+    -- Ignoring id, layout/view options and `index`
+    of realm, type, text_content, series, video, playlist
+on blocks
+for each row
+execute procedure queue_block_related_items_for_reindex_on_change();

--- a/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
+++ b/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
@@ -92,7 +92,7 @@ create view search_series as
     select
         series.id, series.state, series.opencast_id,
         series.read_roles, series.write_roles,
-        series.title, series.description,
+        series.title, series.description, series.updated, series.created, series.metadata,
         coalesce(
             array_agg((
                 -- Using a nested query here improves the overall performance

--- a/backend/src/db/tests/search_queue.rs
+++ b/backend/src/db/tests/search_queue.rs
@@ -15,11 +15,18 @@ struct Setup {
     cat: Key,
     momo: Key,
     people: Key,
-    video_free: Key,
-    video_a: Key,
-    video_b: Key,
     series_a: Key,
+    series_b: Key,
+    series_c: Key,
     series_empty: Key,
+    video_free0: Key,
+    video_free1: Key,
+    video_a0: Key,
+    video_a1: Key,
+    video_b0: Key,
+    video_b1: Key,
+    video_b2: Key,
+    video_c0: Key,
 }
 
 /// Create a test DB with a few test objects in it. The search queue is cleared
@@ -35,21 +42,30 @@ struct Setup {
 async fn setup() -> Result<(TestDb, Setup)> {
     let db = TestDb::with_migrations().await?;
 
-    let animals = db.add_realm("animals", Key(0), "animals").await?;
-    let people = db.add_realm("people", Key(0), "people").await?;
-    let cat = db.add_realm("cat", animals, "cat").await?;
-    let dog = db.add_realm("dog", animals, "dog").await?;
-    let momo = db.add_realm("momo", cat, "momo").await?;
+    let animals = db.add_realm("Animals", Key(0), "animals").await?;
+    let people = db.add_realm("People", Key(0), "people").await?;
+    let cat = db.add_realm("Cat", animals, "cat").await?;
+    let dog = db.add_realm("Dog", animals, "dog").await?;
+    let momo = db.add_realm("Momo", cat, "momo").await?;
 
-    let series_a = db.add_series("Empty", "series-empty").await?;
-    let series_empty = db.add_series("Non empty", "series-non-empty").await?;
-    let video_free = db.add_event("Lonely", 123, "lonely-123", None).await?;
-    let video_a = db.add_event("Video A", 60, "video-a", Some(series_a)).await?;
-    let video_b = db.add_event("Video B", 80, "video-b", Some(series_a)).await?;
+    let series_a = db.add_series("Series A", "series-a").await?;
+    let series_b = db.add_series("Series B", "series-b").await?;
+    let series_c = db.add_series("Series C", "series-c").await?;
+    let series_empty = db.add_series("Empty", "series-empty").await?;
+    let video_free0 = db.add_event("Lonely0", 123, "lonely0", None).await?;
+    let video_free1 = db.add_event("Lonely1", 543, "lonely1", None).await?;
+    let video_a0 = db.add_event("Video A0", 60, "video-a0", Some(series_a)).await?;
+    let video_a1 = db.add_event("Video A1", 80, "video-a1", Some(series_a)).await?;
+    let video_b0 = db.add_event("Video B0", 100, "video-b0", Some(series_b)).await?;
+    let video_b1 = db.add_event("Video B1", 101, "video-b1", Some(series_b)).await?;
+    let video_b2 = db.add_event("Video B2", 102, "video-b2", Some(series_b)).await?;
+    let video_c0 = db.add_event("Video C0", 200, "video-c0", Some(series_c)).await?;
 
     db.clear_search_queue().await?;
     Ok((db, Setup {
-        animals, people, cat, dog, momo, video_free, video_a, video_b, series_a, series_empty,
+        animals, people, cat, dog, momo,
+        series_a, series_b, series_c, series_empty,
+        video_free0, video_free1, video_a0, video_a1, video_b0, video_b1, video_b2, video_c0
     }))
 }
 
@@ -65,20 +81,24 @@ async fn on_realm_add() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn on_realm_change() -> Result<()> {
     let (db, Setup {
-        cat, animals, people, momo, dog, video_free, video_a, video_b, series_a, series_empty, ..
+        cat, animals, people, momo, dog, video_free0, video_a0, video_a1, series_a, series_empty, ..
     }) = setup().await?;
 
     // Mount series and videos into some realms.
-    db.add_video_block(animals, video_free, 0).await?;
+    db.add_video_block(animals, video_free0, 0).await?;
     let cat_series_block = db.add_series_block(cat, series_a, 0).await?;
     db.add_series_block(people, series_empty, 0).await?;
     db.add_series_block(dog, series_empty, 0).await?;
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
         (series_empty, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
-        (video_free, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
+        (video_free0, IndexItemKind::Event),
+        (animals, IndexItemKind::Realm),
+        (cat, IndexItemKind::Realm),
+        (people, IndexItemKind::Realm),
+        (dog, IndexItemKind::Realm),
     ]);
 
 
@@ -94,8 +114,8 @@ async fn on_realm_change() -> Result<()> {
         (momo, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     // Change name of realm with block and children with blocks
@@ -108,9 +128,9 @@ async fn on_realm_change() -> Result<()> {
         (dog, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),      // bc mounted in cat
         (series_empty, IndexItemKind::Series),  // bc mounted in dog
-        (video_a, IndexItemKind::Event),        // bc in series_a which is mounted in cat
-        (video_b, IndexItemKind::Event),        // bc in series_a which is mounted in cat
-        (video_free, IndexItemKind::Event),     // bc mounted in animals
+        (video_a0, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_a1, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_free0, IndexItemKind::Event),     // bc mounted in animals
     ]);
 
     // Change name of `people`.
@@ -132,12 +152,12 @@ async fn on_realm_change() -> Result<()> {
         (momo, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     // Change `name_from_block`
-    let second_block = db.add_video_block(cat, video_a, 1).await?;
+    let second_block = db.add_video_block(cat, video_a0, 1).await?;
     db.clear_search_queue().await?;
     db.execute(
         "update realms set name_from_block = $2 where id = $1",
@@ -147,8 +167,8 @@ async fn on_realm_change() -> Result<()> {
         (momo, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
 
@@ -165,8 +185,8 @@ async fn on_realm_change() -> Result<()> {
         (momo, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     // Change name of realm with block and children with blocks
@@ -179,9 +199,9 @@ async fn on_realm_change() -> Result<()> {
         (dog, IndexItemKind::Realm),
         (series_a, IndexItemKind::Series),      // bc mounted in cat
         (series_empty, IndexItemKind::Series),  // bc mounted in dog
-        (video_a, IndexItemKind::Event),        // bc in series_a which is mounted in cat
-        (video_b, IndexItemKind::Event),        // bc in series_a which is mounted in cat
-        (video_free, IndexItemKind::Event),     // bc mounted in animals
+        (video_a0, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_a1, IndexItemKind::Event),        // bc in series_a which is mounted in cat
+        (video_free0, IndexItemKind::Event),     // bc mounted in animals
     ]);
 
     Ok(())
@@ -212,17 +232,23 @@ async fn on_event_add() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_event_change() -> Result<()> {
-    let (db, Setup { video_a, animals, cat, dog, momo, .. }) = setup().await?;
+    let (db, Setup { video_a0, series_a, animals, cat, dog, momo, .. }) = setup().await?;
 
     // Change title without being inside a block.
-    db.execute("update events set title = 'different' where id = $1", &[&video_a]).await?;
-    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    db.execute("update events set title = 'different' where id = $1", &[&video_a0]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a0, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
 
     // Change title while not a name source.
-    let block = db.add_video_block(animals, video_a, 0).await?;
+    let block = db.add_video_block(animals, video_a0, 0).await?;
     db.clear_search_queue().await?;
-    db.execute("update events set title = 'different2' where id = $1", &[&video_a]).await?;
-    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    db.execute("update events set title = 'different2' where id = $1", &[&video_a0]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a0, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
 
     // Change title while a name source.
     db.execute(
@@ -230,33 +256,40 @@ async fn on_event_change() -> Result<()> {
         &[&block, &animals],
     ).await?;
     db.clear_search_queue().await?;
-    db.execute("update events set title = 'bonanza' where id = $1", &[&video_a]).await?;
+    db.execute("update events set title = 'bonanza' where id = $1", &[&video_a0]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
         (animals, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (dog, IndexItemKind::Realm),
         (momo, IndexItemKind::Realm),
     ]);
 
-    // Changing the series just queues the video.
+    // Changing the series of the video.
     db.clear_search_queue().await?;
-    db.execute("update events set series = null where id = $1", &[&video_a]).await?;
-    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    db.execute("update events set series = null where id = $1", &[&video_a0]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a0, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
 
-    // As does changing other fields.
+    // Changing duration.
     db.clear_search_queue().await?;
-    db.execute("update events set duration = 987 where id = $1", &[&video_a]).await?;
-    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    db.execute("update events set duration = 987 where id = $1", &[&video_a0]).await?;
+    assert_eq!(db.search_queue().await?, set![(video_a0, IndexItemKind::Event)]);
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_event_remove() -> Result<()> {
-    let (db, Setup { video_a, .. }) = setup().await?;
-    db.execute("delete from events where id = $1", &[&video_a]).await?;
-    assert_eq!(db.search_queue().await?, set![(video_a, IndexItemKind::Event)]);
+    let (db, Setup { video_a0, series_a, .. }) = setup().await?;
+    db.execute("delete from events where id = $1", &[&video_a0]).await?;
+    assert_eq!(db.search_queue().await?, set![
+        (video_a0, IndexItemKind::Event),
+        (series_a, IndexItemKind::Series),
+    ]);
     Ok(())
 }
 
@@ -270,14 +303,14 @@ async fn on_series_add() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_series_change() -> Result<()> {
-    let (db, Setup { series_a, video_a, video_b, animals, cat, dog, momo, .. }) = setup().await?;
+    let (db, Setup { series_a, video_a0, video_a1, animals, cat, dog, momo, .. }) = setup().await?;
 
     // Change title without being inside a block.
     db.execute("update series set title = 'different' where id = $1", &[&series_a]).await?;
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     // Change title while not a name source.
@@ -286,8 +319,8 @@ async fn on_series_change() -> Result<()> {
     db.execute("update series set title = 'different2' where id = $1", &[&series_a]).await?;
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     // Change title while a name source.
@@ -299,8 +332,8 @@ async fn on_series_change() -> Result<()> {
     db.execute("update series set title = 'bonanza' where id = $1", &[&series_a]).await?;
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
         (animals, IndexItemKind::Realm),
         (cat, IndexItemKind::Realm),
         (dog, IndexItemKind::Realm),
@@ -313,8 +346,8 @@ async fn on_series_change() -> Result<()> {
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
         // The videos don't have to be queued, but they currently are and it doesn't really hurt.
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
 
     Ok(())
@@ -322,7 +355,7 @@ async fn on_series_change() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_series_remove() -> Result<()> {
-    let (db, Setup { series_a, series_empty, video_a, video_b, .. }) = setup().await?;
+    let (db, Setup { series_a, series_empty, video_a0, video_a1, .. }) = setup().await?;
     db.execute("delete from series where id = $1", &[&series_empty]).await?;
     assert_eq!(db.search_queue().await?, set![(series_empty, IndexItemKind::Series)]);
 
@@ -330,58 +363,88 @@ async fn on_series_remove() -> Result<()> {
     db.execute("delete from series where id = $1", &[&series_a]).await?;
     assert_eq!(db.search_queue().await?, set![
         (series_a, IndexItemKind::Series),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
     ]);
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_video_block_add_modify_delete() -> Result<()> {
-    let (db, Setup { cat, series_a, video_a, video_b, video_free, momo, .. }) = setup().await?;
+    let (db, Setup {
+        cat, momo,
+        series_b, series_c,
+        video_a0, video_b0, video_b1, video_b2, video_c0, video_free0, video_free1, ..
+    }) = setup().await?;
 
-    // Add a video block -> the series and all its videos are now listed.
-    let block = db.add_video_block(cat, video_a, 0).await?;
+    // Add a video block
+    let block = db.add_video_block(cat, video_a0, 0).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
-        (series_a, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event),
+        (cat, IndexItemKind::Realm),
     ]);
 
-    // Change `video` field: listed status changes.
+    // Add a few more blocks
+    db.add_series_block(cat, series_c, 1).await?;
+    db.add_video_block(momo, video_free0, 0).await?;
+    db.add_series_block(momo, series_b, 1).await?;
+
+    // Change `video` field
     db.clear_search_queue().await?;
-    db.execute("update blocks set video = $1 where id = $2", &[&video_free, &block]).await?;
+    db.execute("update blocks set video = $1 where id = $2", &[&video_free1, &block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
-        (video_free, IndexItemKind::Event),
-        (series_a, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event), // old video
+        (video_free1, IndexItemKind::Event), // new video
+
+        // Realm and all hosted items
+        (cat, IndexItemKind::Realm),
+        (series_c, IndexItemKind::Series),
+        (video_c0, IndexItemKind::Event),
     ]);
 
-    // When the block is used as name source, and the title of the event is
-    // updated, the realms are queued.
+    // Use the block as name source and update title of event.
     db.execute(
         "update realms set name = null, name_from_block = $1 where id = $2",
         &[&block, &cat],
     ).await?;
     db.clear_search_queue().await?;
-    db.execute("update events set title = 'different' where id = $1", &[&video_free]).await?;
+    db.execute("update events set title = 'different' where id = $1", &[&video_free1]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_free, IndexItemKind::Event),
+        (video_free1, IndexItemKind::Event), // video itself
+
+        // Host realm of that series and all mounted items
         (cat, IndexItemKind::Realm),
+        (series_c, IndexItemKind::Series),
+        (video_c0, IndexItemKind::Event),
+
+        // Child realm and all hosted items
         (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
-    // Changing the video of the block also queues the realms as the name is retrieved from it.
+    // Changing the video of the block used as name source.
     db.clear_search_queue().await?;
-    db.execute("update blocks set video = $1 where id = $2", &[&video_a, &block]).await?;
+    db.execute("update blocks set video = $1 where id = $2", &[&video_a0, &block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
-        (video_free, IndexItemKind::Event),
-        (series_a, IndexItemKind::Series),
+        (video_free1, IndexItemKind::Event), // old video
+        (video_a0, IndexItemKind::Event), // new video
+
+        // Host realm of that series and all mounted items
         (cat, IndexItemKind::Realm),
+        (series_c, IndexItemKind::Series),
+        (video_c0, IndexItemKind::Event),
+
+        // Child realm and all hosted items
         (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
 
@@ -397,18 +460,31 @@ async fn on_video_block_add_modify_delete() -> Result<()> {
         &[&cat],
     ).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
+        // Host realm of that series and all mounted items
         (cat, IndexItemKind::Realm),
+        (video_a0, IndexItemKind::Event),
+        (series_c, IndexItemKind::Series),
+        (video_c0, IndexItemKind::Event),
+
+        // Child realm and all hosted items
         (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
     // Delete block
     db.clear_search_queue().await?;
     db.execute("delete from blocks where id = $1", &[&block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
-        (series_a, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event), // video itself
+
+        // Host realm of that series and all mounted items
+        (cat, IndexItemKind::Realm),
+        (series_c, IndexItemKind::Series),
+        (video_c0, IndexItemKind::Event),
     ]);
 
     Ok(())
@@ -416,28 +492,45 @@ async fn on_video_block_add_modify_delete() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn on_series_block_add_modify_delete() -> Result<()> {
-    let (db, Setup { cat, series_a, series_empty, video_a, video_b, momo, .. }) = setup().await?;
+    let (db, Setup {
+        cat, momo,
+        series_a, series_b, series_empty,
+        video_a0, video_a1, video_b0, video_b1, video_b2, video_c0, video_free0, ..
+    }) = setup().await?;
 
-    // Add a series block -> the series and all its videos are now listed.
+    // Add a series block -> the series, all its videos and the realm are now listed.
     let block = db.add_series_block(cat, series_a, 0).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
         (series_a, IndexItemKind::Series),
+        (cat, IndexItemKind::Realm),
     ]);
 
-    // Change `series` field: listed status changes.
+    // Add a few more blocks
+    db.add_video_block(cat, video_c0, 1).await?;
+    db.add_video_block(momo, video_free0, 0).await?;
+    db.add_series_block(momo, series_b, 1).await?;
+
+
+    // Change `series` field
     db.clear_search_queue().await?;
     db.execute("update blocks set series = $1 where id = $2", &[&series_empty, &block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        // Old series & videos
         (series_a, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
+
+        // New series
         (series_empty, IndexItemKind::Series),
+
+        // Realm and all hosted items
+        (cat, IndexItemKind::Realm),
+        (video_c0, IndexItemKind::Event), // Also mounted on realm
     ]);
 
-    // When the block is used as name source, and the title of the series is
-    // updated, the realms are queued.
+    // Use block as name source & update title of series.
     db.execute(
         "update realms set name = null, name_from_block = $1 where id = $2",
         &[&block, &cat],
@@ -445,21 +538,43 @@ async fn on_series_block_add_modify_delete() -> Result<()> {
     db.clear_search_queue().await?;
     db.execute("update series set title = 'different' where id = $1", &[&series_empty]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (series_empty, IndexItemKind::Series),
+        (series_empty, IndexItemKind::Series), // series itself
+
+        // Host realm of that series and all mounted items
         (cat, IndexItemKind::Realm),
+        (video_c0, IndexItemKind::Event),
+
+        // Child realm and all hosted items
         (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
-    // Changing the video of the block also queues the realms as the name is retrieved from it.
+    // Changing the series of the name source block.
     db.clear_search_queue().await?;
     db.execute("update blocks set series = $1 where id = $2", &[&series_a, &block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (series_empty, IndexItemKind::Series), // old series
+
+        // New series and its events
         (series_a, IndexItemKind::Series),
-        (series_empty, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
+
+        // Host realm of that series and all mounted items
         (cat, IndexItemKind::Realm),
+        (video_c0, IndexItemKind::Event),
+
+        // Child realm and all hosted items
         (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
 
@@ -475,19 +590,30 @@ async fn on_series_block_add_modify_delete() -> Result<()> {
         &[&cat],
     ).await?;
     assert_eq!(db.search_queue().await?, set![
+        // Affected realm and all mounted items
         (cat, IndexItemKind::Realm),
-        (momo, IndexItemKind::Realm),
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (video_c0, IndexItemKind::Event),
         (series_a, IndexItemKind::Series),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
+
+        // Child realm and all hosted items
+        (momo, IndexItemKind::Realm),
+        (video_free0, IndexItemKind::Event),
+        (series_b, IndexItemKind::Series),
+        (video_b0, IndexItemKind::Event),
+        (video_b1, IndexItemKind::Event),
+        (video_b2, IndexItemKind::Event),
     ]);
 
     // Delete block
     db.clear_search_queue().await?;
     db.execute("delete from blocks where id = $1", &[&block]).await?;
     assert_eq!(db.search_queue().await?, set![
-        (video_a, IndexItemKind::Event),
-        (video_b, IndexItemKind::Event),
+        (cat, IndexItemKind::Realm),
+        (video_c0, IndexItemKind::Event),
+        (video_a0, IndexItemKind::Event),
+        (video_a1, IndexItemKind::Event),
         (series_a, IndexItemKind::Series),
     ]);
 

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -115,6 +115,16 @@ pub struct PlaylistEntry {
     pub content_id: String,
 }
 
+/// Represents the `playlist_entry` type defined in `31-playlists.sql`.
+#[derive(Debug, FromSql, ToSql, Clone, Serialize, Deserialize)]
+#[postgres(name = "search_thumbnail_info")]
+pub struct SearchThumbnailInfo {
+    pub url: Option<String>,
+    pub live: bool,
+    pub audio_only: bool,
+    pub read_roles: Vec<String>,
+}
+
 /// Represents extra metadata in the DB. Is a map from "namespace" to a
 /// `string -> string array` map.
 ///

--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -42,7 +42,7 @@ pub(crate) use self::{
 
 /// The version of search index schema. Increase whenever there is a change that
 /// requires an index rebuild.
-const VERSION: u32 = 4;
+const VERSION: u32 = 5;
 
 
 // ===== Configuration ============================================================================

--- a/backend/src/search/playlist.rs
+++ b/backend/src/search/playlist.rs
@@ -17,7 +17,7 @@ pub(crate) struct Playlist {
     pub(crate) opencast_id: String,
     pub(crate) title: String,
     pub(crate) description: Option<String>,
-    pub(crate) creator: String,
+    pub(crate) creator: Option<String>,
 
     // See `search::Event::*_roles` for notes that also apply here.
     pub(crate) read_roles: Vec<String>,

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -40,13 +40,12 @@ impl_from_db!(
     select: {
         search_series.{
             id, opencast_id, title, description, read_roles, write_roles,
-            listed_via_events, host_realms,
+            host_realms,
         },
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
-        let listed = host_realms.iter().any(|realm| !realm.is_user_realm())
-            || row.listed_via_events();
+        let listed = host_realms.iter().any(|realm| !realm.is_user_realm());
         Self {
             id: row.id(),
             opencast_id: row.opencast_id(),

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -4,7 +4,7 @@ use tokio_postgres::GenericClient;
 
 use crate::{
     prelude::*,
-    db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
+    db::{types::{Key, SearchThumbnailInfo}, util::{collect_rows_mapped, impl_from_db}},
 };
 
 use super::{realm::Realm, SearchId, IndexItem, IndexItemKind, util};
@@ -26,6 +26,7 @@ pub(crate) struct Series {
     // store it explicitly to filter for this condition in Meili.
     pub(crate) listed: bool,
     pub(crate) host_realms: Vec<Realm>,
+    pub(crate) thumbnails: Vec<SearchThumbnailInfo>,
 }
 
 impl IndexItem for Series {
@@ -40,7 +41,7 @@ impl_from_db!(
     select: {
         search_series.{
             id, opencast_id, title, description, read_roles, write_roles,
-            host_realms,
+            host_realms, thumbnails
         },
     },
     |row| {
@@ -55,6 +56,7 @@ impl_from_db!(
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
             listed,
             host_realms,
+            thumbnails: row.thumbnails(),
         }
     }
 );

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -143,10 +143,10 @@ const query = graphql`
                         created
                         hostRealms { path }
                     }
-                    ... on SearchSeriesExtended {
+                    ... on SearchSeries {
                         title
                         description
-                        thumbnailInfo { thumbnail isLive audioOnly }
+                        thumbnails { thumbnail isLive audioOnly }
                     }
                     ... on SearchRealm { name path ancestorNames }
                 }
@@ -382,12 +382,12 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => (
                     endTime: unwrapUndefined(item.endTime),
                     hostRealms: unwrapUndefined(item.hostRealms),
                 }} />;
-            } else if (item.__typename === "SearchSeriesExtended") {
+            } else if (item.__typename === "SearchSeries") {
                 return <SearchSeries key={item.id} {...{
                     id: item.id,
                     title: unwrapUndefined(item.title),
                     description: unwrapUndefined(item.description),
-                    thumbnailInfo: unwrapUndefined(item.thumbnailInfo),
+                    thumbnails: unwrapUndefined(item.thumbnails),
                 }} />;
             } else if (item.__typename === "SearchRealm") {
                 return <SearchRealm key={item.id} {...{
@@ -560,10 +560,10 @@ type SearchSeriesProps = {
     id: string;
     title: string;
     description: string | null;
-    thumbnailInfo: readonly ThumbnailInfo[] | undefined;
+    thumbnails: readonly ThumbnailInfo[] | undefined;
 }
 
-const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, thumbnailInfo }) =>
+const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, thumbnails }) =>
     <Item key={id} link={DirectSeriesRoute.url({ seriesId: id })}>
         <WithIcon Icon={LuLibrary} iconSize={28} hideIconOnMobile>
             <div css={{
@@ -586,13 +586,13 @@ const SearchSeries: React.FC<SearchSeriesProps> = ({ id, title, description, thu
                 />}
             </div>
         </WithIcon>
-        <ThumbnailStack {...{ thumbnailInfo, title }} />
+        <ThumbnailStack {...{ thumbnails, title }} />
     </Item>
 ;
 
-type ThumbnailStackProps = Pick<SearchSeriesProps, "title" | "thumbnailInfo">
+type ThumbnailStackProps = Pick<SearchSeriesProps, "title" | "thumbnails">
 
-const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnailInfo, title }) => (
+const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, title }) => (
     <div css={{
         ...thumbnailCss,
         outline: 0,
@@ -621,7 +621,7 @@ const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnailInfo, title })
             gridRow: "1 / span 10",
         },
     }}>
-        {thumbnailInfo?.map((info, idx) => <div key={idx}>
+        {thumbnails?.map((info, idx) => <div key={idx}>
             <SeriesThumbnail {...{ info, title }} />
         </div>)}
     </div>

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -757,19 +757,13 @@ type SearchSeries implements Node {
   title: String!
   description: String
   hostRealms: [SearchRealm!]!
+  thumbnails: [ThumbnailInfo!]!
 }
 
 type ThumbnailInfo {
   thumbnail: String
   isLive: Boolean!
   audioOnly: Boolean!
-}
-
-type SearchSeriesExtended implements Node {
-  id: ID!
-  title: String!
-  description: String
-  thumbnailInfo: [ThumbnailInfo!]!
 }
 
 type User {


### PR DESCRIPTION
See commits for more info. The main motivation was to fix the last remaining spots disagreeing with #1211, as well as add trigger logic to automatically queue playlists and their events for reindex. The latter part is why this PR unblocks the next release.

But since there were some minor bugs as well, and the logic was spread over many migrations, the easiest way to achieve this was to rewrite all triggering logic. Now everything is in one file and, I think, simpler and more future-proof. My hope is that with this PR, we won't have to touch the trigger logic or search views anytime soon. I added more fields to the search views and erred all triggers on the side of "queue more often than necessary". 

I also adjusted the unit tests checking this behavior and added new ones. Finally, I used this opportunity to get rid of the SQL query in `search::perform` by moving the event thumbnails into the series search index directly. Adding the SQL query was just a quick'n'dirty solution back then, since it would have required essentially this PR.