### PR TITLE
Add border-radius to video player

### DIFF
--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -165,6 +165,9 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
                     width: "unset !important",
                 },
             },
+            "div.player-container": {
+                borderRadius: 8,
+            },
             display: "flex",
             flexDirection: "column",
             // We want to be able to see the full header, the video title and some metadata.


### PR DESCRIPTION
As the title says, this adds a small border-radius to paella player.
This is mainly here so people can test it to help decide if we want this or not.