### PR TITLE
Remove frame control button plugin

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -515,13 +515,6 @@ const PAELLA_CONFIG = {
             tabIndex: 7,
             parentContainer: "optionsContainer",
         },
-        "es.upv.paella.frameControlButtonPlugin": {
-            enabled: true,
-            side: "right",
-            order: 8,
-            tabIndex: 8,
-            parentContainer: "optionsContainer",
-        },
 
         // Buttons on the right side outside of settings menu
         "es.upv.paella.captionsSelectorPlugin": {


### PR DESCRIPTION
We already have slide previews and users can skip to sections using the progress bar.
Suggested in https://github.com/elan-ev/tobira/pull/1295#issuecomment-2569574154.