### PR TITLE
Show deleted blocks only in edit mode

### DIFF
--- a/frontend/src/routes/manage/Realm/Content/Block.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Block.tsx
@@ -143,7 +143,7 @@ export const EditBlock: React.FC<Props> = ({
 
                     {/* TODO This counters the negative margin we employ to render title blocks. */}
                     <div css={{ marginBottom: 16 }}>
-                        <Block {...{ block, realm }} />
+                        <Block edit {...{ block, realm }} />
                     </div>
                 </>}
         </div>

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -48,14 +48,15 @@ const playlistFragment = graphql`
 
 type FromBlockProps = SharedProps & {
     fragRef: PlaylistBlockData$key;
+    edit?: boolean;
 }
 
 export const PlaylistBlockFromBlock: React.FC<FromBlockProps> = ({ fragRef, ...rest }) => {
     const { t } = useTranslation();
     const { playlist, ...block } = useFragment(blockFragment, fragRef);
-    return playlist == null
+    return playlist == null && rest.edit
         ? <Card kind="error">{t("playlist.deleted-playlist-block")}</Card>
-        : <PlaylistBlockFromPlaylist fragRef={playlist} {...rest} {...block} />;
+        : playlist != null && <PlaylistBlockFromPlaylist fragRef={playlist} {...rest} {...block} />;
 };
 
 type BlockProps = Partial<Omit<Fields<PlaylistBlockData$data>, "playlist">>;

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -49,14 +49,16 @@ const seriesFragment = graphql`
 
 type FromBlockProps = SharedProps & {
     fragRef: SeriesBlockData$key;
+    edit?: boolean;
 };
 
 export const SeriesBlockFromBlock: React.FC<FromBlockProps> = ({ fragRef, ...rest }) => {
     const { t } = useTranslation();
     const { series, ...block } = useFragment(blockFragment, fragRef);
-    return series == null
+
+    return series == null && rest.edit
         ? <Card kind="error">{t("series.deleted-series-block")}</Card>
-        : <SeriesBlockFromSeries fragRef={series} {...rest} {...block} />;
+        : series != null && <SeriesBlockFromSeries fragRef={series} {...rest} {...block} />;
 };
 
 type BlockProps = Partial<Omit<Fields<SeriesBlockData$data>, "series">>;

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -18,9 +18,10 @@ export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "Authorized
 type Props = {
     fragRef: VideoBlockData$key;
     basePath: string;
+    edit?: boolean;
 };
 
-export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
+export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
     const { t } = useTranslation();
     const { event: protoEvent, showTitle, showLink } = useFragment(graphql`
         fragment VideoBlockData on VideoBlock {
@@ -55,8 +56,12 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath }) => {
     `, fragRef);
     const [event, refetch] = useEventWithAuthData(protoEvent);
 
-    if (event == null) {
+    if (event == null && edit) {
         return <Card kind="error">{t("video.deleted-video-block")}</Card>;
+    }
+
+    if (event == null) {
+        return null;
     }
 
     if (event.__typename === "NotAllowed") {

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -47,9 +47,10 @@ export const Blocks: React.FC<BlocksProps> = ({ realm: realmRef }) => {
 type BlockProps = {
     realm: BlocksRealmData$key;
     block: BlocksBlockData$key;
+    edit?: boolean;
 };
 
-export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
+export const Block: React.FC<BlockProps> = ({ block: blockRef, realm, edit }) => {
     const { path } = useFragment(graphql`
         fragment BlocksRealmData on Realm {
             path
@@ -74,9 +75,11 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
         {match(__typename, {
             "TitleBlock": () => <TitleBlock fragRef={block} />,
             "TextBlock": () => <TextBlockByQuery fragRef={block} />,
-            "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} basePath={basePath} />,
-            "VideoBlock": () => <VideoBlock fragRef={block} basePath={basePath} />,
-            "PlaylistBlock": () => <PlaylistBlockFromBlock fragRef={block} basePath={basePath} />,
+            "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} {...{ basePath, edit }} />,
+            "VideoBlock": () => <VideoBlock fragRef={block} {...{ basePath, edit }} />,
+            "PlaylistBlock": () => (
+                <PlaylistBlockFromBlock fragRef={block} {...{ basePath, edit }} />
+            ),
         })}
     </div>;
 };


### PR DESCRIPTION
This will hopefully help prevent some confusion regarding "missing" (i.e. deleted) series. Previously, a note saying "The series referenced here was deleted." was shown. This is now only shown on the "edit page" route, meaning it's still possible for admins to see that there has been some block before, but regular users won't see that anymore and probably don't need to either.