### PR TITLE
Remove `log.log_http_headers` config and move log calls into submodules

### DIFF
--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -30,19 +30,8 @@ use super::{Context, Response, response};
 /// This is the main HTTP entry point, called for each incoming request.
 pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Response {
     let time_incoming = Instant::now();
-    trace!(
-        method = ?req.method(),
-        path = req.uri().path_and_query().map_or("", |pq| pq.as_str()),
-        "Incoming HTTP request",
-    );
-    if ctx.config.log.log_http_headers {
-        let mut out = String::new();
-        for (name, value) in req.headers() {
-            use std::fmt::Write;
-            write!(out, "\n  {}: {}", name, String::from_utf8_lossy(value.as_bytes())).unwrap();
-        }
-        trace!("HTTP Headers: {}", out);
-    }
+    super::log::req::log(&req);
+    super::log::headers::log(&req);
 
     let method = req.method().clone();
     let path = req.uri().path().trim_end_matches('/');

--- a/backend/src/http/log.rs
+++ b/backend/src/http/log.rs
@@ -1,0 +1,35 @@
+//! This module contains a bunch of small inline modules to make it possible to
+//! easily filter out individual log messages with out filter system.
+
+
+use hyper::{body::Incoming, Request};
+use crate::prelude::*;
+
+pub mod req {
+    use super::*;
+
+    pub fn log(req: &Request<Incoming>) {
+        trace!(
+            method = ?req.method(),
+            path = req.uri().path_and_query().map_or("", |pq| pq.as_str()),
+            "Incoming HTTP request",
+        );
+    }
+}
+
+
+
+pub mod headers {
+    use super::*;
+
+    pub fn log(req: &Request<Incoming>) {
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let mut out = String::new();
+            for (name, value) in req.headers() {
+                use std::fmt::Write;
+                write!(out, "\n  {}: {}", name, String::from_utf8_lossy(value.as_bytes())).unwrap();
+            }
+            trace!("HTTP Headers: {}", out);
+        }
+    }
+}

--- a/backend/src/http/mod.rs
+++ b/backend/src/http/mod.rs
@@ -38,6 +38,7 @@ use self::{
 
 mod assets;
 mod handlers;
+mod log;
 pub(crate) mod response;
 
 

--- a/backend/src/logger.rs
+++ b/backend/src/logger.rs
@@ -52,11 +52,6 @@ pub(crate) struct LogConfig {
     /// If this is set to `false`, log messages are not written to stdout.
     #[config(default = true)]
     pub(crate) stdout: bool,
-
-    /// If set to `true`, HTTP header of each incoming request are logged
-    /// (with 'trace' level).
-    #[config(default = false)]
-    pub(crate) log_http_headers: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/docs/docs/setup/auth/user/index.md
+++ b/docs/docs/setup/auth/user/index.md
@@ -40,6 +40,15 @@ Tobira only gets new data about a user at login, and it's impossible to implemen
 If you can't use the built-in session management, use `"callback:..."`, which gives you full flexibility.
 `"trust-auth-headers"` should be avoided as it has some disadvantages compared to `"callback:..."` (header length limits, easier to configure, ...), but you can still use it if it works well within your system.
 
+:::tip
+
+For debugging your integration, configure the following log filter:
+
+```toml
+[log]
+filters."tobira::http" = "trace"
+```
+:::
 
 ## User information Tobira needs
 

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -392,12 +392,6 @@
 # Default value: true
 #stdout = true
 
-# If set to `true`, HTTP header of each incoming request are logged
-# (with 'trace' level).
-#
-# Default value: false
-#log_http_headers = false
-
 
 [opencast]
 # URL to Opencast. Currently used for all purposes (syncing, Studio,


### PR DESCRIPTION
This rather ad-hoc random config option was weird. Now two noisy log messages can be individually filtered by moving them to separate submodules. This changes the default when just setting `filters.tobira = "trace`" in that now, HTTP headers are also printed. But I think that's totally fine.

Fixes #1291