### PR TITLE
Make `searchAll*` endpoints sort items by date when query is empty 

### DIFF
--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -310,13 +310,15 @@ pub(crate) async fn all_events(
         }
     }).to_string();
 
-    let res = context.search.event_index.search()
-        .with_query(user_query)
-        .with_limit(50)
-        .with_show_matches_position(true)
-        .with_filter(&filter)
-        .execute::<search::Event>()
-        .await;
+    let mut query = context.search.event_index.search();
+    query.with_query(user_query);
+    query.with_limit(50);
+    query.with_show_matches_position(true);
+    query.with_filter(&filter);
+    if user_query.is_empty() {
+        query.with_sort(&["created_timestamp:desc"]);
+    }
+    let res = query.execute::<search::Event>().await;
     let results = handle_search_result!(res, EventSearchOutcome);
     let items = results.hits.into_iter().map(|h| h.result).collect();
     let total_hits = results.estimated_total_hits.unwrap_or(0);
@@ -359,13 +361,15 @@ pub(crate) async fn all_series(
         }
     }).to_string();
 
-    let res = context.search.series_index.search()
-        .with_query(user_query)
-        .with_show_matches_position(true)
-        .with_filter(&filter)
-        .with_limit(50)
-        .execute::<search::Series>()
-        .await;
+    let mut query = context.search.series_index.search();
+    query.with_query(user_query);
+    query.with_show_matches_position(true);
+    query.with_filter(&filter);
+    query.with_limit(50);
+    if user_query.is_empty() {
+        query.with_sort(&["created_timestamp:desc"]);
+    }
+    let res = query.execute::<search::Series>().await;
     let results = handle_search_result!(res, SeriesSearchOutcome);
     let items = results.hits.into_iter().map(|h| h.result).collect();
     let total_hits = results.estimated_total_hits.unwrap_or(0);
@@ -401,13 +405,15 @@ pub(crate) async fn all_playlists(
         }
     }).to_string();
 
