### PR TITLE
Update appkit to 0.4, react-icons to 5.5, and focus-trap-react to 11

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-typescript": "^7.25.7",
         "@emotion/cache": "^11.13.1",
         "@emotion/react": "^11.13.3",
-        "@opencast/appkit": "^0.3.1",
+        "@opencast/appkit": "^0.4.0",
         "@svgr/webpack": "^8.1.0",
         "babel-loader": "^9.2.1",
         "babel-plugin-relay": "^16.2.0",
@@ -2011,24 +2011,26 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
-      "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.5.tgz",
+      "integrity": "sha512-BX3jKxo39Ba05pflcQmqPPwc0qdNsdNi/eweAFtoIdrJWNen2sVEWMEac3i6jU55Qfx+lOcdMNKYn2CtWmlnOQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@floating-ui/react-dom": "^2.0.1",
-        "aria-hidden": "^1.2.3",
-        "tabbable": "^6.0.1"
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
       "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -2039,9 +2041,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -2163,15 +2166,17 @@
       }
     },
     "node_modules/@opencast/appkit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.3.1.tgz",
-      "integrity": "sha512-t0/UddTChHIuGxwaI4RV0bETk+IHkQI07kvC88jaqgonPmUbY1CLQaxihMHaZB4guTzaIY9umOAUuaxq7nuC4g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opencast/appkit/-/appkit-0.4.0.tgz",
+      "integrity": "sha512-2a0XAodoTgCsbebcTVWfvmS000KwdQon6Y6j96oIFBCdB3pxIf1z4Y3y/ywSeu8pTz2iZsmNgBN3jF+Eap+Idg==",
+      "license": "MIT",
       "peerDependencies": {
         "@emotion/react": "^11.11.4",
-        "@floating-ui/react": "^0.24.3",
-        "focus-trap-react": "^10.2.3",
+        "@floating-ui/react": "^0.27.5",
+        "focus-trap-react": "^10.2.3 || ^11.0.3",
         "react": "^18.2.0",
-        "react-icons": "^4.9.0",
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.5.0",
         "react-merge-refs": "^2.0.2"
       }
     },
@@ -3195,18 +3200,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/aria-hidden": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
-      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "babel-plugin-relay": "^16.2.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^12.0.2",
-        "focus-trap-react": "^10.3.0",
+        "focus-trap-react": "^11.0.3",
         "graphql": "^16.9.0",
         "hls.js": "^1.5.15",
         "i18next": "^23.15.2",
@@ -2609,7 +2609,6 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -5297,25 +5296,28 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
     },
     "node_modules/focus-trap-react": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.0.tgz",
-      "integrity": "sha512-XrCTj44uNE0clTA47y1AbIb7tM7w6+zi6WrJzb4RxRe3uAIIivkBCwlsCqe7R3vPRT/LCQzfe4+N/KjtJMQMgw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.3.tgz",
+      "integrity": "sha512-tS1+enWS/gwCHk2WIF3KpM2oz7Y3HsnRImzHZNRgCBLWXzNG4XQVlJgbqdLr4lBKRXGdDBjQYitSh1bf2xe4Ag==",
+      "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.6.0",
+        "focus-trap": "^7.6.4",
         "tabbable": "^6.2.0"
       },
       "peerDependencies": {
-        "prop-types": "^15.8.1",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/for-each": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-i18next": "^15.0.2",
-        "react-icons": "^4.12.0",
+        "react-icons": "^5.5.0",
         "react-markdown": "^9.0.1",
         "react-merge-refs": "^2.1.1",
         "react-relay": "^16.2.0",
@@ -8407,9 +8407,10 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-typescript": "^7.25.7",
     "@emotion/cache": "^11.13.1",
     "@emotion/react": "^11.13.3",
-    "@opencast/appkit": "^0.3.1",
+    "@opencast/appkit": "^0.4.0",
     "@svgr/webpack": "^8.1.0",
     "babel-loader": "^9.2.1",
     "babel-plugin-relay": "^16.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-i18next": "^15.0.2",
-    "react-icons": "^4.12.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "^9.0.1",
     "react-merge-refs": "^2.1.1",
     "react-relay": "^16.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "babel-plugin-relay": "^16.2.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^12.0.2",
-    "focus-trap-react": "^10.3.0",
+    "focus-trap-react": "^11.0.3",
     "graphql": "^16.9.0",
     "hls.js": "^1.5.15",
     "i18next": "^23.15.2",

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-    LuAlertTriangle, LuLogIn, LuMoon, LuSun, LuFolder, LuFilm,
+    LuTriangleAlert, LuLogIn, LuMoon, LuSun, LuFolder, LuFilm,
     LuUpload, LuVideo, LuLogOut, LuChevronDown, LuUserCheck,
 } from "react-icons/lu";
 import { HiOutlineFire, HiOutlineTranslate } from "react-icons/hi";
