### PR TITLE
Add placeholder for unsynced events

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -550,19 +550,12 @@ impl AuthorizedEvent {
                 read_roles, write_roles, preview_roles, \
                 metadata, is_live, updated, created, state \
             ) values ( \
-                $1, $2, $3, $4, $5, $6, $7, $8, \
+                $1, $2, $3, $4, $5, '{{}}', $6, $7, \
                 '{{}}', '{{}}', false, '-infinity', now(), 'waiting' \
             ) returning id \
         ");
 
         let acl = convert_acl_input(event.acl);
-        let dummy_tracks = vec![EventTrack {
-            uri: "https://example.org/video.mp4".to_string(),
-            flavor: "presenter/preview".to_string(),
-            mimetype: Some("video/mp4".to_string()),
-            resolution: Some([1280, 720]),
-            is_master: Some(true),
-        }];
 
         context.db.execute(&query, &[
             &event.opencast_id,
@@ -570,7 +563,6 @@ impl AuthorizedEvent {
             &event.description,
             &event.creators,
             &event.series_id.map(|id| id.key_for(Id::SERIES_KIND)),
-            &dummy_tracks,
             &acl.read_roles,
             &acl.write_roles,
         ]).await?;

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -36,7 +36,7 @@ use super::{
             UpdateVideoBlock,
             RemovedBlock,
         },
-        event::AuthorizedEvent,
+        event::{AuthorizedEvent, NewEvent},
     },
 };
 
@@ -54,6 +54,13 @@ impl Mutation {
     /// Creates the current users realm. Errors if it already exists.
     async fn create_my_user_realm(context: &Context) -> ApiResult<Realm> {
         Realm::create_user_realm(context).await
+    }
+
+    /// Creates a placeholder event in the DB when a video is uploaded.
+    /// With that, the event can be listed on the "My videos" page before
+    /// its processing in Opencast is finished and the event is synced.
+    async fn create_placeholder_event(event: NewEvent, context: &Context) -> ApiResult<AuthorizedEvent> {
+        AuthorizedEvent::create_placeholder(event, context).await
     }
 
     /// Deletes the given event. Meaning: a deletion request is sent to Opencast, the event

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -376,4 +376,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     41: "series-index",
     42: "series-view-and-deletion-timestamp",
     43: "search-views-without-deletions",
+    44: "redo-events-no-null-tracks-constraint",
 ];

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -375,4 +375,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     40: "realm-names-constraint-revision",
     41: "series-index",
     42: "series-view-and-deletion-timestamp",
+    43: "search-views-without-deletions",
 ];

--- a/backend/src/db/migrations/43-search-views-without-deletions.sql
+++ b/backend/src/db/migrations/43-search-views-without-deletions.sql
@@ -1,0 +1,85 @@
+-- Updates/reapplies search views to omit deleted events and series.
+
+
+drop view search_events;
+create view search_events as
+    select
+        events.id, events.opencast_id, events.state,
+        events.series, series.title as series_title,
+        events.title, events.description, events.creators,
+        events.thumbnail, events.duration,
+        events.is_live, events.updated, events.created, events.start_time, events.end_time,
+        events.read_roles, events.write_roles, events.preview_roles,
+        coalesce(
+            array_agg(
+                distinct
+                row(search_realms.*)::search_realms
+            ) filter(where search_realms.id is not null),
+            '{}'
+        ) as host_realms,
+        is_audio_only(events.tracks) as audio_only,
+        coalesce(
+            array_agg(playlists.id)
+                filter(where playlists.id is not null),
+            '{}'
+        ) as containing_playlists,
+        (
+            select array_agg(t)
+            from (
+                select unnest(texts) as t
+                from event_texts
+                where event_id = events.id and ty = 'slide-text'
+            ) as subquery
+        ) as slide_texts,
+        (
+            select array_agg(t)
+            from (
+                select unnest(texts) as t
+                from event_texts
+                where event_id = events.id and ty = 'caption'
+            ) as subquery
+        ) as caption_texts,
+        (events.credentials is not null) as has_password
+    from all_events as events
+    left join all_series as series
+        on events.series = series.id
+        and series.tobira_deletion_timestamp is null
+    -- This syntax instead of `foo = any(...)` to use the index, which is not
+    -- otherwise used.
+    left join playlists on array[events.opencast_id] <@ event_entry_ids(entries)
+    left join blocks on (
+        type = 'series' and blocks.series = events.series
+        or type = 'video' and blocks.video = events.id
+        or type = 'playlist' and blocks.playlist = playlists.id
+    )
+    left join search_realms on search_realms.id = blocks.realm
+    where events.tobira_deletion_timestamp is null
+    group by events.id, series.id;
+
+
+drop view search_series;
+create view search_series as
+    select
+        series.id, series.state, series.opencast_id,
+        series.read_roles, series.write_roles,
+        series.title, series.description, series.updated, series.created, series.metadata,
+        array(
+            select search_thumbnail_info_for_event(events.*) from events
+                where series = series.id
+        ) as thumbnails,
+        coalesce(
+            array_agg((
+                -- Using a nested query here improves the overall performance
+                -- for the main use case: 'where id = any(...)'. If we would
+                -- use a join instead, the runtime would be the same with or
+                -- without the 'where id' (roughly 300ms on my machine).
+                select row(search_realms.*)::search_realms
+                from search_realms
+                where search_realms.id = blocks.realm
+            )) filter(where blocks.realm is not null),
+            '{}'
+        ) as host_realms
+    from all_series as series
+    left join blocks on type = 'series' and blocks.series = series.id
+    where series.tobira_deletion_timestamp is null
+    group by series.id;

