### PR TITLE
Fix deserialization of old harvest responses

### DIFF
--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -132,7 +132,8 @@ pub struct SearchThumbnailInfo {
 /// `"dcterms"` for the dc terms (most common namespace). The value for each
 /// namespace is a simple string-key map where each value is an array of string
 /// values.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct ExtraMetadata {
     /// Metadata of the dcterms
     #[serde(default)]
@@ -179,7 +180,8 @@ impl<'a> FromSql<'a> for ExtraMetadata {
 /// Represents the type for the `custom_action_roles` field from `32-custom-actions.sql`.
 /// This holds a mapping of actions to lists holding roles that are allowed
 /// to carry out the respective action.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct CustomActions(pub(crate) HashMap<String, Vec<String>>);
 
 impl ToSql for CustomActions {

--- a/backend/src/sync/harvest/minimal-response.json
+++ b/backend/src/sync/harvest/minimal-response.json
@@ -1,0 +1,37 @@
+{
+    "includesItemsUntil": 1727867693398,
+    "hasMore": false,
+    "items":
+    [
+        {
+            "kind": "series",
+            "id": "4b9c6f57-e4af-43dd-ad6e-fee3644fbef4",
+            "acl": {},
+            "title": "Cats",
+            "updated": 1727866771932
+        },
+        {
+            "metadata": {},
+            "kind": "event",
+            "created": 1727866740000,
+            "creators": ["Pixabay"],
+            "acl": {},
+            "title": "Video Of A Tabby Cat",
+            "tracks": [],
+            "duration": 11440,
+            "isLive": false,
+            "id": "002cff10-e0c2-4f0a-a06d-1e5c8dfef13c",
+            "updated": 1727866860840
+        },
+        {
+            "kind": "series-deleted",
+            "id": "eec06048-703d-40b1-a058-478f8bfc13f4",
+            "updated": 1727867627087
+        },
+        {
+            "kind": "event-deleted",
+            "id": "ef29ba59-2e8e-4949-acaf-8b8e42bed37e",
+            "updated": 1727867851377
+        }
+    ]
+}

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -6,6 +6,7 @@ use crate::db::types::{CustomActions, EventCaption, EventTrack, EventSegment, Ex
 
 /// What the harvesting API returns.
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct HarvestResponse {
     #[serde(with = "chrono::serde::ts_milliseconds")]
@@ -15,6 +16,7 @@ pub(crate) struct HarvestResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(tag = "kind")]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum HarvestItem {
@@ -114,6 +116,7 @@ impl HarvestItem {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Track {
     uri: String,
@@ -136,6 +139,7 @@ impl Into<EventTrack> for Track {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Caption {
     uri: String,
@@ -152,6 +156,7 @@ impl Into<EventCaption> for Caption {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Segment {
     uri: String,
@@ -167,7 +172,8 @@ impl Into<EventSegment> for Segment {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct Acl {
     #[serde(default)]
     pub(crate) read: Vec<String>,
@@ -178,10 +184,156 @@ pub(crate) struct Acl {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PlaylistEntry {
     pub id: i64,
     #[serde(rename = "type")]
     pub ty: String,
     pub content_id: String,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use super::*;
+
+
+    fn timestamp(ts: u64) -> DateTime<Utc> {
+        DateTime::from_timestamp(ts as i64 / 1000, (ts % 1000) as u32 * 1000_000).unwrap()
+    }
+
+
+    // Makes sure that Tobira can still deserialize a harvest response by the
+    // `MIN_REQUIRED_API_VERSION`. Otherwise, we would have to bump that
+    // version.
+    const OLDEST_SUPPORTED_RESPONSE: &str = include_str!("v1.0-response.json");
+
+    #[test]
+    fn can_deserialize_oldest_supported_response() {
+        let deser = serde_json::from_str::<HarvestResponse>(OLDEST_SUPPORTED_RESPONSE).unwrap();
+        assert_eq!(deser, HarvestResponse {
+            includes_items_until: timestamp(1727867693398),
+            has_more: false,
+            items: vec![
+                HarvestItem::Series {
+                    id: "4b9c6f57-e4af-43dd-ad6e-fee3644fbef4".into(),
+                    title: "Cats".into(),
+                    description: Some("Several videos of cats".into()),
+                    acl: Acl {
+                        read: vec!["ROLE_ANONYMOUS".into()],
+                        write: vec!["ROLE_ANONYMOUS".into()],
+                        custom_actions: CustomActions::default(),
+                    },
+                    updated: timestamp(1727866771932),
+                    created: None,
+                    metadata: ExtraMetadata::default(),
+                },
+                HarvestItem::Event {
+                    id: "002cff10-e0c2-4f0a-a06d-1e5c8dfef13c".into(),
+                    title: "Video Of A Tabby Cat".into(),
+                    description: None,
+                    acl: Acl {
+                        read: vec!["ROLE_ADMIN".into(), "ROLE_ANONYMOUS".into()],
+                        write: vec!["ROLE_ADMIN".into()],
+                        custom_actions: CustomActions::default(),
+                    },
+                    updated: timestamp(1727866860840),
+                    created: timestamp(1727866740000),
+                    creators: vec!["Pixabay".to_owned()],
+                    metadata: ExtraMetadata {
+                        dcterms: HashMap::from([
+                            ("license".to_owned(), vec!["CC0".to_owned()]),
+                        ]),
+                        ..ExtraMetadata::default()
+                    },
+                    part_of: Some("4b9c6f57-e4af-43dd-ad6e-fee3644fbef4".into()),
+                    thumbnail: Some("http://localhost:8080/static/mh_default_org/engage-player/002cff10\
+                        -e0c2-4f0a-a06d-1e5c8dfef13c/11566598-693b-4f94-9787-5d420be66a3d/cat-bokeh\
+                        -x265-480p_1.000s-player.jpg".into()),
+                    slide_text: None,
+                    duration: 11440,
+                    is_live: false,
+                    start_time: None,
+                    end_time: None,
+                    tracks: vec![
+                        Track {
+                            uri: "http://localhost:8080/static/mh_default_org/engage-player/\
+                                002cff10-e0c2-4f0a-a06d-1e5c8dfef13c/7547400e-d872-4bd1-bd63-\
+                                7af340865ae5/cat-bokeh-x265-480p.mp4".into(),
+                            flavor: "presenter/preview".into(),
+                            mimetype: Some("video/mp4".into()),
+                            resolution: Some([854, 480]),
+                            is_master: None,
+                        }
+                    ],
+                    captions: vec![],
+                    segments: vec![],
+                },
+
+                HarvestItem::SeriesDeleted {
+                    id: "eec06048-703d-40b1-a058-478f8bfc13f4".into(),
+                    updated: timestamp(1727867627087),
+                },
+                HarvestItem::EventDeleted {
+                    id: "ef29ba59-2e8e-4949-acaf-8b8e42bed37e".into(),
+                    updated: timestamp(1727867851377),
+                }
+            ],
+        });
+    }
+
+    // Similar to the one above, but trimming it down to the minimal number of
+    // fields specified.
+    const MINIMAL_RESPONSE: &str = include_str!("minimal-response.json");
+
+    #[test]
+    fn can_deserialize_minimal_response() {
+        let deser = serde_json::from_str::<HarvestResponse>(MINIMAL_RESPONSE).unwrap();
+        assert_eq!(deser, HarvestResponse {
+            includes_items_until: timestamp(1727867693398),
+            has_more: false,
+            items: vec![
+                HarvestItem::Series {
+                    id: "4b9c6f57-e4af-43dd-ad6e-fee3644fbef4".into(),
+                    title: "Cats".into(),
+                    description: None,
+                    acl: Acl::default(),
+                    updated: timestamp(1727866771932),
+                    created: None,
+                    metadata: ExtraMetadata::default(),
+                },
+                HarvestItem::Event {
+                    id: "002cff10-e0c2-4f0a-a06d-1e5c8dfef13c".into(),
+                    title: "Video Of A Tabby Cat".into(),
+                    description: None,
+                    acl: Acl::default(),
+                    updated: timestamp(1727866860840),
+                    created: timestamp(1727866740000),
+                    creators: vec!["Pixabay".to_owned()],
+                    metadata: ExtraMetadata::default(),
+                    part_of: None,
+                    thumbnail: None,
+                    slide_text: None,
+                    duration: 11440,
+                    is_live: false,
+                    start_time: None,
+                    end_time: None,
+                    tracks: vec![],
+                    captions: vec![],
+                    segments: vec![],
+                },
+
+                HarvestItem::SeriesDeleted {
+                    id: "eec06048-703d-40b1-a058-478f8bfc13f4".into(),
+                    updated: timestamp(1727867627087),
+                },
+                HarvestItem::EventDeleted {
+                    id: "ef29ba59-2e8e-4949-acaf-8b8e42bed37e".into(),
+                    updated: timestamp(1727867851377),
+                }
+            ],
+        });
+    }
 }

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -62,8 +62,9 @@ pub(crate) enum HarvestItem {
         acl: Acl,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
-        #[serde(with = "chrono::serde::ts_milliseconds")]
-        created: DateTime<Utc>,
+        #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
+        created: Option<DateTime<Utc>>,
+        #[serde(default)]
         metadata: ExtraMetadata,
     },
 

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -37,12 +37,13 @@ pub(crate) enum HarvestItem {
         acl: Acl,
         is_live: bool,
         metadata: ExtraMetadata,
-        #[serde(with = "chrono::serde::ts_milliseconds_option")]
+        #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
         start_time: Option<DateTime<Utc>>,
-        #[serde(with = "chrono::serde::ts_milliseconds_option")]
+        #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
         end_time: Option<DateTime<Utc>>,
         #[serde(with = "chrono::serde::ts_milliseconds")]
         updated: DateTime<Utc>,
+        #[serde(default)]
         segments: Vec<Segment>,
         slide_text: Option<String>,
     },

--- a/backend/src/sync/harvest/v1.0-response.json
+++ b/backend/src/sync/harvest/v1.0-response.json
@@ -1,0 +1,89 @@
+{
+    "includesItemsUntil": 1727867693398,
+    "hasMore": false,
+    "items":
+    [
+        {
+            "kind": "series",
+            "description": "Several videos of cats",
+            "id": "4b9c6f57-e4af-43dd-ad6e-fee3644fbef4",
+            "acl":
+            {
+                "read":
+                [
+                    "ROLE_ANONYMOUS"
+                ],
+                "write":
+                [
+                    "ROLE_ANONYMOUS"
+                ]
+            },
+            "title": "Cats",
+            "updated": 1727866771932
+        },
+        {
+            "partOf": "4b9c6f57-e4af-43dd-ad6e-fee3644fbef4",
+            "thumbnail": "http://localhost:8080/static/mh_default_org/engage-player/002cff10-e0c2-4f0a-a06d-1e5c8dfef13c/11566598-693b-4f94-9787-5d420be66a3d/cat-bokeh-x265-480p_1.000s-player.jpg",
+            "metadata":
+            {
+                "dcterms":
+                {
+                    "license":
+                    [
+                        "CC0"
+                    ]
+                }
+            },
+            "kind": "event",
+            "created": 1727866740000,
+            "creators":
+            [
+                "Pixabay"
+            ],
+            "description": null,
+            "acl":
+            {
+                "read":
+                [
+                    "ROLE_ADMIN",
+                    "ROLE_ANONYMOUS"
+                ],
+                "write":
+                [
+                    "ROLE_ADMIN"
+                ]
+            },
+            "title": "Video Of A Tabby Cat",
+            "tracks":
+            [
+                {
+                    "flavor": "presenter/preview",
+                    "mimetype": "video/mp4",
+                    "uri": "http://localhost:8080/static/mh_default_org/engage-player/002cff10-e0c2-4f0a-a06d-1e5c8dfef13c/7547400e-d872-4bd1-bd63-7af340865ae5/cat-bokeh-x265-480p.mp4",
+                    "resolution":
+                    [
+                        854,
+                        480
+                    ]
+                }
+            ],
+            "duration": 11440,
+            "isLive": false,
+            "timelinePreview": null,
+            "startTime": null,
+            "id": "002cff10-e0c2-4f0a-a06d-1e5c8dfef13c",
+            "endTime": null,
+            "updated": 1727866860840
+        },
+        {
+            "kind": "series-deleted",
+            "id": "eec06048-703d-40b1-a058-478f8bfc13f4",
+            "updated": 1727867627087
+        },
+        {
+            "kind": "event-deleted",
+            "id": "ef29ba59-2e8e-4949-acaf-8b8e42bed37e",
+            "updated": 1727867851377
+        }
+    ]
+}


### PR DESCRIPTION
We accidentally stopped supporting old harvest APIs (i.e. requiring people to update Opencast) without realizing (and consequently, without mentioning it in the changelog). This fixes it, making Tobira harvesting work with the earliest version again, as currently promised. 

Versions v2.9, v2.10 and v2.11 are affected. The first requires Opencast 14.10, the latter two require Opencast 15.6.