### PR TITLE
Correct conflicting "no/missing videos" note

### DIFF
--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -212,7 +212,7 @@ videolist-block:
   no-videos: No videos
   unauthorized: Missing permissions
   hidden-items:
-    unauthorized_one: One video requires additional permissions to view. 
+    unauthorized_one: One video requires additional permissions to view.
     unauthorized_other: '{{count}} videos require additional permissions to view.'
     missing_one: One video is missing.
     missing_other: '{{count}} videos are missing.'

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -154,13 +154,14 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     );
 
     const eventsNotEmpty = items.length > 0;
+    const hasHiddenItems = missingItems + unauthorizedItems > 0;
 
     return <OrderContext.Provider value={{ eventOrder, setEventOrder, allowOriginalOrder }}>
         <VideoListBlockContainer
             showViewOptions={eventsNotEmpty}
             {...{ title, description, initialLayout, isPlaylist }}
         >
-            {(mainItems.length === 0 && upcomingLiveEvents.length === 0)
+            {(mainItems.length + upcomingLiveEvents.length === 0 && !hasHiddenItems)
                 ? <div css={{ padding: 14 }}>{t("videolist-block.no-videos")}</div>
                 : <>
                     {upcomingLiveEvents.length > 1 && (
@@ -171,7 +172,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
                     {renderEvents(mainItems)}
                 </>
             }
-            {missingItems + unauthorizedItems > 0 && <div css={{ marginTop: 16 }}>
+            {hasHiddenItems && <div css={{ marginTop: 16 }}>
                 {missingItems > 0 && <HiddenItemsInfo>
                     {t("videolist-block.hidden-items.missing", { count: missingItems })}
                 </HiddenItemsInfo>}


### PR DESCRIPTION
When a series block has only videos that a user can't see because they are lacking necessary authorization, there were two messages shown, one saying "no videos", and another saying something along the lines of "n videos are missing authorization".

This removes the "no videos" message in these cases.

Resolves #1384 