### PR TITLE
Add configurable deletion modes for series, events and playlists

### DIFF
--- a/backend/src/config/theme.rs
+++ b/backend/src/config/theme.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt, path::PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::model::LangKey;
-use super::{color::ColorConfig};
+use super::color::ColorConfig;
 
 
 #[derive(Debug, confique::Config)]

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -494,6 +494,27 @@
 # Default value: 8
 #concurrent_download_tasks = 8
 
+# List of deletion modes that determine which, if any, realm pages are to be deleted
+# automatically when the corresponding Opencast item (series, event or playlist)
+# is deleted.
+# If configured, Tobira will delete the corresponding realm page(s) when they meet
+# the following conditions:
+# - Realm name is derived from the deleted item.
+# - Realm has no sub realms.
+# - Realm has no other blocks than the deleted item.
+#
+# The last option can be disabled by adding `:eager` to the deletion mode.
+#
+# Example:
+# ```
+# auto_delete_pages = ["series", "events:eager"]
+# ```
+#
+# This would delete series pages in non-eager mode and event pages in eager mode.
+#
+# Default value: []
+#auto_delete_pages = []
+
 
 [meili]
 # The access key. This can be the master key, but ideally should be an API


### PR DESCRIPTION
Automatic realm deletion can now be configured for series, events (and playlists, though that won't do anything for now). If configured, Tobira will delete the corresponding realm page(s) when they meet the following conditions:
- Realm name is derived from the deleted item.
- Realm has no sub realms.
- Realm has no other blocks than the deleted item.

The last condition can be disabled by adding `:eager` to the deletion mode.

This is the Tobira side of #1176 