### PR TITLE
Change diff reference for admin UI check

### DIFF
--- a/.github/workflows/check-admin-ui-api.yml
+++ b/.github/workflows/check-admin-ui-api.yml
@@ -33,7 +33,7 @@ jobs:
           npx graphql-inspector diff \
             --rule .github/workflows/check-admin-ui-api/rule.js \
             --onComplete .github/workflows/check-admin-ui-api/onComplete.js \
-            git:${{ github.event.pull_request.base.sha }}:frontend/src/schema.graphql \
+            git:${{ github.event.pull_request.base.ref }}:frontend/src/schema.graphql \
             git:${{ github.event.pull_request.head.sha }}:frontend/src/schema.graphql \
             | tee >( \
               grep -v ^::set-output \


### PR DESCRIPTION
Previously, this was pointing to the file from the base commit of the PR. While this works fine for PRs that target the "main" branch, when a PR targets any other branch, we'll want to reference the branch's name rather than a specific commit SHA.

At least that's what I think is going on.