### PR TITLE
Make JWT contain auth claims to grant correct permissions

### DIFF
--- a/backend/src/api/jwt.rs
+++ b/backend/src/api/jwt.rs
@@ -1,26 +1,88 @@
 use juniper::GraphQLEnum;
+use serde_json::json;
 
-use crate::{api::err::not_authorized, auth::AuthContext, prelude::HasRoles};
+use crate::{
+    api::err::{invalid_input, not_authorized},
+    auth::AuthContext,
+    db::util::select,
+    prelude::HasRoles,
+};
 
-use super::{err::ApiResult, Context};
+use super::{err::ApiResult, Context, Id};
 
 
-pub(crate) fn jwt(service: JwtService, context: &Context) -> ApiResult<String> {
+pub(crate) async fn jwt(
+    service: JwtService,
+    event: Option<Id>,
+    context: &Context,
+) -> ApiResult<String> {
     let AuthContext::User(user) = &context.auth else {
         return Err(not_authorized!("only logged in users can get a JWT"));
     };
 
-    let (is_allowed, action) = match service {
-        JwtService::Upload => (user.can_upload(&context.config.auth), "upload"),
-        JwtService::Studio => (user.can_use_studio(&context.config.auth), "use Studio"),
-        JwtService::Editor => (user.can_use_editor(&context.config.auth), "use the editor"),
-    };
-
-    if !is_allowed {
-        return Err(not_authorized!("User {} does not have permission to {}", user.username, action));
+    macro_rules! deny {
+        ($action:literal) => {
+            return Err(not_authorized!(
+                "User {} does not have permission to {}",
+                user.username,
+                $action,
+            ));
+        };
     }
 
-    Ok(context.jwt.new_token(&user))
+    match service {
+        JwtService::Upload => {
+            if !user.can_upload(&context.config.auth) {
+                deny!("upload");
+            }
+            Ok(context.jwt.new_token(Some(&user), json!({
+                "roles": ["ROLE_STUDIO"],
+            })))
+        }
+
+        JwtService::Studio => {
+            if !user.can_use_studio(&context.config.auth) {
+                deny!("use Studio");
+            }
+            Ok(context.jwt.new_token(Some(&user), json!({
+                "roles": ["ROLE_STUDIO"],
+            })))
+        }
+
+        JwtService::Editor => {
+            if !user.can_use_editor(&context.config.auth) {
+                deny!("use the editor");
+            }
+            let Some(event) = event else {
+                return Err(invalid_input!("'event' is not specified for editor JWT"));
+            };
+            let Some(event) = event.key_for(Id::EVENT_KIND) else {
+                return Err(invalid_input!("'event' is not an event"));
+            };
+
+            let (selection, mapping) = select!(opencast_id, write_roles);
+            let row = context.db.query_opt(
+                &format!("select {selection} from events where id = $1"),
+                &[&event],
+            ).await?;
+            let Some(row) = row else {
+                return Err(invalid_input!("'event' does not exist"));
+            };
+            let opencast_id: String = mapping.opencast_id.of(&row);
+            let write_roles: Vec<String> = mapping.write_roles.of(&row);
+
+            if !context.auth.overlaps_roles(&write_roles) {
+                deny!("edit that event");
+            }
+
+            let key = format!("e:{opencast_id}");
+            Ok(context.jwt.new_token(Some(&user), json!({
+                "oc": {
+                    key: ["read", "write"],
+                },
+            })))
+        }
+    }
 }
 
 /// Services a user can be pre-authenticated for using a JWT

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -92,9 +92,11 @@ impl Query {
         }
     }
 
-    /// Returns a new JWT that can be used to authenticate against Opencast for using the given service
-    fn jwt(service: JwtService, context: &Context) -> ApiResult<String> {
-        jwt(service, context)
+    /// Returns a new JWT that can be used to authenticate against Opencast for
+    /// using the given service. For `service = Editor`, `event` has to be
+    /// specified.
+    async fn jwt(service: JwtService, event: Option<Id>, context: &Context) -> ApiResult<String> {
+        jwt(service, event, context).await
     }
 
     /// Retrieve a node by globally unique ID. Mostly useful for relay.

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -68,6 +68,7 @@ const Page: React.FC<Props> = ({ event }) => {
                     {user.canUseEditor && !event.isLive && event.canWrite && (
                         <ExternalLink
                             service="EDITOR"
+                            event={event.id}
                             params={{
                                 id: event.opencastId,
                                 callbackUrl: document.location.href,

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -544,8 +544,12 @@ type Query {
   playlistById(id: ID!): Playlist
   "Returns the current user."
   currentUser: User
-  "Returns a new JWT that can be used to authenticate against Opencast for using the given service"
-  jwt(service: JwtService!): String!
+  """
+    Returns a new JWT that can be used to authenticate against Opencast for
+    using the given service. For `service = Editor`, `event` has to be
+    specified.
+  """
+  jwt(service: JwtService!, event: ID): String!
   "Retrieve a node by globally unique ID. Mostly useful for relay."
   node(id: ID!): Node
   "Returns `null` if the query is too short."


### PR DESCRIPTION
Previously, our JWTs just contained user information, but not actual information about what the user is supposed to be able to do in Opencast. The roles for JWT users were just hard coded in the Opencast security config. But this did not quite work for the editor, as there, Tobira has to state "this user can edit this event" (see #600).

This commit fixes that by attaching auth information according to the standard introduced here: https://github.com/opencast/opencast/pull/6177

For the uploader and studio, `role: ["ROLE_STUDIO"]` is passed. For the editor, that's `oc: { "e:${id}": ["read", "write"] }`.

This commit also passes the username as `sub` in addition to `username`, to be in line with said standard. Including the username twice is a waste of space of course, but for now it's the best way to be backwards compatible with older Opencasts. We will remove the `username` claim in the future, which means admins need to update their JWT config in Opencast.

Fixes #600 