### PR TITLE
Fix frontend logo matching

### DIFF
--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -267,10 +267,13 @@ export const useLogoConfig = () => {
     const lang = i18n.resolvedLanguage;
     const logos = CONFIG.logos;
 
-    const findLogo = (size: "wide" | "narrow") => logos
-        .filter(l => l.size === size || !l.size)
-        .filter(l => l.mode === mode || !l.mode)
-        .find(l => l.lang === lang || !l.lang);
+    const findLogo = (size: "wide" | "narrow") => {
+        const list = logos
+            .filter(l => l.size === size || !l.size)
+            .filter(l => l.mode === mode || !l.mode);
+
+        return list.find(l => l.lang === lang) || list.find(l => !l.lang || l.lang === "default");
+    };
 
     const wide = findLogo("wide");
     const narrow = findLogo("narrow");


### PR DESCRIPTION
The previous version didn't check for "default" as specified language.
Also, the language check didn't take into account that the logos array isn't sorted and would just return the first logo
matching either "null" or the language. 

This will now do two checks:
- The first one looks for an exact match, and
- if that isn't found, the second one looks for logos with either null or "default" language.