--- a/backend/src/db/migrations/44-redo-events-no-null-tracks-constraint.sql
+++ b/backend/src/db/migrations/44-redo-events-no-null-tracks-constraint.sql
@@ -1,0 +1,10 @@
+-- There is already the `ready_event_has_fields` constraint in
+-- 05-events.sql. The `no_null_tracks` constraint was added later
+-- to also prevent `waiting` events from having no tracks, but
+-- it turns out that we actually don't want that constraint for
+-- the purpose of creating dummy events for waiting.
+alter table all_events
+    drop constraint no_null_tracks,
+    add constraint no_null_tracks check (
+        array_length(tracks, 1) = 0 or array_position(tracks, null) is null
+    );

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -335,10 +335,6 @@ acl:
   authorized-groups: Autorisierte Gruppen
   authorized-users: Autorisierte Personen
   editing-disabled: Bearbeitung der Zugangsberechtigungen ist deaktiviert.
-  workflow-active: >
-    Änderung der Berechtigungen ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
-    <br />
-    Bitte versuchen Sie es später nochmal.
   locked-to-series: >
     Die Berechtigungen dieses Videos werden durch seine <1>Serie</1> bestimmt und können daher nicht bearbeitet werden.
   users-no-options:
@@ -447,6 +443,12 @@ manage:
       synced: Synchronisiert?
       part-of: 'Teil von:'
       is-live: Live?
+    workflow-status:
+      active: Das Video wird momentan noch verarbeitet. Bitte versuchen Sie es später nochmal.
+      unknown: >
+        Der Status dieses Videos in Opencast ist unbekannt, daher kann es nicht bearbeitet werden.
+        <br />
+        Bitte versuchen Sie es später nochmal.
 
   series:
     created-note: Serie wurde erstellt.
@@ -491,10 +493,6 @@ manage:
     save: Metadaten speichern
     errors:
       field-required: Dieses Feld darf nicht leer sein.
-    event-workflow-active: >
-      Änderung der Metadaten ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
-      <br />
-      Bitte versuchen Sie es später nochmal.
 
   table:
     page-showing-ids: '{{start}}–{{end}} von {{total}}'
@@ -682,10 +680,10 @@ api-remote-errors:
   event:
     not-found: "Aktion fehlgeschlagen: Video nicht gefunden."
     not-allowed: Sie haben nicht die Berechtigung, diese Videoaktion durchzuführen.
-    workflow:
+    workflow-status:
       not-allowed: Sie haben nicht die Berechtigung, die Workflowaktivität für dieses Video abzufragen.
-      active-acl: $t(acl.workflow-active)
-      active-metadata: $t(metadata-form.event-workflow-active)
+      active: $t(manage.video.workflow-status.active)
+      unknown:  $t(manage.video.workflow-status.unknown)
   series:
     not-found: "Aktion fehlgeschlagen: Serie nicht gefunden."
     not-allowed: Sie haben nicht die Berechtigung, diese Serienaktion durchzuführen.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -148,8 +148,8 @@ video:
     title: Video noch nicht verarbeitet
     text: >
       Das gewünschte Video ist leider noch nicht vollständig verarbeitet worden. Dies sollte
-      in Kürze automatisch passieren. Versuchen Sie es in wenigen Minuten noch einmal.
-    label: unverarbeitet
+      in Kürze automatisch passieren. Versuchen Sie es später noch einmal.
+    label: noch nicht verarbeitet
   thumbnail-for: Vorschaubild für „{{video}}“
   live: Live
   upcoming: Anstehend

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -329,10 +329,6 @@ acl:
   authorized-groups: Authorized groups
   authorized-users: Authorized users
   editing-disabled: Access policy editing is disabled.
-  workflow-active: >
-    Changing the access policy is not possible at this time, since the video is being processed in the background.
-    <br />
-    Please try again later.
   locked-to-series: The access policy of this video is determined by its <1>series</1> and can't be edited.
   users-no-options:
     initial-searchable: Type to search for users by name (or enter exact email/username)
