### PR TITLE
Add `opencast.external_api_node` config value 

### DIFF
--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -30,6 +30,7 @@ pub(crate) async fn run(shared: &args::Shared, args: &Args) -> Result<()> {
     };
     let meili = check_meili(&config).await;
     let opencast_sync = check_opencast_sync(&config).await;
+    let oc_external_api = check_external_api(&config).await;
     info!("Done verifing various things");
 
 
@@ -61,6 +62,7 @@ pub(crate) async fn run(shared: &args::Shared, args: &Args) -> Result<()> {
         _ => {},
     }
     print_outcome(&mut any_errors, "Connection to Opencast harvesting API", &opencast_sync);
+    print_outcome(&mut any_errors, "Connection to Opencast external API", &oc_external_api);
 
     println!();
     if any_errors {
@@ -152,6 +154,15 @@ async fn check_opencast_sync(config: &Config) -> Result<()> {
     let client = OcClient::new(config)?;
     crate::sync::check_compatibility(&client).await?;
     client.test_harvest().await?;
+    Ok(())
+}
+
+async fn check_external_api(config: &Config) -> Result<()> {
+    let client = OcClient::new(config)?;
+    let versions = client.external_api_versions().await?;
+    info!("External API version: {}", versions.default);
+    debug!("External API supported versions: {:?}", versions.versions);
+    // TODO: actually check the version against our requirements maybe?
     Ok(())
 }
 

--- a/backend/src/config/opencast.rs
+++ b/backend/src/config/opencast.rs
@@ -31,6 +31,10 @@ pub(crate) struct OpencastConfig {
     /// the ingest API.
     pub(crate) upload_node: Option<HttpHost>,
 
+    /// Explicitly set Opencast node for "external API" use (used to modify
+    /// Opencast data from Tobira).
+    pub(crate) external_api_node: Option<HttpHost>,
+
     /// Explicitly set base-URL to Opencast Studio.
     ///
     /// Example: "https://admin.oc.my-uni.edu/studio".
@@ -66,6 +70,10 @@ impl OpencastConfig {
 
     pub(crate) fn upload_node(&self) -> &HttpHost {
         self.upload_node.as_ref().unwrap_or_else(|| self.unwrap_host())
+    }
+
+    pub(crate) fn external_api_node(&self) -> &HttpHost {
+        self.external_api_node.as_ref().unwrap_or_else(|| self.unwrap_host())
     }
 
     pub(crate) fn studio_url(&self) -> ToolBaseUri {

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -25,7 +25,7 @@ pub(crate) async fn run(daemon: bool, db: DbConnection, config: &Config) -> Resu
 }
 
 pub(crate) async fn check_compatibility(client: &OcClient) -> Result<()> {
-    let response = client.get_version().await.context("failed to fetch API version")?;
+    let response = client.get_tobira_api_version().await.context("failed to fetch API version")?;
     let version = response.version();
     if !version.is_compatible() {
         bail!("Tobira-module API version incompatible! Required: \

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -407,6 +407,10 @@
 # the ingest API.
 #upload_node =
 
+# Explicitly set Opencast node for "external API" use (used to modify
+# Opencast data from Tobira).
+#external_api_node =
+
 # Explicitly set base-URL to Opencast Studio.
 #
 # Example: "https://admin.oc.my-uni.edu/studio".


### PR DESCRIPTION
This allows admins to override which OC node is used for external API
operations. Previously, `sync_node` was used, which was not always
correct.

Fixes #1216