### PR TITLE
Add config to lock video ACLs to their series

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -334,6 +334,8 @@ impl AuthorizedEvent {
                     synced_data: None,
                     created: None,
                     metadata: None,
+                    read_roles: vec![],
+                    write_roles: vec![],
                 }))
             } else {
                 // We need to load the series as fields were requested that were not preloaded.

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -122,6 +122,11 @@ pub(crate) struct GeneralConfig {
     /// or takes an unusually long time to complete.
     #[config(default = true)]
     pub allow_acl_edit: bool,
+
+    /// Activating this will disable ACL editing for events that are part of a series.
+    /// For the uploader, this means that the ACL of the series will be used.
+    #[config(default = false)]
+    pub lock_acl_to_series: bool,
 }
 
 const INTERNAL_RESERVED_PATHS: &[&str] = &["favicon.ico", "robots.txt", ".well-known"];

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -282,6 +282,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         "showDownloadButton": config.general.show_download_button,
         "usersSearchable": config.general.users_searchable,
         "allowAclEdit": config.general.allow_acl_edit,
+        "lockAclToSeries": config.general.lock_acl_to_series,
         "footerLinks": config.general.footer_links,
         "metadataLabels": config.general.metadata,
         "paellaPluginConfig": config.player.paella_plugin_config,

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -137,6 +137,12 @@
 # Default value: true
 #allow_acl_edit = true
 
+# Activating this will disable ACL editing for events that are part of a series.
+# For the uploader, this means that the ACL of the series will be used.
+#
+# Default value: false
+#lock_acl_to_series = false
+
 
 [db]
 # The username of the database user.

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -28,6 +28,7 @@ type Config = {
     showDownloadButton: boolean;
     usersSearchable: boolean;
     allowAclEdit: boolean;
+    lockAclToSeries: boolean;
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -115,7 +115,7 @@ user:
   manage-content: Verwalten
 
 login-page:
-  heading: Anmeldung 
+  heading: Anmeldung
   user-id: Nutzerkennung
   password: Passwort
   bad-credentials: 'Anmeldung fehlgeschlagen: Falsche Anmeldedaten.'
@@ -321,6 +321,7 @@ upload:
     opencast-server-error: Opencast-Server-Fehler (unerwartete Antwort).
     opencast-unreachable: 'Netzwerkfehler: Opencast kann nicht erreicht werden.'
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
+    failed-fetching-series-acl: Abruf der Serienzugangsberechtigungen fehlgeschlagen.
 
 acl:
   unknown-user-note: unbekannt
@@ -341,6 +342,8 @@ manage:
       Änderung der Berechtigungen ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
       <br />
       Bitte versuchen Sie es später nochmal.
+    locked-to-series: >
+      Die Berechtigungen dieses Videos werden durch seine Serie bestimmt und können daher nicht bearbeitet werden.
     users-no-options:
       initial-searchable: Nach Name suchen oder exakten Nutzernamen/exakte E-Mail angeben
       none-found-searchable: Keine Personen gefunden

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -318,6 +318,7 @@ upload:
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
+    failed-fetching-series-acl: Failed to fetch series acl.
 
 acl:
   unknown-user-note: unknown
@@ -338,6 +339,8 @@ manage:
       Changing the access policy is not possible at this time, since the video is being processed in the background.
       <br />
       Please try again later.
+    locked-to-series: >
+      The access policy of this video is determined by its series and can't be edited.
     users-no-options:
       initial-searchable: Type to search for users by name (or enter exact email/username)
       none-found-searchable: No user found

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -1,17 +1,17 @@
 import React, { MutableRefObject, ReactNode, useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { graphql, useFragment } from "react-relay";
+import { fetchQuery, graphql, useFragment } from "react-relay";
 import { keyframes } from "@emotion/react";
 import { Controller, useController, useForm } from "react-hook-form";
 import { LuCheckCircle, LuUpload, LuInfo } from "react-icons/lu";
-import { WithTooltip, assertNever, bug, unreachable } from "@opencast/appkit";
+import { Spinner, WithTooltip, assertNever, bug, unreachable } from "@opencast/appkit";
 
 import { RootLoader } from "../layout/Root";
-import { loadQuery } from "../relay";
+import { environment, loadQuery } from "../relay";
 import { UploadQuery } from "./__generated__/UploadQuery.graphql";
 import { makeRoute } from "../rauta";
 import { ErrorDisplay, errorDisplayInfo } from "../util/err";
-import { useNavBlocker } from "./util";
+import { mapAcl, useNavBlocker } from "./util";
 import CONFIG from "../config";
 import { Button, boxError, ErrorBox, Card } from "@opencast/appkit";
 import { LinkButton } from "../ui/LinkButton";
@@ -34,6 +34,10 @@ import {
     AccessKnownRolesData$key,
 } from "../ui/__generated__/AccessKnownRolesData.graphql";
 import { READ_WRITE_ACTIONS } from "../util/permissionLevels";
+import {
+    UploadSeriesAclQuery,
+    UploadSeriesAclQuery$data,
+} from "./__generated__/UploadSeriesAclQuery.graphql";
 
 
 const PATH = "/~manage/upload" as const;
@@ -64,11 +68,14 @@ const query = graphql`
     }
 `;
 
-
+export type AclArray = NonNullable<UploadSeriesAclQuery$data["series"]>["acl"];
 type Metadata = {
     title: string;
     description: string;
-    series?: string;
+    series?: {
+        id: string;
+        acl: AclArray;
+    };
     acl: Acl;
 };
 
@@ -663,6 +670,14 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ state }) => {
 };
 
 
+const SeriesAclQuery = graphql`
+    query UploadSeriesAclQuery($seriesId: String!) {
+        series: seriesByOpencastId(id: $seriesId) {
+            acl { role actions info { label implies large } }
+        }
+    }
+`;
+
 type MetaDataEditProps = {
     onSave: (metadata: Metadata) => void;
     disabled: boolean;
@@ -680,6 +695,56 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
     const titleFieldId = useId();
     const descriptionFieldId = useId();
     const seriesFieldId = useId();
+    const [lockedAcl, setLockedAcl] = useState<Acl | null>(null);
+    const [aclError, setAclError] = useState<ReactNode>(null);
+    const [aclLoading, setAclLoading] = useState(false);
+    const aclEditingLocked = !!lockedAcl || aclLoading || !!aclError;
+
+    const fetchSeriesAcl = async (seriesId: string): Promise<Acl | null> => {
+        const data = await fetchQuery<UploadSeriesAclQuery>(
+            environment,
+            SeriesAclQuery,
+            { seriesId }
+        ).toPromise();
+
+        if (!data?.series?.acl) {
+            return null;
+        }
+
+        return mapAcl(data.series.acl);
+    };
+
+    const onSeriesChange = async (data: { opencastId?: string }) => {
+        setAclError(null);
+
+        if (!data?.opencastId) {
+            setLockedAcl(null);
+            return;
+        }
+
+        seriesField.onChange({ id: data.opencastId });
+
+        if (CONFIG.lockAclToSeries) {
+            setAclLoading(true);
+            try {
+                const seriesAcl = await fetchSeriesAcl(data.opencastId);
+                setLockedAcl(seriesAcl);
+                seriesField.onChange({
+                    id: data.opencastId,
+                    acl: seriesAcl,
+                });
+            } catch (e) {
+                setAclError(
+                    <ErrorDisplay
+                        error={e}
+                        failedAction={t("upload.errors.failed-fetching-series-acl")}
+                    />
+                );
+            } finally {
+                setAclLoading(false);
+            }
+        }
+    };
 
     const defaultAcl: Acl = new Map([
         [user.userRole, {
@@ -770,7 +835,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
                     inputId={seriesFieldId}
                     writableOnly
                     menuPlacement="top"
-                    onChange={data => seriesField.onChange(data?.opencastId)}
+                    onChange={data => onSeriesChange({ opencastId: data?.opencastId })}
                     onBlur={seriesField.onBlur}
                     required={CONFIG.upload.requireSeries}
                 />
@@ -784,17 +849,32 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
                     marginBottom: 12,
                     fontSize: 22,
                 }}>{t("manage.my-videos.acl.title")}</h2>
-                <Controller
-                    name="acl"
-                    control={control}
-                    render={({ field }) => <AclSelector
-                        userIsRequired
-                        onChange={field.onChange}
-                        acl={field.value}
-                        knownRoles={knownRoles}
-                        permissionLevels={READ_WRITE_ACTIONS}
-                    />}
-                />
+                {boxError(aclError)}
+                {aclLoading && <Spinner size={20} />}
+                {lockedAcl && (
+                    <Card kind="info" iconPos="left" css={{
+                        maxWidth: 700,
+                        fontSize: 14,
+                        marginBottom: 10,
+                    }}>
+                        {t("manage.access.locked-to-series")}
+                    </Card>
+                )}
+                <div {...aclEditingLocked && { inert: "true" }} css={{
+                    ...aclEditingLocked && { opacity: .7 },
+                }}>
+                    <Controller
+                        name="acl"
+                        control={control}
+                        render={({ field }) => <AclSelector
+                            userIsRequired
+                            onChange={field.onChange}
+                            acl={lockedAcl ?? field.value}
+                            knownRoles={knownRoles}
+                            permissionLevels={READ_WRITE_ACTIONS}
+                        />}
+                    />
+                </div>
             </InputContainer>
 
             {/* Submit button */}
@@ -1039,7 +1119,7 @@ const finishUpload = async (
         }
 
         // Add ACL
-        {
+        if (!CONFIG.lockAclToSeries) {
             const acl = constructAcl(metadata.acl);
             const body = new FormData();
             body.append("flavor", "security/xacml+episode");
@@ -1088,7 +1168,7 @@ const constructDcc = (metadata: Metadata, user: User): string => {
             </dcterms:created>
             ${tag("dcterms:title", metadata.title)}
             ${tag("dcterms:description", metadata.description)}
-            ${tag("dcterms:isPartOf", metadata.series)}
+            ${tag("dcterms:isPartOf", metadata.series?.id)}
             ${tag("dcterms:creator", user.displayName)}
             ${tag("dcterms:spatial", "Tobira Upload")}
         </dublincore>

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -11,6 +11,7 @@ import { boxError } from "@opencast/appkit";
 import { displayCommitError } from "./util";
 import { currentRef } from "../../../util";
 import { MODERATE_ADMIN_ACTIONS } from "../../../util/permissionLevels";
+import { mapAcl } from "../../util";
 
 
 const fragment = graphql`
@@ -36,12 +37,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const ownerDisplayName = (realm.ancestors[0] ?? realm).ownerDisplayName;
     const saveModalRef = useRef<ConfirmationModalHandle>(null);
 
-    const [initialAcl, inheritedAcl]: Acl[] = [realm.ownAcl, realm.inheritedAcl].map(acl => new Map(
-        acl.map(item => [item.role, {
-            actions: new Set(item.actions),
-            info: item.info,
-        }])
-    ));
+    const [initialAcl, inheritedAcl] = [realm.ownAcl, realm.inheritedAcl].map(mapAcl);
 
     const [selections, setSelections] = useState<Acl>(initialAcl);
 

--- a/frontend/src/routes/util.tsx
+++ b/frontend/src/routes/util.tsx
@@ -6,6 +6,7 @@ import { match } from "@opencast/appkit";
 import { Link, useRouter } from "../router";
 import CONFIG from "../config";
 import { LoginRoute, REDIRECT_STORAGE_KEY } from "./Login";
+import { AclArray } from "./Upload";
 
 
 export const b64regex = "[a-zA-Z0-9\\-_]";
@@ -94,4 +95,11 @@ export const LoginLink: React.FC<LoginLinkProps> = ({ className, children }) => 
         htmlLink={!!CONFIG.auth.loginLink}
         {...{ className }}
     >{children}</Link>
+);
+
+export const mapAcl = (acl?: AclArray) => new Map(
+    acl?.map(item => [item.role, {
+        actions: new Set(item.actions),
+        info: item.info,
+    }])
 );

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -805,6 +805,7 @@ type Series implements Node {
   created: DateTime
   metadata: ExtraMetadata
   syncedData: SyncedSeriesData
+  acl: [AclItem!]!
   hostRealms: [Realm!]!
   entries: [VideoListEntry!]!
   """

--- a/frontend/src/ui/SearchableSelect.tsx
+++ b/frontend/src/ui/SearchableSelect.tsx
@@ -144,7 +144,12 @@ export const VideoListSelector: React.FC<VideoListSelectorProps> = ({
         query SearchableSelectSeriesQuery($q: String!, $writableOnly: Boolean!) {
             series: searchAllSeries(query: $q, writableOnly: $writableOnly) {
                 ... on SeriesSearchResults {
-                    items { id opencastId title description }
+                    items {
+                        id
+                        opencastId
+                        title
+                        description
+                    }
                 }
             }
         }


### PR DESCRIPTION
This will disable ACL editing for the uploader and the ACL UI when the video is part of a series.
Uploaded videos will then adopt the ACL of that series.

This needs to be configured with `lock_acl_to_series`, the default for this is `false`.

Closes https://github.com/elan-ev/tobira/issues/1006