### PR TITLE
WIP: Debug overlay

### DIFF
--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -377,16 +377,19 @@ async fn handle_api(req: Request<Incoming>, ctx: &Context) -> Result<Response, R
 
     // Create an appropriate HTTP response.
     let body = serde_json::to_string(&gql_response).unwrap();
+    let duration = before.elapsed();
     let out = Response::builder()
         .status(if gql_response.is_ok() { StatusCode::OK } else { StatusCode::BAD_REQUEST })
         .header(header::CONTENT_TYPE, "application/json")
+        .header("x-tobira-num-queries", num_queries.to_string())
+        .header("x-tobira-duration", duration.as_millis().to_string())
         .body(body.into())
         .unwrap();
 
     trace!(
         "Finished /graphql query with {} SQL queries in {:.2?} (user: {})",
         num_queries,
-        before.elapsed(),
+        duration,
         username,
     );
 

--- a/frontend/src/layout/Root.tsx
+++ b/frontend/src/layout/Root.tsx
@@ -16,6 +16,7 @@ import { OperationType } from "relay-runtime";
 import { UserData$key } from "../__generated__/UserData.graphql";
 import { useNoindexTag } from "../util";
 import { useRouter } from "../router";
+import { DebugOverlay } from "../util/DebugOverlay";
 
 
 export const MAIN_PADDING = 16;
@@ -163,6 +164,7 @@ export const RootLoaderImpl = <Q extends QueryWithUserData>({
         <UserProvider data={userData?.currentUser}>
             <Root nav={nav(data)}>
                 <React.Fragment key={counter.current}>{render(data)}</React.Fragment>
+                <DebugOverlay key={"_" + counter.current} />
             </Root>
         </UserProvider>
     );

--- a/frontend/src/relay/index.ts
+++ b/frontend/src/relay/index.ts
@@ -10,6 +10,7 @@ import type {
 
 import { hasErrors, APIError, ServerError, NotJson } from "./errors";
 import { NetworkError } from "../util/err";
+import { queryInfos } from "../util/DebugOverlay";
 
 
 export const environment = new Environment({
@@ -24,6 +25,18 @@ export const environment = new Environment({
 
             if (!response.ok) {
                 throw new ServerError(response);
+            }
+
+            const numQueries = response.headers.get("x-tobira-num-queries");
+            const duration = response.headers.get("x-tobira-duration");
+            if (numQueries !== null && duration !== null) {
+                if (queryInfos.length >= 5) {
+                    queryInfos.shift();
+                }
+                queryInfos.push({
+                    numQueries: Number(numQueries),
+                    duration: Number(duration),
+                });
             }
 
             // Download full response and parse as JSON.

--- a/frontend/src/util/DebugOverlay.tsx
+++ b/frontend/src/util/DebugOverlay.tsx
@@ -1,0 +1,69 @@
+import { COLORS } from "../color";
+
+
+export type QueryInfo = {
+    /** In ms */
+    duration: number;
+    numQueries: number;
+};
+
+export const queryInfos: QueryInfo[] = [];
+
+export const DebugOverlay: React.FC = () => (
+    <div css={{
+        position: "fixed",
+        bottom: 0,
+        left: 2,
+        zIndex: 1000,
+        background: COLORS.neutral05,
+    }}>
+        <div css={{
+            position: "absolute",
+            inset: 0,
+            background: "linear-gradient(var(--color-neutral05), transparent 60%)",
+            zIndex: 500,
+        }} />
+        {queryInfos.map((info, i) => (
+            <div key={i} css={{
+                position: "relative",
+                margin: "3px 0",
+                hr: {
+                    margin: 0,
+                },
+                div: {
+                    position: "absolute",
+                    left: "100%",
+                    bottom: -3,
+                    width: 150,
+                    paddingLeft: 8,
+                    fontSize: 12,
+                    background: COLORS.neutral05,
+                    display: "none",
+                },
+                "&:hover > div": {
+                    display: "initial",
+                },
+            }}>
+                <hr css={{
+                    width: info.duration * 4,
+                    border: "none",
+                    borderTop: "3px solid #df3a3a",
+                }} />
+
+                {/* Show one dot per query, with each dot being 3x3 px and 3px spacing */}
+                <hr css={{
+                    width: info.numQueries * 6 - 3,
+                    height: 3,
+                    border: "none",
+                    backgroundImage:
+                        "linear-gradient(to right, yellow 50%, rgba(255,255,255,0) 0%)",
+                    backgroundPosition: "left",
+                    backgroundSize: "6px 3px",
+                    backgroundRepeat: "repeat-x",
+                }} />
+
+                <div>{info.duration}ms, {info.numQueries} queries</div>
+            </div>
+        ))}
+    </div>
+);


### PR DESCRIPTION
Inspired by https://github.com/elan-ev/tobira/pull/1314 and a recent example where I caught another n+1 problem in a PR review, I think we (devs) need some way to quiclky catch those problems. I found the one in #1314 fairly randomly and it could have stayed undiscovered for quite some more time. It's just an easy mistake to make. Is the n+1 problem really that  bad? Well, it's not the worst but having this in the code base is dangerous as it can lead to unexpected slowness. And then you usually notice it in production at an inconvenient time. That would suck.

I also think it would be useful to more clearly see the duration of a request to notice when there are slow SQL queries for example. This information is already logged in `trace` level, but we usually don't run with that level during development and even then, it's easy to overlook it in the logs. 

So I started this small experiment of adding a debug overlay so that we devs cannot escape that information. There are many open questions and todos:

- Is this information useful enough to warrant this distracting overlay?
- We devs probably need a way to disable it whenever we do design-heavy work?
- This should clearly only be enabled for devs: how do we do that? When experimental features are active? When hostname is `localhost`? When built in debug mode? We might want to see this on test deployments as well?
- Is there other interesting stuff for a debug overlay?
- TODO: need to adjust the colors to work with light mode. Didn't want to put work into this before we know if/how we want this.
- Is this information security sensitive, i.e. should the backend not send it out in production environments?