### PR TITLE
Fix `tobira worker` on single-CPU machines by using fewer DB connections

### DIFF
--- a/backend/src/search/cmd.rs
+++ b/backend/src/search/cmd.rs
@@ -86,7 +86,7 @@ async fn update(meili: &Client, config: &Config, daemon: bool) -> Result<()> {
     meili.prepare_and_rebuild_if_necessary(&mut db).await?;
 
     if daemon {
-        super::update_index_daemon(meili, &mut db).await.map(|_| ())
+        super::update_index_daemon(meili, &pool).await.map(|_| ())
     } else {
         super::update_index(meili, &mut db).await?;
         info!("Done updating the search index (no more items queued)");

--- a/backend/src/sync/cmd.rs
+++ b/backend/src/sync/cmd.rs
@@ -105,13 +105,13 @@ pub(crate) async fn run(args: &Args, config: &Config) -> Result<()> {
         SyncCommand::Run { daemon } => {
             info!("Starting Tobira <-> Opencast synchronization ...");
             let before = Instant::now();
-            super::run(daemon, conn, config).await?;
+            super::run(daemon, &db, config).await?;
             info!("Finished harvest in {:.2?}", before.elapsed());
             Ok(())
         }
         SyncCommand::Reset { yes_absolutely_reset: yes } => reset(conn, yes).await,
         SyncCommand::Texts { cmd: TextsCommand::Fetch { daemon } } => {
-            super::text::fetch_update(conn, config, daemon).await
+            super::text::fetch_update(&db, config, daemon).await
         }
         SyncCommand::Texts { cmd: TextsCommand::Status } => text_status(conn).await,
         SyncCommand::Texts { cmd: TextsCommand::Queue { all, missing, ref events } } => {

--- a/backend/src/sync/mod.rs
+++ b/backend/src/sync/mod.rs
@@ -1,7 +1,9 @@
 use core::fmt;
 use std::time::Duration;
 
-use crate::{config::Config, db::DbConnection, prelude::*};
+use deadpool_postgres::Pool;
+
+use crate::{config::Config, prelude::*};
 
 
 pub(crate) mod cmd;
@@ -18,10 +20,10 @@ pub(crate) use self::client::OcClient;
 const MIN_REQUIRED_API_VERSION: ApiVersion = ApiVersion::new(1, 0);
 
 
-pub(crate) async fn run(daemon: bool, db: DbConnection, config: &Config) -> Result<()> {
+pub(crate) async fn run(daemon: bool, pool: &Pool, config: &Config) -> Result<()> {
     let client = OcClient::new(config)?;
     check_compatibility(&client).await?;
-    harvest::run(daemon, config, &client, db).await
+    harvest::run(daemon, config, &client, pool).await
 }
 
 pub(crate) async fn check_compatibility(client: &OcClient) -> Result<()> {


### PR DESCRIPTION
Previously, `worker` did create a single, long-standing DB connection for every single semantic "task", like harvesting or DB maintenance. With Tobira 3.0, we added a fifth task (text fetching) and thus a fifth DB connection. But our DB pool library (deadpool) restricts the number of connections to num_cpus * 4 by default. This lead to `tobira worker` freezing during startup on machines with only a single CPU.

We could just increase the max number of connections, but I decided to instead "properly" fix this and make all worker tasks only hold a DB connection while they need it. In particular, all these tasks sleep for most of their time, while waiting for new work. During that sleep period, we don't need to hold a DB connection. The `serve` command has no problem with the max connection limit, as it only acquires a connection for each request and drops it afterwards. So it might happen that a request might need to wait when 4 others are already being processed, but we never run into a deadlock. The worker now also works like that.

Apart from solving the deadlock problem, having fewer open DB connections is also just nice for not wasting resources. Keeping a connection open also costs for the DB server.