### PR TITLE
Allow configuring logos for multiple languages

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -53,12 +53,9 @@ poll_period = "1min"
 interpret_eth_passwords = true
 
 [theme]
-logo.large.path = "/opt/tobira/{{ id }}/logo-large.svg"
-logo.large.resolution = [643, 217]
-logo.large_dark.path = "/opt/tobira/{{ id }}/logo-large-dark.svg"
-logo.large_dark.resolution = [643, 217]
-logo.small.path = "/opt/tobira/{{ id }}/logo-small.svg"
-logo.small.resolution = [102, 115]
-logo.small_dark.path = "/opt/tobira/{{ id }}/logo-small.svg"
-logo.small_dark.resolution = [212, 182]
 favicon = "/opt/tobira/{{ id }}/favicon.svg"
+logos = [
+    { path = "/opt/tobira/{{ id }}/logo-large.svg",  mode = "light", size = "wide", resolution = [425, 182] },
+    { path = "/opt/tobira/{{ id }}/logo-large-dark.svg", mode = "dark", size = "wide", resolution = [425, 182] },
+    { path = "/opt/tobira/{{ id }}/logo-small.svg", size = "narrow", resolution = [212, 182] },
+]

--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -6,7 +6,7 @@ users_searchable = true
 [general.metadata]
 dcterms.source = "builtin:source"
 dcterms.license = "builtin:license"
-dcterms.spatial = { en = "Location", de = "Ort" }
+dcterms.spatial = { default = "Location", de = "Ort" }
 
 [db]
 database = "tobira-{{ id }}"

