### PR TITLE
Update paella-core to 1.49.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "i18next-browser-languagedetector": "^7.2.0",
         "lucide-react": "^0.439.0",
         "paella-basic-plugins": "1.44.10",
-        "paella-core": "1.49.3",
+        "paella-core": "1.49.6",
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.0",
         "paella-slide-plugins": "1.48.1",
@@ -7690,9 +7690,10 @@
       }
     },
     "node_modules/paella-core": {
-      "version": "1.49.3",
-      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.49.3.tgz",
-      "integrity": "sha512-h558NyjOM7WcdxCZQUxUw12GjDJr4wADKGDMQK7dJ0w2QENxdFvaNaeUmopzzUDOBwWSYrZ2QKy+4zcfonk81A==",
+      "version": "1.49.6",
+      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.49.6.tgz",
+      "integrity": "sha512-90tZ+0AuAukCrTMykvCx4FbVhzSsS96nEgGvGr6DHp/hf7fW87ncye0GzntaAaB+ndmAs+FQl8oHRiZtUuYgbw==",
+      "license": "ECL-2.0",
       "dependencies": {
         "core-js": "^3.8.2",
         "hls.js": "^1.0.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "i18next-browser-languagedetector": "^7.2.0",
     "lucide-react": "^0.439.0",
     "paella-basic-plugins": "1.44.10",
-    "paella-core": "1.49.3",
+    "paella-core": "1.49.6",
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.0",
     "paella-slide-plugins": "1.48.1",


### PR DESCRIPTION
This fixes an issue where the popup menu in paella wasn't sticking to its trigger button correctly.

Closes #1231 