@@ -46,7 +46,7 @@ export const UserBox: React.FC = () => {
         boxContent = <Spinner css={iconCss} />;
     } else if (user === "error") {
         // TODO: tooltip
-        boxContent = <LuAlertTriangle css={iconCss} />;
+        boxContent = <LuTriangleAlert css={iconCss} />;
     } else if (user === "none") {
         boxContent = <LoggedOut />;
     } else {
@@ -248,7 +248,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
             icon: match(logoutState, {
                 "idle": () => <LuLogOut />,
                 "pending": () => <Spinner />,
-                "error": () => <LuAlertTriangle />,
+                "error": () => <LuTriangleAlert />,
             }),
             children: t("user.logout"),
             css: {

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, Suspense } from "react";
-import { LuFrown, LuAlertTriangle } from "react-icons/lu";
+import { LuFrown, LuTriangleAlert } from "react-icons/lu";
 import { Translation, useTranslation } from "react-i18next";
 import {
     graphql, useFragment, usePreloadedQuery,
@@ -155,7 +155,7 @@ const Embed: React.FC<EmbedProps> = ({ query, queryRef }) => {
 
     if (event.__typename === "NotAllowed") {
         return <PlayerPlaceholder>
-            <LuAlertTriangle />
+            <LuTriangleAlert />
             <div>{t("api-remote-errors.view.event")}</div>
         </PlayerPlaceholder>;
     }
@@ -190,7 +190,7 @@ export const BlockEmbedRoute = makeRoute({
 
         return {
             render: () => <PlayerPlaceholder>
-                <LuAlertTriangle />
+                <LuTriangleAlert />
                 <div>
                     <Translation>{t => t("embed.not-supported")}</Translation>
                 </div>
@@ -206,7 +206,7 @@ class ErrorBoundary extends GlobalErrorBoundary {
         }
 
         return <PlayerPlaceholder>
-            <LuAlertTriangle />
+            <LuTriangleAlert />
             <div>
                 <Translation>{t => t("errors.embedded")}</Translation>
             </div>

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useState } from "react";
 import { graphql, loadQuery, useMutation } from "react-relay/hooks";
 import type { RealmQuery, RealmQuery$data } from "./__generated__/RealmQuery.graphql";
 import { useTranslation } from "react-i18next";
-import { LuInfo, LuSettings, LuPlusCircle, LuPenSquare } from "react-icons/lu";
+import { LuInfo, LuSettings, LuCirclePlus, LuSquarePen } from "react-icons/lu";
 import { WithTooltip, screenWidthAtMost } from "@opencast/appkit";
 
 import { environment as relayEnv } from "../relay";
@@ -277,8 +277,8 @@ export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
     /* eslint-disable react/jsx-key */
     const buttons: [string, string, ReactElement][] = [
         ["/~manage/realm?path=", t("realm.page-settings"), <LuSettings />],
-        ["/~manage/realm/content?path=", t("realm.edit-page-content"), <LuPenSquare />],
-        ["/~manage/realm/add-child?parent=", t("realm.add-sub-page"), <LuPlusCircle />],
+        ["/~manage/realm/content?path=", t("realm.edit-page-content"), <LuSquarePen />],
+        ["/~manage/realm/add-child?parent=", t("realm.add-sub-page"), <LuCirclePlus />],
     ];
     /* eslint-enable react/jsx-key */
 

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -28,6 +28,7 @@ import {
     Spinner,
     WithTooltip,
     match,
+    matchTag,
     screenWidthAtMost,
     unreachable,
     useColorScheme,
@@ -237,20 +238,16 @@ const SearchPage: React.FC<Props> = ({ q, outcome }) => {
     });
 
 
-    let body;
-    if (outcome.__typename === "EmptyQuery") {
-        body = <CenteredNote>{t("search.too-few-characters")}</CenteredNote>;
-    } else if (outcome.__typename === "SearchUnavailable") {
-        body = <div css={{ textAlign: "center" }}>
+    const body = matchTag(outcome, "__typename", {
+        "EmptyQuery": () => <CenteredNote>{t("search.too-few-characters")}</CenteredNote>,
+        "SearchUnavailable": () => <div css={{ textAlign: "center" }}>
             <Card kind="error" css={{ margin: 32 }}>{t("search.unavailable")}</Card>
-        </div>;
-    } else if (outcome.__typename === "SearchResults") {
-        body = outcome.items.length === 0
+        </div>,
+        "SearchResults": outcome => outcome.items.length === 0
             ? <CenteredNote>{t("search.no-results")}</CenteredNote>
-            : <SearchResults items={outcome.items} />;
-    } else {
-        return unreachable("unknown search outcome");
-    }
+            : <SearchResults items={outcome.items} />,
+        "%other": () => unreachable("unknown search outcome"),
+    });
 
     const hits = outcome.__typename === "SearchResults" ? outcome.totalHits : 0;
     const timingInfo = isExperimentalFlagSet() && outcome.__typename === "SearchResults"
@@ -481,19 +478,16 @@ const SearchResults: React.FC<SearchResultsProps> = ({ items }) => {
                 ? COLORS.neutral25
                 : COLORS.neutral20,
         }}>
-            {items.map(item => {
-                if (item.__typename === "SearchEvent") {
-                    return <SearchEvent key={item.id} {...item} />;
-                } else if (item.__typename === "SearchSeries") {
-                    return <SearchSeries key={item.id} {...item} />;
-                } else if (item.__typename === "SearchRealm") {
-                    return <SearchRealm key={item.id} {...item} />;
-                } else {
+            {items.map(item => matchTag(item, "__typename", {
+                "SearchEvent": item => <SearchEvent key={item.id} {...item} />,
+                "SearchSeries": item => <SearchSeries key={item.id} {...item} />,
+                "SearchRealm": item => <SearchRealm key={item.id} {...item} />,
+                "%other": () => {
                     // eslint-disable-next-line no-console
                     console.warn("Unknown search item type: ", item.__typename);
                     return null;
-                }
-            })}
+                },
+            }))}
         </ul>
     );
 };

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -3,7 +3,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from "reac
 import {
     LuCalendar,
     LuCalendarRange,
-    LuLayout,
+    LuPanelsTopLeft,
     LuRadio,
     LuVolume2,
     LuX,
@@ -1048,7 +1048,7 @@ const SearchRealm: React.FC<RealmItem> = ({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-        }}><LuLayout /></div>,
+        }}><LuPanelsTopLeft /></div>,
         info: (
             <div css={{
                 padding: "6px 0",

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { fetchQuery, graphql, useFragment } from "react-relay";
 import { keyframes } from "@emotion/react";
 import { Controller, useController, useForm } from "react-hook-form";
-import { LuCheckCircle, LuUpload, LuInfo } from "react-icons/lu";
+import { LuCircleCheck, LuUpload, LuInfo } from "react-icons/lu";
 import { Spinner, WithTooltip, assertNever, bug, unreachable } from "@opencast/appkit";
 
 import { RootLoader } from "../layout/Root";
@@ -206,7 +206,7 @@ const UploadMain: React.FC<UploadMainProps> = ({ knownRoles }) => {
             marginTop: "max(16px, 10vh - 50px)",
             gap: 32,
         }}>
-            <LuCheckCircle css={{ fontSize: 64, color: COLORS.happy0 }} />
+            <LuCircleCheck css={{ fontSize: 64, color: COLORS.happy0 }} />
             {t("upload.finished")}
         </div>;
     } else {

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -12,7 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { fetchQuery, OperationType } from "relay-runtime";
 import {
-    LuCode, LuDownload, LuInfo, LuLink, LuQrCode, LuRss, LuSettings, LuShare2, LuUnlock,
+    LuCode, LuDownload, LuInfo, LuLink, LuQrCode, LuRss, LuSettings, LuShare2, LuLockOpen,
 } from "react-icons/lu";
 import { QRCodeCanvas } from "qrcode.react";
 import {
@@ -301,7 +301,7 @@ export const DirectOpencastVideoRoute = makeRoute({
 
         const query = graphql`
             query VideoPageDirectOpencastLinkQuery(
-                $id: String!, 
+                $id: String!,
                 $listId: ID!,
                 $eventUser: String,
                 $eventPassword: String
@@ -779,7 +779,7 @@ const ProtectedPlayer: React.FC<ProtectedPlayerProps> = ({ event, embedded, refe
                         {...{ onSubmit }}
                         state={authState}
                         error={null}
-                        SubmitIcon={LuUnlock}
+                        SubmitIcon={LuLockOpen}
                         labels={{
                             user: t("label.id"),
                             password: t("label.password"),

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -61,7 +61,7 @@ export const EditMode: React.FC<EditModeProps> = props => {
                 SeriesBlock: () => <EditSeriesBlock block={block} />,
                 VideoBlock: () => <EditVideoBlock block={block} />,
                 PlaylistBlock: () => <EditPlaylistBlock block={block} />,
-            }, () => bug("unknown block type"))}
+            }) ?? bug("unknown block type")}
         </FormProvider>
     </EditModeFormContext.Provider>;
 };

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
-import { LuPenSquare } from "react-icons/lu";
+import { LuSquarePen } from "react-icons/lu";
 import { WithTooltip } from "@opencast/appkit";
 
 import type {
@@ -54,7 +54,7 @@ export const EditButtons: React.FC<Props> = ({
         <MoveButtons {...{ realm, index, onCommit, onCompleted }} onError={onMoveError} />
         <WithTooltip tooltip={t("manage.realm.content.edit")}>
             <Button aria-label={t("manage.realm.content.edit")} onClick={onEdit}>
-                <LuPenSquare />
+                <LuSquarePen />
             </Button>
         </WithTooltip>
         <RemoveButton

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -12,7 +12,7 @@ import { ChildOrder } from "./ChildOrder";
 import { General } from "./General";
 import { DangerZone } from "./DangerZone";
 import { LinkButton } from "../../../ui/LinkButton";
-import { LuArrowRightCircle, LuPlusCircle } from "react-icons/lu";
+import { LuCircleArrowRight, LuCirclePlus } from "react-icons/lu";
 import { Card } from "@opencast/appkit";
 import { Nav } from "../../../layout/Navigation";
 import { CenteredContent } from "../../../ui";
@@ -119,11 +119,11 @@ const SettingsPage: React.FC<Props> = ({ realm, data }) => {
             }}>
                 <LinkButton to={realm.path}>
                     {t("manage.realm.view-page")}
-                    <LuArrowRightCircle />
+                    <LuCircleArrowRight />
                 </LinkButton>
                 <LinkButton to={AddChildRoute.url({ parent: realm.path })}>
                     {t("realm.add-sub-page")}
-                    <LuPlusCircle />
+                    <LuCirclePlus />
                 </LinkButton>
             </div>
             <section><General fragRef={realm} /></section>

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -282,7 +282,7 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => 
                 // poll showed that this matches the intuition of almost everyone.
                 "ASCENDING": () => <LuArrowDownNarrowWide />,
                 "DESCENDING": () => <LuArrowUpWideNarrow />,
-            }, () => null)}
+            })}
         </Link>
     </th>;
 };
@@ -504,16 +504,16 @@ const DEFAULT_SORT_DIRECTION: SortDirection = "DESCENDING";
 const queryParamsToVars = (queryParams: URLSearchParams): VariablesOf<VideoManageQuery> => {
     // Sort order
     const sortBy = queryParams.get("sortBy");
-    const column = sortBy !== null && match<string, EventSortColumn>(sortBy, {
-        "title": () => "TITLE",
-        "created": () => "CREATED",
-        "updated": () => "UPDATED",
+    const column = sortBy !== null && match(sortBy, {
+        "title": () => "TITLE" as const,
+        "created": () => "CREATED" as const,
+        "updated": () => "UPDATED" as const,
     });
 
     const sortOrder = queryParams.get("sortOrder");
-    const direction = sortOrder !== null && match<string, SortDirection>(sortOrder, {
-        "desc": () => "DESCENDING",
-        "asc": () => "ASCENDING",
+    const direction = sortOrder !== null && match(sortOrder, {
+        "desc": () => "DESCENDING" as const,
+        "asc": () => "ASCENDING" as const,
     });
 
     const order = !column || !direction
@@ -546,7 +546,7 @@ const varsToQueryParams = (vars: VariablesOf<VideoManageQuery>): URLSearchParams
         searchParams.set("sortOrder", match(vars.order.direction, {
             "ASCENDING": () => "asc",
             "DESCENDING": () => "desc",
-        }, () => ""));
+        }) ?? "");
     }
 
     // Pagination

--- a/frontend/src/routes/util.tsx
+++ b/frontend/src/routes/util.tsx
@@ -47,7 +47,7 @@ export const sortRealms = <T extends { readonly name?: string | null }>(
     return match(sortOrder, {
         "ALPHABETIC_ASC": () => [...realms].sort((a, b) => compare(a.name, b.name)),
         "ALPHABETIC_DESC": () => [...realms].sort((a, b) => compare(b.name, a.name)),
-    }, () => realms);
+    }) ?? realms;
 };
 
 

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -7,7 +7,7 @@ import { Title } from "..";
 import { useTranslation } from "react-i18next";
 import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
-import { LuArrowRightCircle } from "react-icons/lu";
+import { LuCircleArrowRight } from "react-icons/lu";
 import { PlayerContextProvider } from "../player/PlayerContext";
 import { PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
 
@@ -97,7 +97,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
             }}
         >
             {t("video.link")}
-            <LuArrowRightCircle size={18} css={{ marginTop: 1 }} />
+            <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
         </Link>}
     </div>;
 };

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -265,7 +265,7 @@ const orderItems = (
             "OLD_TO_NEW": () => reverseTime ? timeMs(b) - timeMs(a) : timeMs(a) - timeMs(b),
             "AZ": () => collator.compare(a.title, b.title),
             "ZA": () => collator.compare(b.title, a.title),
-        }, unreachable);
+        });
 
 
     mainItems.sort((a, b) => {

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -13,6 +13,7 @@ import type { i18n } from "i18next";
 import {
     match, unreachable, ProtoButton, screenWidthAtMost, screenWidthAbove,
     useColorScheme, Floating, FloatingHandle, useFloatingItemProps, bug,
+    matchTag,
 } from "@opencast/appkit";
 import { keyframes } from "@emotion/react";
 import { IconType } from "react-icons";
@@ -123,18 +124,13 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     const [eventOrder, setEventOrder] = useState<Order>(initialOrder);
     const user = useUser();
 
-    const items = listEntries.map(entry => {
-        if (entry.__typename === "AuthorizedEvent") {
-            const out = readInlineData<VideoListEventData$key>(videoListEventFragment, entry);
-            return out;
-        } else if (entry.__typename === "Missing") {
-            return "missing";
-        } else if (entry.__typename === "NotAllowed") {
-            return "unauthorized";
-        } else {
-            return unreachable();
-        }
-    });
+    const items = listEntries.map(entry => matchTag(entry, "__typename", {
+        "AuthorizedEvent": entry =>
+            readInlineData<VideoListEventData$key>(videoListEventFragment, entry),
+        "Missing": () => "missing" as VideoListItem,
+        "NotAllowed": () => "unauthorized" as VideoListItem,
+        "%other": () => unreachable(),
+    }));
 
     const {
         mainItems,

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -17,7 +17,7 @@ import {
 import { keyframes } from "@emotion/react";
 import { IconType } from "react-icons";
 import {
-    LuColumns, LuList, LuChevronLeft, LuChevronRight, LuPlay, LuLayoutGrid, LuAlertCircle, LuInfo,
+    LuColumns2, LuList, LuChevronLeft, LuChevronRight, LuPlay, LuLayoutGrid, LuCircleAlert, LuInfo,
 } from "react-icons/lu";
 import { graphql, readInlineData } from "react-relay";
 
@@ -414,7 +414,7 @@ const LayoutMenu: React.FC = () => {
     const ref = useRef<FloatingHandle>(null);
 
     const icon = match(state.layoutState, {
-        SLIDER: () => <LuColumns />,
+        SLIDER: () => <LuColumns2 />,
         GALLERY: () => <LuLayoutGrid />,
         LIST: () => <LuList />,
         "%future added value": () => unreachable(),
@@ -477,7 +477,7 @@ const List: React.FC<ListProps> = ({ type, close }) => {
         LayoutTranslationKey,
         IconType
     ][] = [
-        ["SLIDER", "slider", LuColumns],
+        ["SLIDER", "slider", LuColumns2],
         ["GALLERY", "gallery", LuLayoutGrid],
         ["LIST", "list", LuList],
     ];
@@ -913,7 +913,7 @@ const Item: React.FC<ItemProps> = ({
                     + "#2e2e2e, #2e2e2e 30px, #292929 30px, #292929 60px)",
                 color: "#dbdbdb",
             }}>
-                <LuAlertCircle />
+                <LuCircleAlert />
             </BaseThumbnailReplacement>
         </ThumbnailOverlayContainer>
         : <>

--- a/frontend/src/ui/Breadcrumbs.tsx
+++ b/frontend/src/ui/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { LuHome, LuChevronRight } from "react-icons/lu";
+import { LuHouse, LuChevronRight } from "react-icons/lu";
 import { useTranslation } from "react-i18next";
 import { BreadcrumbList, WithContext } from "schema-dts";
 
@@ -43,7 +43,7 @@ export const Breadcrumbs: React.FC<Props> = ({ path, tail }) => {
                         ...focusStyle({ inset: true }),
                         borderRadius: 4,
                     }}>
-                        <LuHome aria-label={t("general.home")} />
+                        <LuHouse aria-label={t("general.home")} />
                     </Link>
                 </li>
                 {path.map((segment, i) => (

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { LuAlertTriangle, LuFilm, LuRadio, LuTrash, LuUserCircle, LuVolume2 } from "react-icons/lu";
+import { LuTriangleAlert, LuFilm, LuRadio, LuTrash, LuCircleUser, LuVolume2 } from "react-icons/lu";
 import { useColorScheme } from "@opencast/appkit";
 
 import { COLORS } from "../color";
@@ -257,7 +257,7 @@ export const ThumbnailImg: React.FC<{ src: string; alt: string }> = ({ src, alt 
                 strokeWidth: 1.5,
             },
         }}>
-            <LuAlertTriangle />
+            <LuTriangleAlert />
             {t("general.failed-to-load-thumbnail")}
         </div>
         : <img
@@ -297,7 +297,7 @@ export const Creators: React.FC<CreatorsProps> = ({ creators, className }) => (
             }}
             {...{ className }}
         >
-            <LuUserCircle css={{
+            <LuCircleUser css={{
                 color: COLORS.neutral60,
                 fontSize: 16,
                 flexShrink: 0,

--- a/frontend/src/ui/index.tsx
+++ b/frontend/src/ui/index.tsx
@@ -1,5 +1,5 @@
 import { match, WithTooltip, screenWidthAbove, useColorScheme } from "@opencast/appkit";
-import { LuAlertTriangle, LuInfo } from "react-icons/lu";
+import { LuTriangleAlert, LuInfo } from "react-icons/lu";
 import { ReactNode } from "react";
 import { CSSObject } from "@emotion/react";
 
@@ -204,7 +204,7 @@ export const InfoWithTooltip: React.FC<InfoWithTooltipProps> = ({ tooltip, mode 
         tooltipCss={{ width: "min(85vw, 460px)" }}
     >
         <span css={{ marginLeft: 6, display: "flex", alignItems: "center" }}>
-            {mode === "info" ? <LuInfo /> : <LuAlertTriangle css={{ color: COLORS.danger0 }}/>}
+            {mode === "info" ? <LuInfo /> : <LuTriangleAlert css={{ color: COLORS.danger0 }}/>}
         </span>
     </WithTooltip>
 );

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -18,7 +18,7 @@ export function keyOfId(id: string): string {
     return match(id.length, {
         13: () => id.substring(2),
         11: () => id,
-    }, () => bug("argument of `keyOfId` is neither a key nor an ID"));
+    }) ?? bug("argument of `keyOfId` is neither a key nor an ID");
 }
 
 /** Constructs event ID for graphQL by adding the "ev" prefix. */

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -39,6 +39,7 @@ const config: CallableOption = (_env, argv) => ({
         // https://gist.github.com/LukasKalbertodt/382cb53a85fcf6e7d1f5235625c6f4fb
         alias: {
             "react": path.join(__dirname, "node_modules/react"),
+            "focus-trap-react": path.join(__dirname, "node_modules/focus-trap-react"),
             "@emotion/react": path.join(__dirname, "node_modules/@emotion/react"),
         },
     },


### PR DESCRIPTION
Main goal of this was to update appkit. But this required an update of react-icons as well. This is two separate commits, but just for review ease, just the first commit does not work on its own. 

In terms of changelog for Tobira:
- For users: https://github.com/opencast/appkit/pull/9
- For devs: well, appkit update