### PR TITLE
Make event ACL editable via Tobira

### DIFF
--- a/backend/src/api/err.rs
+++ b/backend/src/api/err.rs
@@ -135,6 +135,10 @@ macro_rules! not_authorized {
     ($($t:tt)+) => { $crate::api::err::api_err!(NotAuthorized, $($t)*) };
 }
 
+macro_rules! internal_server_error {
+    ($($t:tt)+) => { $crate::api::err::api_err!(InternalServerError, $($t)*) };
+}
+
 macro_rules! opencast_unavailable {
     ($($t:tt)+) => { $crate::api::err::api_err!(OpencastUnavailable, $($t)*) };
 }
@@ -142,6 +146,7 @@ macro_rules! opencast_unavailable {
 pub(crate) use api_err;
 pub(crate) use invalid_input;
 pub(crate) use not_authorized;
+pub(crate) use internal_server_error;
 pub(crate) use opencast_unavailable;
 
 

--- a/backend/src/api/err.rs
+++ b/backend/src/api/err.rs
@@ -33,6 +33,9 @@ pub(crate) enum ApiErrorKind {
 
     /// Communication error with Opencast.
     OpencastUnavailable,
+
+    /// Generic Opencast error.
+    OpencastError,
 }
 
 impl ApiErrorKind {
@@ -43,6 +46,7 @@ impl ApiErrorKind {
             Self::NotAuthorized => "NOT_AUTHORIZED",
             Self::InternalServerError => "INTERNAL_SERVER_ERROR",
             Self::OpencastUnavailable => "OPENCAST_UNAVAILABLE",
+            Self::OpencastError => "OPENCAST_ERROR",
         }
     }
 
@@ -52,6 +56,7 @@ impl ApiErrorKind {
             Self::NotAuthorized => "Not authorized",
             Self::InternalServerError => "Internal server error",
             Self::OpencastUnavailable => "Opencast unavailable",
+            Self::OpencastError => "Opencast error",
         }
     }
 }
@@ -135,19 +140,19 @@ macro_rules! not_authorized {
     ($($t:tt)+) => { $crate::api::err::api_err!(NotAuthorized, $($t)*) };
 }
 
-macro_rules! internal_server_error {
-    ($($t:tt)+) => { $crate::api::err::api_err!(InternalServerError, $($t)*) };
-}
-
 macro_rules! opencast_unavailable {
     ($($t:tt)+) => { $crate::api::err::api_err!(OpencastUnavailable, $($t)*) };
+}
+
+macro_rules! opencast_error {
+    ($($t:tt)+) => { $crate::api::err::api_err!(OpencastError, $($t)*) };
 }
 
 pub(crate) use api_err;
 pub(crate) use invalid_input;
 pub(crate) use not_authorized;
-pub(crate) use internal_server_error;
 pub(crate) use opencast_unavailable;
+pub(crate) use opencast_error;
 
 
 // ===== Helper macro to inspect DbError ==================================================

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -1,5 +1,6 @@
-use juniper::GraphQLObject;
+use juniper::{GraphQLInputObject, GraphQLObject};
 use postgres_types::BorrowToSql;
+use serde::Serialize;
 
 use crate::{api::{util::TranslatedString, Context, err::ApiResult}, db::util::select};
 
@@ -93,4 +94,10 @@ where
             }),
         }
     }).await.map_err(Into::into)
