### PR TITLE
Move config sync.{user,password} to opencast.*

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -45,10 +45,10 @@ file = "/var/log/tobira/{{ id }}-${cmd}.log"
 
 [opencast]
 host = "https://tobira-test-oc.ethz.ch"
-
-[sync]
 user = "admin"
 password = "{{ opencast_admin_password }}"
+
+[sync]
 poll_period = "1min"
 interpret_eth_passwords = true
 

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -47,8 +47,8 @@ impl OcClient {
             http_client: crate::util::http_client()?,
             sync_node: config.opencast.sync_node().clone(),
             external_api_node: config.opencast.external_api_node().clone(),
-            auth_header: config.sync.basic_auth_header(),
-            username: config.sync.user.clone(),
+            auth_header: config.opencast.basic_auth_header(),
+            username: config.opencast.user.clone(),
         })
     }
 

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -1,5 +1,3 @@
-use base64::Engine as _;
-use secrecy::{ExposeSecret as _, Secret};
 use core::fmt;
 use std::time::Duration;
 
@@ -41,14 +39,6 @@ pub(crate) async fn check_compatibility(client: &OcClient) -> Result<()> {
 
 #[derive(Debug, confique::Config)]
 pub(crate) struct SyncConfig {
-    /// Username of the user used to communicate with Opencast for data syncing.
-    /// This user has to have access to all events and series. Currently, that
-    /// user has to be admin.
-    user: String,
-
-    /// Password of the user used to communicate with Opencast.
-    password: Secret<String>,
-
     /// A rough estimate of how many items (events & series) are transferred in
     /// each HTTP request while harvesting (syncing) with the Opencast
     /// instance.
@@ -82,15 +72,6 @@ pub(crate) struct SyncConfig {
     /// load on Opencast, increase to speed up download a bit.
     #[config(default = 8)]
     concurrent_download_tasks: u8,
-}
-
-impl SyncConfig {
-    pub(crate) fn basic_auth_header(&self) -> Secret<String> {
-        let credentials = format!("{}:{}", self.user, self.password.expose_secret());
-        let encoded_credentials = base64::engine::general_purpose::STANDARD.encode(credentials);
-        let auth_header = format!("Basic {}", encoded_credentials);
-        Secret::new(auth_header)
-    }
 }
 
 /// Version of the Tobira-module API in Opencast.

--- a/backend/src/sync/text/mod.rs
+++ b/backend/src/sync/text/mod.rs
@@ -321,7 +321,7 @@ impl Context {
 
             let mut headers = header::HeaderMap::new();
             let mut header_value = header::HeaderValue::try_from(
-                config.sync.basic_auth_header().expose_secret()
+                config.opencast.basic_auth_header().expose_secret()
             ).unwrap();
             header_value.set_sensitive(true);
             headers.insert(header::AUTHORIZATION, header_value);

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -440,9 +440,8 @@
 # Default value: []
 #other_hosts = []
 
-
-[sync]
-# Username of the user used to communicate with Opencast for data syncing.
+# Username of the user used to communicate with Opencast for data syncing
+# and external API authentication.
 # This user has to have access to all events and series. Currently, that
 # user has to be admin.
 #
@@ -454,6 +453,8 @@
 # Required! This value must be specified.
 #password =
 
+
+[sync]
 # A rough estimate of how many items (events & series) are transferred in
 # each HTTP request while harvesting (syncing) with the Opencast
 # instance.

--- a/frontend/tests/util/isolation.ts
+++ b/frontend/tests/util/isolation.ts
@@ -147,8 +147,6 @@ const tobiraConfig = ({ index, port, dbName, rootPath }: {
 
     [opencast]
     host = "https://dummy.invalid" # Not used in UI tests
-
-    [sync]
     user = "admin"
     password = "opencast"
 

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -37,10 +37,10 @@ secret_key = "jwt-key.pem"
 
 [opencast]
 host = "http://localhost:8081"
-
-[sync]
 user = "admin"
 password = "opencast"
+
+[sync]
 preferred_harvest_size = 3
 interpret_eth_passwords = true
 


### PR DESCRIPTION
Does the thing.

Closes https://github.com/elan-ev/tobira/issues/1219