--- a/backend/src/cmd/check.rs
+++ b/backend/src/cmd/check.rs
@@ -103,13 +103,8 @@ fn print_outcome<T>(any_errors: &mut bool, label: &str, result: &Result<T>) {
 async fn check_referenced_files(config: &Config) -> Result<()> {
     // TODO: log file & unix socket?
 
-    let mut files = vec![
-        &config.theme.favicon,
-        &config.theme.logo.large.path,
-    ];
-    files.extend(config.theme.logo.small.as_ref().map(|l| &l.path));
-    files.extend(config.theme.logo.large_dark.as_ref().map(|l| &l.path));
-    files.extend(config.theme.logo.small_dark.as_ref().map(|l| &l.path));
+    let mut files = vec![&config.theme.favicon];
+    files.extend(config.theme.logos.iter().map(|logo| &logo.path));
     files.extend(&config.theme.font.files);
     files.extend(&config.theme.font.extra_css);
     files.extend(config.auth.jwt.secret_key.as_ref());

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -161,14 +161,7 @@ impl Config {
             fix_path(&base, p);
         }
 
-        fix_path(&base, &mut self.theme.logo.large.path);
-        if let Some(logo) = &mut self.theme.logo.small {
-            fix_path(&base, &mut logo.path);
-        }
-        if let Some(logo) = &mut self.theme.logo.large_dark {
-            fix_path(&base, &mut logo.path);
-        }
-        if let Some(logo) = &mut self.theme.logo.small_dark {
+        for logo in &mut self.theme.logos {
             fix_path(&base, &mut logo.path);
         }
         fix_path(&base, &mut self.theme.favicon);

--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -1,7 +1,7 @@
 use std::{fmt, path::PathBuf};
 use serde::{Deserialize, Serialize};
 
-use super::color::ColorConfig;
+use super::{color::ColorConfig, translated_string::LangKey};
 
 
 #[derive(Debug, confique::Config)]
@@ -42,7 +42,7 @@ pub(crate) struct ThemeConfig {
 pub(crate) struct LogoDef {
     pub(crate) size: Option<LogoSize>,
     pub(crate) mode: Option<LogoMode>,
-    pub(crate) lang: Option<String>,
+    pub(crate) lang: Option<LangKey>,
     pub(crate) path: PathBuf,
     pub(crate) resolution: LogoResolution,
 }

--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -1,4 +1,5 @@
-use std::{path::PathBuf, fmt};
+use std::{fmt, path::PathBuf};
+use serde::{Deserialize, Serialize};
 
 use super::color::ColorConfig;
 
@@ -10,13 +11,24 @@ pub(crate) struct ThemeConfig {
     #[config(default = 85)]
     pub(crate) header_height: u32,
 
-    /// Logo used in the top left corner of the page. Using SVG logos is recommended.
-    /// See the documentation on theming/logos for more info!
-    #[config(nested)]
-    pub(crate) logo: LogoConfig,
-
     /// Path to an SVG file that is used as favicon.
     pub(crate) favicon: PathBuf,
+
+    /// Logo used in the top left corner of the page. Using SVG logos is recommended.
+    /// You can configure specific logos for small and large screens, dark and light mode,
+    /// and any number of languages. Example:
+    ///
+    /// ```
+    /// logos = [
+    ///     { path = "logo-large.svg", resolution = [425, 182] },
+    ///     { path = "logo-large-en.svg", lang = "en", resolution = [425, 182] },
+    ///     { path = "logo-large-dark.svg", mode = "dark", resolution = [425, 182] },
+    ///     { path = "logo-small.svg", size = "narrow", resolution = [212, 182] },
+    /// ]
+    /// ```
+    ///
+    /// See the documentation on theming/logos for more info and additional examples!
+    pub(crate) logos: Vec<LogoDef>,
 
     /// Colors used in the UI. Specified in sRGB.
     #[config(nested)]
@@ -26,36 +38,42 @@ pub(crate) struct ThemeConfig {
     pub(crate) font: FontConfig,
 }
 
-
-#[derive(Debug, confique::Config)]
-pub(crate) struct LogoConfig {
-    /// The normal, usually wide logo that is shown on desktop screens. The
-    /// value is a map with a `path` and `resolution` key:
-    ///
-    ///     large = { path = "logo.svg", resolution = [20, 8] }
-    ///
-    /// The resolution is only an aspect ratio. It is used to avoid layout
-    /// shifts in the frontend by allocating the correct size for the logo
-    /// before the browser loaded the file.
-    pub(crate) large: LogoDef,
-
-    /// A less wide logo used for narrow screens.
-    pub(crate) small: Option<LogoDef>,
-    
-    /// Large logo for dark mode usage.
-    pub(crate) large_dark: Option<LogoDef>,
-
-    /// Small logo for dark mode usage.
-    pub(crate) small_dark: Option<LogoDef>,
-}
-
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct LogoDef {
+    pub(crate) size: Option<LogoSize>,
+    pub(crate) mode: Option<LogoMode>,
+    pub(crate) lang: Option<String>,
     pub(crate) path: PathBuf,
     pub(crate) resolution: LogoResolution,
 }
 
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogoSize {
+    Wide,
+    Narrow,
+}
+
+impl fmt::Display for LogoSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogoMode {
+    Light,
+    Dark,
+}
+
+impl fmt::Display for LogoMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct LogoResolution(pub(crate) [u32; 2]);
 
 impl fmt::Debug for LogoResolution {

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -247,7 +247,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         .map(|logo| json!({
             "size": logo.size.as_ref().map(ToString::to_string),
             "mode": logo.mode.as_ref().map(ToString::to_string),
-            "lang": logo.lang.clone(),
+            "lang": logo.lang.as_ref().map(ToString::to_string),
             "path": generate_http_path(logo),
             "resolution": logo.resolution,
         }))

--- a/backend/src/sync/stats.rs
+++ b/backend/src/sync/stats.rs
@@ -86,8 +86,6 @@ struct ConfigStats {
     logout_link_overridden: bool,
     /// Value of `auth.pre_auth_external_links`.
     uses_pre_auth: bool,
-    /// Whether `theme.logo.small` is set.
-    has_narrow_logo: bool,
 }
 
 
@@ -118,7 +116,6 @@ impl Stats {
                 login_link_overridden: config.auth.login_link.is_some(),
                 logout_link_overridden: config.auth.logout_link.is_some(),
                 uses_pre_auth: config.auth.pre_auth_external_links,
-                has_narrow_logo: config.theme.logo.small.is_some(),
             },
         })
     }

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -533,30 +533,23 @@
 # Required! This value must be specified.
 #favicon =
 
-
 # Logo used in the top left corner of the page. Using SVG logos is recommended.
-# See the documentation on theming/logos for more info!
-[theme.logo]
-# The normal, usually wide logo that is shown on desktop screens. The
-# value is a map with a `path` and `resolution` key:
+# You can configure specific logos for small and large screens, dark and light mode,
+# and any number of languages. Example:
 #
-#     large = { path = "logo.svg", resolution = [20, 8] }
+# ```
+# logos = [
+#     { path = "logo-large.svg", resolution = [425, 182] },
+#     { path = "logo-large-en.svg", lang = "en", resolution = [425, 182] },
+#     { path = "logo-large-dark.svg", mode = "dark", resolution = [425, 182] },
+#     { path = "logo-small.svg", size = "narrow", resolution = [212, 182] },
+# ]
+# ```
 #
-# The resolution is only an aspect ratio. It is used to avoid layout
-# shifts in the frontend by allocating the correct size for the logo
-# before the browser loaded the file.
+# See the documentation on theming/logos for more info and additional examples!
 #
 # Required! This value must be specified.
-#large =
-
-# A less wide logo used for narrow screens.
-#small =
-
-# Large logo for dark mode usage.
-#large_dark =
-
-# Small logo for dark mode usage.
-#small_dark =
+#logos =
 
 
 # Colors used in the UI. Specified in sRGB.

--- a/docs/docs/setup/theme.md
+++ b/docs/docs/setup/theme.md
@@ -21,14 +21,57 @@ Once the logo file is created and configured, adjust `header_height` to your lik
 This is the height of the header (and thus also your logo) in pixels.
 Only the logo is stretched, all other elements are vertically centered within the header.
 
-You can also configure a second logo file as `logo.small` which is used for narrow screens (e.g. phones).
-This is usually roughly square.
-We strongly recommend setting this smaller logo, as otherwise, the main logo (especially if it is very wide) might get shrunk on narrow screens in order to still show the other elements in the header.
 
-You should also test if the logo is  properly configured for dark mode:
-- To use a different image for dark mode, set `logo.large_dark` and `logo.small_dark` appropriately.
-- If your normal logo already works well for dark mode, set `logo.large_dark` and `logo.small_dark` to the same values as `large` and `small`, respectively.
-- If `logo.large_dark` and `logo.small_dark` are not set, `large` and `small` are used, but with all colors inverted. This might work for you in special cases, e.g. if your logo is fully black or transparent.
+You can configure different logo files for different cases, depending on device-size (mobile vs desktop), color scheme (light vs dark) and language. In the simplest case of using a single logo for all cases, your config looks like this:
+
+```toml title=config.toml
+[theme]
+logos = [
+    { path = "logo.svg", resolution = [20, 8] },
+]
+```
+
+Note that the resolution is only an aspect ratio that is used to prevent layout shifts.
+
+Most likely, you want to configure different logos for desktop and mobile, for example.
+You can do that by duplicating the line and adding `size = "narrow"` and `size = "wide"` to the entries:
+
+```toml title=config.toml
+[theme]
+logos = [
+    { size = "wide", path = "logo-desktop.svg", resolution = [20, 8] },
+    { size = "narrow", path = "logo-mobile.svg", resolution = [1, 1] },
+]
+```
+
+You can split these entries further by adding `mode = "light"` and `mode = "dark"`.
+Let's say you only need to configure a dark version of your large logo, as your small one works well in dark mode already:
+
+```toml title=config.toml
+[theme]
+logos = [
+    { size = "wide", mode = "light", path = "logo-desktop-light.svg", resolution = [20, 8] },
+    { size = "wide", mode = "dark", path = "logo-desktop-dark.svg", resolution = [20, 8] },
+    { size = "narrow", path = "logo-mobile.svg", resolution = [1, 1] },
+]
+```
+
+Finally, you can add the `lang = ".."` field to specify different logos for different languages (e.g. `"en"` and `"de"`).
+Here, `"*"` can be specified as the default logo when there is no logo specified for a specific language.
+Continuing the example, lets say the wide logos are language specific in that we have a specific logo for German and want to use another one for all other languages.
+
+```toml title=config.toml
+[theme]
+logos = [
+    { size = "wide", mode = "light", lang = "*", path = "logo-desktop-light.svg", resolution = [20, 8] },
+    { size = "wide", mode = "light", lang = "de", path = "logo-desktop-light-de.svg", resolution = [20, 8] },
+    { size = "wide", mode = "dark", lang = "*", path = "logo-desktop-dark.svg", resolution = [20, 8] },
+    { size = "wide", mode = "dark", lang = "de", path = "logo-desktop-dark-de.svg", resolution = [20, 8] },
+    { size = "narrow", path = "logo-mobile.svg", resolution = [1, 1] },
+]
+```
+
+The order in which these distinguishing fields (`size`, `mode`, `lang`) are added is up to you, and you can can split and merge these entries however you like, as long as for each specific case (i.e. tuple of `(size, mode, lang)`), there is exactly one applicable logo definition.
 
 
 ## Favicon

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -31,7 +31,7 @@ type Config = {
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;
-    logo: LogoConfig;
+    logos: LogoConfig;
     plyr: PlyrConfig;
     upload: UploadConfig;
     paellaPluginConfig: object;
@@ -63,16 +63,12 @@ type AuthConfig = {
 };
 
 type LogoConfig = {
-    large: SingleLogoConfig;
-    small: SingleLogoConfig | null;
-    largeDark: SingleLogoConfig | null;
-    smallDark: SingleLogoConfig | null;
-};
-
-type SingleLogoConfig = {
+    size: "wide" | "narrow"| null;
+    mode: "light" | "dark"| null;
+    lang: string | null;
     path: string;
     resolution: number[];
-};
+}[];
 
 type PlyrConfig = {
     blankVideo: string;

--- a/frontend/src/layout/header/Logo.tsx
+++ b/frontend/src/layout/header/Logo.tsx
@@ -1,18 +1,20 @@
 import { useTranslation } from "react-i18next";
-import { screenWidthAbove, screenWidthAtMost, useColorScheme } from "@opencast/appkit";
+import { screenWidthAbove, screenWidthAtMost } from "@opencast/appkit";
 
 import CONFIG from "../../config";
 import { BREAKPOINT_SMALL } from "../../GlobalStyle";
 import { Link } from "../../router";
 import { focusStyle } from "../../ui";
-import { translatedConfig } from "../../util";
+import { translatedConfig, useLogoConfig } from "../../util";
 import { HEADER_BASE_PADDING } from "./ui";
 import { COLORS } from "../../color";
 
 
 export const Logo: React.FC = () => {
     const { t, i18n } = useTranslation();
-    const isDark = useColorScheme().scheme === "dark";
+    const logos = useLogoConfig();
+
+    const alt = t("general.logo-alt", { title: translatedConfig(CONFIG.siteTitle, i18n) });
 
     // This is a bit tricky: we want to specify the `width` and `height`
     // attributes on the `img` elements in order to avoid layout shift. That
@@ -32,24 +34,6 @@ export const Logo: React.FC = () => {
     // The solution is to calculate the correct `flex-basis` for the `<a>`
     // element manually.
 
-    const large = CONFIG.logo.large;
-    const small = CONFIG.logo.small ?? CONFIG.logo.large;
-    const largeDark = CONFIG.logo.largeDark ?? CONFIG.logo.large;
-    const smallDark = CONFIG.logo.smallDark
-        ?? CONFIG.logo.largeDark
-        ?? CONFIG.logo.small
-        ?? CONFIG.logo.large;
-
-    // If the dark logos are not specified, we default to the white ones but
-    // inverting them.
-    const invertLargeDark = CONFIG.logo.largeDark === null;
-    const invertSmallDark = CONFIG.logo.smallDark === null && CONFIG.logo.largeDark === null;
-
-    const alt = t("general.logo-alt", { title: translatedConfig(CONFIG.siteTitle, i18n) });
-    const invertCss = {
-        filter: "invert(100%) hue-rotate(180deg)",
-    };
-
     return (
         <Link to="/" css={{
             height: `calc(100% + ${HEADER_BASE_PADDING * 2}px)`,
@@ -66,24 +50,22 @@ export const Logo: React.FC = () => {
             },
         }}>
             <img
-                width={(isDark ? largeDark : large).resolution[0]}
-                height={(isDark ? largeDark : large).resolution[1]}
-                src={(isDark ? largeDark : large).path}
+                width={logos.wide.resolution[0]}
+                height={logos.wide.resolution[1]}
+                src={logos.wide.path}
                 alt={alt}
                 css={{
-                    ...isDark && invertLargeDark && invertCss,
                     [screenWidthAtMost(BREAKPOINT_SMALL)]: {
                         display: "none",
                     },
                 }}
             />
             <img
-                width={(isDark ? smallDark : small).resolution[0]}
-                height={(isDark ? smallDark : small).resolution[1]}
-                src={(isDark ? smallDark : small).path}
+                width={logos.narrow.resolution[0]}
+                height={logos.narrow.resolution[1]}
+                src={logos.narrow.path}
                 alt={alt}
                 css={{
-                    ...isDark && invertSmallDark && invertCss,
                     [screenWidthAbove(BREAKPOINT_SMALL)]: {
                         display: "none",
                     },

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -1,7 +1,7 @@
 import { i18n } from "i18next";
 import { MutableRefObject, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { bug, match } from "@opencast/appkit";
+import { bug, match, useColorScheme } from "@opencast/appkit";
 
 import CONFIG, { TranslatedString } from "../config";
 import { TimeUnit } from "../ui/Input";
@@ -260,3 +260,25 @@ export const getCredentials = (kind: IdKind, id: string): Credentials => {
 
 export const credentialsStorageKey = (kind: IdKind, id: string) =>
     CREDENTIALS_STORAGE_KEY + kind + "-" + id;
+
+export const useLogoConfig = () => {
+    const { i18n } = useTranslation();
+    const mode = useColorScheme().scheme;
+    const lang = i18n.resolvedLanguage;
+    const logos = CONFIG.logos;
+
+    const findLogo = (size: "wide" | "narrow") => logos
+        .filter(l => l.size === size || !l.size)
+        .filter(l => l.mode === mode || !l.mode)
+        .find(l => l.lang === lang || !l.lang);
+
+    const wide = findLogo("wide");
+    const narrow = findLogo("narrow");
+
+    if (!wide || !narrow) {
+        // Shouldn't happen™, but helps with type safety.
+        bug("missing logos in configuration");
+    }
+
+    return { wide, narrow };
+};

--- a/frontend/tests/util/isolation.ts
+++ b/frontend/tests/util/isolation.ts
@@ -61,6 +61,12 @@ export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
             ["serve", "--config", configPath],
             // { stdio: "inherit" }
         );
+        tobiraProcess.addListener("exit", code => {
+            if (code != null) {
+                throw new Error(`Failed to start Tobira process (exit code ${code}). `
+                    + 'Invalid config? (Hint: try setting stdio: "inherit" in isolation.ts)');
+            }
+        });
         await waitPort({ port, interval: 10, output: "silent" });
 
 

--- a/frontend/tests/util/isolation.ts
+++ b/frontend/tests/util/isolation.ts
@@ -112,6 +112,7 @@ const runTobiraCommand = async (tobira: TobiraProcess, args: string[]) =>
 
 
 // TODO: DB
+/* eslint-disable max-len */
 const tobiraConfig = ({ index, port, dbName, rootPath }: {
     index: number;
     port: number;
@@ -151,13 +152,10 @@ const tobiraConfig = ({ index, port, dbName, rootPath }: {
     password = "opencast"
 
     [theme]
-    logo.large.path = "${rootPath}/util/dev-config/logo-large.svg"
-    logo.large.resolution = [425, 182]
-    logo.large_dark.path = "${rootPath}/util/dev-config/logo-large-dark.svg"
-    logo.large_dark.resolution = [425, 182]
-    logo.small.path = "${rootPath}/util/dev-config/logo-small.svg"
-    logo.small.resolution = [212, 182]
-    logo.small_dark.path = "${rootPath}/util/dev-config/logo-small.svg"
-    logo.small_dark.resolution = [212, 182]
     favicon = "${rootPath}/util/dev-config/favicon.svg"
+    logos = [
+        { path = "${rootPath}/util/dev-config/logo-large.svg", mode = "light", size = "wide", resolution = [425, 182] },
+        { path = "${rootPath}/util/dev-config/logo-large-dark.svg", mode = "dark", size = "wide", resolution = [425, 182] },
+        { path = "${rootPath}/util/dev-config/logo-small.svg", size = "narrow", resolution = [212, 182] }
+    ]
 `;

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -45,14 +45,6 @@ preferred_harvest_size = 3
 interpret_eth_passwords = true
 
 [theme]
-logo.large.path = "logo-large.svg"
-logo.large.resolution = [425, 182]
-logo.large_dark.path = "logo-large-dark.svg"
-logo.large_dark.resolution = [425, 182]
-logo.small.path = "logo-small.svg"
-logo.small.resolution = [212, 182]
-logo.small_dark.path = "logo-small.svg"
-logo.small_dark.resolution = [212, 182]
 favicon = "favicon.svg"
 # color.primary = "#215CAF" # ETH Blau
 # color.primary = "#627313" # ETH Grün
@@ -60,3 +52,9 @@ favicon = "favicon.svg"
 # color.primary = "#B7352D" # ETH Rot
 # color.primary = "#A7117A" # ETH Purpur
 # color.primary = "#4B67AB" # Bern Blue
+
+logos = [
+    { path = "logo-large.svg", mode = "light", size = "wide", resolution = [425, 182] },
+    { path = "logo-large-dark.svg", mode = "dark", size = "wide", resolution = [425, 182] },
+    { path = "logo-small.svg", size = "narrow", resolution = [212, 182] },
+]


### PR DESCRIPTION
This will make it possible to configure logos for any number of languages (though for now, Tobira only knows what to do with english, german and non-language-specific logos).

This is a breaking change, as it changes the way logo files are configured. Previous configurations won't work anymore.
Specifics and examples for the new configuration will be available in our docs.

Closes #1271 