+}
+
+#[derive(Debug, GraphQLInputObject, Serialize)]
+pub(crate) struct AclInputEntry {
+    pub role: String,
+    pub actions: Vec<String>,
 }

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -407,7 +407,7 @@ impl AuthorizedEvent {
 
     pub(crate) async fn delete(id: Id, context: &Context) -> ApiResult<RemovedEvent> {
         let event = Self::load_by_id(id, context)
-            .await? 
+            .await?
             .ok_or_else(|| err::invalid_input!(
                 key = "event.delete.not-found",
                 "event not found",

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -478,6 +478,10 @@ impl AuthorizedEvent {
     }
 
     pub(crate) async fn update_acl(id: Id, acl: Vec<AclInputEntry>, context: &Context) -> ApiResult<AuthorizedEvent> {
+        if !context.config.general.allow_acl_edit {
+            return Err(err::not_authorized!("editing ACLs is not allowed"));
+        }
+
         info!(event_id = %id, "Requesting ACL update of event");
         let event = Self::load_for_api(
             id,

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -381,7 +381,7 @@ impl Realm {
         self.owner_display_name.as_deref()
     }
 
-    /// Returns the acl of this realm, combining moderator and admin roles and assigns 
+    /// Returns the acl of this realm, combining moderator and admin roles and assigns
     /// the respective actions that are necessary for UI purposes.
     async fn own_acl(&self, context: &Context) -> ApiResult<Acl> {
         let raw_roles_sql = "

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -251,12 +251,12 @@ impl Realm {
             admin_roles = coalesce($3, admin_roles) \
             where id = $1",
             &[&realm.key, &permissions.moderator_roles, &permissions.admin_roles],
-        )
-        .await?;
+        ).await?;
 
         Self::load_by_key(realm.key, context).await.map(Option::unwrap).inspect_(|new| {
             info!(
-                "Updated permissions of realm {:?} ({}) from moderators: '{:?}' to '{:?}' and from admins: '{:?}' to '{:?}'",
+                "Updated permissions of realm {:?} ({}) from moderators: '{:?}' to '{:?}' \
+                and from admins: '{:?}' to '{:?}'",
                 realm.key,
                 realm.full_path,
                 realm.moderator_roles,

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -182,7 +182,7 @@ impl Series {
 
             return Ok(RemoveMountedSeriesOutcome::RemovedRealm(removed_realm));
         }
-        
+
         if old_realm.name_from_block.map(Id::block) == Some(blocks[0].id()) {
             // The realm has its name derived from the series block that is being removed - so the name
             // shouldn't be used anymore. Ideally this would restore the previous title,

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -6,6 +6,7 @@ use super::{
     err::ApiResult,
     id::Id,
     model::{
+        acl::AclInputEntry,
         series::{Series, NewSeries},
         realm::{
             ChildIndex,
@@ -65,6 +66,17 @@ impl Mutation {
     /// in subsequent harvesting results.
     async fn delete_video(id: Id, context: &Context) -> ApiResult<RemovedEvent> {
         AuthorizedEvent::delete(id, context).await
+    }
+
+    /// Updates the acl of a given event by sending the changes to Opencast.
+    /// The `acl` parameter can include `read` and `write` roles, as these are the
+    /// only roles that can be assigned in frontend for now. `preview` and
+    /// `custom_actions` will be added in the future.
+    /// If successful, the updated ACL are stored in Tobira without waiting for an upcoming sync - however
+    /// this means it might get overwritten again if the update in Opencast failed for some reason.
+    /// This solution should be improved in the future.
+    async fn update_event_acl(id: Id, acl: Vec<AclInputEntry>, context: &Context) -> ApiResult<AuthorizedEvent> {
+        AuthorizedEvent::update_acl(id, acl, context).await
     }
 
     /// Sets the order of all children of a specific realm.

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -58,7 +58,7 @@ impl Mutation {
     /// Deletes the given event. Meaning: a deletion request is sent to Opencast, the event
     /// is marked as "deletion pending" in Tobira, and fully removed once Opencast
     /// finished deleting the event.
-    /// 
+    ///
     /// Returns the deletion timestamp in case of success and errors otherwise.
     /// Note that "success" in this case only means the request was successfully sent
     /// and accepted, not that the deletion itself succeeded, which is instead checked
@@ -259,7 +259,7 @@ impl Mutation {
     /// it is renamed to its path segment. If the realm has no sub-realms,
     /// it is removed completely.
     /// Errors if the given realm does not have exactly one series block referring to the
-    /// specified series. 
+    /// specified series.
     async fn remove_series_mount_point(
         series_oc_id: String,
         path: String,

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -134,7 +134,6 @@ impl AuthContext {
         }
         Ok(())
     }
-    
 }
 
 impl User {

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -12,7 +12,7 @@ pub(crate) struct GeneralConfig {
 
     /// Public URL to Tobira (without path).
     /// Used for RSS feeds, as those require specifying absolute URLs to resources.
-    /// 
+    ///
     /// Example: "https://tobira.my-uni.edu".
     pub(crate) tobira_url: HttpHost,
 
@@ -22,12 +22,12 @@ pub(crate) struct GeneralConfig {
     /// These can be specified in multiple languages.
     /// Consent is prompted upon first use and only if this is configured. It is
     /// re-prompted when any of these values change.
-    /// 
+    ///
     /// We recommend not to configure this unless absolutely necessary,
     /// in order to not degrade the user experience needlessly.
-    /// 
+    ///
     /// Example:
-    /// 
+    ///
     /// ```
     /// initial_consent.title.en = "Terms & Conditions"
     /// initial_consent.button.en = "Agree"
@@ -49,7 +49,7 @@ pub(crate) struct GeneralConfig {
     /// add custom ones. Note that these two default links are special and can
     /// be specified with only the shown string. To add custom ones, you need
     /// to define a label and a link. The link is either the same for every language
-    /// or can be specified for each language in the same manner as the label. 
+    /// or can be specified for each language in the same manner as the label.
     /// Example:
     ///
     /// ```

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -110,6 +110,18 @@ pub(crate) struct GeneralConfig {
     /// (partial) name.
     #[config(default = false)]
     pub users_searchable: bool,
+
+    /// This allows users to edit the ACL of events they have write access for.
+    /// Doing so will update these in Opencast and start the `republish-metadata`
+    /// workflow to propagate the changes to other publications as well.
+    /// Instead of waiting for the workflow however, Tobira will also immediately
+    /// store the updated ACL in its database.
+    ///
+    /// Note that this might lead to situations where the event ACL in Tobira is different
+    /// from that in other publications, mainly if the afore mentioned workflow fails
+    /// or takes an unusually long time to complete.
+    #[config(default = true)]
+    pub allow_acl_edit: bool,
 }
 
 const INTERNAL_RESERVED_PATHS: &[&str] = &["favicon.ico", "robots.txt", ".well-known"];

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -278,6 +278,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         "initialConsent": config.general.initial_consent,
         "showDownloadButton": config.general.show_download_button,
         "usersSearchable": config.general.users_searchable,
+        "allowAclEdit": config.general.allow_acl_edit,
         "footerLinks": config.general.footer_links,
         "metadataLabels": config.general.metadata,
         "paellaPluginConfig": config.player.paella_plugin_config,

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -206,6 +206,20 @@ impl OcClient {
         self.http_client.request(req).await.map_err(Into::into)
     }
 
+    pub async fn start_workflow(&self, oc_id: &str, workflow_id: &str) -> Result<Response<Incoming>> {
+        let params = Serializer::new(String::new())
+            .append_pair("event_identifier", &oc_id)
+            .append_pair("workflow_definition_identifier", &workflow_id)
+            .finish();
+        let req = self.authed_req_builder(&self.external_api_node, "/api/workflows")
+            .method(http::Method::POST)
+            .header(http::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(params.into())
+            .expect("failed to build request");
+
+        self.http_client.request(req).await.map_err(Into::into)
+    }
+
     fn build_authed_req(&self, node: &HttpHost, path_and_query: &str) -> (Uri, Request<RequestBody>) {
         let req = self.authed_req_builder(node, path_and_query)
             .body(RequestBody::empty())

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc, TimeZone};
+use form_urlencoded::Serializer;
 use hyper::{
     Response, Request, StatusCode,
     body::Incoming,
@@ -10,10 +11,11 @@ use hyper::{
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::{connect::HttpConnector, Client};
 use secrecy::{ExposeSecret, Secret};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tap::TapFallible;
 
 use crate::{
+    api::{model::acl::AclInputEntry, Context},
     config::{Config, HttpHost},
     prelude::*,
     sync::harvest::HarvestResponse,
@@ -139,11 +141,66 @@ impl OcClient {
         Ok(out)
     }
 
-    pub async fn delete_event(&self, oc_id: &String) -> Result<Response<Incoming>> {
-        let pq = format!("/api/events/{}", oc_id);
+    pub async fn delete_event(&self, oc_id: &str) -> Result<Response<Incoming>> {
+        let pq = format!("/api/events/{oc_id}");
         let req = self.authed_req_builder(&self.external_api_node, &pq)
             .method(http::Method::DELETE)
             .body(RequestBody::empty())
+            .expect("failed to build request");
+
+        self.http_client.request(req).await.map_err(Into::into)
+    }
+
+    pub async fn update_event_acl(
+        &self,
+        oc_id: &str,
+        acl: &[AclInputEntry],
+        context: &Context,
+    ) -> Result<Response<Incoming>> {
+        let pq = format!("/api/events/{oc_id}/acl");
+
+        // Temporary solution to add custom and preview roles
+        // Todo: remove again once frontend sends these roles.
+        let extra_roles_sql = "\
+            select unnest(preview_roles) as role, 'preview' as action from events where opencast_id = $1
+            union
+            select role, key as action
+            from jsonb_each_text(
+                (select custom_action_roles from events where opencast_id = $1)
+            ) as actions(key, value)
+            cross join lateral jsonb_array_elements_text(value::jsonb) as role(role)
+        ";
+
+        let extra_roles = context.db.query_mapped(&extra_roles_sql, dbargs![&oc_id], |row| {
+            let role: String = row.get("role");
+            let action: String = row.get("action");
+            AclInput {
+                allow: true,
+                action,
+                role,
+            }
+        }).await?;
+
+        let mut access_policy = Vec::new();
+        access_policy.extend(extra_roles);
+
+        for entry in acl {
+            access_policy.extend(
+                entry.actions.iter().map(|action| AclInput {
+                    allow: true,
+                    action: action.clone(),
+                    role: entry.role.clone(),
+                }),
+            );
+        }
+
+        let params = Serializer::new(String::new())
+            .append_pair("acl", &serde_json::to_string(&access_policy).expect("Failed to serialize"))
+            .finish();
+        let req = self.authed_req_builder(&self.external_api_node, &pq)
+            .method(http::Method::PUT)
+            .header(http::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(params.into())
             .expect("failed to build request");
 
         self.http_client.request(req).await.map_err(Into::into)
@@ -210,4 +267,11 @@ impl OcClient {
 pub struct ExternalApiVersions {
     pub default: String,
     pub versions: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AclInput {
+    allow: bool,
+    action: String,
+    role: String,
 }

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -123,6 +123,19 @@
 # Default value: false
 #users_searchable = false
 
+# This allows users to edit the ACL of events they have write access for.
+# Doing so will update these in Opencast and start the `republish-metadata`
+# workflow to propagate the changes to other publications as well.
+# Instead of waiting for the workflow however, Tobira will also immediately
+# store the updated ACL in its database.
+#
+# Note that this might lead to situations where the event ACL in Tobira is different
+# from that in other publications, mainly if the afore mentioned workflow fails
+# or takes an unusually long time to complete.
+#
+# Default value: true
+#allow_acl_edit = true
+
 
 [db]
 # The username of the database user.

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -22,7 +22,7 @@
 
 # Public URL to Tobira (without path).
 # Used for RSS feeds, as those require specifying absolute URLs to resources.
-# 
+#
 # Example: "https://tobira.my-uni.edu".
 #
 # Required! This value must be specified.
@@ -34,12 +34,12 @@
 # These can be specified in multiple languages.
 # Consent is prompted upon first use and only if this is configured. It is
 # re-prompted when any of these values change.
-# 
+#
 # We recommend not to configure this unless absolutely necessary,
 # in order to not degrade the user experience needlessly.
-# 
+#
 # Example:
-# 
+#
 # ```
 # initial_consent.title.en = "Terms & Conditions"
 # initial_consent.button.en = "Agree"
@@ -62,7 +62,7 @@
 # add custom ones. Note that these two default links are special and can
 # be specified with only the shown string. To add custom ones, you need
 # to define a label and a link. The link is either the same for every language
-# or can be specified for each language in the same manner as the label. 
+# or can be specified for each language in the same manner as the label.
 # Example:
 #
 # ```

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -27,6 +27,7 @@ type Config = {
     initialConsent: InitialConsent | null;
     showDownloadButton: boolean;
     usersSearchable: boolean;
+    allowAclEdit: boolean;
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -48,6 +48,7 @@ errors:
   might-need-to-login-link: Sie müssen sich möglicherweise <1>einloggen</1>.
   invalid-input: Ungültige Eingabe.
   opencast-unavailable: Opencast ist momentan nicht erreichbar.
+  opencast-error: Unerwartete Opencast Antwort.
   internal-server-error: Interner Server-Fehler (es ist ein Problem mit dem Server aufgetreten).
   are-you-connected-to-internet: Sind Sie mit dem Internet verbunden?
   unknown: Unbekannter Fehler.
@@ -335,6 +336,11 @@ manage:
   access:
     authorized-groups: Autorisierte Gruppen
     authorized-users: Autorisierte Personen
+    editing-disabled: Bearbeitung der Zugangsberechtigungen ist deaktiviert.
+    workflow-active: >
+      Änderung der Berechtigungen ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
+      <br />
+      Bitte versuchen Sie es später nochmal.
     users-no-options:
       initial-searchable: Nach Name suchen oder exakten Nutzernamen/exakte E-Mail angeben
       none-found-searchable: Keine Personen gefunden
@@ -665,6 +671,9 @@ api-remote-errors:
     acl:
       not-found: "Zugriffsrechte konnten nicht geändert werden: Video nicht gefunden."
       not-allowed: Sie haben nicht die Berechtigung, die Zugriffsreche dieses Videos zu ändern.
+    workflow:
+      not-allowed: Sie haben nicht die Berechtigung, die Workflowaktivität für dieses Video abzufragen.
+      active: $t(manage.access.workflow-active)
 
 embed:
   not-supported: Diese Seite kann nicht eingebettet werden.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -350,8 +350,9 @@ manage:
       yourself: Sie
       subset-warning: 'Diese Auswahl ist bereits in den folgenden Gruppen enthalten: {{groups}}.'
       inherited: 'Geerbte Berechtigungen:'
-      inherited-tooltip: > 
-        Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden auf alle Unterseiten vererbt.
+      inherited-tooltip: >
+        Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden auf alle Unterseiten
+        vererbt.
       actions:
         title: Berechtigung
         read: Lesen

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -662,6 +662,9 @@ api-remote-errors:
     delete:
       not-found: Das zu löschende Video existiert nicht. Möglicherweise wurde es bereits entfernt.
       not-allowed: Sie haben nicht die Berechtigung, dieses Video zu löschen.
+    acl:
+      not-found: "Zugriffsrechte konnten nicht geändert werden: Video nicht gefunden."
+      not-allowed: Sie haben nicht die Berechtigung, die Zugriffsreche dieses Videos zu ändern.
 
 embed:
   not-supported: Diese Seite kann nicht eingebettet werden.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -47,6 +47,7 @@ errors:
   might-need-to-login-link: You might need to <1>login</1>.
   invalid-input: Invalid input.
   opencast-unavailable: Opencast is currently not available.
+  opencast-error: Opencast returned an unexpected response.
   internal-server-error: Internal server error (something is wrong with the server).
   are-you-connected-to-internet: Are you connected to the internet?
   unknown: Unknown error.
@@ -332,6 +333,11 @@ manage:
   access:
     authorized-groups: Authorized groups
     authorized-users: Authorized users
+    editing-disabled: Access policy editing is disabled.
+    workflow-active: >
+      Changing the access policy is not possible at this time, since the video is being processed in the background.
+      <br />
+      Please try again later.
     users-no-options:
       initial-searchable: Type to search for users by name (or enter exact email/username)
       none-found-searchable: No user found
@@ -640,6 +646,9 @@ api-remote-errors:
     acl:
       not-found: "Access policy update failed: video not found."
       not-allowed: You are not allowed to update the access policies of this video.
+    workflow:
+      not-allowed: You are not allowed to inquire about workflow activity of this video.
+      active: $t(manage.access.workflow-active)
 
 embed:
   not-supported: This page can't be embedded.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -637,6 +637,9 @@ api-remote-errors:
         The video you are trying to delete does not exist.
         It might have been removed already.
       not-allowed: You are not allowed to delete this video.
+    acl:
+      not-found: "Access policy update failed: video not found."
+      not-allowed: You are not allowed to update the access policies of this video.
 
 embed:
   not-supported: This page can't be embedded.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -112,7 +112,7 @@ user:
   manage-content: Manage
 
 login-page:
-  heading: Login 
+  heading: Login
   user-id: User ID
   password: Password
   bad-credentials: 'Login failed: invalid credentials.'
@@ -163,7 +163,7 @@ video:
     title: Download
     presenter: Video (speaker)
     slides: Video (presentation)
-    info: > 
+    info: >
       Here you can download the video(s) in different formats/qualities (Right click - Save as).
   manage: Manage
   start: Start

--- a/frontend/src/relay/errors.ts
+++ b/frontend/src/relay/errors.ts
@@ -115,4 +115,5 @@ export type ErrorKind = "INVALID_INPUT"
     | "NOT_AUTHORIZED"
     | "INTERNAL_SERVER_ERROR"
     | "OPENCAST_UNAVAILABLE"
+    | "OPENCAST_ERROR"
 ;

--- a/frontend/src/routes/manage/Video/Access.tsx
+++ b/frontend/src/routes/manage/Video/Access.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { boxError, currentRef, WithTooltip } from "@opencast/appkit";
+import { boxError, Card, currentRef, WithTooltip } from "@opencast/appkit";
 import { useRef, useState } from "react";
 import { LuInfo } from "react-icons/lu";
 import { graphql, useFragment, useMutation } from "react-relay";
@@ -22,6 +22,7 @@ import { READ_WRITE_ACTIONS } from "../../../util/permissionLevels";
 import { ConfirmationModalHandle } from "../../../ui/Modal";
 import { displayCommitError } from "../Realm/util";
 import { AccessUpdateAclMutation } from "./__generated__/AccessUpdateAclMutation.graphql";
+import CONFIG from "../../../config";
 
 
 export const ManageVideoAccessRoute = makeManageVideoRoute(
@@ -55,7 +56,11 @@ const AclPage: React.FC<AclPageProps> = ({ event, data }) => {
         <Breadcrumbs path={breadcrumbs} tail={t("manage.my-videos.acl.title")} />
         <PageTitle title={t("manage.my-videos.acl.title")} />
         {event.hostRealms.length < 1 && <UnlistedNote />}
-        <AccessUI {...{ event, knownRoles }} />
+        <br />
+        {CONFIG.allowAclEdit
+            ? <AccessUI {...{ event, knownRoles }} />
+            : <Card kind="info">ACL editing is disabled.</Card>
+        }
     </>;
 };
 

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -12,9 +12,10 @@ import { b64regex } from "../../util";
 import { Thumbnail } from "../../../ui/Video";
 import { SharedVideoManageQuery } from "./__generated__/SharedVideoManageQuery.graphql";
 import { Link } from "../../../router";
-import { eventId, isExperimentalFlagSet, keyOfId } from "../../../util";
+import { eventId, keyOfId } from "../../../util";
 import { DirectVideoRoute, VideoRoute } from "../../Video";
 import { ManageVideosRoute } from ".";
+import CONFIG from "../../../config";
 
 
 export const PAGE_WIDTH = 1100;
@@ -155,7 +156,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         },
     ];
 
-    if (isExperimentalFlagSet()) {
+    if (CONFIG.allowAclEdit) {
         entries.splice(1, 0, {
             url: `/~manage/videos/${id}/access`,
             page: "acl",

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { LuCornerLeftUp, LuInfo, LuShield, LuPlay, LuPenLine } from "react-icons/lu";
+import { LuCornerLeftUp, LuInfo, LuShieldCheck, LuPlay, LuPenLine } from "react-icons/lu";
 import { graphql } from "react-relay";
 
 import { RootLoader } from "../../../layout/Root";
@@ -165,7 +165,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         entries.splice(1, 0, {
             url: `/~manage/videos/${id}/access`,
             page: "acl",
-            body: <><LuShield />{t("manage.my-videos.acl.title")}</>,
+            body: <><LuShieldCheck />{t("manage.my-videos.acl.title")}</>,
         });
     }
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -296,12 +296,9 @@ type SearchUnavailable {
   dummy: Boolean
 }
 
-input UpdatePlaylistBlock {
-  playlist: ID
-  showTitle: Boolean
-  showMetadata: Boolean
-  order: VideoListOrder
-  layout: VideoListLayout
+input AclInputEntry {
+  role: String!
+  actions: [String!]!
 }
 
 type AuthorizedEvent implements Node {
@@ -337,6 +334,14 @@ type AuthorizedEvent implements Node {
     Otherwise, `false` is returned.
   """
   isReferencedByRealm(path: String!): Boolean!
+}
+
+input UpdatePlaylistBlock {
+  playlist: ID
+  showTitle: Boolean
+  showMetadata: Boolean
+  order: VideoListOrder
+  layout: VideoListLayout
 }
 
 "A block just showing some title."
@@ -547,6 +552,16 @@ type Mutation {
     in subsequent harvesting results.
   """
   deleteVideo(id: ID!): RemovedEvent!
+  """
+    Updates the acl of a given event by sending the changes to Opencast.
+    The `acl` parameter can include `read` and `write` roles, as these are the
+    only roles that can be assigned in frontend for now. `preview` and
+    `custom_actions` will be added in the future.
+    If successful, the updated ACL are stored in Tobira without waiting for an upcoming sync - however
+    this means it might get overwritten again if the update in Opencast failed for some reason.
+    This solution should be improved in the future.
+  """
+  updateEventAcl(id: ID!, acl: [AclInputEntry!]!): AuthorizedEvent!
   """
     Sets the order of all children of a specific realm.
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -322,6 +322,8 @@ type AuthorizedEvent implements Node {
   "Whether the current user has write access to this event."
   canWrite: Boolean!
   tobiraDeletionTimestamp: DateTimeUtc
+  "Whether the event has active workflows."
+  hasActiveWorkflows: Boolean!
   series: Series
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -786,28 +786,26 @@ type AclEditButtonsProps = {
     saveModalRef: React.RefObject<ConfirmationModalHandle>;
 }
 
-export const AclEditButtons: React.FC<AclEditButtonsProps> = (
-    {
-        selections,
-        setSelections,
-        initialAcl,
-        onSubmit,
-        className,
-        inFlight,
-        inheritedAcl,
-        userIsOwner,
-        saveModalRef,
-        kind,
-    }
-) => {
+export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
+    selections,
+    setSelections,
+    initialAcl,
+    onSubmit,
+    className,
+    inFlight,
+    inheritedAcl,
+    userIsOwner,
+    saveModalRef,
+    kind,
+}) => {
     const { t } = useTranslation();
     const user = useUser();
     const resetModalRef = useRef<ModalHandle>(null);
 
-    const containsUser = (acl: Acl) => isRealUser(user) && (userIsOwner || user.roles.some(r =>
-        r === COMMON_ROLES.ADMIN
-        || acl.get(r)?.actions.has(kind)
-        || inheritedAcl?.get(r)?.actions.has(kind))
+    const containsUser = (acl: Acl) => isRealUser(user) && (
+        userIsOwner || user.roles.some(r => r === COMMON_ROLES.ADMIN
+            || acl.get(r)?.actions.has(kind)
+            || inheritedAcl?.get(r)?.actions.has(kind))
     );
 
     const selectionIsInitial = selections.size === initialAcl.size
@@ -817,8 +815,9 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = (
         });
 
     const submit = onSubmit;
+    const buttonsDisabled = inFlight || selectionIsInitial;
 
-    useNavBlocker(!selectionIsInitial);
+    useNavBlocker(inFlight || !selectionIsInitial);
 
     return (
         <div {...{ className }} css={{
@@ -829,9 +828,9 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = (
         }}>
             {/* Reset button */}
             <Button
-                disabled={selectionIsInitial}
+                disabled={buttonsDisabled}
                 onClick={() => currentRef(resetModalRef).open()}
-                css={{ ...!selectionIsInitial && { ":hover": { color: COLORS.danger0 } } }}
+                css={{ ...!buttonsDisabled && { ":hover": { color: COLORS.danger0 } } }}
             >
                 {t("manage.access.reset-modal.label")}
             </Button>
@@ -856,13 +855,12 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = (
 
             {/* Save button */}
             <Button
-                disabled={selectionIsInitial}
-                onClick={() =>
-                    !containsUser(selections)
-                        ? currentRef(saveModalRef).open()
-                        : submit(selections)
+                disabled={buttonsDisabled}
+                onClick={() => !containsUser(selections)
+                    ? currentRef(saveModalRef).open()
+                    : submit(selections)
                 }
-                css={{ ...!selectionIsInitial && { ":hover": { color: COLORS.happy0 } } }}
+                css={{ ...!buttonsDisabled && { ":hover": { color: COLORS.happy0 } } }}
             >{t("general.action.save")}</Button>
             {inFlight && <div css={{ marginTop: 16 }}><Spinner size={20} /></div>}
             <ConfirmationModal

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -828,6 +828,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
         }}>
             {/* Reset button */}
             <Button
+                kind="danger"
                 disabled={buttonsDisabled}
                 onClick={() => currentRef(resetModalRef).open()}
                 css={{ ...!buttonsDisabled && { ":hover": { color: COLORS.danger0 } } }}
@@ -855,6 +856,8 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
 
             {/* Save button */}
             <Button
+                type="submit"
+                kind="call-to-action"
                 disabled={buttonsDisabled}
                 onClick={() => !containsUser(selections)
                     ? currentRef(saveModalRef).open()

--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -1,7 +1,7 @@
-import { i18n, ParseKeys } from "i18next";
+import { i18n } from "i18next";
 import React from "react";
 import { ReactNode } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { match } from "@opencast/appkit";
 
 import { APIError, NotJson, ServerError } from "../relay";
@@ -24,7 +24,7 @@ type ErrorDisplayInfo = {
      * A list of causes: human readable strings (already translated). Usually
      * contains a single element.
      */
-    causes: Set<string>;
+    causes: Set<ReactNode>;
 
     /**
      * If `true`, this error is likely caused by a programming bug or server
@@ -67,13 +67,16 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
     } else if (error instanceof APIError) {
         // OK response, but it contained GraphQL errors.
         const kinds = new Set();
-        const causes = new Set<string>();
+        const causes = new Set<ReactNode>();
         let notOurFault = true;
         for (const err of error.errors) {
             // Use a message fitting to the exact error key, if it is present.
             const translationKey = err.key ? `api-remote-errors.${err.key}` : null;
             if (translationKey && i18n.exists(translationKey)) {
-                const msg = t(translationKey as ParseKeys);
+                // @ts-expect-error: Dynamically passed i18next keys need to be typed
+                // more strictly than just `string` or `ParseKeys` for the `<Trans>`
+                // component.
+                const msg = <Trans i18nKey={translationKey} />;
                 causes.add(msg);
                 continue;
             }
@@ -107,7 +110,7 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
                     },
                     OPENCAST_ERROR: () => {
                         notOurFault = false;
-                        return "errors.opencast-error";
+                        return t("errors.opencast-error");
                     },
                 });
                 causes.add(msg);
@@ -154,8 +157,8 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ failedAction, ...pro
         <p css={textColor}>
             {failedAction && failedAction + " "}
             {causes.length === 1
-                ? causes[0] + " "
-                : <ul>{causes.map(cause => <li key={cause}>{cause}</li>)}</ul>
+                ? <>{causes[0]}{" "}</>
+                : <ul>{causes.map(cause => <li key={cause?.toString()}>{cause}</li>)}</ul>
             }
             {info.potentiallyInternetProblem && t("errors.are-you-connected-to-internet")}
         </p>

--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -105,6 +105,10 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
                         notOurFault = false;
                         return t("errors.opencast-unavailable");
                     },
+                    OPENCAST_ERROR: () => {
+                        notOurFault = false;
+                        return "errors.opencast-error";
+                    },
                 });
                 causes.add(msg);
             }


### PR DESCRIPTION
This will allow users to update event ACL in Opencast via Tobira. Doing so will trigger the `republish-metadata` workflow, so the changes will be propagated to all publications.

Closes #1264 
<sub>can be reviewed commit by commit<sub>