### PR TITLE
Fix known groups/users label-related default key and typing

### DIFF
--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -71,7 +71,7 @@ fn print_group(group: &KnownGroup) {
     print!(r#"    {}: {{ "label": {{"#, json!(group.role));
 
     // Sort by key to get consistent ordering (hashmap order is random).
-    let mut labels = group.label.0.iter().collect::<Vec<_>>();
+    let mut labels = group.label.iter().collect::<Vec<_>>();
     labels.sort();
     for (lang, label) in labels {
         print!(" {}: {}", json!(lang), json!(label));

--- a/frontend/relay.config.js
+++ b/frontend/relay.config.js
@@ -12,7 +12,7 @@ module.exports = {
         "Cursor": "string",
         "ByteSpan": "string",
         "ExtraMetadata": "Record<string, Record<string, string[]>>",
-        "TranslatedString": "Record<string, string>",
+        "TranslatedString": "{ default: string } & Record<string, string | undefined>",
     },
     schemaExtensions: [APP_PATH],
 };

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -748,7 +748,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({ onSave, disabled, knownRole
         [user.userRole, {
             actions: new Set(["read", "write"]),
             info: {
-                label: { "_": user.displayName },
+                label: { "default": user.displayName },
                 implies: null,
                 large: false,
             },

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -270,7 +270,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                 prev.set(option.role, {
                     actions: new Set([permissionLevels.default]),
                     info: {
-                        label: info?.label ?? { "_": option.label },
+                        label: info?.label ?? { "default": option.label },
                         implies: [...info?.implies ?? new Set()],
                         large: info?.large ?? false,
                     },
@@ -883,7 +883,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
 // ===== Helper functions
 // ==============================================================================================
 
-type TranslatedLabel = Record<string, string>;
+type TranslatedLabel = { default: string } & Record<string, string | undefined>;
 
 /** Returns a label for the role, if known to Tobira. */
 const getLabel = (role: string, label: TranslatedLabel | undefined, i18n: i18n) => {
@@ -925,11 +925,14 @@ const insertBuiltinRoleInfo = (
     i18n: i18n,
     addAnonymous: boolean,
 ) => {
-    const keyToTranslatedString = (key: ParseKeys): TranslatedLabel => Object.fromEntries(
-        i18n.languages
-            .filter(lng => i18n.exists(key, { lng }))
-            .map(lng => [lng, i18n.t(key, { lng })])
-    );
+    const keyToTranslatedString = (key: ParseKeys): TranslatedLabel => ({
+        default: i18n.t(key, { lng: "en" }),
+        ...Object.fromEntries(
+            i18n.languages
+                .filter(lng => i18n.exists(key, { lng }))
+                .map(lng => [lng, i18n.t(key, { lng })])
+        ),
+    });
 
     const anonymousInfo = {
         implies: [],


### PR DESCRIPTION
Things I forgot in #1316. The reason for why I didn't notice is that the `TranslatedLabel` type was bad. In particular, `Record<string, _>` seems to behave differently than I assumed. It's very lenient. Now I made typing more strict in multiple places. In the backend, the translated string will also check the default field when loading from DB, in order to keep the API description guarantees.

This fixes the ACL editor being buggy or crashing when dealing with users.