### PR TITLE
Add "My series" page

### DIFF
--- a/backend/src/api/common.rs
+++ b/backend/src/api/common.rs
@@ -1,12 +1,7 @@
-use bincode::Options;
-use juniper::{GraphQLScalar, InputValue, ScalarValue};
-use serde::{Deserialize, Serialize};
-
 use crate::{
     api::{
         Id,
         Context,
-        err::{self, ApiResult},
         model::{
             event::AuthorizedEvent,
             series::Series,
@@ -15,7 +10,6 @@ use crate::{
             search::{SearchEvent, SearchRealm, SearchSeries},
         },
     },
-    prelude::*,
     search::Playlist as SearchPlaylist,
 };
 
@@ -46,56 +40,3 @@ pub(crate) trait Node {
 pub(crate) struct NotAllowed;
 
 super::util::impl_object_with_dummy_field!(NotAllowed);
-
-
-/// Opaque cursor for pagination. Serializes as string.
-///
-/// Ideally, this would be generic over something `Serialize + Deserialize`.
-/// However, junipers `graphql_scalar` macro doesn't work with generics
-/// (sigh). So it's easier to just eagerly create the base64 string in `new`
-/// and `deserialize`.
-///
-/// The actual cursor is a base64 encoded string. The encoded bytes are the
-/// serialization format from `bincode`, a compact binary serializer. Of course
-/// we could also have serialized it as JSON and base64 encoded it then, but
-/// that would be a waste of network bandwidth.
-#[derive(Debug, Clone, GraphQLScalar)]
-#[graphql(
-    description = "An opaque cursor used for pagination",
-    parse_token(String),
-)]
-pub(crate) struct Cursor(String);
-
-impl Cursor {
-    pub(crate) fn new(data: impl Serialize) -> Self {
-        let mut b64writer = base64::write::EncoderStringWriter::new(
-            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        );
-        bincode::DefaultOptions::new().serialize_into(&mut b64writer, &data)
-            .unwrap_or_else(|e| unreachable!("bincode serialize failed without size limit: {}", e));
-        Self(b64writer.into_inner())
-    }
-
-    pub(crate) fn deserialize<T>(&self) -> ApiResult<T>
-    where
-        for<'de> T: Deserialize<'de>,
-    {
-        let mut bytes = self.0.as_bytes();
-        let b64reader = base64::read::DecoderReader::new(
-            &mut bytes,
-            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        );
-        bincode::DefaultOptions::new()
-            .deserialize_from(b64reader)
-            .map_err(|e| err::invalid_input!("given cursor is invalid: {}", e))
-    }
-
-    fn to_output<S: ScalarValue>(&self) -> juniper::Value<S> {
-        juniper::Value::scalar(self.0.clone())
-    }
-
-    fn from_input<S: ScalarValue>(input: &InputValue<S>) -> Result<Self, String> {
-        let s = input.as_string_value().ok_or("expected string")?;
-        Ok(Self(s.into()))
-    }
-}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -21,7 +21,7 @@ mod subscription;
 pub(crate) use self::{
     id::Id,
     context::Context,
-    common::{Cursor, Node, NodeValue},
+    common::{Node, NodeValue},
 };
 
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -27,6 +27,7 @@ use crate::{
         Id,
         Node,
         NodeValue,
+        util::LazyLoad,
     },
     db::{
         types::{EventCaption, EventSegment, EventState, EventTrack, Credentials},
@@ -353,6 +354,8 @@ impl AuthorizedEvent {
                     metadata: None,
                     read_roles: None,
                     write_roles: None,
+                    num_videos: LazyLoad::NotLoaded,
+                    thumbnail_stack: LazyLoad::NotLoaded,
                 }))
             } else {
                 // We need to load the series as fields were requested that were not preloaded.
@@ -664,7 +667,11 @@ impl AuthorizedEvent {
             join_clause: "left join series on series.id = events.series",
         };
 
-        load_writable_for_user(context, order, offset, limit, parts).await
+        load_writable_for_user(
+            context, order, offset, limit, parts,
+            AuthorizedEvent::select(),
+            AuthorizedEvent::from_row_start,
+        ).await
     }
 }
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -666,7 +666,11 @@ impl LoadableAsset for AuthorizedEvent {
     }
 
     fn table_name() -> &'static str {
-        "events"
+        "all_events"
+    }
+
+    fn alias() -> Option<&'static str> {
+        Some("events")
     }
 
     fn sort_clauses(_column: &str) -> (&str, &str) {

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -660,14 +660,16 @@ impl AuthorizedEvent {
 
 impl LoadableAsset for AuthorizedEvent {
     fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
-        let (selection, mapping) = select!(
-            resource: AuthorizedEvent from AuthorizedEvent::select().with_omitted_table_prefix("events"),
-        );
+        let (selection, mapping) = select!(resource: AuthorizedEvent);
         (selection, mapping.resource)
     }
 
     fn table_name() -> &'static str {
-        "all_events"
+        "events"
+    }
+
+    fn sort_clauses(_column: &str) -> (&str, &str) {
+        ("left join series on series.id = events.series", "")
     }
 }
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -39,6 +39,7 @@ use super::{
         LoadableAsset,
         PageInfo,
         SortOrder,
+        VideosSortColumn,
     },
 };
 
