### PR TITLE
Change `mount_series` endpoint to accept and move existing series

### DIFF
--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -6,12 +6,12 @@ use self::{
     subscription::Subscription,
 };
 
+pub(crate) mod err;
 pub(crate) mod util;
 pub(crate) mod model;
 
 mod common;
 mod context;
-mod err;
 mod id;
 mod jwt;
 mod mutation;

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -5,7 +5,7 @@ use postgres_types::ToSql;
 use crate::{
     api::{
         Context,
-        err::ApiResult,
+        err::{invalid_input, ApiResult},
         Id,
         model::{
             realm::Realm,
@@ -17,12 +17,16 @@ use crate::{
     prelude::*,
 };
 
-use super::playlist::VideoListEntry;
+use super::{
+    block::{BlockValue, NewSeriesBlock, VideoListLayout, VideoListOrder},
+    playlist::VideoListEntry,
+    realm::{NewRealm, RealmSpecifier, RemoveMountedSeriesOutcome, UpdatedRealmName},
+};
 
 
 pub(crate) struct Series {
     pub(crate) key: Key,
-    opencast_id: String,
+    pub(crate) opencast_id: String,
     synced_data: Option<SyncedSeriesData>,
     title: String,
     created: Option<DateTime<Utc>>,
@@ -98,6 +102,148 @@ impl Series {
             .await?
             .pipe(|row| Self::from_row_start(&row))
             .pipe(Ok)
+    }
+
+    pub(crate) async fn announce(series: NewSeries, context: &Context) -> ApiResult<Self> {
+        context.auth.required_trusted_external()?;
+        Self::create(series, context).await
+    }
+
+    pub(crate) async fn add_mount_point(
+        series_oc_id: String,
+        target_path: String,
+        context: &Context,
+    ) -> ApiResult<Realm> {
+        context.auth.required_trusted_external()?;
+
+        let series = Self::load_by_opencast_id(series_oc_id, context)
+            .await?
+            .ok_or_else(|| invalid_input!("`seriesId` does not refer to a valid series"))?;
+
+        let target_realm = Realm::load_by_path(target_path, context)
+            .await?
+            .ok_or_else(|| invalid_input!("`targetPath` does not refer to a valid realm"))?;
+
+        let blocks = BlockValue::load_for_realm(target_realm.key, context).await?;
+        if !blocks.is_empty() {
+            return Err(invalid_input!("series can only be mounted in empty realms"));
+        }
+
+        BlockValue::add_series(
+            Id::realm(target_realm.key),
+            0,
+            NewSeriesBlock {
+                series: series.id(),
+                show_title: false,
+                show_metadata: true,
+                order: VideoListOrder::NewToOld,
+                layout: VideoListLayout::Gallery,
+            },
+            context,
+        ).await?;
+
+        let block = &BlockValue::load_for_realm(target_realm.key, context).await?[0];
+
+        Realm::rename(
+            target_realm.id(),
+            UpdatedRealmName::from_block(block.id()),
+            context,
+        ).await
+    }
+
+    pub(crate) async fn remove_mount_point(
+        series_oc_id: String,
+        path: String,
+        context: &Context,
+    ) -> ApiResult<RemoveMountedSeriesOutcome> {
+        context.auth.required_trusted_external()?;
+
+        let series = Self::load_by_opencast_id(series_oc_id, context)
+            .await?
+            .ok_or_else(|| invalid_input!("`seriesId` does not refer to a valid series"))?;
+
+        let old_realm = Realm::load_by_path(path, context)
+            .await?
+            .ok_or_else(|| invalid_input!("`path` does not refer to a valid realm"))?;
+
+        let blocks = BlockValue::load_for_realm(old_realm.key, context).await?;
+
+        if blocks.len() != 1 {
+            return Err(invalid_input!("series can only be removed if it is the realm's only block"));
+        }
+
+        if !matches!(&blocks[0], BlockValue::SeriesBlock(b) if b.series == Some(series.id())) {
+            return Err(invalid_input!("the series is not mounted on the specified realm"));
+        }
+
+        if old_realm.children(context).await?.len() == 0 {
+            // The realm has no children, so it can be removed.
+            let removed_realm = Realm::remove(old_realm.id(), context).await?;
+
+            return Ok(RemoveMountedSeriesOutcome::RemovedRealm(removed_realm));
+        }
+        
+        if old_realm.name_from_block.map(Id::block) == Some(blocks[0].id()) {
+            // The realm has its name derived from the series block that is being removed - so the name
+            // shouldn't be used anymore. Ideally this would restore the previous title,
+            // but that isn't stored anywhere. Instead the realm is given the name of its path segment.
+            Realm::rename(
+                old_realm.id(),
+                UpdatedRealmName::plain(old_realm.path_segment),
+                context,
+            ).await?;
+        }
+
+        let removed_block = BlockValue::remove(blocks[0].id(), context).await?;
+
+        Ok(RemoveMountedSeriesOutcome::RemovedBlock(removed_block))
+    }
+
+    pub(crate) async fn mount(
+        series: NewSeries,
+        parent_realm_path: String,
+        new_realms: Vec<RealmSpecifier>,
+        context: &Context,
+    ) -> ApiResult<Realm> {
+        context.auth.required_trusted_external()?;
+
+        // Check parameters
+        if new_realms.iter().rev().skip(1).any(|r| r.name.is_none()) {
+            return Err(invalid_input!("all new realms except the last need to have a name"));
+        }
+
+        let parent_realm = Realm::load_by_path(parent_realm_path, context)
+            .await?
+            .ok_or_else(|| invalid_input!("`parentRealmPath` does not refer to a valid realm"))?;
+
+        if new_realms.is_empty() {
+            let blocks = BlockValue::load_for_realm(parent_realm.key, context).await?;
+            if !blocks.is_empty() {
+                return Err(invalid_input!("series can only be mounted in empty realms"));
+            }
+        }
+
+        // Create series
+        let series = Series::create(series, context).await?;
+
+        // Create realms
+        let target_realm = {
+            let mut target_realm = parent_realm;
+            for RealmSpecifier { name, path_segment } in new_realms {
+                target_realm = Realm::add(NewRealm {
+                    // The `unwrap_or` case is only potentially used for the
+                    // last realm, which is renamed below anyway. See the check
+                    // above.
+                    name: name.unwrap_or_else(|| "temporary-dummy-name".into()),
+                    path_segment,
+                    parent: Id::realm(target_realm.key),
+                }, context).await?
+            }
+            target_realm
+        };
+
+        // Create mount point
+        Self::add_mount_point(series.opencast_id, target_realm.full_path, context).await
     }
 }
 
@@ -176,7 +322,7 @@ impl Node for Series {
 
 #[derive(GraphQLInputObject)]
 pub(crate) struct NewSeries {
-    opencast_id: String,
+    pub(crate) opencast_id: String,
     title: String,
     // TODO In the future this `struct` can be extended with additional
     // (potentially optional) fields. For now we only need these.

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use tokio_postgres::Error as PgError;
 
 use crate::{
+    api::err::{not_authorized, ApiError},
     db::util::select,
     http::{response, Context, Response},
     prelude::*,
@@ -103,6 +104,14 @@ impl AuthContext {
             Self::User(user) => format!("'{}'", user.username).into(),
         }
     }
+
+    pub fn required_trusted_external(&self) -> Result<(), ApiError> {
+        if *self != Self::TrustedExternal {
+            return Err(not_authorized!("only trusted external applications can use this mutation"));
+        }
+        Ok(())
+    }
+    
 }
 
 impl User {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -597,6 +597,19 @@ type Mutation {
     the list. The first item is sub-realm of the root realm.
   """
   createRealmLineage(realms: [RealmLineageComponent!]!): CreateRealmLineageOutcome!
+  "Stores series information in Tobira's DB, so it can be mounted without having to be harvested first."
+  announceSeries(series: NewSeries!): Series!
+  "Adds a series block to an empty realm and makes that realm derive its name from said series."
+  addSeriesMountPoint(seriesOcId: String!, targetPath: String!): Realm!
+  """
+    Removes the series block of given series from the given realm.
+    If the realm has sub-realms and used to derive its name from the block,
+    it is renamed to its path segment. If the realm has no sub-realms,
+    it is removed completely.
+    Errors if the given realm does not have exactly one series block referring to the
+    specified series.
+  """
+  removeSeriesMountPoint(seriesOcId: String!, path: String!): RemoveMountedSeriesOutcome!
   """
     Atomically mount a series into an (empty) realm.
     Creates all the necessary realms on the path to the target
@@ -726,6 +739,8 @@ type EmptyQuery {
   """
   dummy: Boolean
 }
+
+union RemoveMountedSeriesOutcome = RemovedRealm | RemovedBlock
 
 union PlaylistSearchOutcome = SearchUnavailable | PlaylistSearchResults
 


### PR DESCRIPTION
This is necessary for an upcoming admin UI feature which will allow admins to change the path of series pages with no other blocks (part of https://github.com/opencast/opencast-admin-interface/issues/311).

This shouldn't break any existing behaviour.
Related Opencast and admin UI PRs: https://github.com/opencast/opencast/pull/6091, https://github.com/opencast/opencast-admin-interface/pull/878.