@@ -422,6 +418,12 @@ manage:
       synced: Synchronized?
       part-of: 'Part of:'
       is-live: Live?
+    workflow-status:
+      active: The video is currently being processed in the background. Please try again later.
+      unknown: >
+        The status of this video in Opencast is unknown, therefore it can't be edited.
+        <br />
+        Please try again later.
 
   series:
     created-note: Series has been created.
@@ -467,10 +469,6 @@ manage:
     save: Save metadata
     errors:
       field-required: This field is required (cannot be empty).
-    event-workflow-active: >
-      Changing the metadata is not possible at this time, since the video is being processed in the background.
-      <br />
-      Please try again later.
 
   table:
     page-showing-ids: '{{start}}–{{end}} of {{total}}'
@@ -646,10 +644,10 @@ api-remote-errors:
   event:
     not-found: "Action failed: Video not found."
     not-allowed: You are not allowed to perform this video action.
-    workflow:
+    workflow-status:
       not-allowed: You are not allowed to inquire about workflow activity of this video.
-      active-acl: $t(acl.workflow-active)
-      active-metadata: $t(metadata-form.event-workflow-active)
+      active: $t(manage.video.workflow-status.active)
+      unknown:  $t(manage.video.workflow-status.unknown)
   series:
     not-found: "Action failed: series not found."
     not-allowed: You are not allowed to perform this series action.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -146,8 +146,8 @@ video:
     title: Video not processed yet
     text: >
       This video hasn't been fully processed yet. This should