-    let res = context.search.playlist_index.search()
-        .with_query(user_query)
-        .with_show_matches_position(true)
-        .with_filter(&filter)
-        .with_limit(50)
-        .execute::<search::Playlist>()
-        .await;
+    let mut query = context.search.playlist_index.search();
+    query.with_query(user_query);
+    query.with_show_matches_position(true);
+    query.with_filter(&filter);
+    query.with_limit(50);
+    if user_query.is_empty() {
+        query.with_sort(&["updated_timestamp:desc"]);
+    }
+    let res = query.execute::<search::Playlist>().await;
     let results = handle_search_result!(res, PlaylistSearchOutcome);
     let items = results.hits.into_iter().map(|h| h.result).collect();
     let total_hits = results.estimated_total_hits.unwrap_or(0);

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -316,7 +316,7 @@ pub(crate) async fn all_events(
     query.with_show_matches_position(true);
     query.with_filter(&filter);
     if user_query.is_empty() {
-        query.with_sort(&["created_timestamp:desc"]);
+        query.with_sort(&["updated_timestamp:desc"]);
     }
     let res = query.execute::<search::Event>().await;
     let results = handle_search_result!(res, EventSearchOutcome);
@@ -367,7 +367,7 @@ pub(crate) async fn all_series(
     query.with_filter(&filter);
     query.with_limit(50);
     if user_query.is_empty() {
-        query.with_sort(&["created_timestamp:desc"]);
+        query.with_sort(&["updated_timestamp:desc"]);
     }
     let res = query.execute::<search::Series>().await;
     let results = handle_search_result!(res, SeriesSearchOutcome);

--- a/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
+++ b/backend/src/db/migrations/37-redo-search-triggers-and-listed.sql
@@ -78,7 +78,7 @@ create view search_events as
         events.series, series.title as series_title,
         events.title, events.description, events.creators,
         events.thumbnail, events.duration,
-        events.is_live, events.created, events.start_time, events.end_time,
+        events.is_live, events.updated, events.created, events.start_time, events.end_time,
         events.read_roles, events.write_roles,
         coalesce(
             array_agg(

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -22,6 +22,8 @@ pub(crate) struct Event {
     pub(crate) creators: Vec<String>,
     pub(crate) thumbnail: Option<String>,
     pub(crate) duration: i64,
+    pub(crate) updated: DateTime<Utc>,
+    pub(crate) updated_timestamp: i64,
     pub(crate) created: DateTime<Utc>,
     pub(crate) created_timestamp: i64,
     pub(crate) start_time: Option<DateTime<Utc>>,
@@ -61,13 +63,14 @@ impl_from_db!(
     select: {
         search_events.{
             id, series, series_title, title, description, creators, thumbnail,
-            duration, is_live, created, start_time, end_time, audio_only,
+            duration, is_live, updated, created, start_time, end_time, audio_only,
             read_roles, write_roles, host_realms,
         },
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
         let end_time = row.end_time();
+        let updated = row.updated();
         let created = row.created();
         Self {
             id: row.id(),
@@ -80,6 +83,8 @@ impl_from_db!(
             duration: row.duration(),
             is_live: row.is_live(),
             audio_only: row.audio_only(),
+            updated,
+            updated_timestamp: updated.timestamp(),
             created,
             created_timestamp: created.timestamp(),
             start_time: row.start_time(),
@@ -118,6 +123,6 @@ pub(super) async fn prepare_index(index: &Index) -> Result<()> {
     util::lazy_set_special_attributes(index, "event", FieldAbilities {
         searchable: &["title", "creators", "description", "series_title"],
         filterable: &["listed", "read_roles", "write_roles", "is_live", "end_time_timestamp", "created_timestamp"],
-        sortable: &["created_timestamp"],
+        sortable: &["updated_timestamp"],
     }).await
 }

--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -8,7 +8,7 @@ use crate::{
     db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
 };
 
-use super::{realm::Realm, SearchId, IndexItem, IndexItemKind, util};
+use super::{realm::Realm, util::{self, FieldAbilities}, IndexItem, IndexItemKind, SearchId};
 
 
 
@@ -115,10 +115,9 @@ impl Event {
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {
-    util::lazy_set_special_attributes(
-        index,
-        "event",
-        &["title", "creators", "description", "series_title"],
-        &["listed", "read_roles", "write_roles", "is_live", "end_time_timestamp", "created_timestamp"],
-    ).await
+    util::lazy_set_special_attributes(index, "event", FieldAbilities {
+        searchable: &["title", "creators", "description", "series_title"],
+        filterable: &["listed", "read_roles", "write_roles", "is_live", "end_time_timestamp", "created_timestamp"],
+        sortable: &["created_timestamp"],
+    }).await
 }

--- a/backend/src/search/playlist.rs
+++ b/backend/src/search/playlist.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use meilisearch_sdk::indexes::Index;
 use serde::{Serialize, Deserialize};
 use tokio_postgres::GenericClient;
@@ -7,7 +8,7 @@ use crate::{
     db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
 };
 
-use super::{realm::Realm, SearchId, IndexItem, IndexItemKind, util};
+use super::{realm::Realm, util::{self, FieldAbilities}, IndexItem, IndexItemKind, SearchId};
 
 
 
@@ -18,6 +19,8 @@ pub(crate) struct Playlist {
     pub(crate) title: String,
     pub(crate) description: Option<String>,
     pub(crate) creator: Option<String>,
+    pub(crate) updated: DateTime<Utc>,
+    pub(crate) updated_timestamp: i64,
 
     // See `search::Event::*_roles` for notes that also apply here.
     pub(crate) read_roles: Vec<String>,
@@ -43,17 +46,20 @@ impl_from_db!(
             id, opencast_id,
             title, description, creator,
             read_roles, write_roles,
-            host_realms,
+            host_realms, updated,
         },
     },
     |row| {
         let host_realms = row.host_realms::<Vec<Realm>>();
+        let updated = row.updated();
         Self {
             id: row.id(),
             opencast_id: row.opencast_id(),
             title: row.title(),
             description: row.description(),
             creator: row.creator(),
+            updated,
+            updated_timestamp: updated.timestamp(),
             read_roles: util::encode_acl(&row.read_roles::<Vec<String>>()),
             write_roles: util::encode_acl(&row.write_roles::<Vec<String>>()),
             listed: host_realms.iter().any(|realm| !realm.is_user_realm()),
@@ -84,10 +90,9 @@ impl Playlist {
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {
-    util::lazy_set_special_attributes(
-        index,
-        "playlist",
-        &["title", "description"],
-        &["read_roles", "write_roles"],
-    ).await
+    util::lazy_set_special_attributes(index, "playlist", FieldAbilities {
+        searchable: &["title", "description"],
+        filterable: &["read_roles", "write_roles"],
+        sortable: &["updated_timestamp"],
+    }).await
 }

--- a/backend/src/search/realm.rs
+++ b/backend/src/search/realm.rs
@@ -5,7 +5,7 @@ use tokio_postgres::GenericClient;
 
 use crate::{prelude::*, db::{types::Key, util::{collect_rows_mapped, impl_from_db}}};
 
-use super::{SearchId, IndexItem, IndexItemKind, util};
+use super::{util::{self, FieldAbilities}, IndexItem, IndexItemKind, SearchId};
 
 
 /// Representation of realms in the search index.
@@ -71,10 +71,9 @@ impl Realm {
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {
-    util::lazy_set_special_attributes(
-        index,
-        "realm",
-        &["name"],
-        &["is_root", "is_user_realm"],
-    ).await
+    util::lazy_set_special_attributes(index, "realm", FieldAbilities {
+        searchable: &["name"],
+        filterable: &["is_root", "is_user_realm"],
+        sortable: &[],
+    }).await
 }

--- a/backend/src/search/user.rs
+++ b/backend/src/search/user.rs
@@ -7,7 +7,7 @@ use crate::{
     db::{types::Key, util::{collect_rows_mapped, impl_from_db}},
 };
 
-use super::{SearchId, IndexItem, IndexItemKind, util};
+use super::{util::{self, FieldAbilities}, IndexItem, IndexItemKind, SearchId};
 
 
 
@@ -64,10 +64,9 @@ impl User {
 }
 
 pub(super) async fn prepare_index(index: &Index) -> Result<()> {
-    util::lazy_set_special_attributes(
-        index,
-        "user",
-        &["display_name"],
-        &[],
-    ).await
+    util::lazy_set_special_attributes(index, "user", FieldAbilities {
+        searchable: &["display_name"],
+        filterable: &[],
+        sortable: &[],
+    }).await
 }

--- a/backend/src/search/util.rs
+++ b/backend/src/search/util.rs
@@ -10,23 +10,33 @@ use crate::{
 use super::Client;
 
 
+pub(super) struct FieldAbilities<'a> {
+    pub(super) searchable: &'a [&'a str],
+    pub(super) filterable: &'a [&'a str],
+    pub(super) sortable: &'a [&'a str],
+}
+
 // Helper function to only set special attributes when they are not correctly
 // set yet. Unfortunately Meili seems to perform lots of work when setting
 // them, even if the special attribute set was the same before.
 pub(super) async fn lazy_set_special_attributes(
     index: &Index,
     index_name: &str,
-    searchable_attrs: &[&str],
-    filterable_attrs: &[&str],
+    fields: FieldAbilities<'_>,
 ) -> Result<()> {
-    if index.get_searchable_attributes().await? != searchable_attrs {
+    if index.get_searchable_attributes().await? != fields.searchable {
         debug!("Updating `searchable_attributes` of {index_name} index");
-        index.set_searchable_attributes(searchable_attrs).await?;
+        index.set_searchable_attributes(fields.searchable).await?;
     }
 
-    if index.get_filterable_attributes().await? != filterable_attrs {
+    if index.get_filterable_attributes().await? != fields.filterable {
         debug!("Updating `filterable_attributes` of {index_name} index");
-        index.set_filterable_attributes(filterable_attrs).await?;
+        index.set_filterable_attributes(fields.filterable).await?;
+    }
+
+    if index.get_sortable_attributes().await? != fields.sortable {
+        debug!("Updating `sortable_attributes` of {index_name} index");
+        index.set_sortable_attributes(fields.sortable).await?;
     }
 
     Ok(())


### PR DESCRIPTION
This is useful for adding video/series/playlist blocks, as users are
very likely to include an item that they recently created/uploaded. Once
a search query is entered, the ordering reverts back to normal:
relevancy.

Solves https://github.com/elan-ev/tobira/issues/1013

This changes the search index, but the index version was already bumped
a few commits ago and there was no release in between.

---

Draft as this is based on #1217 