### PR TITLE
Stop using ubuntu-20.04 in GitHub actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ name: Create draft release and build release artifacts
 jobs:
   create-draft-release:
     name: Create draft release from tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Create draft release
         uses: softprops/action-gh-release@v1
@@ -25,7 +25,7 @@ jobs:
 
   build-and-attach-artifacts:
     name: Build and attach release artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
   build-musl:
     name: Build musl release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -32,24 +32,19 @@ jobs:
     - name: Determine build mode
       run: |
         target_dir="target"
-        if (( "$(date +%w)" % 2 == 0 )); then
-          sudo apt install -y musl-dev musl-tools
-          rustup target add x86_64-unknown-linux-musl
-          printf -- "--target=x86_64-unknown-linux-musl " >> .cargo-flags
-          printf "musl" >> .cache-key
-          target_dir="${target_dir}/x86_64-unknown-linux-musl"
-        else
-          printf "gnu" >> .cache-key
-        fi
+        sudo apt install -y musl-dev musl-tools
+        rustup target add x86_64-unknown-linux-musl
+        printf -- "--target=x86_64-unknown-linux-musl " >> .cargo-flags
+        target_dir="${target_dir}/x86_64-unknown-linux-musl"
 
         if [[ "$GITHUB_REPOSITORY" == "elan-ev/tobira" ]] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
           printf -- "--profile=release-ci" >> .cargo-flags
-          printf -- "-release" >> .cache-key
+          printf -- "release" >> .cache-key
           echo "ci_targetdir=${target_dir}/release-ci" >> $GITHUB_ENV
           echo "ci_webpack_flags=production" >> $GITHUB_ENV
         else
           printf -- "--features=embed-in-debug" >> .cargo-flags
-          printf -- "-dev" >> .cache-key
+          printf -- "dev" >> .cache-key
           echo "ci_targetdir=${target_dir}/debug" >> $GITHUB_ENV
           echo "ci_webpack_flags=development" >> $GITHUB_ENV
         fi
@@ -140,7 +135,7 @@ jobs:
   # --------------------------------------------------------------------------
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     services:
       postgres:
@@ -178,7 +173,6 @@ jobs:
     - name: Read cache key
       run: echo "cache_key=$(cat .cache-key)" >> $GITHUB_ENV
     - name: Install MUSL dependencies
-      if: startsWith(env.cache_key, 'musl')
       run: |
         sudo apt install -y musl-dev musl-tools
         rustup target add x86_64-unknown-linux-musl

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +39,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: >-
       ${{ (
         github.actor == 'LukasKalbertodt' ||

--- a/.github/workflows/remove-deployment.yml
+++ b/.github/workflows/remove-deployment.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   main:
     if: github.repository_owner == 'elan-ev'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
The ubuntu-20.04 runner are deprecated for a while now and will be completely disabled very soon.

For some actions, the runner OS really didn't matter. They changed to `ubuntu-latest`. But when actually building the Tobira binary, the OS determines the minimum-required libc version. Previously, our builds required libc 2.31, but with Ubuntu 22.04, it requires 2.35. Our test deployment VM uses CentOS Stream 9, which has an older libc version.

With this commit, builds for the test deployment are always -musl builds. This means it easily works on the test deployment. Further, release builds will use Ubuntu 22.04 and thus require 2.35 now.

With more work and slowing down CI, we could lower the required libc version. But given that we offer a -musl build and I cannot see any disadvantages of that, we don't want to spend any time improving the -gnu build now.