### PR TITLE
Allow configuring custom names for matomo files

### DIFF
--- a/backend/src/config/matomo.rs
+++ b/backend/src/config/matomo.rs
@@ -7,13 +7,23 @@ use crate::prelude::*;
 pub(crate) struct MatomoConfig {
     /// URL of your Matomo server. Example: "https://matomo.myuni.edu/matomo/".
     ///
-    /// Note: Adding `matomo.js` to the URL configured here should result in a
-    /// URL to a publicly accessible JS file.
+    /// Note: Adding the filename of the Matomo script to the URL configured here should result in
+    /// a URL to a publicly accessible JS file.
     #[config(deserialize_with = deserialize_server)]
     pub(crate) server: Option<Uri>,
 
     /// Matomo site ID, e.g. `side_id = "1"`
     pub(crate) site_id: Option<String>,
+
+    /// Filename for the Matomo JS script.
+    /// Default: "matomo.js"
+    #[config(default = "matomo.js")]
+    pub(crate) tracker_url_js: String,
+
+    /// Filename for the Matomo PHP endpoint.
+    /// Default: "matomo.php"
+    #[config(default = "matomo.php")]
+    pub(crate) tracker_url_php: String,
 }
 
 impl MatomoConfig {
@@ -32,12 +42,15 @@ impl MatomoConfig {
             _paq.push(['enableLinkTracking']);
             (function() {{
               var u="{server}";
-              _paq.push(['setTrackerUrl', u+'matomo.php']);
+              _paq.push(['setTrackerUrl', u+'{php}']);
               _paq.push(['setSiteId', '{site_id}']);
               var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-              g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+              g.async=true; g.src=u+'{js}'; s.parentNode.insertBefore(g,s);
             }})();
-        "#);
+        "#,
+            php = self.tracker_url_php,
+            js = self.tracker_url_js,
+        );
 
         // Fix indentation, super duper important.
         Some(out.replace("\n            ", "\n      "))

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -639,12 +639,24 @@
 [matomo]
 # URL of your Matomo server. Example: "https://matomo.myuni.edu/matomo/".
 #
-# Note: Adding `matomo.js` to the URL configured here should result in a
-# URL to a publicly accessible JS file.
+# Note: Adding the filename of the Matomo script to the URL configured here should result in
+# a URL to a publicly accessible JS file.
 #server =
 
 # Matomo site ID, e.g. `side_id = "1"`
 #site_id =
+
+# Filename for the Matomo JS script.
+# Default: "matomo.js"
+#
+# Default value: "matomo.js"
+#tracker_url_js = "matomo.js"
+
+# Filename for the Matomo PHP endpoint.
+# Default: "matomo.php"
+#
+# Default value: "matomo.php"
+#tracker_url_php = "matomo.php"
 
 
 [player]


### PR DESCRIPTION
The js and php file names for matomo were previously hardcoded, which would mean that other values in the paella config were being ignored. Since at least one institution is using custom values, this needs to be configurable.

The default values are still `matomo.js` and `matomo.php`, so this isn't a breaking change