### PR TITLE
Enable footer links to break into multiple lines

### DIFF
--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -20,8 +20,10 @@ export const Footer: React.FC = () => {
                 listStyle: "none",
                 margin: 0,
                 padding: 0,
+                display: "flex",
+                justifyContent: "center",
+                flexWrap: "wrap",
                 "& > li": {
-                    display: "inline",
                     "&:not(:first-child):before": {
                         content: "\"•\"",
                         color: COLORS.neutral60,


### PR DESCRIPTION
Before, when each footer link contained only a single word, it was unable to break at all, resulting in horizontal scrolling on small screens.