@@ -645,11 +646,11 @@ impl AuthorizedEvent {
 
     pub(crate) async fn load_writable_for_user(
         context: &Context,
-        order: SortOrder,
+        order: SortOrder<VideosSortColumn>,
         offset: i32,
         limit: i32,
     ) -> ApiResult<EventConnection> {
-        let conn: Connection<AuthorizedEvent> = load_writable_for_user::<AuthorizedEvent>(
+        let conn = load_writable_for_user::<AuthorizedEvent, VideosSortColumn>(
             context, order, offset, limit,
         ).await?;
 

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -34,9 +34,9 @@ use super::{
     playlist::VideoListEntry,
     shared::{
         load_writable_for_user,
-        AssetMapping,
+        ItemMapping,
         Connection,
-        LoadableAsset,
+        LoadableItem,
         PageInfo,
         SortOrder,
         VideosSortColumn,
@@ -659,8 +659,8 @@ impl AuthorizedEvent {
     }
 }
 
-impl LoadableAsset for AuthorizedEvent {
-    fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
+impl LoadableItem for AuthorizedEvent {
+    fn selection() -> (String, ItemMapping<<Self as FromDb>::RowMapping>) {
         let (selection, mapping) = select!(resource: AuthorizedEvent);
         (selection, mapping.resource)
     }

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -342,6 +342,7 @@ impl AuthorizedEvent {
                     title: series.title.clone(),
                     synced_data: None,
                     created: None,
+                    updated: None,
                     metadata: None,
                     read_roles: None,
                     write_roles: None,

--- a/backend/src/api/model/mod.rs
+++ b/backend/src/api/model/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod realm;
 pub(crate) mod search;
 pub(crate) mod series;
 pub(crate) mod user;
+pub(crate) mod shared;

--- a/backend/src/api/model/search/mod.rs
+++ b/backend/src/api/model/search/mod.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use juniper::{GraphQLObject, GraphQLScalar, InputValue, ScalarValue};
+use juniper::{GraphQLScalar, InputValue, ScalarValue};
 use meilisearch_sdk::search::{FederationOptions, MatchRange, QueryFederationOptions};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -111,13 +111,6 @@ pub(crate) struct Filters {
     item_type: Option<ItemType>,
     start: Option<DateTime<Utc>>,
     end: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, GraphQLObject)]
-pub(crate) struct ThumbnailInfo {
-    pub(crate) thumbnail: Option<String>,
-    pub(crate) is_live: bool,
-    pub(crate) audio_only: bool,
 }
 
 

--- a/backend/src/api/model/search/series.rs
+++ b/backend/src/api/model/search/series.rs
@@ -5,10 +5,11 @@ use meilisearch_sdk::search::MatchRange;
 
 use crate::{
     api::{Context, Id, Node, NodeValue},
-    search, HasRoles,
+    model::{SeriesThumbnailStack, ThumbnailInfo},
+    search
 };
 
-use super::{field_matches_for, ByteSpan, SearchRealm, ThumbnailInfo};
+use super::{field_matches_for, ByteSpan, SearchRealm};
 
 
 #[derive(Debug, GraphQLObject)]
@@ -19,7 +20,7 @@ pub(crate) struct SearchSeries {
     title: String,
     description: Option<String>,
     host_realms: Vec<SearchRealm>,
-    thumbnails: Vec<ThumbnailInfo>,
+    thumbnail_stack: SeriesThumbnailStack,
     matches: SearchSeriesMatches,
 }
 
@@ -55,15 +56,12 @@ impl SearchSeries {
             host_realms: src.host_realms.into_iter()
                 .map(|r| SearchRealm::without_matches(r))
                 .collect(),
-            thumbnails: src.thumbnails.iter()
-                .filter(|info| context.auth.overlaps_roles(&info.read_roles))
-                .map(|info| ThumbnailInfo {
-                    thumbnail: info.url.clone(),
-                    audio_only: info.audio_only,
-                    is_live: info.live,
-                })
-                .take(3)
-                .collect(),
+            thumbnail_stack: SeriesThumbnailStack {
+                thumbnails: src.thumbnails.into_iter()
+                    .filter_map(|info| ThumbnailInfo::from_search(info, &context.auth))
+                    .take(3)
+                    .collect(),
+            },
             matches,
         }
     }

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -24,7 +24,7 @@ use super::{
     block::{BlockValue, NewSeriesBlock, VideoListLayout, VideoListOrder},
     playlist::VideoListEntry,
     realm::{NewRealm, RealmSpecifier, RemoveMountedSeriesOutcome, UpdatedRealmName},
-    shared::{load_writable_for_user, AssetMapping, Connection, LoadableAsset, PageInfo, SortOrder},
+    shared::{load_writable_for_user, AssetMapping, Connection, LoadableAsset, PageInfo, SeriesSortColumn, SortOrder},
 };
 
 
@@ -277,28 +277,15 @@ impl Series {
 
     pub(crate) async fn load_writable_for_user(
         context: &Context,
-        order: SortOrder,
+        order: SortOrder<SeriesSortColumn>,
         offset: i32,
         limit: i32,
     ) -> ApiResult<SeriesConnection> {
-        let conn: Connection<Series> = load_writable_for_user::<Series>(
+        let conn = load_writable_for_user::<Series, SeriesSortColumn>(
             context, order, offset, limit,
         ).await?;
 
         Ok(SeriesConnection { inner: conn })
-    }
-}
-
-impl LoadableAsset for Series {
-    fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
-        let (selection, mapping) = select!(
-            resource: Series from Series::select().with_omitted_table_prefix("series"),
-        );
-        (selection, mapping.resource)
-    }
-
-    fn table_name() -> &'static str {
-        "series"
     }
 }
 
@@ -388,6 +375,19 @@ pub(crate) struct NewSeries {
     // Since `mountSeries` feels even more like a private API
     // in some way, and since passing stuff like metadata isn't trivial either
     // I think it's okay to leave it at that for now.
+}
+
+impl LoadableAsset for Series {
+    fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
+        let (selection, mapping) = select!(
+            resource: Series from Series::select().with_omitted_table_prefix("series"),
+        );
+        (selection, mapping.resource)
+    }
+
+    fn table_name() -> &'static str {
+        "series"
+    }
 }
 
 // Todo: Make this generic. It's basically the same code that's used for `EventConnection`.

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -406,10 +406,14 @@ impl LoadableAsset for Series {
         "series"
     }
 
+    fn alias() -> Option<&'static str> {
+        None
+    }
+
     fn sort_clauses(column: &str) -> (&str, &str) {
         match column {
-            "count(events.id)" => (
-                "left join events on events.series = series.id",
+            "count(all_events.id)" => (
+                "left join all_events on all_events.series = series.id",
                 "group by series.id",
             ),
             _ => ("", ""),

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -379,14 +379,22 @@ pub(crate) struct NewSeries {
 
 impl LoadableAsset for Series {
     fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
-        let (selection, mapping) = select!(
-            resource: Series from Series::select(),
-        );
+        let (selection, mapping) = select!(resource: Series);
         (selection, mapping.resource)
     }
 
     fn table_name() -> &'static str {
         "series"
+    }
+
+    fn sort_clauses(column: &str) -> (&str, &str) {
+        match column {
+            "count(events.id)" => (
+                "left join events on events.series = series.id",
+                "group by series.id",
+            ),
+            _ => ("", ""),
+        }
     }
 }
 

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -24,7 +24,15 @@ use super::{
     block::{BlockValue, NewSeriesBlock, VideoListLayout, VideoListOrder},
     playlist::VideoListEntry,
     realm::{NewRealm, RealmSpecifier, RemoveMountedSeriesOutcome, UpdatedRealmName},
-    shared::{load_writable_for_user, AssetMapping, Connection, LoadableAsset, PageInfo, SeriesSortColumn, SortOrder},
+    shared::{
+        load_writable_for_user,
+        AssetMapping,
+        Connection,
+        LoadableAsset,
+        PageInfo,
+        SeriesSortColumn,
+        SortOrder,
+    },
 };
 
 
@@ -34,6 +42,7 @@ pub(crate) struct Series {
     pub(crate) synced_data: Option<SyncedSeriesData>,
     pub(crate) title: String,
     pub(crate) created: Option<DateTime<Utc>>,
+    pub(crate) updated: Option<DateTime<Utc>>,
     pub(crate) metadata: Option<ExtraMetadata>,
     pub(crate) read_roles: Option<Vec<String>>,
     pub(crate) write_roles: Option<Vec<String>>,
@@ -49,9 +58,14 @@ impl_from_db!(
     select: {
         series.{
             id, opencast_id, state,
-            title, description, created,
-            metadata, read_roles, write_roles,
+            title, description,
+            metadata, created,
+            read_roles, write_roles,
         },
+        updated: "case \
+            when ${table:series}.updated = '-infinity' then null \
+            else ${table:series}.updated \
+        end",
     },
     |row| {
         Series {
@@ -59,6 +73,7 @@ impl_from_db!(
             opencast_id: row.opencast_id(),
             title: row.title(),
             created: row.created(),
+            updated: row.updated(),
             metadata: row.metadata(),
             read_roles: row.read_roles(),
             write_roles: row.write_roles(),
@@ -306,6 +321,10 @@ impl Series {
 
     fn created(&self) -> &Option<DateTime<Utc>> {
         &self.created
+    }
+
+    fn updated(&self) -> &Option<DateTime<Utc>> {
+        &self.updated
     }
 
     fn metadata(&self) -> &Option<ExtraMetadata> {

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -26,9 +26,9 @@ use super::{
     realm::{NewRealm, RealmSpecifier, RemoveMountedSeriesOutcome, UpdatedRealmName},
     shared::{
         load_writable_for_user,
-        AssetMapping,
+        ItemMapping,
         Connection,
-        LoadableAsset,
+        LoadableItem,
         PageInfo,
         SeriesSortColumn,
         SortOrder,
@@ -396,8 +396,8 @@ pub(crate) struct NewSeries {
     // I think it's okay to leave it at that for now.
 }
 
-impl LoadableAsset for Series {
-    fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
+impl LoadableItem for Series {
+    fn selection() -> (String, ItemMapping<<Self as FromDb>::RowMapping>) {
         let (selection, mapping) = select!(resource: Series);
         (selection, mapping.resource)
     }

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -380,7 +380,7 @@ pub(crate) struct NewSeries {
 impl LoadableAsset for Series {
     fn selection() -> (String, AssetMapping<<Self as FromDb>::RowMapping>) {
         let (selection, mapping) = select!(
-            resource: Series from Series::select().with_omitted_table_prefix("series"),
+            resource: Series from Series::select(),
         );
         (selection, mapping.resource)
     }

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -31,7 +31,7 @@ pub trait ToSqlColumn {
 /// Also includes implementations for the `ToSqlColumn` and `Default` traits of the enum.
 ///
 /// Note that some sort columns might require special join and/or group by clauses in the query.
-/// These must be defined in the `sort_clauses` method of the `LoadableAsset` trait.
+/// These must be defined in the `sort_clauses` method of the `LoadableItem` trait.
 ///
 /// Example usage:
 /// ```
@@ -167,9 +167,9 @@ pub struct PageInfo {
     pub end_index: Option<i32>,
 }
 
-pub type AssetMapping<ResourceMapping> = ResourceMapping;
+pub type ItemMapping<ResourceMapping> = ResourceMapping;
 
-pub trait LoadableAsset: FromDb<RowMapping: Copy> {
+pub trait LoadableItem: FromDb<RowMapping: Copy> {
     fn selection() -> (String, <Self as FromDb>::RowMapping);
     fn table_name() -> &'static str;
     fn alias() -> Option<&'static str>;
@@ -185,7 +185,7 @@ pub(crate) async fn load_writable_for_user<T, C>(
     limit: i32,
 ) -> ApiResult<Connection<T>>
 where
-    T: LoadableAsset + db::util::FromDb,
+    T: LoadableItem + db::util::FromDb,
     C: ToSqlColumn,
 {
     const MAX_COUNT: i32 = 100;

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -1,0 +1,158 @@
+use tokio_postgres::types::ToSql;
+use juniper::{GraphQLEnum, GraphQLInputObject, GraphQLObject};
+
+use crate::{
+    api::{
+        Context,
+        err::{invalid_input, ApiResult},
+    },
+    db,
+    FromDb,
+    HasRoles,
+};
+
+
+#[derive(Debug, Clone, Copy, GraphQLInputObject)]
+pub struct SortOrder {
+    pub column: SortColumn,
+    pub direction: SortDirection,
+}
+
+#[derive(Debug, Clone, Copy, GraphQLEnum)]
+pub enum SortColumn {
+    Title,
+    Created,
+    Updated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, GraphQLEnum)]
+pub enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+impl Default for SortOrder {
+    fn default() -> Self {
+        Self {
+            column: SortColumn::Created,
+            direction: SortDirection::Descending,
+        }
+    }
+}
+
+impl SortColumn {
+    pub fn to_sql(self) -> &'static str {
+        match self {
+            SortColumn::Title => "title",
+            SortColumn::Created => "created",
+            SortColumn::Updated => "updated",
+        }
+    }
+}
+
+impl SortDirection {
+    pub fn to_sql(self) -> &'static str {
+        match self {
+            SortDirection::Ascending => "asc",
+            SortDirection::Descending => "desc",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Connection<T> {
+    pub page_info: PageInfo,
+    pub items: Vec<T>,
+    pub total_count: i32,
+}
+
+#[derive(Debug, Clone, GraphQLObject)]
+pub struct PageInfo {
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
+    pub start_index: Option<i32>,
+    pub end_index: Option<i32>,
+}
+
+pub type AssetMapping<ResourceMapping> = ResourceMapping;
+
+pub trait LoadableAsset: FromDb<RowMapping: Copy> {
+    fn selection() -> (String, <Self as FromDb>::RowMapping);
+    fn table_name() -> &'static str;
+}
+
+pub(crate) async fn load_writable_for_user<T>(
+    context: &Context,
+    order: SortOrder,
+    offset: i32,
+    limit: i32,
+) -> ApiResult<Connection<T>>
+where
+    T: LoadableAsset + db::util::FromDb,
+{
+    const MAX_COUNT: i32 = 100;
+
+    // Argument validation
+    if limit <= 0 {
+        return Err(invalid_input!("argument 'limit' has to be > 0, but is {limit}"));
+    }
+    if offset < 0 {
+        return Err(invalid_input!("argument 'offset' has to be >= 0, but is {offset}"));
+    }
+    let limit = std::cmp::min(limit, MAX_COUNT);
+
+    let mut args = vec![];
+    let arg_user_roles = &context.auth.roles_vec() as &(dyn ToSql + Sync);
+    let acl_filter = if context.auth.is_admin() {
+        String::new()
+    } else {
+        args.push(arg_user_roles);
+        let arg_index = args.len();
+        format!("where write_roles && ${arg_index} and read_roles && ${arg_index}")
+    };
+
+    let table = T::table_name();
+
+    // We need to know the item count before querying the actual items,
+    // to check if the offset is too high. If it is, it's set to the maximum.
+    let total_count = {
+        let query = format!("select count(*) from {table} {acl_filter}");
+        context.db.query_one(&query, &args).await?.get::<_, i64>(0)
+    };
+
+    let offset = ((offset as i64).clamp(0, (total_count - limit as i64).max(0))) as i32;
+
+    let (selection, mapping) = T::selection();
+
+    let query = format!(
+        "select {selection} \
+            from {table} as resource \
+            {acl_filter} \
+            order by ({sort_col}, id) {sort_order} \
+            limit {limit} offset {offset} \
+        ",
+        sort_col = order.column.to_sql(),
+        sort_order = order.direction.to_sql(),
+    );
+
+    // Execute query
+    let items = context.db.query_mapped(&query, args, |row| {
+        // Retrieve actual event data
+        T::from_row(&row, mapping)
+    }).await?;
+
+    let total_count = total_count.try_into().expect("more than 2^31 items?!");
+
+    let page_info = PageInfo {
+        has_next_page: (offset + limit) < total_count,
+        has_previous_page: offset > 0,
+        start_index: (!items.is_empty()).then_some(offset + 1),
+        end_index: (!items.is_empty()).then_some(offset + items.len() as i32),
+    };
+
+    Ok(Connection {
+        total_count,
+        items,
+        page_info,
+    })
+}

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -18,6 +18,8 @@ pub struct SortOrder {
     pub direction: SortDirection,
 }
 
+// TODO: Get rid of this. We need to support custom column names in the future.
+// E.g. playlists do not have a `created` column.
 #[derive(Debug, Clone, Copy, GraphQLEnum)]
 pub enum SortColumn {
     Title,

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -117,6 +117,7 @@ define_sort_column_and_order!(
         Title    => "title",
         Created  => "created",
         Updated  => "updated",
+        EventCount => "(select count(*) from events where events.series = resource.id)",
     };
     pub struct SeriesSortOrder
 );

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -2,15 +2,16 @@ use crate::{
     api::{
         Context,
         err::ApiResult,
-        model::event::{AuthorizedEvent,EventConnection},
+        model::event::AuthorizedEvent,
     },
     auth::User,
     prelude::*,
 };
 
 use super::{
-    series::{Series, SeriesConnection},
-    shared::{SeriesSortColumn, SeriesSortOrder, SortDirection, SortOrder, VideosSortColumn, VideosSortOrder}
+    event::VideosSortOrder,
+    series::{Series, SeriesSortOrder},
+    shared::Connection,
 };
 
 
@@ -76,18 +77,11 @@ impl User {
         &self,
         context: &Context,
         #[graphql(default)]
-        order: Option<VideosSortOrder>,
+        order: VideosSortOrder,
         offset: i32,
         limit: i32,
-    ) -> ApiResult<EventConnection> {
-        let order = order.unwrap_or(VideosSortOrder {
-            column: VideosSortColumn::Created,
-            direction: SortDirection::Descending,
-        });
-        AuthorizedEvent::load_writable_for_user(context, SortOrder {
-            column: order.column,
-            direction: order.direction
-        }, offset, limit).await
+    ) -> ApiResult<Connection<AuthorizedEvent>> {
+        AuthorizedEvent::load_writable_for_user(context, order.into(), offset, limit).await
     }
 
     /// Returns all series that somehow "belong" to the user, i.e. that appear
@@ -96,17 +90,10 @@ impl User {
         &self,
         context: &Context,
         #[graphql(default)]
-        order: Option<SeriesSortOrder>,
+        order: SeriesSortOrder,
         offset: i32,
         limit: i32,
-    ) -> ApiResult<SeriesConnection> {
-        let order = order.unwrap_or(SeriesSortOrder {
-            column: SeriesSortColumn::Created,
-            direction: SortDirection::Descending,
-        });
-        Series::load_writable_for_user(context, SortOrder {
-            column: order.column,
-            direction: order.direction
-        }, offset, limit).await
+    ) -> ApiResult<Connection<Series>> {
+        Series::load_writable_for_user(context, order.into(), offset, limit).await
     }
 }

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -8,7 +8,10 @@ use crate::{
     prelude::*,
 };
 
-use super::shared::SortOrder;
+use super::{
+    series::{Series, SeriesConnection},
+    shared::SortOrder
+};
 
 
 #[juniper::graphql_object(context = Context)]
@@ -78,5 +81,18 @@ impl User {
         limit: i32,
     ) -> ApiResult<EventConnection> {
         AuthorizedEvent::load_writable_for_user(context, order, offset, limit).await
+    }
+
+    /// Returns all series that somehow "belong" to the user, i.e. that appear
+    /// on the "my series" page.
+    async fn my_series(
+        &self,
+        context: &Context,
+        #[graphql(default)]
+        order: SortOrder,
+        offset: i32,
+        limit: i32,
+    ) -> ApiResult<SeriesConnection> {
+        Series::load_writable_for_user(context, order, offset, limit).await
     }
 }

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -1,13 +1,14 @@
 use crate::{
     api::{
         Context,
-        common::Cursor,
         err::ApiResult,
-        model::event::{AuthorizedEvent, EventConnection, EventSortOrder},
+        model::event::{AuthorizedEvent,EventConnection},
     },
     auth::User,
     prelude::*,
 };
+
+use super::shared::SortOrder;
 
 
 #[juniper::graphql_object(context = Context)]
@@ -68,18 +69,14 @@ impl User {
     /// on the "my videos" page. This also returns events that have been marked
     /// as deleted (meaning their deletion in Opencast has been requested but they
     /// are not yet removed from Tobira's database).
-    ///
-    /// Exactly one of `first` and `last` must be set!
     async fn my_videos(
         &self,
-        #[graphql(default)]
-        order: EventSortOrder,
-        first: Option<i32>,
-        after: Option<Cursor>,
-        last: Option<i32>,
-        before: Option<Cursor>,
         context: &Context,
+        #[graphql(default)]
+        order: SortOrder,
+        offset: i32,
+        limit: i32,
     ) -> ApiResult<EventConnection> {
-        AuthorizedEvent::load_writable_for_user(context, order, first, after, last, before).await
+        AuthorizedEvent::load_writable_for_user(context, order, offset, limit).await
     }
 }

--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     series::{Series, SeriesConnection},
-    shared::SortOrder
+    shared::{SeriesSortColumn, SeriesSortOrder, SortDirection, SortOrder, VideosSortColumn, VideosSortOrder}
 };
 
 
@@ -76,11 +76,18 @@ impl User {
         &self,
         context: &Context,
         #[graphql(default)]
-        order: SortOrder,
+        order: Option<VideosSortOrder>,
         offset: i32,
         limit: i32,
     ) -> ApiResult<EventConnection> {
-        AuthorizedEvent::load_writable_for_user(context, order, offset, limit).await
+        let order = order.unwrap_or(VideosSortOrder {
+            column: VideosSortColumn::Created,
+            direction: SortDirection::Descending,
+        });
+        AuthorizedEvent::load_writable_for_user(context, SortOrder {
+            column: order.column,
+            direction: order.direction
+        }, offset, limit).await
     }
 
     /// Returns all series that somehow "belong" to the user, i.e. that appear
@@ -89,10 +96,17 @@ impl User {
         &self,
         context: &Context,
         #[graphql(default)]
-        order: SortOrder,
+        order: Option<SeriesSortOrder>,
         offset: i32,
         limit: i32,
     ) -> ApiResult<SeriesConnection> {
-        Series::load_writable_for_user(context, order, offset, limit).await
+        let order = order.unwrap_or(SeriesSortOrder {
+            column: SeriesSortColumn::Created,
+            direction: SortDirection::Descending,
+        });
+        Series::load_writable_for_user(context, SortOrder {
+            column: order.column,
+            direction: order.direction
+        }, offset, limit).await
     }
 }

--- a/backend/src/api/util.rs
+++ b/backend/src/api/util.rs
@@ -13,3 +13,26 @@ macro_rules! impl_object_with_dummy_field {
 }
 
 pub(crate) use impl_object_with_dummy_field;
+
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LazyLoad<T> {
+    Loaded(T),
+    NotLoaded,
+}
+
+impl<T> LazyLoad<T> {
+    pub fn unwrap(self) -> T {
+        match self {
+            LazyLoad::Loaded(t) => t,
+            LazyLoad::NotLoaded => panic!("unwrapped a unloaded LazyLoad"),
+        }
+    }
+
+    pub fn as_ref(&self) -> LazyLoad<&T> {
+        match self {
+            LazyLoad::Loaded(t) => LazyLoad::Loaded(t),
+            LazyLoad::NotLoaded => LazyLoad::NotLoaded,
+        }
+    }
+}

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -373,4 +373,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     38: "event-texts",
     39: "preview-roles-and-credentials",
     40: "realm-names-constraint-revision",
+    41: "series-index",
 ];

--- a/backend/src/db/migrations/41-series-index.sql
+++ b/backend/src/db/migrations/41-series-index.sql
@@ -1,0 +1,3 @@
+-- This migration adds an index to perform queries like `write_roles && $1` on the whole table.
+
+create index idx_series_write_roles on series using gin (write_roles);

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -83,16 +83,6 @@ pub struct PlaylistEntry {
     pub content_id: String,
 }
 
-/// Represents the `playlist_entry` type defined in `31-playlists.sql`.
-#[derive(Debug, FromSql, ToSql, Clone, Serialize, Deserialize)]
-#[postgres(name = "search_thumbnail_info")]
-pub struct SearchThumbnailInfo {
-    pub url: Option<String>,
-    pub live: bool,
-    pub audio_only: bool,
-    pub read_roles: Vec<String>,
-}
-
 /// Represents the `timespan_text` type.
 #[derive(Debug, FromSql, ToSql)]
 #[postgres(name = "timespan_text")]

--- a/backend/src/model/event/mod.rs
+++ b/backend/src/model/event/mod.rs
@@ -1,0 +1,39 @@
+use juniper::GraphQLObject;
+use postgres_types::{FromSql, ToSql};
+use serde::{Deserialize, Serialize};
+
+use crate::{auth::AuthContext, HasRoles};
+
+
+/// Information necessary to render a thumbnail.
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct ThumbnailInfo {
+    pub(crate) url: Option<String>,
+    pub(crate) live: bool,
+    pub(crate) audio_only: bool,
+}
+
+/// Thumbnail info with `read_roles` for deferred filtering. Represents the
+/// `search_thumbnail_info` type defined in migration 37.
+#[derive(Debug, FromSql, ToSql, Clone, Serialize, Deserialize)]
+#[postgres(name = "search_thumbnail_info")]
+pub struct SearchThumbnailInfo {
+    pub url: Option<String>,
+    pub live: bool,
+    pub audio_only: bool,
+    pub read_roles: Vec<String>,
+}
+
+impl ThumbnailInfo {
+    pub(crate) fn from_search(info: SearchThumbnailInfo, auth: &AuthContext) -> Option<Self> {
+        if auth.overlaps_roles(info.read_roles) {
+            Some(Self {
+                url: info.url,
+                live: info.live,
+                audio_only: info.audio_only,
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -7,12 +7,16 @@
 //! either of `db`, `api` or any other submodule as they are used in multiple
 //! situations (loading from DB, exposing via API, ...).
 
+mod event;
 mod extra_metadata;
 mod key;
+mod series;
 mod translated_string;
 
 pub(crate) use self::{
     extra_metadata::ExtraMetadata,
     key::Key,
+    event::{SearchThumbnailInfo, ThumbnailInfo},
+    series::SeriesThumbnailStack,
     translated_string::{LangKey, TranslatedString},
 };

--- a/backend/src/model/series/mod.rs
+++ b/backend/src/model/series/mod.rs
@@ -1,0 +1,9 @@
+use juniper::GraphQLObject;
+
+use super::ThumbnailInfo;
+
+
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct SeriesThumbnailStack {
+    pub(crate) thumbnails: Vec<ThumbnailInfo>,
+}

--- a/backend/src/search/series.rs
+++ b/backend/src/search/series.rs
@@ -6,7 +6,8 @@ use tokio_postgres::GenericClient;
 use crate::{
     prelude::*,
     model::Key,
-    db::{types::SearchThumbnailInfo, util::{collect_rows_mapped, impl_from_db}},
+    model::SearchThumbnailInfo,
+    db::util::{collect_rows_mapped, impl_from_db},
 };
 
 use super::{realm::Realm, util::{self, FieldAbilities}, IndexItem, IndexItemKind, SearchId};

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -438,6 +438,7 @@ manage:
       descending: absteigend
       title: Titel
       created: Erstellt
+      updated: Aktualisiert
     no-entries-found: Keine Einträge gefunden.
     missing-date: Unbekannt
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -208,6 +208,7 @@ series:
     text: >
       Die Daten der gewünschten Serie wurden leider noch nicht vollständig übertragen. Dies sollte
       in Kürze automatisch passieren. Versuchen Sie es in wenigen Minuten noch einmal!
+    label: nicht synchronisiert
 
 videolist-block:
   upcoming-live-streams: "Anstehende Livestreams ({{count}})"
@@ -438,6 +439,10 @@ manage:
       title: Titel
       created: Erstellt
     no-entries-found: Keine Einträge gefunden.
+
+  my-series:
+    title: Meine Serien
+    missing-date: Unbekannt
 
   my-videos:
     title: Meine Videos

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -439,10 +439,10 @@ manage:
       title: Titel
       created: Erstellt
     no-entries-found: Keine Einträge gefunden.
+    missing-date: Unbekannt
 
   my-series:
     title: Meine Serien
-    missing-date: Unbekannt
 
   my-videos:
     title: Meine Videos

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -425,7 +425,7 @@ manage:
       Seite. Solange Sie angemeldet sind und die benötigten Rechte haben, gibt es dort entsprechende
       Seitenverwaltungs-Buttons in der Seitenleiste bzw. im Menu.
 
-  asset-table:
+  item-table:
     page-showing-ids: '{{start}}–{{end}} von {{total}}'
     navigation:
       first: Erste Seite

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -443,6 +443,8 @@ manage:
 
   my-series:
     title: Meine Serien
+    content: Inhalt
+    no-of-videos: '{{count}} Videos'
 
   my-videos:
     title: Meine Videos

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -28,6 +28,7 @@ general:
     select:
       no-options: Keine Optionen
       select-option: Option auswählen
+  no-description: Keine Beschreibung
 
 welcome:
   title: Willkommen zu Tobira!
@@ -152,7 +153,7 @@ video:
   stream-not-started-yet: Dieser Stream hat noch nicht begonnen.
   started: Gestartet
   started-when: Gestartet {{duration}}
-  starts: Startet 
+  starts: Startet
   starts-in: Startet {{duration}}
   description:
     show-more: ...mehr anzeigen
@@ -214,7 +215,7 @@ videolist-block:
   no-videos: Keine Videos
   unauthorized: Fehlende Berechtigung
   hidden-items:
-    unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte. 
+    unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte.
     unauthorized_other: 'Für {{count}} Videos fehlen Ihnen die Zugriffsrechte.'
     missing_one: Ein Video wurde nicht gefunden.
     missing_other: '{{count}} Videos wurden nicht gefunden.'
@@ -423,8 +424,8 @@ manage:
       Seite. Solange Sie angemeldet sind und die benötigten Rechte haben, gibt es dort entsprechende
       Seitenverwaltungs-Buttons in der Seitenleiste bzw. im Menu.
 
-  my-videos:
-    title: Meine Videos
+  asset-table:
+    page-showing-ids: '{{start}}–{{end}} von {{total}}'
     navigation:
       first: Erste Seite
       previous: Vorherige Seite
@@ -436,9 +437,10 @@ manage:
       descending: absteigend
       title: Titel
       created: Erstellt
-    no-description: Keine Beschreibung
-    page-showing-video-ids: '{{start}}–{{end}} von {{total}}'
-    no-videos-found: Keine Videos gefunden.
+    no-entries-found: Keine Einträge gefunden.
+
+  my-videos:
+    title: Meine Videos
     details:
       title: Videodetails
       share-direct-link: Via Direktlink teilen

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -419,6 +419,7 @@ manage:
       descending: descending
       title: Title
       created: Created
+      updated: Updated
     no-entries-found: No entries found.
     missing-date: Unknown
 

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -27,6 +27,7 @@ general:
     select:
       no-options: No options
       select-option: Select option
+  no-description: No description
 
 welcome:
   title: Welcome to Tobira!
@@ -212,7 +213,7 @@ videolist-block:
   no-videos: No videos
   unauthorized: Missing permissions
   hidden-items:
-    unauthorized_one: One video requires additional permissions to view. 
+    unauthorized_one: One video requires additional permissions to view.
     unauthorized_other: '{{count}} videos require additional permissions to view.'
     missing_one: One video is missing.
     missing_other: '{{count}} videos are missing.'
@@ -404,8 +405,8 @@ manage:
       To rename, modify, and delete pages, navigate to the page in question. If you
       are logged in and have the necessary permissions, page management buttons will appear.
 
-  my-videos:
-    title: My videos
+  asset-table:
+    page-showing-ids: '{{start}}–{{end}} of {{total}}'
     navigation:
       first: First page
       previous: Previous page
@@ -417,9 +418,10 @@ manage:
       descending: descending
       title: Title
       created: Created
-    no-description: No description
-    page-showing-video-ids: '{{start}}–{{end}} of {{total}}'
-    no-videos-found: No videos found.
+    no-entries-found: No entries found.
+
+  my-videos:
+    title: My videos
     details:
       title: Video details
       share-direct-link: Share via direct link

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -406,7 +406,7 @@ manage:
       To rename, modify, and delete pages, navigate to the page in question. If you
       are logged in and have the necessary permissions, page management buttons will appear.
 
-  asset-table:
+  item-table:
     page-showing-ids: '{{start}}–{{end}} of {{total}}'
     navigation:
       first: First page

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -424,6 +424,8 @@ manage:
 
   my-series:
     title: My series
+    content: Content
+    no-of-videos: '{{count}} videos'
 
   my-videos:
     title: My videos

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -206,6 +206,7 @@ series:
     text: >
       The data of the requested series has not been fully transferred yet. This should
       happen automatically soon. Try again in a few minutes.
+    label: not synchronized
 
 videolist-block:
   upcoming-live-streams: "Upcoming live streams ({{count}})"
@@ -419,6 +420,10 @@ manage:
       title: Title
       created: Created
     no-entries-found: No entries found.
+
+  my-series:
+    title: My series
+    missing-date: Unknown
 
   my-videos:
     title: My videos

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -420,10 +420,10 @@ manage:
       title: Title
       created: Created
     no-entries-found: No entries found.
+    missing-date: Unknown
 
   my-series:
     title: My series
-    missing-date: Unknown
 
   my-videos:
     title: My videos

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -26,6 +26,8 @@ import { ManageRoute } from "../../routes/manage";
 import { ManageVideosRoute } from "../../routes/manage/Video";
 import { LoginLink } from "../../routes/util";
 import { CREDENTIALS_STORAGE_KEY } from "../../routes/Video";
+import { ManageSeriesRoute } from "../../routes/manage/Series";
+import SeriesIcon from "../../icons/series.svg";
 
 
 
@@ -220,6 +222,12 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
             icon: <LuFilm />,
             wrapper: <Link to={ManageVideosRoute.url} />,
             children: t("manage.my-videos.title"),
+            css: indent,
+        },
+        {
+            icon: <SeriesIcon />,
+            wrapper: <Link to={ManageSeriesRoute.url} />,
+            children: t("manage.my-series.title"),
             css: indent,
         },
         ...user.canUpload ? [{

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -29,6 +29,7 @@ import { ManageVideoTechnicalDetailsRoute } from "./routes/manage/Video/Technica
 import React from "react";
 import { ManageVideoAccessRoute } from "./routes/manage/Video/Access";
 import { DirectPlaylistOCRoute, DirectPlaylistRoute } from "./routes/Playlist";
+import { ManageSeriesRoute } from "./routes/manage/Series";
 
 
 
@@ -65,6 +66,7 @@ const {
         ManageVideoDetailsRoute,
         ManageVideoTechnicalDetailsRoute,
         ManageRealmRoute,
+        ManageSeriesRoute,
         UploadRoute,
         AddChildRoute,
         ManageRealmContentRoute,

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -189,7 +189,7 @@ const query = graphql`
                         id
                         title
                         description
-                        thumbnails { thumbnail isLive audioOnly }
+                        thumbnailStack { thumbnails { url live audioOnly } }
                         hostRealms { path ancestorNames }
                         matches { title description }
                     }
@@ -848,12 +848,12 @@ const TextMatchTooltip: React.FC<TextMatchTooltipProps> = ({ previewImage, textM
 
 type ThumbnailInfo = {
     readonly audioOnly: boolean;
-    readonly isLive: boolean;
-    readonly thumbnail: string | null | undefined;
+    readonly live: boolean;
+    readonly url: string | null | undefined;
 }
 
 const SearchSeries: React.FC<SeriesItem> = ({
-    id, title, description, thumbnails, matches, hostRealms,
+    id, title, description, thumbnailStack, matches, hostRealms,
 }) => {
     // TODO: decide what to do in the case of more than two host realms. Direct
     // link should be avoided.
@@ -863,7 +863,7 @@ const SearchSeries: React.FC<SeriesItem> = ({
 
     return <Item key={id} breakpoint={550} link={link}>{{
         image: <Link to={link} tabIndex={-1}>
-            <ThumbnailStack {...{ thumbnails, title }} />
+            <ThumbnailStack {...{ thumbnailStack, title }} />
         </Link>,
         info: <div css={{
             display: "flex",
@@ -894,9 +894,9 @@ const SearchSeries: React.FC<SeriesItem> = ({
     }}</Item>;
 };
 
-type ThumbnailStackProps = Pick<SeriesItem, "title" | "thumbnails">
+type ThumbnailStackProps = Pick<SeriesItem, "title" | "thumbnailStack">
 
-export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, title }) => {
+export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnailStack, title }) => {
     const isDarkScheme = useColorScheme().scheme === "dark";
 
     return (
@@ -939,12 +939,12 @@ export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, titl
                 gridRow: "1 / span 10",
             },
         }}>
-            {thumbnails.slice(0, 3).map((info, idx) => <div key={idx}>
+            {thumbnailStack.thumbnails.slice(0, 3).map((info, idx) => <div key={idx}>
                 <SeriesThumbnail {...{ info, title }} />
             </div>)}
             {/* Add fake thumbnails to always have 3. The visual image of 3 things behind each other
                 is more important than actually showing the correct number of thumbnails. */}
-            {[...Array(Math.max(0, 3 - thumbnails.length))].map((_, idx) => (
+            {[...Array(Math.max(0, 3 - thumbnailStack.thumbnails.length))].map((_, idx) => (
                 <div key={"dummy" + idx}>
                     <DummySeriesStackThumbnail isDark={isDarkScheme} />
                 </div>
@@ -999,10 +999,10 @@ const SeriesThumbnail: React.FC<SeriesThumbnailProps> = ({ info, title }) => {
     const isDark = useColorScheme().scheme === "dark";
 
     let inner;
-    if (info.thumbnail != null) {
+    if (info.url != null) {
         // We have a proper thumbnail.
         inner = <ThumbnailImg
-            src={info.thumbnail}
+            src={info.url}
             alt={t("series.entry-of-series-thumbnail", { series: title })}
         />;
     } else {
@@ -1016,7 +1016,7 @@ const SeriesThumbnail: React.FC<SeriesThumbnailProps> = ({ info, title }) => {
 
     return <ThumbnailOverlayContainer>
         {inner}
-        {info.isLive && overlay}
+        {info.live && overlay}
     </ThumbnailOverlayContainer>;
 };
 

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -896,7 +896,7 @@ const SearchSeries: React.FC<SeriesItem> = ({
 
 type ThumbnailStackProps = Pick<SeriesItem, "title" | "thumbnails">
 
-const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, title }) => {
+export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, title }) => {
     const isDarkScheme = useColorScheme().scheme === "dark";
 
     return (

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -13,7 +13,7 @@ import {
     createQueryParamsParser,
     DateColumn,
     descriptionStyle,
-    ManageAssets,
+    ManageItems,
     TableRow,
     thumbnailLinkStyle,
     titleLinkStyle,
@@ -48,7 +48,7 @@ export const ManageSeriesRoute = makeRoute({
                 nav={() => <ManageNav active={PATH} />}
                 render={data => !data.currentUser
                     ? <NotAuthorized />
-                    : <ManageAssets
+                    : <ManageItems
                         vars={vars}
                         connection={data.currentUser.mySeries}
                         titleKey="manage.my-series.title"
@@ -109,12 +109,12 @@ export const seriesColumns: ColumnProps[] = [
     },
     {
         key: "UPDATED",
-        label: "manage.asset-table.columns.updated",
+        label: "manage.item-table.columns.updated",
         column: series => "updated" in series && <DateColumn date={series.updated ?? undefined} />,
     },
     {
         key: "CREATED",
-        label: "manage.asset-table.columns.created",
+        label: "manage.item-table.columns.created",
         column: series => <DateColumn date={series.created ?? undefined} />,
     },
 ];

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -10,8 +10,8 @@ import { loadQuery } from "../../../relay";
 import { NotAuthorized } from "../../../ui/error";
 import {
     ColumnProps,
-    CreatedColumn,
     createQueryParamsParser,
+    DateColumn,
     descriptionStyle,
     ManageAssets,
     TableRow,
@@ -79,6 +79,7 @@ const query = graphql`
                     id
                     title
                     created
+                    updated
                     syncedData { description }
                     entries {
                         __typename
@@ -107,9 +108,14 @@ export const seriesColumns: ColumnProps[] = [
         </td>,
     },
     {
+        key: "UPDATED",
+        label: "manage.asset-table.columns.updated",
+        column: series => "updated" in series && <DateColumn date={series.updated ?? undefined} />,
+    },
+    {
         key: "CREATED",
         label: "manage.asset-table.columns.created",
-        column: series => <CreatedColumn created={series.created ?? undefined} />,
+        column: series => <DateColumn date={series.created ?? undefined} />,
     },
 ];
 

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -79,13 +79,8 @@ const query = graphql`
                     created
                     updated
                     syncedData { description }
-                    entries {
-                        __typename
-                        ...on AuthorizedEvent {
-                            isLive
-                            syncedData { thumbnail audioOnly }
-                        }
-                    }
+                    numVideos
+                    thumbnailStack { thumbnails { url live audioOnly }}
                 }
             }
         }
@@ -95,7 +90,6 @@ const query = graphql`
 export type SeriesConnection = NonNullable<SeriesManageQuery$data["currentUser"]>["mySeries"];
 export type Series = SeriesConnection["items"];
 export type SingleSeries = Series[number];
-export type Entry = SingleSeries["entries"][number];
 
 export const seriesColumns: ColumnProps<SingleSeries>[] = [
     {
@@ -103,7 +97,7 @@ export const seriesColumns: ColumnProps<SingleSeries>[] = [
         label: "manage.my-series.content",
         headerWidth: 112,
         column: ({ item }) => <td css={{ fontSize: 14 }}>
-            {i18n.t("manage.my-series.no-of-videos", { count: item.entries?.length })}
+            {i18n.t("manage.my-series.no-of-videos", { count: item.numVideos })}
         </td>,
     },
     {
@@ -123,20 +117,11 @@ export const SeriesRow: React.FC<{ item: SingleSeries }> = ({ item }) => {
     // Todo: change to "series details" route when available
     const link = DirectSeriesRoute.url({ seriesId: item.id });
 
-    type AuthorizedEvent = Extract<Entry, { __typename: "AuthorizedEvent" }>;
-    const thumbnails = item.entries
-        .filter((e): e is AuthorizedEvent => e.__typename === "AuthorizedEvent")
-        .map(e => ({
-            isLive: e.isLive,
-            audioOnly: e.syncedData ? e.syncedData.audioOnly : false,
-            thumbnail: e.syncedData?.thumbnail,
-        }));
-
     return (
         <TableRow
             thumbnail={<Link to={link} css={{ ...thumbnailLinkStyle }}>
                 <span css={{ "> div": { width: "100%" } }}>
-                    <ThumbnailStack title={item.title} {...{ thumbnails }} />
+                    <ThumbnailStack title={item.title} thumbnailStack={item.thumbnailStack} />
                 </span>
             </Link>}
             title={<Link to={link} css={{ ...titleLinkStyle }}>{item.title}</Link>}

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -1,0 +1,147 @@
+import { graphql } from "react-relay";
+
+import { ManageNav } from "..";
+import { RootLoader } from "../../../layout/Root";
+
+import { makeRoute } from "../../../rauta";
+import { loadQuery } from "../../../relay";
+import { NotAuthorized } from "../../../ui/error";
+import {
+    CreatedColumn,
+    descriptionStyle,
+    ManageAssets,
+    queryParamsToVars,
+    TableRow,
+    thumbnailLinkStyle,
+    titleLinkStyle,
+} from "../shared";
+import { useColorScheme } from "@opencast/appkit";
+import { useTranslation } from "react-i18next";
+import { COLORS } from "../../../color";
+import {
+    SeriesManageQuery,
+    SeriesManageQuery$data,
+} from "./__generated__/SeriesManageQuery.graphql";
+import { Link } from "../../../router";
+import { ThumbnailStack } from "../../Search";
+import { DirectSeriesRoute } from "../../Series";
+import { SmallDescription } from "../../../ui/metadata";
+
+
+const PATH = "/~manage/series" as const;
+
+export const ManageSeriesRoute = makeRoute({
+    url: PATH,
+    match: url => {
+        if (url.pathname !== PATH) {
+            return null;
+        }
+
+        const vars = queryParamsToVars(url.searchParams);
+        const queryRef = loadQuery<SeriesManageQuery>(query, vars);
+
+        return {
+            render: () => <RootLoader
+                {...{ query, queryRef }}
+                noindex
+                nav={() => <ManageNav active={PATH} />}
+                render={data => !data.currentUser
+                    ? <NotAuthorized />
+                    : <ManageAssets
+                        vars={vars}
+                        connection={data.currentUser.mySeries}
+                        titleKey="manage.my-series.title"
+                    />
+                }
+            />,
+            dispose: () => queryRef.dispose(),
+        };
+    },
+});
+
+const query = graphql`
+    query SeriesManageQuery(
+        $order: SortOrder!,
+        $offset: Int!,
+        $limit: Int!,
+    ) {
+        ...UserData
+        currentUser {
+            mySeries(order: $order, offset: $offset, limit: $limit) {
+                __typename
+                totalCount
+                pageInfo {
+                    hasNextPage hasPreviousPage
+                    startIndex endIndex
+                }
+                items {
+                    id
+                    title
+                    created
+                    syncedData { description }
+                    entries {
+                        __typename
+                        ...on AuthorizedEvent {
+                            isLive
+                            syncedData { thumbnail audioOnly }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export type SeriesConnection = NonNullable<SeriesManageQuery$data["currentUser"]>["mySeries"];
+export type Series = SeriesConnection["items"];
+
+export const SeriesRow: React.FC<{ series: Series[number] }> = ({ series }) => {
+    const { t } = useTranslation();
+    const isDark = useColorScheme().scheme === "dark";
+    const created = series.created && new Date(series.created);
+
+    // Todo: change to "series details" route when available
+    const link = DirectSeriesRoute.url({ seriesId: series.id });
+
+    // Seems odd, but simply checking `e => e.__typename === "AuthorizedEvent"` will produce
+    // TS2339 errors when compiling.
+    type Entry = Series[number]["entries"][number];
+    const isAuthorizedEvent = (e: Entry): e is Extract<
+        Entry, { __typename: "AuthorizedEvent" }
+    > => e.__typename === "AuthorizedEvent";
+
+    const thumbnails = series.entries
+        .filter(isAuthorizedEvent)
+        .map(e => ({
+            isLive: e.isLive,
+            audioOnly: e.syncedData ? e.syncedData.audioOnly : false,
+            thumbnail: e.syncedData?.thumbnail,
+        }));
+
+    return (
+        <TableRow
+            thumbnail={<Link to={link} css={{ ...thumbnailLinkStyle }}>
+                <span css={{ "> div": { width: "100%" } }}>
+                    <ThumbnailStack title={series.title} {...{ thumbnails }} />
+                </span>
+            </Link>}
+            title={<Link to={link} css={{ ...titleLinkStyle }}>{series.title}</Link>}
+            description={series.syncedData && <SmallDescription
+                css={{ ...descriptionStyle }}
+                text={series.syncedData.description}
+            />}
+            syncInfo={{
+                isSynced: !!series.syncedData,
+                notReadyLabel: "series.not-ready.label",
+            }}
+        >
+            {created
+                ? <CreatedColumn {...{ created }} />
+                : <i css={{ color: isDark ? COLORS.neutral60 : COLORS.neutral50 }}>
+                    {t("manage.my-series.missing-date")}
+                </i>
+            }
+        </TableRow>
+    );
+};
+

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -1,8 +1,10 @@
+import { Fragment } from "react";
 import { graphql } from "react-relay";
+import i18n from "../../../i18n";
+import { match } from "@opencast/appkit";
 
 import { ManageNav } from "..";
 import { RootLoader } from "../../../layout/Root";
-
 import { makeRoute } from "../../../rauta";
 import { loadQuery } from "../../../relay";
 import { NotAuthorized } from "../../../ui/error";
@@ -16,7 +18,6 @@ import {
     thumbnailLinkStyle,
     titleLinkStyle,
 } from "../shared";
-import { match } from "@opencast/appkit";
 import {
     SeriesManageQuery,
     SeriesManageQuery$data,
@@ -26,7 +27,6 @@ import { Link } from "../../../router";
 import { ThumbnailStack } from "../../Search";
 import { DirectSeriesRoute } from "../../Series";
 import { SmallDescription } from "../../../ui/metadata";
-import { Fragment } from "react";
 
 
 const PATH = "/~manage/series" as const;
@@ -99,6 +99,14 @@ export type SingleSeries = Series[number];
 
 export const seriesColumns: ColumnProps[] = [
     {
+        key: "EVENT_COUNT",
+        label: "manage.my-series.content",
+        headerWidth: 112,
+        column: series => "entries" in series && <td css={{ fontSize: 14 }}>
+            {i18n.t("manage.my-series.no-of-videos", { count: series.entries.length })}
+        </td>,
+    },
+    {
         key: "CREATED",
         label: "manage.asset-table.columns.created",
         column: series => <CreatedColumn created={series.created ?? undefined} />,
@@ -153,6 +161,7 @@ const parseSeriesColumn = (sortBy: string | null): SeriesSortColumn =>
         "title": () => "TITLE",
         "created": () => "CREATED",
         "updated": () => "UPDATED",
+        "event_count": () => "EVENT_COUNT",
     }) : "CREATED";
 
 const queryParamsToSeriesVars = createQueryParamsParser<SeriesSortColumn>(parseSeriesColumn);

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -52,6 +52,7 @@ export const ManageSeriesRoute = makeRoute({
                         vars={vars}
                         connection={data.currentUser.mySeries}
                         titleKey="manage.my-series.title"
+                        additionalColumns={seriesColumns}
                     />
                 }
             />,
@@ -97,25 +98,26 @@ const query = graphql`
 export type SeriesConnection = NonNullable<SeriesManageQuery$data["currentUser"]>["mySeries"];
 export type Series = SeriesConnection["items"];
 export type SingleSeries = Series[number];
+export type Entry = SingleSeries["entries"][number];
 
 export const seriesColumns: ColumnProps[] = [
     {
         key: "EVENT_COUNT",
         label: "manage.my-series.content",
         headerWidth: 112,
-        column: series => "entries" in series && <td css={{ fontSize: 14 }}>
-            {i18n.t("manage.my-series.no-of-videos", { count: series.entries.length })}
+        column: series => <td css={{ fontSize: 14 }}>
+            {i18n.t("manage.my-series.no-of-videos", { count: series.entries?.length })}
         </td>,
     },
     {
         key: "UPDATED",
         label: "manage.item-table.columns.updated",
-        column: series => "updated" in series && <DateColumn date={series.updated ?? undefined} />,
+        column: series => <DateColumn date={series.updated} />,
     },
     {
         key: "CREATED",
         label: "manage.item-table.columns.created",
-        column: series => <DateColumn date={series.created ?? undefined} />,
+        column: series => <DateColumn date={series.created} />,
     },
 ];
 
@@ -126,7 +128,6 @@ export const SeriesRow: React.FC<{ series: SingleSeries }> = ({ series }) => {
 
     // Seems odd, but simply checking `e => e.__typename === "AuthorizedEvent"` will produce
     // TS2339 errors when compiling.
-    type Entry = SingleSeries["entries"][number];
     type AuthorizedEvent = Extract<Entry, { __typename: "AuthorizedEvent" }>;
     const isAuthorizedEvent = (e: Entry): e is AuthorizedEvent =>
         e.__typename === "AuthorizedEvent";

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -26,7 +26,7 @@ import {
     createQueryParamsParser,
     DateColumn,
     descriptionStyle,
-    ManageAssets,
+    ManageItems,
     TableRow,
     thumbnailLinkStyle,
     titleLinkStyle,
@@ -52,7 +52,7 @@ export const ManageVideosRoute = makeRoute({
                 nav={() => <ManageNav active={PATH} />}
                 render={data => !data.currentUser
                     ? <NotAuthorized />
-                    : <ManageAssets
+                    : <ManageItems
                         vars={vars}
                         connection={data.currentUser.myVideos}
                         titleKey="manage.my-videos.title"
@@ -112,13 +112,13 @@ export type Event = Events[number];
 export const videoColumns: ColumnProps[] = [
     {
         key: "UPDATED",
-        label: "manage.asset-table.columns.updated",
+        label: "manage.item-table.columns.updated",
         column: event => (event.syncedData && "updated" in event.syncedData)
             && <DateColumn date={event.syncedData.updated} />,
     },
     {
         key: "CREATED",
-        label: "manage.asset-table.columns.created",
+        label: "manage.item-table.columns.created",
         column: event => <DateColumn date={event.created ?? undefined} />,
     },
 ];

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -23,8 +23,8 @@ import { relativeDate } from "../../../ui/time";
 import CONFIG from "../../../config";
 import {
     ColumnProps,
-    CreatedColumn,
     createQueryParamsParser,
+    DateColumn,
     descriptionStyle,
     ManageAssets,
     TableRow,
@@ -111,9 +111,15 @@ export type Event = Events[number];
 // Todo: add series column
 export const videoColumns: ColumnProps[] = [
     {
+        key: "UPDATED",
+        label: "manage.asset-table.columns.updated",
+        column: event => (event.syncedData && "updated" in event.syncedData)
+            && <DateColumn date={event.syncedData.updated} />,
+    },
+    {
         key: "CREATED",
         label: "manage.asset-table.columns.created",
-        column: event => <CreatedColumn created={event.created ?? undefined} />,
+        column: event => <DateColumn date={event.created ?? undefined} />,
     },
 ];
 

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { useColorScheme } from "@opencast/appkit";
+import { match, useColorScheme } from "@opencast/appkit";
 
 import { ManageNav } from "..";
 import { RootLoader } from "../../../layout/Root";
 import {
     VideoManageQuery,
     VideoManageQuery$data,
+    VideosSortColumn,
 } from "./__generated__/VideoManageQuery.graphql";
 import { makeRoute } from "../../../rauta";
 import { loadQuery } from "../../../relay";
@@ -21,9 +22,9 @@ import { relativeDate } from "../../../ui/time";
 import CONFIG from "../../../config";
 import {
     CreatedColumn,
+    createQueryParamsParser,
     descriptionStyle,
     ManageAssets,
-    queryParamsToVars,
     TableRow,
     thumbnailLinkStyle,
     titleLinkStyle,
@@ -39,7 +40,7 @@ export const ManageVideosRoute = makeRoute({
             return null;
         }
 
-        const vars = queryParamsToVars(url.searchParams);
+        const vars = queryParamsToVideosVars(url.searchParams);
         const queryRef = loadQuery<VideoManageQuery>(query, vars);
 
         return {
@@ -63,7 +64,7 @@ export const ManageVideosRoute = makeRoute({
 
 const query = graphql`
     query VideoManageQuery(
-        $order: SortOrder!,
+        $order: VideosSortOrder!,
         $offset: Int!,
         $limit: Int!,
     ) {
@@ -179,3 +180,12 @@ const PendingDeletionBody: React.FC<PendingDeleteBodyProps> = ({
         </div>
     );
 };
+
+const parseVideosColumn = (sortBy: string | null): VideosSortColumn =>
+    sortBy !== null ? match<string, VideosSortColumn>(sortBy, {
+        "title": () => "TITLE",
+        "created": () => "CREATED",
+        "updated": () => "UPDATED",
+    }) : "CREATED";
+
+const queryParamsToVideosVars = createQueryParamsParser<VideosSortColumn>(parseVideosColumn);

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,16 +1,10 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-    LuArrowDownNarrowWide, LuArrowUpWideNarrow, LuChevronLeft, LuChevronRight,
-} from "react-icons/lu";
-import { graphql, VariablesOf } from "react-relay";
-import { match, useColorScheme, Card } from "@opencast/appkit";
+import { graphql } from "react-relay";
+import { useColorScheme } from "@opencast/appkit";
 
-import { ManageNav, ManageRoute } from "..";
+import { ManageNav } from "..";
 import { RootLoader } from "../../../layout/Root";
 import {
-    SortColumn,
-    SortDirection,
     VideoManageQuery,
     VideoManageQuery$data,
 } from "./__generated__/VideoManageQuery.graphql";
@@ -20,15 +14,12 @@ import { Link } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Thumbnail } from "../../../ui/Video";
 import { keyOfId } from "../../../util";
-import FirstPage from "../../../icons/first-page.svg";
-import LastPage from "../../../icons/last-page.svg";
 import { SmallDescription } from "../../../ui/metadata";
-import { Breadcrumbs } from "../../../ui/Breadcrumbs";
-import { PageTitle } from "../../../layout/header/ui";
 import { COLORS } from "../../../color";
 import { InfoWithTooltip } from "../../../ui";
 import { relativeDate } from "../../../ui/time";
 import CONFIG from "../../../config";
+import { ManageAssets, queryParamsToVars } from "../shared";
 
 
 const PATH = "/~manage/videos" as const;
@@ -50,7 +41,12 @@ export const ManageVideosRoute = makeRoute({
                 nav={() => <ManageNav active={PATH} />}
                 render={data => !data.currentUser
                     ? <NotAuthorized />
-                    : <ManageVideos vars={vars} connection={data.currentUser.myVideos} />
+                    : <ManageAssets
+                        vars={vars}
+                        connection={data.currentUser.myVideos}
+                        titleKey="manage.my-videos.title"
+                        Row={Row}
+                    />
                 }
             />,
             dispose: () => queryRef.dispose(),
@@ -101,206 +97,7 @@ const query = graphql`
 export type EventConnection = NonNullable<VideoManageQuery$data["currentUser"]>["myVideos"];
 export type Events = EventConnection["items"];
 
-type Props = {
-    connection: EventConnection;
-    vars: VariablesOf<VideoManageQuery>;
-};
-
-const LIMIT = 15;
-
-/** Main part of this page */
-const ManageVideos: React.FC<Props> = ({ connection, vars }) => {
-    const { t } = useTranslation();
-
-    const totalCount = connection.totalCount;
-    const limit = vars.limit ?? 15;
-    const offset = vars.offset ?? 0;
-    const page = Math.floor(offset / limit) + 1;
-
-    useEffect(() => {
-        const maxPage = Math.ceil(totalCount / limit);
-        if (page > maxPage) {
-            window.location.href = `?page=${maxPage}`;
-        }
-        // Checking for page < 1 is done in `queryParamsToVars`.
-    }, [page, totalCount, limit]);
-
-    let inner;
-    if (connection.items.length === 0 && connection.totalCount === 0) {
-        inner = <Card kind="info">{t("manage.my-videos.no-videos-found")}</Card>;
-    } else {
-        inner = <>
-            <PageNavigation {...{ vars, connection }} />
-            <div css={{ flex: "1 0 0", margin: "16px 0" }}>
-                <EventTable events={connection.items} vars={vars} />
-            </div>
-            <PageNavigation {...{ vars, connection }} />
-        </>;
-    }
-
-    const title = t("manage.my-videos.title");
-
-    return (
-        <div css={{
-            display: "flex",
-            flexDirection: "column",
-            height: "100%",
-        }}>
-            <Breadcrumbs
-                path={[{ label: t("user.manage-content"), link: ManageRoute.url }]}
-                tail={title}
-            />
-            <PageTitle title={title} css={{ marginBottom: 32 }}/>
-            {inner}
-        </div>
-    );
-};
-
-const THUMBNAIL_WIDTH = 16 * 8;
-
-type EventTableProps = {
-    events: Events;
-    vars: VariablesOf<VideoManageQuery>;
-};
-
-const EventTable: React.FC<EventTableProps> = ({ events, vars }) => {
-    const { t } = useTranslation();
-
-    // We need to know whether the table header is in its "sticky" position to apply a box
-    // shadow to indicate that the user can still scroll up. This solution uses intersection
-    // observer. Compare: https://stackoverflow.com/a/57991537/2408867
-    const [headerSticks, setHeaderSticks] = useState(false);
-    const tableHeaderRef = useRef<HTMLTableSectionElement>(null);
-    useEffect(() => {
-        const tableHeader = tableHeaderRef.current;
-        if (tableHeader) {
-            const observer = new IntersectionObserver(
-                ([e]) => setHeaderSticks(!e.isIntersecting),
-                { threshold: [1], rootMargin: "-1px 0px 0px 0px" },
-            );
-
-            observer.observe(tableHeader);
-            return () => observer.unobserve(tableHeader);
-        }
-        return () => {};
-    });
-
-    return <div css={{ position: "relative" }}>
-        <table css={{
-            width: "100%",
-            borderSpacing: 0,
-            tableLayout: "fixed",
-            "& > thead": {
-                position: "sticky",
-                top: 0,
-                zIndex: 10,
-                backgroundColor: COLORS.neutral05,
-                "&  > tr > th": {
-                    borderBottom: `1px solid ${COLORS.neutral25}`,
-                    textAlign: "left",
-                    padding: "8px 12px",
-                },
-                ...headerSticks && {
-                    boxShadow: "0 0 20px rgba(0, 0, 0, 0.3)",
-                    clipPath: "inset(0px 0px -20px 0px)",
-                },
-            },
-            "& > tbody": {
-                "& > tr:hover, tr:focus-within": {
-                    backgroundColor: COLORS.neutral15,
-                },
-                "& > tr:not(:first-child) > td": {
-                    borderTop: `1px solid ${COLORS.neutral25}`,
-                },
-                "& td": {
-                    padding: 6,
-                    verticalAlign: "top",
-                    "&:not(:first-child)": {
-                        padding: "8px 12px 8px 8px",
-                    },
-                },
-            },
-        }}>
-            <colgroup>
-                <col span={1} css={{ width: THUMBNAIL_WIDTH + 2 * 6 }} />
-                <col span={1} />
-                <col span={1} css={{ width: 135 }} />
-            </colgroup>
-
-            <thead ref={tableHeaderRef}>
-                <tr>
-                    <th></th>
-                    <ColumnHeader
-                        label={t("manage.my-videos.columns.title")}
-                        sortKey="TITLE"
-                        {...{ vars }}
-                    />
-                    <ColumnHeader
-                        label={t("manage.my-videos.columns.created")}
-                        sortKey="CREATED"
-                        {...{ vars }}
-                    />
-                </tr>
-            </thead>
-            <tbody>
-                {events.map(event => <Row key={event.id} event={event} />)}
-            </tbody>
-        </table>
-    </div>;
-};
-
-type ColumnHeaderProps = {
-    label: string;
-    sortKey: SortColumn;
-    vars: VariablesOf<VideoManageQuery>;
-};
-
-const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => {
-    const { t } = useTranslation();
-    const direction = vars.order.column === sortKey && vars.order.direction === "ASCENDING"
-        ? "DESCENDING"
-        : "ASCENDING";
-    const directionTransKey = direction.toLowerCase() as Lowercase<typeof direction>;
-
-    return <th>
-        <Link
-            aria-label={t("manage.my-videos.columns.description",
-                { title: label, direction: t(`manage.my-videos.columns.${directionTransKey}`) })
-            }
-            to={varsToLink({
-                order: {
-                    column: sortKey,
-                    direction,
-                },
-                limit: vars.limit,
-                offset: vars.offset,
-            })}
-            css={{
-                display: "inline-flex",
-                alignItems: "center",
-                cursor: "pointer",
-                transition: "color 70ms",
-                textDecoration: "none",
-                borderRadius: 4,
-                outlineOffset: 1,
-                "& > svg": {
-                    marginLeft: 6,
-                    fontSize: 22,
-                },
-            }}
-        >
-            {label}
-            {vars.order.column === sortKey && match(vars.order.direction, {
-                // Seems like this is flipped right? But no, a short internal
-                // poll showed that this matches the intuition of almost everyone.
-                "ASCENDING": () => <LuArrowDownNarrowWide />,
-                "DESCENDING": () => <LuArrowUpWideNarrow />,
-            }, () => null)}
-        </Link>
-    </th>;
-};
-
-const Row: React.FC<{ event: Events[number] }> = ({ event }) => {
+const Row: React.FC<{ asset: Events[number] }> = ({ asset: event }) => {
     const isDark = useColorScheme().scheme === "dark";
     const created = new Date(event.created);
     const link = `${PATH}/${keyOfId(event.id)}`;
@@ -422,178 +219,4 @@ const PendingDeletionBody: React.FC<PendingDeleteBodyProps> = ({
             />
         </div>
     );
-};
-
-type PageNavigationProps = {
-    connection: EventConnection;
-    vars: VariablesOf<VideoManageQuery>;
-};
-
-const PageNavigation: React.FC<PageNavigationProps> = ({ connection, vars }) => {
-    const { t } = useTranslation();
-    const pageInfo = connection.pageInfo;
-    const total = connection.totalCount;
-
-    const limit = vars.limit ?? LIMIT;
-    const offset = vars.offset ?? 0;
-
-    const prevOffset = Math.max(0, offset - limit);
-    const nextOffset = offset + limit;
-    const lastOffset = total > 0
-        ? Math.floor((total - 1) / limit) * limit
-        : 0;
-
-    return (
-        <div css={{
-            display: "flex",
-            justifyContent: "flex-end",
-            alignItems: "center",
-            gap: 48,
-        }}>
-            <div>
-                {t("manage.my-videos.page-showing-video-ids", {
-                    start: connection.pageInfo.startIndex ?? "?",
-                    end: connection.pageInfo.endIndex ?? "?",
-                    total,
-                })}
-            </div>
-            <div css={{ display: "flex", alignItems: "center" }}>
-                {/* First page */}
-                <PageLink
-                    vars={{ ...vars, offset: 0 }}
-                    disabled={!pageInfo.hasPreviousPage && connection.items.length === limit}
-                    label={t("manage.my-videos.navigation.first")}
-                ><FirstPage /></PageLink>
-                {/* Previous page */}
-                <PageLink
-                    vars={{ ...vars, offset: prevOffset }}
-                    disabled={!pageInfo.hasPreviousPage}
-                    label={t("manage.my-videos.navigation.previous")}
-                ><LuChevronLeft /></PageLink>
-                {/* Next page */}
-                <PageLink
-                    vars={{ ...vars, offset: nextOffset }}
-                    disabled={!pageInfo.hasNextPage}
-                    label={t("manage.my-videos.navigation.next")}
-                ><LuChevronRight /></PageLink>
-                {/* Last page */}
-                <PageLink
-                    vars={{ ...vars, offset: lastOffset }}
-                    disabled={!pageInfo.hasNextPage}
-                    label={t("manage.my-videos.navigation.last")}
-                ><LastPage /></PageLink>
-            </div>
-        </div>
-    );
-};
-
-type PageLinkProps = {
-    vars: VariablesOf<VideoManageQuery>;
-    disabled: boolean;
-    children: ReactNode;
-    label: string;
-};
-
-const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled, label }) => (
-    <Link
-        to={varsToLink(vars)}
-        tabIndex={disabled ? -1 : 0}
-        aria-hidden={disabled}
-        aria-label={label}
-        css={{
-            background: "none",
-            border: "none",
-            fontSize: 24,
-            padding: "4px 4px",
-            margin: "0 4px",
-            lineHeight: 0,
-            borderRadius: 4,
-            ...disabled
-                ? {
-                    color: COLORS.neutral25,
-                    pointerEvents: "none",
-                }
-                : {
-                    color: COLORS.neutral60,
-                    cursor: "pointer",
-                    ":hover, :focus": {
-                        color: COLORS.neutral90,
-                    },
-                },
-        }}
-    >{children}</Link>
-);
-
-const DEFAULT_SORT_COLUMN: SortColumn = "CREATED";
-const DEFAULT_SORT_DIRECTION: SortDirection = "DESCENDING";
-
-/** Reads URL query parameters and converts them into query variables */
-const queryParamsToVars = (queryParams: URLSearchParams): VariablesOf<VideoManageQuery> => {
-    // Sort order
-    const sortBy = queryParams.get("sortBy");
-    const column = sortBy !== null && match<string, SortColumn>(sortBy, {
-        "title": () => "TITLE",
-        "created": () => "CREATED",
-        "updated": () => "UPDATED",
-    });
-
-    const sortOrder = queryParams.get("sortOrder");
-    const direction = sortOrder !== null && match<string, SortDirection>(sortOrder, {
-        "desc": () => "DESCENDING",
-        "asc": () => "ASCENDING",
-    });
-
-    const order = !column || !direction
-        ? { column: DEFAULT_SORT_COLUMN, direction: DEFAULT_SORT_DIRECTION }
-        : { column, direction };
-
-    // Pagination
-    const pageParam = queryParams.get("page");
-    const page = pageParam ? parseInt(pageParam, 10) : 1;
-    if (page < 1) {
-        window.location.href = "?page=1";
-    }
-
-    const limitParam = queryParams.get("limit");
-    const limit = limitParam ? parseInt(limitParam, 10) : LIMIT;
-
-    const offset = Math.max(0, (page - 1) * limit);
-
-    return { order, limit, offset };
-};
-
-/** Converts query variables to URL query parameters */
-const varsToQueryParams = (vars: VariablesOf<VideoManageQuery>): URLSearchParams => {
-    const searchParams = new URLSearchParams();
-
-    // Sort order
-    const isDefaultOrder = vars.order.column === DEFAULT_SORT_COLUMN
-        && vars.order.direction === DEFAULT_SORT_DIRECTION;
-    if (!isDefaultOrder) {
-        searchParams.set("sortBy", vars.order.column.toLowerCase());
-        searchParams.set("sortOrder", match(vars.order.direction, {
-            "ASCENDING": () => "asc",
-            "DESCENDING": () => "desc",
-        }, () => ""));
-    }
-
-    // Pagination
-    const limit = vars.limit ?? LIMIT;
-    const offset = vars.offset ?? 0;
-    const page = Math.floor(offset / limit) + 1;
-
-    if (page !== 1) {
-        searchParams.set("page", String(page));
-    }
-    if (limit !== LIMIT) {
-        searchParams.set("limit", String(limit));
-    }
-
-    return searchParams;
-};
-
-const varsToLink = (vars: VariablesOf<VideoManageQuery>): string => {
-    const url = new URL(document.location.href);
-    url.search = varsToQueryParams(vars).toString();
-    return url.href;
 };

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -56,6 +56,7 @@ export const ManageVideosRoute = makeRoute({
                         vars={vars}
                         connection={data.currentUser.myVideos}
                         titleKey="manage.my-videos.title"
+                        additionalColumns={videoColumns}
                     />
                 }
             />,
@@ -113,13 +114,12 @@ export const videoColumns: ColumnProps[] = [
     {
         key: "UPDATED",
         label: "manage.item-table.columns.updated",
-        column: event => (event.syncedData && "updated" in event.syncedData)
-            && <DateColumn date={event.syncedData.updated} />,
+        column: event => <DateColumn date={event.updated} />,
     },
     {
         key: "CREATED",
         label: "manage.item-table.columns.created",
-        column: event => <DateColumn date={event.created ?? undefined} />,
+        column: event => <DateColumn date={event.created} />,
     },
 ];
 
@@ -157,7 +157,12 @@ export const EventRow: React.FC<{ event: Event }> = ({ event }) => {
             notReadyLabel: "video.not-ready.label",
         }}
         customColumns={videoColumns.map(col => <Fragment key={col.key}>
-            {col.column(event)}
+            {col.column({
+                ...event,
+                description: event.description,
+                updated: event.syncedData?.updated,
+                created: event.created,
+            })}
         </Fragment>)}
     />;
 };

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
 import { match, useColorScheme } from "@opencast/appkit";
@@ -21,6 +22,7 @@ import { InfoWithTooltip } from "../../../ui";
 import { relativeDate } from "../../../ui/time";
 import CONFIG from "../../../config";
 import {
+    ColumnProps,
     CreatedColumn,
     createQueryParamsParser,
     descriptionStyle,
@@ -104,9 +106,18 @@ const query = graphql`
 
 export type EventConnection = NonNullable<VideoManageQuery$data["currentUser"]>["myVideos"];
 export type Events = EventConnection["items"];
+export type Event = Events[number];
 
-export const EventRow: React.FC<{ event: Events[number] }> = ({ event }) => {
-    const created = new Date(event.created);
+// Todo: add series column
+export const videoColumns: ColumnProps[] = [
+    {
+        key: "CREATED",
+        label: "manage.asset-table.columns.created",
+        column: event => <CreatedColumn created={event.created ?? undefined} />,
+    },
+];
+
+export const EventRow: React.FC<{ event: Event }> = ({ event }) => {
     const link = `${PATH}/${keyOfId(event.id)}`;
 
     const deletionIsPending = Boolean(event.tobiraDeletionTimestamp);
@@ -139,9 +150,10 @@ export const EventRow: React.FC<{ event: Events[number] }> = ({ event }) => {
             isSynced: !!event.syncedData,
             notReadyLabel: "video.not-ready.label",
         }}
-    >
-        <CreatedColumn {...{ created }} />
-    </TableRow>;
+        customColumns={videoColumns.map(col => <Fragment key={col.key}>
+            {col.column(event)}
+        </Fragment>)}
+    />;
 };
 
 type PendingDeleteBodyProps = {

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -24,6 +24,8 @@ import { translatedConfig } from "../../util";
 import i18n from "../../i18n";
 import { UploadRoute } from "../Upload";
 import { ManageVideosRoute } from "./Video";
+import SeriesIcon from "../../icons/series.svg";
+import { ManageSeriesRoute } from "./Series";
 
 
 const PATH = "/~manage" as const;
@@ -73,7 +75,11 @@ const Manage: React.FC = () => {
 
 
 type ManageNavProps = {
-    active?: typeof PATH | typeof ManageVideosRoute.url | typeof UploadRoute.url | `/@${string}`;
+    active?: typeof PATH
+        | typeof ManageVideosRoute.url
+        | typeof UploadRoute.url
+        | typeof ManageSeriesRoute.url
+        | `/@${string}`;
 };
 
 export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
@@ -86,6 +92,7 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
     const entries: [NonNullable<ManageNavProps["active"]>, string, ReactElement][] = [
         [PATH, t("manage.dashboard.title"), <LuLayoutTemplate />],
         [ManageVideosRoute.url, t("manage.my-videos.title"), <LuFilm />],
+        [ManageSeriesRoute.url, t("manage.my-series.title"), <SeriesIcon />],
     ];
     if (isRealUser(user) && user.canCreateUserRealm) {
         entries.splice(

--- a/frontend/src/routes/manage/shared.tsx
+++ b/frontend/src/routes/manage/shared.tsx
@@ -26,7 +26,7 @@ import { SeriesSortColumn } from "./Series/__generated__/SeriesManageQuery.graph
 
 
 type Connection = EventConnection | SeriesConnection;
-type AssetVars = {
+type ItemVars = {
     order: {
         column: SortColumn;
         direction: SortDirection;
@@ -37,16 +37,16 @@ type AssetVars = {
 
 type SharedProps = {
     connection: Connection;
-    vars: AssetVars;
+    vars: ItemVars;
 };
 
-type ManageAssetsProps = SharedProps & {
+type ManageItemProps = SharedProps & {
     titleKey: ParseKeys;
 }
 
 const LIMIT = 15;
 
-export const ManageAssets: React.FC<ManageAssetsProps> = ({ connection, vars, titleKey }) => {
+export const ManageItems: React.FC<ManageItemProps> = ({ connection, vars, titleKey }) => {
     const { t } = useTranslation();
 
     const totalCount = connection.totalCount;
@@ -66,12 +66,12 @@ export const ManageAssets: React.FC<ManageAssetsProps> = ({ connection, vars, ti
 
     let inner;
     if (connection.items.length === 0 && connection.totalCount === 0) {
-        inner = <Card kind="info">{t("manage.asset-table.no-entries-found")}</Card>;
+        inner = <Card kind="info">{t("manage.item-table.no-entries-found")}</Card>;
     } else {
         inner = <>
             <PageNavigation {...{ vars, connection }} />
             <div css={{ flex: "1 0 0", margin: "16px 0" }}>
-                <AssetTable {...{ vars, connection }} />
+                <ItemTable {...{ vars, connection }} />
             </div>
             <PageNavigation {...{ vars, connection }} />
         </>;
@@ -97,21 +97,21 @@ export const ManageAssets: React.FC<ManageAssetsProps> = ({ connection, vars, ti
 
 const THUMBNAIL_WIDTH = 16 * 8;
 
-type Asset = Event | SingleSeries;
+type Item = Event | SingleSeries;
 type SortColumn = VideosSortColumn | SeriesSortColumn;
 
 export type ColumnProps = {
     key: SortColumn;
     label: ParseKeys;
     headerWidth?: number;
-    column: (item: Asset) => ReactNode;
+    column: (item: Item) => ReactNode;
 };
 
 type GenericTableProps = SharedProps & {
     thumbnailWidth?: number;
 }
 
-const AssetTable: React.FC<GenericTableProps> = ({
+const ItemTable: React.FC<GenericTableProps> = ({
     connection,
     vars,
     thumbnailWidth,
@@ -197,7 +197,7 @@ const AssetTable: React.FC<GenericTableProps> = ({
                     <th></th>
                     {/* Title */}
                     <ColumnHeader
-                        label={t("manage.asset-table.columns.title")}
+                        label={t("manage.item-table.columns.title")}
                         sortKey="TITLE"
                         {...{ vars }}
                     />
@@ -262,7 +262,7 @@ export const DateColumn: React.FC<{ date?: string }> = ({ date }) => {
                 </span>
             </>
             : <i css={greyColor}>
-                {t("manage.asset-table.missing-date")}
+                {t("manage.item-table.missing-date")}
             </i>
         }
     </td>;
@@ -280,10 +280,10 @@ type TableRowProps = {
 };
 
 /**
- * A row in the asset table
- * This is assuming that each asset (video, series, playlist) has a thumbnail, title,
+ * A row in the item table.
+ * This is assuming that each item (video, series, playlist) has a thumbnail, title,
  * and description. These can still be somewhat customized.
- * Additional columns can be declared in the respective asset column arrays.
+ * Additional columns can be declared in the respective item column arrays.
  */
 export const TableRow: React.FC<TableRowProps> = ({
     thumbnail,
@@ -334,7 +334,7 @@ export const TableRow: React.FC<TableRowProps> = ({
 type ColumnHeaderProps = {
     label: string;
     sortKey: SortColumn;
-    vars: AssetVars;
+    vars: ItemVars;
 };
 
 const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => {
@@ -346,8 +346,8 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => 
 
     return <th>
         <Link
-            aria-label={t("manage.asset-table.columns.description",
-                { title: label, direction: t(`manage.asset-table.columns.${directionTransKey}`) })
+            aria-label={t("manage.item-table.columns.description",
+                { title: label, direction: t(`manage.item-table.columns.${directionTransKey}`) })
             }
             to={varsToLink({
                 order: {
@@ -404,7 +404,7 @@ const PageNavigation: React.FC<SharedProps> = ({ connection, vars }) => {
             gap: 48,
         }}>
             <div>
-                {t("manage.asset-table.page-showing-ids", {
+                {t("manage.item-table.page-showing-ids", {
                     start: connection.pageInfo.startIndex ?? "?",
                     end: connection.pageInfo.endIndex ?? "?",
                     total,
@@ -415,25 +415,25 @@ const PageNavigation: React.FC<SharedProps> = ({ connection, vars }) => {
                 <PageLink
                     vars={{ ...vars, offset: 0 }}
                     disabled={!pageInfo.hasPreviousPage && connection.items.length === limit}
-                    label={t("manage.asset-table.navigation.first")}
+                    label={t("manage.item-table.navigation.first")}
                 ><FirstPage /></PageLink>
                 {/* Previous page */}
                 <PageLink
                     vars={{ ...vars, offset: prevOffset }}
                     disabled={!pageInfo.hasPreviousPage}
-                    label={t("manage.asset-table.navigation.previous")}
+                    label={t("manage.item-table.navigation.previous")}
                 ><LuChevronLeft /></PageLink>
                 {/* Next page */}
                 <PageLink
                     vars={{ ...vars, offset: nextOffset }}
                     disabled={!pageInfo.hasNextPage}
-                    label={t("manage.asset-table.navigation.next")}
+                    label={t("manage.item-table.navigation.next")}
                 ><LuChevronRight /></PageLink>
                 {/* Last page */}
                 <PageLink
                     vars={{ ...vars, offset: lastOffset }}
                     disabled={!pageInfo.hasNextPage}
-                    label={t("manage.asset-table.navigation.last")}
+                    label={t("manage.item-table.navigation.last")}
                 ><LastPage /></PageLink>
             </div>
         </div>
@@ -441,7 +441,7 @@ const PageNavigation: React.FC<SharedProps> = ({ connection, vars }) => {
 };
 
 type PageLinkProps = {
-    vars: AssetVars;
+    vars: ItemVars;
     disabled: boolean;
     children: ReactNode;
     label: string;
@@ -531,7 +531,7 @@ export function createQueryParamsParser<ColumnType extends string>(
 }
 
 /** Converts query variables to URL query parameters */
-const varsToQueryParams = (vars: AssetVars): URLSearchParams => {
+const varsToQueryParams = (vars: ItemVars): URLSearchParams => {
     const searchParams = new URLSearchParams();
 
     // Sort order
@@ -560,7 +560,7 @@ const varsToQueryParams = (vars: AssetVars): URLSearchParams => {
     return searchParams;
 };
 
-const varsToLink = (vars: AssetVars): string => {
+const varsToLink = (vars: ItemVars): string => {
     const url = new URL(document.location.href);
     url.search = varsToQueryParams(vars).toString();
     return url.href;

--- a/frontend/src/routes/manage/shared.tsx
+++ b/frontend/src/routes/manage/shared.tsx
@@ -246,19 +246,19 @@ export const descriptionStyle = {
 } as const;
 
 // Used for both `EventRow` and `SeriesRow`.
-export const CreatedColumn: React.FC<{ created?: string }> = ({ created }) => {
+export const DateColumn: React.FC<{ date?: string }> = ({ date }) => {
     const { t, i18n } = useTranslation();
     const isDark = useColorScheme().scheme === "dark";
-    const createdDate = created && new Date(created);
+    const parsedDate = date && new Date(date);
     const greyColor = { color: isDark ? COLORS.neutral60 : COLORS.neutral50 };
 
     return <td css={{ fontSize: 14 }}>
-        {createdDate
+        {parsedDate
             ? <>
-                {createdDate.toLocaleDateString(i18n.language)}
+                {parsedDate.toLocaleDateString(i18n.language)}
                 <br />
                 <span css={greyColor}>
-                    {createdDate.toLocaleTimeString(i18n.language)}
+                    {parsedDate.toLocaleTimeString(i18n.language)}
                 </span>
             </>
             : <i css={greyColor}>

--- a/frontend/src/routes/manage/shared.tsx
+++ b/frontend/src/routes/manage/shared.tsx
@@ -1,0 +1,406 @@
+import { Card, match } from "@opencast/appkit";
+import { useState, useRef, useEffect, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { VariablesOf } from "react-relay";
+import {
+    LuArrowDownNarrowWide,
+    LuArrowUpWideNarrow,
+    LuChevronLeft,
+    LuChevronRight,
+} from "react-icons/lu";
+
+
+import FirstPage from "../../icons/first-page.svg";
+import LastPage from "../../icons/last-page.svg";
+import { ManageRoute } from ".";
+import { COLORS } from "../../color";
+import { PageTitle } from "../../layout/header/ui";
+import { Breadcrumbs } from "../../ui/Breadcrumbs";
+import {
+    VideoManageQuery,
+    SortDirection,
+    SortColumn,
+} from "./Video/__generated__/VideoManageQuery.graphql";
+import { EventConnection, Events } from "./Video";
+import { Link } from "../../router";
+import { ParseKeys } from "i18next";
+
+
+type Assets = Events;
+type AssetConnection = EventConnection;
+type AssetVars = VariablesOf<VideoManageQuery>;
+type TableRow = React.FC<{ asset: Events[number] }>;
+
+type Props = {
+    connection: AssetConnection;
+    vars: AssetVars;
+    Row: TableRow;
+    titleKey: ParseKeys;
+};
+
+const LIMIT = 15;
+
+export const ManageAssets: React.FC<Props> = ({ connection, vars, Row, titleKey }) => {
+    const { t } = useTranslation();
+
+    const totalCount = connection.totalCount;
+    const limit = vars.limit ?? 15;
+    const pageParam = new URLSearchParams(document.location.search).get("page");
+    const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+    useEffect(() => {
+        const maxPage = Math.max(Math.ceil(totalCount / limit), 1);
+
+        if (page > maxPage) {
+            window.location.href = `?page=${maxPage}`;
+        } else if (page < 1) {
+            window.location.href = "?page=1";
+        }
+    }, [page, totalCount, limit]);
+
+    let inner;
+    if (connection.items.length === 0 && connection.totalCount === 0) {
+        inner = <Card kind="info">{t("manage.asset-table.no-entries-found")}</Card>;
+    } else {
+        inner = <>
+            <PageNavigation {...{ vars, connection }} />
+            <div css={{ flex: "1 0 0", margin: "16px 0" }}>
+                <AssetTable assets={connection.items} vars={vars} Row={Row} />
+            </div>
+            <PageNavigation {...{ vars, connection }} />
+        </>;
+    }
+
+    const title = t(titleKey);
+
+    return (
+        <div css={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100%",
+        }}>
+            <Breadcrumbs
+                path={[{ label: t("user.manage-content"), link: ManageRoute.url }]}
+                tail={title}
+            />
+            <PageTitle title={title} css={{ marginBottom: 32 }}/>
+            {inner}
+        </div>
+    );
+};
+
+const THUMBNAIL_WIDTH = 16 * 8;
+
+type AssetTableProps = {
+    assets: Assets;
+    vars: AssetVars;
+    Row: TableRow;
+};
+
+const AssetTable: React.FC<AssetTableProps> = ({ assets, vars, Row }) => {
+    const { t } = useTranslation();
+
+    // We need to know whether the table header is in its "sticky" position to apply a box
+    // shadow to indicate that the user can still scroll up. This solution uses intersection
+    // observer. Compare: https://stackoverflow.com/a/57991537/2408867
+    const [headerSticks, setHeaderSticks] = useState(false);
+    const tableHeaderRef = useRef<HTMLTableSectionElement>(null);
+    useEffect(() => {
+        const tableHeader = tableHeaderRef.current;
+        if (tableHeader) {
+            const observer = new IntersectionObserver(
+                ([e]) => setHeaderSticks(!e.isIntersecting),
+                { threshold: [1], rootMargin: "-1px 0px 0px 0px" },
+            );
+
+            observer.observe(tableHeader);
+            return () => observer.unobserve(tableHeader);
+        }
+        return () => {};
+    });
+
+    return <div css={{ position: "relative" }}>
+        <table css={{
+            width: "100%",
+            borderSpacing: 0,
+            tableLayout: "fixed",
+            "& > thead": {
+                position: "sticky",
+                top: 0,
+                zIndex: 10,
+                backgroundColor: COLORS.neutral05,
+                "&  > tr > th": {
+                    borderBottom: `1px solid ${COLORS.neutral25}`,
+                    textAlign: "left",
+                    padding: "8px 12px",
+                },
+                ...headerSticks && {
+                    boxShadow: "0 0 20px rgba(0, 0, 0, 0.3)",
+                    clipPath: "inset(0px 0px -20px 0px)",
+                },
+            },
+            "& > tbody": {
+                "& > tr:hover, tr:focus-within": {
+                    backgroundColor: COLORS.neutral15,
+                },
+                "& > tr:not(:first-child) > td": {
+                    borderTop: `1px solid ${COLORS.neutral25}`,
+                },
+                "& td": {
+                    padding: 6,
+                    verticalAlign: "top",
+                    "&:not(:first-child)": {
+                        padding: "8px 12px 8px 8px",
+                    },
+                },
+            },
+        }}>
+            <colgroup>
+                <col span={1} css={{ width: THUMBNAIL_WIDTH + 2 * 6 }} />
+                <col span={1} />
+                <col span={1} css={{ width: 135 }} />
+            </colgroup>
+
+            <thead ref={tableHeaderRef}>
+                <tr>
+                    <th></th>
+                    <ColumnHeader
+                        label={t("manage.asset-table.columns.title")}
+                        sortKey="TITLE"
+                        {...{ vars }}
+                    />
+                    <ColumnHeader
+                        label={t("manage.asset-table.columns.created")}
+                        sortKey="CREATED"
+                        {...{ vars }}
+                    />
+                </tr>
+            </thead>
+            <tbody>
+                {assets.map(asset => <Row key={asset.id} asset={asset} />)}
+            </tbody>
+        </table>
+    </div>;
+};
+
+type ColumnHeaderProps = {
+    label: string;
+    sortKey: SortColumn;
+    vars: AssetVars;
+};
+
+const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => {
+    const { t } = useTranslation();
+    const direction = vars.order.column === sortKey && vars.order.direction === "ASCENDING"
+        ? "DESCENDING"
+        : "ASCENDING";
+    const directionTransKey = direction.toLowerCase() as Lowercase<typeof direction>;
+
+    return <th>
+        <Link
+            aria-label={t("manage.asset-table.columns.description",
+                { title: label, direction: t(`manage.asset-table.columns.${directionTransKey}`) })
+            }
+            to={varsToLink({
+                order: {
+                    column: sortKey,
+                    direction,
+                },
+                limit: vars.limit,
+                offset: vars.offset,
+            })}
+            css={{
+                display: "inline-flex",
+                alignItems: "center",
+                cursor: "pointer",
+                transition: "color 70ms",
+                textDecoration: "none",
+                borderRadius: 4,
+                outlineOffset: 1,
+                "& > svg": {
+                    marginLeft: 6,
+                    fontSize: 22,
+                },
+            }}
+        >
+            {label}
+            {vars.order.column === sortKey && match(vars.order.direction, {
+                // Seems like this is flipped right? But no, a short internal
+                // poll showed that this matches the intuition of almost everyone.
+                "ASCENDING": () => <LuArrowDownNarrowWide />,
+                "DESCENDING": () => <LuArrowUpWideNarrow />,
+            }, () => null)}
+        </Link>
+    </th>;
+};
+
+type PageNavigationProps = {
+    connection: AssetConnection;
+    vars: AssetVars;
+};
+
+const PageNavigation: React.FC<PageNavigationProps> = ({ connection, vars }) => {
+    const { t } = useTranslation();
+    const pageInfo = connection.pageInfo;
+    const total = connection.totalCount;
+
+    const limit = vars.limit ?? LIMIT;
+    const offset = vars.offset ?? 0;
+
+    const prevOffset = Math.max(0, offset - limit);
+    const nextOffset = offset + limit;
+    const lastOffset = total > 0
+        ? Math.floor((total - 1) / limit) * limit
+        : 0;
+
+    return (
+        <div css={{
+            display: "flex",
+            justifyContent: "flex-end",
+            alignItems: "center",
+            gap: 48,
+        }}>
+            <div>
+                {t("manage.asset-table.page-showing-ids", {
+                    start: connection.pageInfo.startIndex ?? "?",
+                    end: connection.pageInfo.endIndex ?? "?",
+                    total,
+                })}
+            </div>
+            <div css={{ display: "flex", alignItems: "center" }}>
+                {/* First page */}
+                <PageLink
+                    vars={{ ...vars, offset: 0 }}
+                    disabled={!pageInfo.hasPreviousPage && connection.items.length === limit}
+                    label={t("manage.asset-table.navigation.first")}
+                ><FirstPage /></PageLink>
+                {/* Previous page */}
+                <PageLink
+                    vars={{ ...vars, offset: prevOffset }}
+                    disabled={!pageInfo.hasPreviousPage}
+                    label={t("manage.asset-table.navigation.previous")}
+                ><LuChevronLeft /></PageLink>
+                {/* Next page */}
+                <PageLink
+                    vars={{ ...vars, offset: nextOffset }}
+                    disabled={!pageInfo.hasNextPage}
+                    label={t("manage.asset-table.navigation.next")}
+                ><LuChevronRight /></PageLink>
+                {/* Last page */}
+                <PageLink
+                    vars={{ ...vars, offset: lastOffset }}
+                    disabled={!pageInfo.hasNextPage}
+                    label={t("manage.asset-table.navigation.last")}
+                ><LastPage /></PageLink>
+            </div>
+        </div>
+    );
+};
+
+type PageLinkProps = {
+    vars: AssetVars;
+    disabled: boolean;
+    children: ReactNode;
+    label: string;
+};
+
+const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled, label }) => (
+    <Link
+        to={varsToLink(vars)}
+        tabIndex={disabled ? -1 : 0}
+        aria-hidden={disabled}
+        aria-label={label}
+        css={{
+            background: "none",
+            border: "none",
+            fontSize: 24,
+            padding: "4px 4px",
+            margin: "0 4px",
+            lineHeight: 0,
+            borderRadius: 4,
+            ...disabled
+                ? {
+                    color: COLORS.neutral25,
+                    pointerEvents: "none",
+                }
+                : {
+                    color: COLORS.neutral60,
+                    cursor: "pointer",
+                    ":hover, :focus": {
+                        color: COLORS.neutral90,
+                    },
+                },
+        }}
+    >{children}</Link>
+);
+
+const DEFAULT_SORT_COLUMN: SortColumn = "CREATED";
+const DEFAULT_SORT_DIRECTION: SortDirection = "DESCENDING";
+
+/** Reads URL query parameters and converts them into query variables */
+export const queryParamsToVars = (queryParams: URLSearchParams): AssetVars => {
+    // Sort order
+    const sortBy = queryParams.get("sortBy");
+    const column = sortBy !== null && match<string, SortColumn>(sortBy, {
+        "title": () => "TITLE",
+        "created": () => "CREATED",
+        "updated": () => "UPDATED",
+    });
+
+    const sortOrder = queryParams.get("sortOrder");
+    const direction = sortOrder !== null && match<string, SortDirection>(sortOrder, {
+        "desc": () => "DESCENDING",
+        "asc": () => "ASCENDING",
+    });
+
+    const order = !column || !direction
+        ? { column: DEFAULT_SORT_COLUMN, direction: DEFAULT_SORT_DIRECTION }
+        : { column, direction };
+
+    // Pagination
+    const pageParam = queryParams.get("page");
+    const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+    const limitParam = queryParams.get("limit");
+    const limit = limitParam ? parseInt(limitParam, 10) : LIMIT;
+
+    const offset = Math.max(0, (page - 1) * limit);
+
+    return { order, limit, offset };
+};
+
+/** Converts query variables to URL query parameters */
+const varsToQueryParams = (vars: AssetVars): URLSearchParams => {
+    const searchParams = new URLSearchParams();
+
+    // Sort order
+    const isDefaultOrder = vars.order.column === DEFAULT_SORT_COLUMN
+        && vars.order.direction === DEFAULT_SORT_DIRECTION;
+    if (!isDefaultOrder) {
+        searchParams.set("sortBy", vars.order.column.toLowerCase());
+        searchParams.set("sortOrder", match(vars.order.direction, {
+            "ASCENDING": () => "asc",
+            "DESCENDING": () => "desc",
+        }, () => ""));
+    }
+
+    // Pagination
+    const limit = vars.limit ?? LIMIT;
+    const offset = vars.offset ?? 0;
+    const page = Math.floor(offset / limit) + 1;
+
+    if (page !== 1) {
+        searchParams.set("page", String(page));
+    }
+    if (limit !== LIMIT) {
+        searchParams.set("limit", String(limit));
+    }
+
+    return searchParams;
+};
+
+const varsToLink = (vars: AssetVars): string => {
+    const url = new URL(document.location.href);
+    url.search = varsToQueryParams(vars).toString();
+    return url.href;
+};

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -8,12 +8,6 @@ schema {
   mutation: Mutation
 }
 
-enum EventSortColumn {
-  TITLE
-  CREATED
-  UPDATED
-}
-
 enum ItemType {
   EVENT
   SERIES
@@ -31,6 +25,12 @@ enum RealmOrder {
   BY_INDEX
   ALPHABETIC_ASC
   ALPHABETIC_DESC
+}
+
+enum SortColumn {
+  TITLE
+  CREATED
+  UPDATED
 }
 
 enum SortDirection {
@@ -65,12 +65,6 @@ input AclInputEntry {
 input ChildIndex {
   id: ID!
   index: Int!
-}
-
-"Defines the sort order for events."
-input EventSortOrder {
-  column: EventSortColumn!
-  direction: SortDirection!
 }
 
 input Filters {
@@ -128,6 +122,11 @@ input RealmLineageComponent {
 input RealmSpecifier {
   name: String
   pathSegment: String!
+}
+
+input SortOrder {
+  column: SortColumn!
+  direction: SortDirection!
 }
 
 input UpdatePlaylistBlock {
@@ -190,9 +189,6 @@ interface Node {
 
 "A byte range, encoded as two hex numbers separated by `-`."
 scalar ByteSpan
-
-"An opaque cursor used for pagination"
-scalar Cursor
 
 """
   Combined date and time (with time zone) in [RFC 3339][0] format.
@@ -312,20 +308,9 @@ type EmptyQuery {
 }
 
 type EventConnection {
-  pageInfo: EventPageInfo!
+  pageInfo: PageInfo!
   items: [AuthorizedEvent!]!
   totalCount: Int!
-}
-
-type EventPageInfo {
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startCursor: Cursor
-  endCursor: Cursor
-  "The index of the first returned event."
-  startIndex: Int
-  "The index of the last returned event."
-  endIndex: Int
 }
 
 type EventSearchResults {
@@ -486,6 +471,13 @@ type NotAllowed {
     have at least one field. Always returns `null`.
   """
   dummy: Boolean
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startIndex: Int
+  endIndex: Int
 }
 
 "A simple realm name: a fixed string."
@@ -931,10 +923,8 @@ type User {
     on the "my videos" page. This also returns events that have been marked
     as deleted (meaning their deletion in Opencast has been requested but they
     are not yet removed from Tobira's database).
-
-    Exactly one of `first` and `last` must be set!
   """
-  myVideos(order: EventSortOrder! = {column: "CREATED", direction: "DESCENDING"}, first: Int, after: Cursor, last: Int, before: Cursor): EventConnection!
+  myVideos(order: SortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): EventConnection!
 }
 
 "A block for presenting a single Opencast event"

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -27,7 +27,7 @@ enum RealmOrder {
   ALPHABETIC_DESC
 }
 
-enum SortColumn {
+enum SeriesSortColumn {
   TITLE
   CREATED
   UPDATED
@@ -55,6 +55,13 @@ enum VideoListOrder {
   AZ
   ZA
   ORIGINAL
+}
+
+enum VideosSortColumn {
+  TITLE
+  CREATED
+  UPDATED
+  SERIES
 }
 
 input AclInputEntry {
@@ -124,8 +131,8 @@ input RealmSpecifier {
   pathSegment: String!
 }
 
-input SortOrder {
-  column: SortColumn!
+input SeriesSortOrder {
+  column: SeriesSortColumn!
   direction: SortDirection!
 }
 
@@ -173,6 +180,11 @@ input UpdatedPermissions {
 input UpdatedRealmName {
   plain: String
   block: ID
+}
+
+input VideosSortOrder {
+  column: VideosSortColumn!
+  direction: SortDirection!
 }
 
 "A `Block`: a UI element that belongs to a realm."
@@ -930,12 +942,12 @@ type User {
     as deleted (meaning their deletion in Opencast has been requested but they
     are not yet removed from Tobira's database).
   """
-  myVideos(order: SortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): EventConnection!
+  myVideos(order: VideosSortOrder = null, offset: Int!, limit: Int!): EventConnection!
   """
     Returns all series that somehow "belong" to the user, i.e. that appear
     on the "my series" page.
   """
-  mySeries(order: SortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): SeriesConnection!
+  mySeries(order: SeriesSortOrder = null, offset: Int!, limit: Int!): SeriesConnection!
 }
 
 "A block for presenting a single Opencast event"

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -782,7 +782,7 @@ type SearchSeries implements Node {
   title: String!
   description: String
   hostRealms: [SearchRealm!]!
-  thumbnails: [ThumbnailInfo!]!
+  thumbnailStack: SeriesThumbnailStack!
   matches: SearchSeriesMatches!
 }
 
@@ -813,6 +813,8 @@ type Series implements Node {
   updated: DateTime
   metadata: ExtraMetadata
   syncedData: SyncedSeriesData
+  numVideos: Int!
+  thumbnailStack: SeriesThumbnailStack!
   acl: [AclItem!]
   hostRealms: [Realm!]!
   entries: [VideoListEntry!]!
@@ -846,6 +848,10 @@ type SeriesSearchResults {
   totalHits: Int!
   "How long searching took in ms."
   duration: Int!
+}
+
+type SeriesThumbnailStack {
+  thumbnails: [ThumbnailInfo!]!
 }
 
 type SyncedEventData {
@@ -887,9 +893,10 @@ type TextMatch {
   highlights: [ByteSpan!]!
 }
 
+"Information necessary to render a thumbnail."
 type ThumbnailInfo {
-  thumbnail: String
-  isLive: Boolean!
+  url: String
+  live: Boolean!
   audioOnly: Boolean!
 }
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -488,9 +488,7 @@ type NotAllowed {
 
 type PageInfo {
   hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startIndex: Int
-  endIndex: Int
+  hasPrevPage: Boolean!
 }
 
 "A simple realm name: a fixed string."
@@ -944,12 +942,12 @@ type User {
     as deleted (meaning their deletion in Opencast has been requested but they
     are not yet removed from Tobira's database).
   """
-  myVideos(order: VideosSortOrder = null, offset: Int!, limit: Int!): EventConnection!
+  myVideos(order: VideosSortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): EventConnection!
   """
     Returns all series that somehow "belong" to the user, i.e. that appear
     on the "my series" page.
   """
-  mySeries(order: SeriesSortOrder = null, offset: Int!, limit: Int!): SeriesConnection!
+  mySeries(order: SeriesSortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): SeriesConnection!
 }
 
 "A block for presenting a single Opencast event"

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -31,6 +31,7 @@ enum SeriesSortColumn {
   TITLE
   CREATED
   UPDATED
+  EVENT_COUNT
 }
 
 enum SortDirection {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -812,6 +812,7 @@ type Series implements Node {
   opencastId: String!
   title: String!
   created: DateTime
+  updated: DateTime
   metadata: ExtraMetadata
   syncedData: SyncedSeriesData
   acl: [AclItem!]

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -823,6 +823,12 @@ type SeriesBlock implements Block {
   realm: Realm!
 }
 
+type SeriesConnection {
+  pageInfo: PageInfo!
+  items: [Series!]!
+  totalCount: Int!
+}
+
 type SeriesSearchResults {
   items: [SearchSeries!]!
   totalHits: Int!
@@ -925,6 +931,11 @@ type User {
     are not yet removed from Tobira's database).
   """
   myVideos(order: SortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): EventConnection!
+  """
+    Returns all series that somehow "belong" to the user, i.e. that appear
+    on the "my series" page.
+  """
+  mySeries(order: SortOrder! = {column: "CREATED", direction: "DESCENDING"}, offset: Int!, limit: Int!): SeriesConnection!
 }
 
 "A block for presenting a single Opencast event"

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -60,7 +60,7 @@ export const SmallDescription: React.FC<SmallDescriptionProps> = ({
             ...sharedStyle,
             fontStyle: "italic",
             color: isDark ? COLORS.neutral60 : COLORS.neutral50,
-        }}>{t("manage.my-videos.no-description")}</div>;
+        }}>{t("general.no-description")}</div>;
     } else {
         return <div {...{ className }} css={{
             ...sharedStyle,
@@ -88,7 +88,7 @@ export const Description = forwardRef<HTMLDivElement, DescriptionProps>(
         const stripped = text?.trim();
         if (!stripped) {
             return <div {...{ className }} css={{ fontStyle: "italic" }}>
-                {t("manage.my-videos.no-description")}
+                {t("general.no-description")}
             </div>;
         }
 


### PR DESCRIPTION
This adds a page to the "manage pages" area were users can see a list of their series.
Most of these changes are related to generalizing the "My videos" backend and frontend code, so it can also be used for series-, and later on playlist management.

This PR also addresses two issues related to the "My videos" table.

Please note that this is only the first step in adding a proper series management in Tobira. Right now, the list entries link directly to the corresponding series. This will be changed later to link to a "Series details" page.

Note for the reviewer: This is probably better to review file-by-file, since a lot of the commits touch and revise the same files.

Part of https://github.com/elan-ev/tobira/issues/355
Fixes https://github.com/elan-ev/tobira/issues/759
Closes https://github.com/elan-ev/tobira/issues/527