-      happen automatically soon. Try again in a few minutes.
-    label: unprocessed
+      happen automatically soon. Try again later.
+    label: not processed yet
   thumbnail-for: Thumbnail for “{{video}}”
   live: Live
   upcoming: Upcoming

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -818,7 +818,10 @@ const SearchSeries: React.FC<SeriesItem> = ({
 
     return <Item key={id} breakpoint={550} link={link}>{{
         image: <Link to={link} tabIndex={-1}>
-            <ThumbnailStack thumbnails={thumbnailStack.thumbnails} {...{ title }} />
+            <ThumbnailStack
+                thumbnails={thumbnailStack.thumbnails}
+                {...{ title }}
+            />
         </Link>,
         info: <div css={{
             display: "flex",

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -353,7 +353,7 @@ const DatePicker: React.FC<DatePickerProps> = ({ router }) => {
                     type="date"
                     onChange={e => handleChange(e.target.value, "start")}
                 />
-                <span>-</span>
+                <span>{"-"}</span>
                 <input
                     value={endDate ?? ""}
                     css={inputStyle}

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -11,7 +11,7 @@ import { boxError } from "@opencast/appkit";
 import { displayCommitError } from "./util";
 import { currentRef } from "../../../util";
 import { MODERATE_ADMIN_ACTIONS } from "../../../util/permissionLevels";
-import { mapAcl } from "../../util";
+import { aclArrayToMap } from "../../util";
 
 
 const fragment = graphql`
@@ -37,7 +37,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const ownerDisplayName = (realm.ancestors[0] ?? realm).ownerDisplayName;
     const saveModalRef = useRef<ConfirmationModalHandle>(null);
 
-    const [initialAcl, inheritedAcl] = [realm.ownAcl, realm.inheritedAcl].map(mapAcl);
+    const [initialAcl, inheritedAcl] = [realm.ownAcl, realm.inheritedAcl].map(aclArrayToMap);
 
     const [selections, setSelections] = useState<Acl>(initialAcl);
 

--- a/frontend/src/routes/manage/Series/Create.tsx
+++ b/frontend/src/routes/manage/Series/Create.tsx
@@ -24,6 +24,7 @@ import { CreateSeriesMutation } from "./__generated__/CreateSeriesMutation.graph
 import { useNotification } from "../../../ui/NotificationContext";
 import { NotAuthorized } from "../../../ui/error";
 import { ManageSeriesDetailsRoute } from "./SeriesDetails";
+import { aclMapToArray } from "../../util";
 
 
 export const CREATE_SERIES_PATH = "/~manage/create-series" as const;
@@ -103,12 +104,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
                     title: data.title,
                     description: data.description,
                 },
-                acl: [...data.acl].map(
-                    ([role, { actions }]) => ({
-                        role,
-                        actions: [...actions],
-                    }),
-                ),
+                acl: aclMapToArray(data.acl),
             },
             onCompleted: response => {
                 const returnPath = ManageSeriesDetailsRoute.url({

--- a/frontend/src/routes/manage/Series/SeriesAccess.tsx
+++ b/frontend/src/routes/manage/Series/SeriesAccess.tsx
@@ -10,7 +10,7 @@ import { AccessEditor, AclPage, SubmitAclProps } from "../Shared/Access";
 import i18n from "../../../i18n";
 import { SeriesAccessAclMutation } from "./__generated__/SeriesAccessAclMutation.graphql";
 import { isSynced } from "../../../util";
-import { NotReadyNote } from "../../util";
+import { aclMapToArray, NotReadyNote } from "../../util";
 
 
 export const ManageSeriesAccessRoute = makeManageSeriesRoute(
@@ -49,12 +49,7 @@ const SeriesAclEditor: React.FC<SeriesAclPageProps> = ({ series, data }) => {
         commit({
             variables: {
                 id: series.id,
-                acl: [...selections].map(
-                    ([role, { actions }]) => ({
-                        role,
-                        actions: [...actions],
-                    }),
-                ),
+                acl: aclMapToArray(selections),
             },
             onCompleted: () => currentRef(saveModalRef).done(),
             onError: error => {

--- a/frontend/src/routes/manage/Series/SeriesDetails.tsx
+++ b/frontend/src/routes/manage/Series/SeriesDetails.tsx
@@ -21,6 +21,8 @@ import {
 import { useNotification } from "../../../ui/NotificationContext";
 import { ManageVideoListContent } from "../Shared/EditVideoList";
 import { SeriesDetailsContentMutation } from "./__generated__/SeriesDetailsContentMutation.graphql";
+import { isSynced } from "../../../util";
+import { NotReadyNote } from "../../util";
 
 
 const updateSeriesMetadata = graphql`
@@ -59,7 +61,6 @@ export const ManageSeriesDetailsRoute = makeManageSeriesRoute(
     "details",
     "",
     series => <DetailsPage
-        kind="series"
         pageTitle="manage.series.details.title"
         item={series}
         breadcrumb={{
@@ -68,6 +69,7 @@ export const ManageSeriesDetailsRoute = makeManageSeriesRoute(
         }}
         sections={series => [
             <NotificationSection key="notification" />,
+            <SeriesNoteSection key="series-note" {...{ series }} />,
             <UpdatedCreatedInfo key="date-info" item={series} />,
             <SeriesButtonSection key="button-section" {...{ series }} />,
             <DirectLink key="direct-link" url={
@@ -90,6 +92,9 @@ const NotificationSection: React.FC = () => {
     const { Notification } = useNotification();
     return <Notification />;
 };
+
+const SeriesNoteSection: React.FC<{ series: Series }> = ({ series }) =>
+    !isSynced(series) && <NotReadyNote kind="series" />;
 
 const SeriesButtonSection: React.FC<{ series: Series }> = ({ series }) => {
     const { t } = useTranslation();

--- a/frontend/src/routes/manage/Series/SeriesDetails.tsx
+++ b/frontend/src/routes/manage/Series/SeriesDetails.tsx
@@ -21,7 +21,7 @@ import {
 import { useNotification } from "../../../ui/NotificationContext";
 import { ManageVideoListContent } from "../Shared/EditVideoList";
 import { SeriesDetailsContentMutation } from "./__generated__/SeriesDetailsContentMutation.graphql";
-import { isSynced } from "../../../util";
+import { Inertable, isSynced } from "../../../util";
 import { NotReadyNote } from "../../util";
 
 
@@ -126,11 +126,13 @@ const SeriesContentSection: React.FC<{ series: Series }> = ({ series }) => {
     const { t } = useTranslation();
     const [commit, inFlight] = useMutation<SeriesDetailsContentMutation>(editSeriesContent);
 
-    return <ManageVideoListContent
-        listId={series.id}
-        listEntries={[...series.entries]}
-        getUpdatedEntries={data => [...data.updateSeriesContent.entries]}
-        description={t("manage.series.details.edit-note")}
-        {...{ commit, inFlight }}
-    />;
+    return <Inertable isInert={!isSynced(series)}>
+        <ManageVideoListContent
+            listId={series.id}
+            listEntries={[...series.entries]}
+            getUpdatedEntries={data => [...data.updateSeriesContent.entries]}
+            description={t("manage.series.details.edit-note")}
+            {...{ commit, inFlight }}
+        />
+    </Inertable>;
 };

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -133,7 +133,7 @@ const seriesColumns: ColumnProps<SingleSeries>[] = [
 const SeriesRow: React.FC<{ item: SingleSeries }> = ({ item }) => <TableRow
     itemType="series"
     item={item}
-    thumbnail={deletionIsPending => <SeriesThumbnail series={item} {...{ deletionIsPending }} />}
+    thumbnail={status => <SeriesThumbnail series={item} seriesStatus={status} />}
     link={`${PATH}/${keyOfId(item.id)}`}
     customColumns={seriesColumns.map(col => <col.column key={col.key} item={item} />)}
 />;

--- a/frontend/src/routes/manage/Shared/Access.tsx
+++ b/frontend/src/routes/manage/Shared/Access.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../ui/Access";
 import { READ_WRITE_ACTIONS } from "../../../util/permissionLevels";
 import { AclArray } from "../../Upload";
-import { mapAcl } from "../../util";
+import { aclArrayToMap } from "../../util";
 import { ManageRoute } from "..";
 import CONFIG from "../../../config";
 import { PageTitle } from "../../../layout/header/ui";
@@ -81,7 +81,7 @@ export const AccessEditor: React.FC<AccessEditorProps> = ({
 }) => {
     const knownRoles = useFragment(knownRolesFragment, data);
     const saveModalRef = useRef<ConfirmationModalHandle>(null);
-    const acl = mapAcl(rawAcl);
+    const acl = aclArrayToMap(rawAcl);
     const [selections, setSelections] = useState<Acl>(acl);
     const [commitError, setCommitError] = useState<JSX.Element | null>(null);
 

--- a/frontend/src/routes/manage/Shared/Details.tsx
+++ b/frontend/src/routes/manage/Shared/Details.tsx
@@ -20,7 +20,6 @@ import { displayCommitError } from "../Realm/util";
 import { ConfirmationModal, ConfirmationModalHandle } from "../../../ui/Modal";
 import { Link, useRouter } from "../../../router";
 import { useNotification } from "../../../ui/NotificationContext";
-import { NotReadyNote } from "../../util";
 import { preciseDateTime, preferredLocaleForLang } from "../../../ui/time";
 
 
@@ -37,7 +36,6 @@ type Item = OpencastEntity & {
 
 type PageProps<T> = {
     item: T;
-    kind: "video" | "series";
     pageTitle: ParseKeys;
     breadcrumb: {
         label: string;
@@ -48,7 +46,6 @@ type PageProps<T> = {
 
 export const DetailsPage = <T extends Item>({
     item,
-    kind,
     pageTitle,
     breadcrumb,
     sections,
@@ -64,12 +61,11 @@ export const DetailsPage = <T extends Item>({
         return <NotAuthorized />;
     }
 
-    return <>
+    return <div css={{ maxWidth: 750 }}>
         <Breadcrumbs path={breadcrumbs} tail={item.title} />
         <PageTitle title={t(pageTitle)} />
-        {!isSynced(item) && <NotReadyNote {...{ kind }} />}
         {sections(item).map((section, i) => <DetailsSection key={i}>{section}</DetailsSection>)}
-    </>;
+    </div>;
 };
 
 const DetailsSection: React.FC<PropsWithChildren> = ({ children }) => (

--- a/frontend/src/routes/manage/Shared/Table.tsx
+++ b/frontend/src/routes/manage/Shared/Table.tsx
@@ -257,7 +257,6 @@ export const descriptionStyle = {
 
 // Used for both `EventRow` and `SeriesRow`.
 export const DateColumn: React.FC<{ date?: string | null }> = ({ date }) => {
-    const { t } = useTranslation();
     const isDark = useColorScheme().scheme === "dark";
     const parsedDate = date && new Date(date);
     const greyColor = { color: isDark ? COLORS.neutral60 : COLORS.neutral50 };
@@ -265,9 +264,7 @@ export const DateColumn: React.FC<{ date?: string | null }> = ({ date }) => {
     return <td css={{ fontSize: 14 }}>
         {parsedDate
             ? <PrettyDate date={parsedDate} />
-            : <i css={greyColor}>
-                {t("manage.table.missing-date")}
-            </i>
+            : <i css={greyColor}>{"—"}</i>
         }
     </td>;
 };

--- a/frontend/src/routes/manage/Shared/Table.tsx
+++ b/frontend/src/routes/manage/Shared/Table.tsx
@@ -25,6 +25,7 @@ import { SeriesSortColumn } from "../Series/__generated__/SeriesManageQuery.grap
 import { useNotification } from "../../../ui/NotificationContext";
 import { OcEntity } from "../../../util";
 import { isSynced } from "../../../util";
+import { ThumbnailItemStatus } from "../../../ui/Video";
 
 
 type ItemVars = {
@@ -281,7 +282,7 @@ type TableRowItem = {
 
 type TableRowProps<T extends TableRowItem> = {
     itemType: OcEntity;
-    thumbnail: (isPending?: boolean) => ReactNode;
+    thumbnail: (status: ThumbnailItemStatus) => ReactNode;
     link: string;
     item: T;
     customColumns?: ReactNode[];
@@ -298,6 +299,9 @@ export const TableRow = <T extends TableRowItem>({ item, ...props }: TableRowPro
     const deletionTimestamp = item.tobiraDeletionTimestamp;
     const deletionIsPending = Boolean(deletionTimestamp);
     const deletionDate = new Date(deletionTimestamp ?? "");
+    const thumbnailStatus = deletionIsPending ? "deleted" : (
+        !isSynced(item) ? "waiting" : "ready"
+    );
 
     // This checks if the current time is later than the deletion timestamp + twice
     // the configured poll period to ensure at least one sync has taken place
@@ -311,8 +315,10 @@ export const TableRow = <T extends TableRowItem>({ item, ...props }: TableRowPro
         {/* Thumbnail */}
         <td>
             {deletionIsPending
-                ? props.thumbnail(deletionIsPending)
-                : <Link to={props.link} css={{ ...thumbnailLinkStyle }}>{props.thumbnail()}</Link>
+                ? props.thumbnail(thumbnailStatus)
+                : <Link to={props.link} css={{ ...thumbnailLinkStyle }}>
+                    {props.thumbnail(thumbnailStatus)}
+                </Link>
             }
         </td>
         <td>

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -94,7 +94,7 @@ const query = graphql`
                 created
                 canWrite
                 isLive
-                hasActiveWorkflows @include(if: $fetchWorkflowState)
+                workflowStatus @include(if: $fetchWorkflowState)
                 acl { role actions info { label implies large } }
                 syncedData {
                     duration

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -167,6 +167,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         backgroundColor: "black",
         borderRadius: 8,
     };
+
     const thumbnail = <>
         <LuPlay />
         <Thumbnail event={event} />

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -8,7 +8,7 @@ import { NotAuthorized } from "../../../ui/error";
 import { isRealUser, useUser } from "../../../User";
 import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
-import { translatedConfig } from "../../../util";
+import { Inertable, isSynced, translatedConfig } from "../../../util";
 import { DirectVideoRoute, VideoRoute } from "../../Video";
 import { ManageVideosRoute } from ".";
 import CONFIG from "../../../config";
@@ -81,29 +81,31 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
         return <NotAuthorized />;
     }
 
-    return <ButtonSection>
-        {user.canUseEditor && !event.isLive && event.canWrite && (
-            <ExternalLink
-                service="EDITOR"
-                event={event.id}
-                params={{
-                    id: event.opencastId,
-                    callbackUrl: document.location.href,
-                    callbackSystem: translatedConfig(CONFIG.siteTitle, i18n),
-                }}
-                fallback="button"
-                css={buttonStyle(config, "normal", isHighContrast)}
-            >
-                {t("manage.video.details.open-in-editor")}
-            </ExternalLink>
-        )}
-        <DeleteButton
-            item={event}
-            kind="video"
-            returnPath="/~manage/videos"
-            commit={commit}
-        />
-    </ButtonSection>;
+    return <Inertable isInert={!isSynced(event) || !!event.hasActiveWorkflows}>
+        <ButtonSection>
+            {user.canUseEditor && !event.isLive && event.canWrite && (
+                <ExternalLink
+                    service="EDITOR"
+                    event={event.id}
+                    params={{
+                        id: event.opencastId,
+                        callbackUrl: document.location.href,
+                        callbackSystem: translatedConfig(CONFIG.siteTitle, i18n),
+                    }}
+                    fallback="button"
+                    css={buttonStyle(config, "normal", isHighContrast)}
+                >
+                    {t("manage.video.details.open-in-editor")}
+                </ExternalLink>
+            )}
+            <DeleteButton
+                item={event}
+                kind="video"
+                returnPath="/~manage/videos"
+                commit={commit}
+            />
+        </ButtonSection>
+    </Inertable>;
 };
 
 const VideoMetadataSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => {

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -153,7 +153,7 @@ const EventRow: React.FC<{ item: Event }> = ({ item }) => <TableRow
     itemType="video"
     item={item}
     link={`${PATH}/${keyOfId(item.id)}`}
-    thumbnail={deletionIsPending => <Thumbnail event={item} {...{ deletionIsPending }} />}
+    thumbnail={status => <Thumbnail event={item} {...{ status }} />}
     customColumns={videoColumns.map(col => <col.column key={col.key} item={item} />)}
 />;
 

--- a/frontend/src/routes/util.tsx
+++ b/frontend/src/routes/util.tsx
@@ -9,6 +9,7 @@ import { LoginRoute, REDIRECT_STORAGE_KEY } from "./Login";
 import { AclArray } from "./Upload";
 import { RealmOrder } from "../layout/__generated__/NavigationData.graphql";
 import { NoteWithTooltip } from "../ui";
+import { Acl } from "../ui/Access";
 
 
 export const b64regex = "[a-zA-Z0-9\\-_]";
@@ -99,11 +100,24 @@ export const LoginLink: React.FC<LoginLinkProps> = ({ className, children }) => 
     >{children}</Link>
 );
 
-export const mapAcl = (acl?: AclArray) => new Map(
+/**
+ * Converts array-based ACL into a Map structure that is used in frontend.
+ */
+export const aclArrayToMap = (acl?: AclArray) => new Map(
     acl?.map(item => [item.role, {
         actions: new Set(item.actions),
         info: item.info,
     }]),
+);
+
+/**
+ * Converts map-based ACL into an array format required by the backend API.
+ */
+export const aclMapToArray = (acl: Acl) => [...acl].map(
+    ([role, { actions }]) => ({
+        role,
+        actions: [...actions],
+    }),
 );
 
 export const NotReadyNote: React.FC<{ kind: "series" | "video"}> = ({ kind }) => {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -71,6 +71,12 @@ enum VideosSortColumn {
   SERIES
 }
 
+enum WorkflowStatus {
+  BUSY
+  IDLE
+  UNOBTAINABLE
+}
+
 input AclInputEntry {
   role: String!
   actions: [String!]!
@@ -292,7 +298,7 @@ type AuthorizedEvent implements Node {
   canWrite: Boolean!
   tobiraDeletionTimestamp: DateTime
   "Whether the event has active workflows."
-  hasActiveWorkflows: Boolean!
+  workflowStatus: WorkflowStatus!
   series: Series
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -98,6 +98,15 @@ input Filters {
   end: DateTime
 }
 
+input NewEvent {
+  opencastId: String!
+  title: String!
+  description: String
+  seriesId: ID
+  creators: [String!]!
+  acl: [AclInputEntry!]!
+}
+
 input NewPlaylistBlock {
   playlist: ID!
   displayOptions: DisplayOptions!
@@ -381,6 +390,12 @@ type Mutation {
   addRealm(realm: NewRealm!): Realm!
   "Creates the current users realm. Errors if it already exists."
   createMyUserRealm: Realm!
+  """
+    Creates a placeholder event in the DB when a video is uploaded.
+    With that, the event can be listed on the "My videos" page before
+    its processing in Opencast is finished and the event is synced.
+  """
+  createPlaceholderEvent(event: NewEvent!): AuthorizedEvent!
   """
     Deletes the given event. Meaning: a deletion request is sent to Opencast, the event
     is marked as "deletion pending" in Tobira, and fully removed once Opencast

--- a/frontend/src/ui/ThumbnailStack.tsx
+++ b/frontend/src/ui/ThumbnailStack.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from "react-i18next";
-import { LuRadio, LuTrash } from "react-icons/lu";
+import { LuRadio } from "react-icons/lu";
 import { useColorScheme } from "@opencast/appkit";
 
 import {
-    BaseThumbnailReplacement,
     ThumbnailImg,
     ThumbnailOverlay,
     ThumbnailOverlayContainer,
@@ -15,13 +14,19 @@ import { COLORS } from "../color";
 type ThumbnailStackProps = {
     title: string;
     thumbnails: readonly ThumbnailInfo[];
+    className?: string;
 }
 
-export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, title }) => {
+export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({
+    thumbnails,
+    title,
+    className,
+}) => {
     const isDarkScheme = useColorScheme().scheme === "dark";
 
     return (
-        <div css={{
+        <div {...{ className }} css={{
+            position: "relative",
             zIndex: 0,
             margin: "0 auto",
             width: "70%",
@@ -67,7 +72,7 @@ export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, titl
                 is more important than actually showing the correct number of thumbnails. */}
             {[...Array(Math.max(0, 3 - thumbnails.length))].map((_, idx) => (
                 <div key={"dummy" + idx}>
-                    <DummySeriesStackThumbnail isDark={isDarkScheme} />
+                    <DummySeriesStackThumbnail {...{ isDarkScheme }} />
                 </div>
             ))}
         </div>
@@ -75,57 +80,41 @@ export const ThumbnailStack: React.FC<ThumbnailStackProps> = ({ thumbnails, titl
 };
 
 
-type DummySeriesStackThumbnailProps = {
-    isDark: boolean;
-    deletionIsPending?: boolean;
-};
+const DummySeriesStackThumbnail: React.FC<{ isDarkScheme: boolean }> = ({
+    isDarkScheme,
+}) => <ThumbnailOverlayContainer css={{
+    // Pattern from https://css-pattern.com/overlapping-cubes/,
+    // MIT licensed: https://github.com/Afif13/CSS-Pattern
+    "--s": "40px",
+    ...isDarkScheme ? {
+        "--c1": "#2c2c2c",
+        "--c2": "#292929",
+        "--c3": "#262626",
+    } : {
+        "--c1": "#e8e8e8",
+        "--c2": "#e3e3e3",
+        "--c3": "#dddddd",
+    },
 
-const DummySeriesStackThumbnail: React.FC<DummySeriesStackThumbnailProps> = ({
-    isDark,
-    deletionIsPending = false,
-}) => (
-    <ThumbnailOverlayContainer css={{
-        // Pattern from https://css-pattern.com/overlapping-cubes/,
-        // MIT licensed: https://github.com/Afif13/CSS-Pattern
-        "--s": "40px",
-        ...isDark ? {
-            "--c1": "#2c2c2c",
-            "--c2": "#292929",
-            "--c3": "#262626",
-        } : {
-            "--c1": "#e8e8e8",
-            "--c2": "#e3e3e3",
-            "--c3": "#dddddd",
-        },
-
-        "--_g": "0 120deg,#0000 0",
-        ...!deletionIsPending && { background: `
-            conic-gradient(             at calc(250%/3) calc(100%/3),
-                var(--c3) var(--_g)),
-            conic-gradient(from -120deg at calc( 50%/3) calc(100%/3),
-                var(--c2) var(--_g)),
-            conic-gradient(from  120deg at calc(100%/3) calc(250%/3),
-                var(--c1) var(--_g)),
-            conic-gradient(from  120deg at calc(200%/3) calc(250%/3),
-                var(--c1) var(--_g)),
-            conic-gradient(from -180deg at calc(100%/3) 50%,
-                var(--c2)  60deg,var(--c1) var(--_g)),
-            conic-gradient(from   60deg at calc(200%/3) 50%,
-                var(--c1)  60deg,var(--c3) var(--_g)),
-            conic-gradient(from  -60deg at 50% calc(100%/3),
-                var(--c1) 120deg,var(--c2) 0 240deg,var(--c3) 0)
-        ` },
-        backgroundSize: "calc(var(--s)*sqrt(3)) var(--s)",
-        ...deletionIsPending && {
-            backgroundColor: COLORS.neutral50,
-            color: "#dbdbdb",
-        },
-    }}>
-        {deletionIsPending && <BaseThumbnailReplacement>
-            <LuTrash />
-        </BaseThumbnailReplacement>}
-    </ThumbnailOverlayContainer>
-);
+    "--_g": "0 120deg,#0000 0",
+    background: `
+        conic-gradient(             at calc(250%/3) calc(100%/3),
+            var(--c3) var(--_g)),
+        conic-gradient(from -120deg at calc( 50%/3) calc(100%/3),
+            var(--c2) var(--_g)),
+        conic-gradient(from  120deg at calc(100%/3) calc(250%/3),
+            var(--c1) var(--_g)),
+        conic-gradient(from  120deg at calc(200%/3) calc(250%/3),
+            var(--c1) var(--_g)),
+        conic-gradient(from -180deg at calc(100%/3) 50%,
+            var(--c2)  60deg,var(--c1) var(--_g)),
+        conic-gradient(from   60deg at calc(200%/3) 50%,
+            var(--c1)  60deg,var(--c3) var(--_g)),
+        conic-gradient(from  -60deg at 50% calc(100%/3),
+            var(--c1) 120deg,var(--c2) 0 240deg,var(--c3) 0)
+    `,
+    backgroundSize: "calc(var(--s)*sqrt(3)) var(--s)",
+}} />;
 
 type ThumbnailInfo = {
     readonly audioOnly: boolean;
@@ -150,7 +139,11 @@ const SeriesThumbnail: React.FC<SeriesThumbnailProps> = ({ info, title }) => {
             alt={t("series.entry-of-series-thumbnail", { series: title })}
         />;
     } else {
-        inner = <ThumbnailReplacement audioOnly={info.audioOnly} {...{ isDark }} />;
+        inner = <ThumbnailReplacement
+            audioOnly={info.audioOnly}
+            videoStatus={null}
+            {...{ isDark }}
+        />;
     }
 
     const overlay = <ThumbnailOverlay backgroundColor="rgba(200, 0, 0, 0.9)">


### PR DESCRIPTION
These are created when using the Tobira UI to upload a video. Previously, users would need to wait for sync until the video showed up on the "my videos" page.

<img width="1089" alt="Bildschirmfoto 2025-04-08 um 17 13 43" src="https://github.com/user-attachments/assets/d462f804-5487-43f6-822b-a47a52cd59b2" />


Resolves #444 

There are a couple of things to consider and possibly to add in this PR:
- [x] Navigating to "My videos" after finishing the upload will not fetch the new event from DB. The page needs to be manually refreshed to show it.
- [x] Management features for the video need to be disabled (deleting, editing etc).
- [x] We might want to add a special thumbnail or icon for these placeholders, and also a tooltip that explains what it means to be "unprocessed".
- [x] Also, maybe the "updated" column should say something other than "Unknown" .

I will address the remaining points once #1313 is merged (that changes a lot of things related to building these item tables, so I'd rather not run into conflicts).

Resolves #1440 