### PR TITLE
Skip buggy search UI test for firefox

### DIFF
--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -3,7 +3,9 @@ import { test } from "./util/data";
 import { login, logout } from "./util/user";
 
 
-test("Search", async ({ page, standardData, activeSearchIndex }) => {
+test("Search", async ({ page, browserName, standardData, activeSearchIndex }) => {
+    test.skip(browserName === "firefox", "Test is buggy in Firefox somehow...");
+
     await page.goto("/");
     await page.waitForSelector("nav");
     const searchField = page.getByPlaceholder("Search");


### PR DESCRIPTION
We tried fixing it but at this point, we give up. The error is just really weird. We can only reproduce it locally very rarely, it happens very regularly in CI though. It only happens in Firefox, the error is really weird (Element not visible, but we asserted it visible in the line before) and the trace is also useless for debugging this somehow.