### PR TITLE
Optimize GQL queries

### DIFF
--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         NodeValue,
     },
     auth::AuthContext,
-    db::util::{impl_from_db, select},
+    db::util::impl_from_db,
     model::Key,
     prelude::*,
 };
@@ -87,9 +87,19 @@ impl_from_db!(
     select: {
         realms.{
             id, parent, name, name_from_block, path_segment, full_path, index,
-            child_order, resolved_name, owner_display_name, moderator_roles,
+            child_order, owner_display_name, moderator_roles,
             admin_roles, flattened_moderator_roles, flattened_admin_roles,
         },
+        resolved_name: "case \
+           		when ${table:realms}.name_from_block is null then ${table:realms}.name \
+           		else (\
+           			select coalesce(series.title, events.title) \
+           			from blocks \
+           			left join events on blocks.video = events.id \
+           			left join series on blocks.series = series.id \
+           			where blocks.id = ${table:realms}.name_from_block\
+           		)\
+           	end",
     },
     |row| {
         Self {
@@ -113,34 +123,12 @@ impl_from_db!(
 
 impl Realm {
     pub(crate) async fn root(context: &Context) -> ApiResult<Self> {
-        let (selection, mapping) = select!(
-            child_order,
-            moderator_roles,
-            admin_roles,
-            name,
-            name_from_block,
-            resolved_name: "realms.resolved_name",
-        );
+        let selection = Self::select();
         let row = context.db
             .query_one(&format!("select {selection} from realms where id = 0"), &[])
             .await?;
 
-        Ok(Self {
-            key: Key(0),
-            parent_key: None,
-            plain_name: mapping.name.of(&row),
-            resolved_name: mapping.resolved_name.of(&row),
-            name_from_block: mapping.name_from_block.of(&row),
-            path_segment: String::new(),
-            full_path: String::new(),
-            index: 0,
-            child_order: mapping.child_order.of(&row),
-            owner_display_name: None,
-            moderator_roles: mapping.moderator_roles.of(&row),
-            admin_roles: mapping.admin_roles.of(&row),
-            flattened_moderator_roles: mapping.moderator_roles.of(&row),
-            flattened_admin_roles: mapping.admin_roles.of(&row),
-        })
+        Ok(Self::from_row_start(&row))
     }
 
     pub(crate) async fn load_by_id(id: Id, context: &Context) -> ApiResult<Option<Self>> {

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -325,6 +325,10 @@ impl Realm {
     /// (excluding both, the root realm and this realm). It starts with a
     /// direct child of the root and ends with the parent of `self`.
     async fn ancestors(&self, context: &Context) -> ApiResult<Vec<Realm>> {
+        if self.parent_key.is_none() {
+            return Ok(vec![]);
+        }
+
         let selection = Self::select().with_renamed_table("realms", "ancestors");
         let query = format!(
             "select {selection} \

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useState } from "react";
 import { graphql, loadQuery, useMutation } from "react-relay/hooks";
 import type { RealmQuery, RealmQuery$data } from "./__generated__/RealmQuery.graphql";
 import { useTranslation } from "react-i18next";
-import { LuSunrise, LuInfo, LuSettings, LuPlusCircle, LuPenSquare } from "react-icons/lu";
+import { LuInfo, LuSettings, LuPlusCircle, LuPenSquare } from "react-icons/lu";
 import { WithTooltip, screenWidthAtMost } from "@opencast/appkit";
 
 import { environment as relayEnv } from "../relay";
@@ -127,7 +127,6 @@ const query = graphql`
             isUserRealm
             ownerDisplayName
             children { id }
-            blocks { id }
             canCurrentUserModerate
             ancestors { name path ownerDisplayName }
             parent { id }
@@ -175,37 +174,8 @@ const RealmPage: React.FC<Props> = ({ realm }) => {
                 width: 1,
             }}>{siteTitle}</h1>
         )}
-        {realm.blocks.length === 0 && realm.isMainRoot
-            ? <WelcomeMessage />
-            : <Blocks realm={realm} />}
+        <Blocks realm={realm} />
     </>;
-};
-
-const WelcomeMessage: React.FC = () => {
-    const { t } = useTranslation();
-
-    return (
-        <div css={{
-            maxWidth: 500,
-            marginTop: 32,
-            display: "inline-flex",
-            flexDirection: "column",
-            borderRadius: 4,
-            padding: "8px 16px",
-            gap: 16,
-            alignItems: "center",
-            backgroundColor: COLORS.neutral10,
-            border: `2px dashed ${COLORS.happy0}`,
-        }}>
-            <LuSunrise css={{ marginTop: 8, fontSize: 32, minWidth: 32 }} />
-            <div>
-                <h2 css={{ textAlign: "center", fontSize: 20, marginBottom: 16 }}>
-                    {t("welcome.title")}
-                </h2>
-                <p>{t("welcome.body")}</p>
-            </div>
-        </div>
-    );
 };
 
 const UserRealmNote: React.FC<Props> = ({ realm }) => {

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -120,16 +120,13 @@ const query = graphql`
         ... UserData
         currentUser { username canCreateUserRealm }
         realm: realmByPath(path: $path) {
-            id
             name
             path
             isMainRoot
             isUserRealm
             ownerDisplayName
-            children { id }
             canCurrentUserModerate
             ancestors { name path ownerDisplayName }
-            parent { id }
             ... BlocksData
             ... NavigationData
         }

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -1,24 +1,28 @@
 import React from "react";
 import { graphql, useFragment } from "react-relay/hooks";
 import { match } from "@opencast/appkit";
+import { useTranslation } from "react-i18next";
+import { LuSunrise } from "react-icons/lu";
 
 import { BlocksData$key } from "./__generated__/BlocksData.graphql";
 import { BlocksRealmData$key } from "./__generated__/BlocksRealmData.graphql";
 import { BlocksBlockData$key } from "./__generated__/BlocksBlockData.graphql";
+import { RealmQuery$data } from "../../routes/__generated__/RealmQuery.graphql";
 import { TitleBlock } from "./Title";
 import { TextBlockByQuery } from "./Text";
 import { SeriesBlockFromBlock } from "./Series";
 import { VideoBlock } from "./Video";
 import { PlayerGroupProvider } from "../player/PlayerGroupContext";
 import { PlaylistBlockFromBlock } from "./Playlist";
+import { COLORS } from "../../color";
 
 
 type BlocksProps = {
-    realm: BlocksData$key;
+    realm: BlocksData$key & RealmQuery$data["realm"];
 };
 
-export const Blocks: React.FC<BlocksProps> = ({ realm: realmRef }) => {
-    const realm = useFragment(graphql`
+export const Blocks: React.FC<BlocksProps> = ({ realm }) => {
+    const realmWithBlocks = useFragment(graphql`
         fragment BlocksData on Realm {
             ... BlocksRealmData
             blocks {
@@ -26,8 +30,11 @@ export const Blocks: React.FC<BlocksProps> = ({ realm: realmRef }) => {
                 ... BlocksBlockData
             }
         }
-    `, realmRef);
-    const { blocks } = realm;
+    `, realm);
+
+    if (realmWithBlocks.blocks.length === 0 && realm.isMainRoot) {
+        return <WelcomeMessage />;
+    }
 
     return (
         <div css={{
@@ -36,8 +43,8 @@ export const Blocks: React.FC<BlocksProps> = ({ realm: realmRef }) => {
             rowGap: 32,
         }}>
             <PlayerGroupProvider>
-                {blocks.map(
-                    block => <Block key={block.id} realm={realm} block={block} />,
+                {realmWithBlocks.blocks.map(
+                    block => <Block key={block.id} realm={realmWithBlocks} block={block} />,
                 )}
             </PlayerGroupProvider>
         </div>
@@ -79,4 +86,31 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm }) => {
             "PlaylistBlock": () => <PlaylistBlockFromBlock fragRef={block} basePath={basePath} />,
         })}
     </div>;
+};
+
+const WelcomeMessage: React.FC = () => {
+    const { t } = useTranslation();
+
+    return (
+        <div css={{
+            maxWidth: 500,
+            marginTop: 32,
+            display: "inline-flex",
+            flexDirection: "column",
+            borderRadius: 4,
+            padding: "8px 16px",
+            gap: 16,
+            alignItems: "center",
+            backgroundColor: COLORS.neutral10,
+            border: `2px dashed ${COLORS.happy0}`,
+        }}>
+            <LuSunrise css={{ marginTop: 8, fontSize: 32, minWidth: 32 }} />
+            <div>
+                <h2 css={{ textAlign: "center", fontSize: 20, marginBottom: 16 }}>
+                    {t("welcome.title")}
+                </h2>
+                <p>{t("welcome.body")}</p>
+            </div>
+        </div>
+    );
 };


### PR DESCRIPTION
See the commits for details. But in short: 
- for realm pages, this removed 2 useless SQL queries
- For root realm pages and video pages in root context, it gets rid of another query (`ancestors` is always empty for root)
- The SQL execution time for video and realm pages is cut roughly in half (this is only the time spent by the DB server, not the total response time)