### PR TITLE
Add docs about connecting to a local Opencast

### DIFF
--- a/docs/docs/dev/create-release.md
+++ b/docs/docs/dev/create-release.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Create a release

--- a/docs/docs/dev/data.md
+++ b/docs/docs/dev/data.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Database and test data

--- a/docs/docs/dev/editor.md
+++ b/docs/docs/dev/editor.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # IDE/editor setup

--- a/docs/docs/dev/local-opencast.md
+++ b/docs/docs/dev/local-opencast.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 4
+---
+
+# Using a local Opencast
+
+To connect your Tobira with your local Opencast, you don't have to do much as most things are pre-configured.
+You have to start the dev containers with `./x.sh containers start`,
+which also starts an nginx listening on `localhost:8081` and `proxy_pass`ing requests to `localhost:8080`, just adding permissive CORS headers.
+For that to work, you must configure Opencast to listen on `0.0.0.0` instead of the default `127.0.0.1`.
+To do that, change the OC configuration `etc/org.ops4j.pax.web.cfg` and set `org.ops4j.pax.web.listening.addresses` to `0.0.0.0`.
+

--- a/docs/docs/dev/tests.md
+++ b/docs/docs/dev/tests.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Tests

--- a/docs/docs/dev/various-info.md
+++ b/docs/docs/dev/various-info.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Info, Tips & Tricks

--- a/util/containers/README.md
+++ b/util/containers/README.md
@@ -13,3 +13,5 @@ There is a container for a PostgreSQL DB and a container for MeiliSearch.
 These are straight forward.
 Then there is `opencast-cors-proxy` which is just an nginx in front of Opencast to set some CORS headers that are required for the uploader in Tobira to work.
 Finally, the container `tobira-login-handler` implements a login callback with dummy users for developers, which listens on port 3091.
+
+Note: for `opencast-cors-proxy` to work, you have to configure Opencast to listen on `0.0.0.0` by adjusting `etc/org.ops4j.pax.web.cfg`.


### PR DESCRIPTION
I think this is only necessary on Linux, but doesn't hurt to add these docs either way.