### PR TITLE
Fix comment action workflow permissions

### DIFF
--- a/.github/workflows/check-admin-ui-api.yml
+++ b/.github/workflows/check-admin-ui-api.yml
@@ -1,6 +1,6 @@
 name: Admin UI API Check
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - "backend/**"
     - ".github/workflows/check-admin-ui-api.yml"


### PR DESCRIPTION
Hopefully reenables the `int128/comment-action` step.