### PR TITLE
Add metadata (creator & date) and share button to series & playlist blocks

### DIFF
--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -25,6 +25,7 @@ pub(crate) struct AuthorizedPlaylist {
     opencast_id: String,
     title: String,
     description: Option<String>,
+    creator: String,
 
     read_roles: Vec<String>,
     #[allow(dead_code)] // TODO
@@ -48,7 +49,7 @@ crate::api::util::impl_object_with_dummy_field!(Missing);
 impl_from_db!(
     AuthorizedPlaylist,
     select: {
-        playlists.{ id, opencast_id, title, description, read_roles, write_roles },
+        playlists.{ id, opencast_id, title, description, creator, read_roles, write_roles },
     },
     |row| {
         Self {
@@ -56,6 +57,7 @@ impl_from_db!(
             opencast_id: row.opencast_id(),
             title: row.title(),
             description: row.description(),
+            creator: row.creator(),
             read_roles: row.read_roles(),
             write_roles: row.write_roles(),
         }
@@ -118,6 +120,10 @@ impl AuthorizedPlaylist {
 
     fn description(&self) -> Option<&str> {
         self.description.as_deref()
+    }
+
+    fn creator(&self) -> &str {
+        &self.creator
     }
 
     async fn entries(&self, context: &Context) -> ApiResult<Vec<VideoListEntry>> {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -16,7 +16,13 @@ export default defineConfig({
     projects: [
         {
             name: "chromium",
-            use: { ...devices["Desktop Chrome"], channel: "chrome" },
+            use: {
+                ...devices["Desktop Chrome"],
+                channel: "chrome",
+                launchOptions: {
+                    args: ["--headless=new"],
+                },
+            },
         },
 
         {

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -174,7 +174,6 @@ video:
   end: Ende
   ends: Endet
   share:
-    title: $t(video.share.{{title}})
     share-video: Video teilen
     direct-link: Direktlink
     main: Link

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -157,10 +157,6 @@ video:
   description:
     show-more: ...mehr anzeigen
     show-less: Weniger anzeigen
-  embed:
-    copy-embed-code-to-clipboard: Einbettungscode in Zwischenablage kopieren
-  rss:
-    copy-link-to-clipboard: RSS Link in Zwischenablage kopieren
   caption: Untertitel
   download:
     title: Download
@@ -173,13 +169,6 @@ video:
   start: Anfang
   end: Ende
   ends: Endet
-  share:
-    share-video: Video teilen
-    direct-link: Direktlink
-    main: Link
-    embed: Einbetten
-    rss: RSS
-    show-qr-code: QR Code anzeigen
   password:
     heading: Geschütztes Video
     sub-heading: Zugriff zu diesem Video ist beschränkt.
@@ -191,6 +180,17 @@ video:
       password: Passwort
       submit: Freischalten
     invalid-credentials: Ungültige Zugangsdaten.
+
+share:
+  share-video: Video teilen
+  direct-link: Direktlink
+  main: Link
+  embed: Einbetten
+  rss: RSS
+  show-qr-code: QR Code anzeigen
+  copy-link: Link in Zwischenablage kopieren
+  copy-rss: RSS Link in Zwischenablage kopieren
+  copy-embed-code: Einbettungscode in Zwischenablage kopieren
 
 playlist:
   deleted-playlist-block: Die hier referenzierte Playlist wurde gelöscht.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -152,7 +152,7 @@ video:
   stream-not-started-yet: Dieser Stream hat noch nicht begonnen.
   started: Gestartet
   started-when: Gestartet {{duration}}
-  starts: Startet 
+  starts: Startet
   starts-in: Startet {{duration}}
   description:
     show-more: ...mehr anzeigen
@@ -167,7 +167,7 @@ video:
     presenter: Video (Sprecher:in)
     slides: Video (Präsentation)
     info: >
-      Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen 
+      Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen
       (Rechtsklick - Speichern unter).
   manage: Verwalten
   start: Anfang
@@ -214,7 +214,7 @@ videolist-block:
   no-videos: Keine Videos
   unauthorized: Fehlende Berechtigung
   hidden-items:
-    unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte. 
+    unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte.
     unauthorized_other: 'Für {{count}} Videos fehlen Ihnen die Zugriffsrechte.'
     missing_one: Ein Video wurde nicht gefunden.
     missing_other: '{{count}} Videos wurden nicht gefunden.'
@@ -613,7 +613,7 @@ manage:
 
       show-title: Titel anzeigen
       show-link: Link zur Videoseite anzeigen
-      show-description: Beschreibung anzeigen
+      show-description: Beschreibung und Metadaten anzeigen
       display-options: Anzeigeoptionen
 
       cancel: Verwerfen

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -155,10 +155,6 @@ video:
   description:
     show-more: ...show more
     show-less: Show less
-  embed:
-    copy-embed-code-to-clipboard: Copy embed code to clipboard
-  rss:
-    copy-link-to-clipboard: Copy RSS link to clipboard
   caption: Caption
   download:
     title: Download
@@ -170,13 +166,6 @@ video:
   start: Start
   end: End
   ends: Ends
-  share:
-    share-video: Share video
-    direct-link: Direct link
-    main: Link
-    embed: Embed
-    rss: RSS
-    show-qr-code: Show QR code
   password:
     heading: Protected Video
     sub-heading: Access to this video is restricted.
@@ -189,6 +178,17 @@ video:
       password: Password
       submit: Verify
     invalid-credentials: Invalid credentials.
+
+share:
+  share-video: Share video
+  direct-link: Direct link
+  link: Link
+  embed: Embed
+  rss: RSS
+  show-qr-code: Show QR code
+  copy-link: Copy link to clipboard
+  copy-rss: Copy RSS link to clipboard
+  copy-embed-code: Copy embed code to clipboard
 
 playlist:
   deleted-playlist-block: The playlist referenced here was deleted.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -171,7 +171,6 @@ video:
   end: End
   ends: Ends
   share:
-    title: $t(video.share.{{title}})
     share-video: Share video
     direct-link: Direct link
     main: Link

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -586,7 +586,7 @@ manage:
 
       show-title: Show title
       show-link: Show link to video page
-      show-description: Show description
+      show-description: Show description and metadata
       display-options: Display options
 
       cancel: Discard

--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -45,7 +45,7 @@ export const DirectPlaylistOCRoute = makeRoute({
                 {...{ query, queryRef }}
                 noindex
                 nav={data => <Nav fragRef={data.rootRealm} />}
-                render={result => <PlaylistPage playlistFrag={result.playlist} />}
+                render={result => <PlaylistPage realmPath={null} playlistFrag={result.playlist} />}
             />,
             dispose: () => queryRef.dispose(),
         };
@@ -79,7 +79,7 @@ export const DirectPlaylistRoute = makeRoute({
                 {...{ query, queryRef }}
                 noindex
                 nav={data => <Nav fragRef={data.rootRealm} />}
-                render={result => <PlaylistPage playlistFrag={result.playlist} />}
+                render={result => <PlaylistPage realmPath={null} playlistFrag={result.playlist} />}
             />,
             dispose: () => queryRef.dispose(),
         };
@@ -107,9 +107,10 @@ const fragment = graphql`
 
 type PlaylistPageProps = {
     playlistFrag?: PlaylistRouteData$key | null;
+    realmPath: string | null;
 };
 
-const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag }) => {
+const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag, realmPath }) => {
     const { t } = useTranslation();
     const playlist = useFragment(fragment, playlistFrag ?? null);
 
@@ -136,7 +137,7 @@ const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag }) => {
         <div css={{ marginTop: 12 }}>
             <PlaylistBlockFromPlaylist
                 title={t("videolist-block.videos.heading")}
-                basePath="/!v"
+                realmPath={realmPath}
                 fragRef={playlist}
             />
         </div>

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -1,7 +1,6 @@
 import { Trans, useTranslation } from "react-i18next";
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from "react-relay";
 import {
-    LuCalendar,
     LuCalendarRange,
     LuPanelsTopLeft,
     LuRadio,
@@ -45,7 +44,6 @@ import { RouterControl, makeRoute } from "../rauta";
 import { loadQuery } from "../relay";
 import { Link, useRouter } from "../router";
 import {
-    Creators,
     Thumbnail,
     ThumbnailImg,
     ThumbnailOverlay,
@@ -53,7 +51,7 @@ import {
     ThumbnailReplacement,
     formatDuration,
 } from "../ui/Video";
-import { SmallDescription } from "../ui/metadata";
+import { DateAndCreators, SmallDescription } from "../ui/metadata";
 import { Breadcrumbs, BreadcrumbsContainer, BreadcrumbSeparator } from "../ui/Breadcrumbs";
 import { MissingRealmName } from "./util";
 import { ellipsisOverflowCss, focusStyle } from "../ui";
@@ -69,7 +67,6 @@ import { DirectVideoRoute, VideoRoute } from "./Video";
 import { DirectSeriesRoute, SeriesRoute } from "./Series";
 import { PartOfSeriesLink } from "../ui/Blocks/VideoList";
 import { SearchSlidePreviewQuery } from "./__generated__/SearchSlidePreviewQuery.graphql";
-import { RelativeDate } from "../ui/time";
 
 
 export const isSearchActive = (): boolean => document.location.pathname === "/~search";
@@ -557,35 +554,12 @@ const SearchEvent: React.FC<EventItem> = ({
                     ...ellipsisOverflowCss(2),
                     mark: highlightCss(COLORS.primary2),
                 }}>{highlightText(title, matches.title)}</h3>
-                <div css={{
-                    display: "flex",
-                    color: COLORS.neutral80,
-                    fontSize: 12,
-                    gap: 24,
-                    whiteSpace: "nowrap",
-                }}>
-                    <div css={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        <LuCalendar css={{ fontSize: 15, color: COLORS.neutral60 }} />
-                        <RelativeDate date={new Date(startTime ?? created)} isLive={isLive} />
-                    </div>
-                    <Creators creators={highlightedCreators} css={{
-                        minWidth: 0,
-                        fontSize: 12,
-                        svg: {
-                            fontSize: 15,
-                        },
-                        ul: {
-                            display: "inline-block",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                        },
-                        li: {
-                            display: "inline",
-                        },
-                        mark: highlightCss(COLORS.neutral90),
-                    }} />
-                </div>
+                <DateAndCreators
+                    timestamp={startTime ?? created}
+                    isLive={isLive}
+                    creators={highlightedCreators}
+                    css={{ mark: highlightCss(COLORS.neutral90) }}
+                />
 
                 <div css={{ flexGrow: 1, maxHeight: 20 }} />
 

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -284,13 +284,10 @@ const SeriesPage: React.FC<SeriesPageProps> = ({ seriesRef, realmRef, basePath }
     return <div css={{ display: "flex", flexDirection: "column" }}>
         <Breadcrumbs path={breadcrumbs} tail={tail} />
         <PageTitle title={series.title} />
-        <p css={{ maxWidth: "90ch" }}>{series.syncedData.description}</p>
-        <div css={{ marginTop: 12 }}>
-            <SeriesBlockFromSeries
-                title={t("videolist-block.videos.heading")}
-                basePath={basePath}
-                fragRef={series}
-            />
-        </div>
+        <SeriesBlockFromSeries
+            showMetadata
+            basePath={basePath}
+            fragRef={series}
+        />
     </div>;
 };

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -67,7 +67,7 @@ export const SeriesRoute = makeRoute({
                     return <SeriesPage
                         seriesRef={series}
                         realmRef={realm}
-                        basePath={params.realmPath.replace(/\/$/u, "") + "/v"}
+                        realmPath={params.realmPath}
                     />;
                 }}
             />,
@@ -118,7 +118,7 @@ export const OpencastSeriesRoute = makeRoute({
                     return <SeriesPage
                         seriesRef={series}
                         realmRef={realm}
-                        basePath={params.realmPath.replace(/\/$/u, "") + "/v"}
+                        realmPath={params.realmPath}
                     />;
                 }}
             />,
@@ -187,7 +187,7 @@ export const DirectSeriesOCRoute = makeRoute({
                 render={result => <SeriesPage
                     seriesRef={result.series}
                     realmRef={result.rootRealm}
-                    basePath="/!v"
+                    realmPath={null}
                 />}
             />,
             dispose: () => queryRef.dispose(),
@@ -225,7 +225,7 @@ export const DirectSeriesRoute = makeRoute({
                 render={result => <SeriesPage
                     seriesRef={result.series}
                     realmRef={result.rootRealm}
-                    basePath="/!v"
+                    realmPath={null}
                 />}
             />,
             dispose: () => queryRef.dispose(),
@@ -255,10 +255,10 @@ const fragment = graphql`
 type SeriesPageProps = {
     seriesRef?: SeriesRouteData$key | null;
     realmRef: NonNullable<SeriesPageRealmData$key>;
-    basePath: string;
+    realmPath: string | null;
 };
 
-const SeriesPage: React.FC<SeriesPageProps> = ({ seriesRef, realmRef, basePath }) => {
+const SeriesPage: React.FC<SeriesPageProps> = ({ seriesRef, realmRef, realmPath }) => {
     const { t } = useTranslation();
     const series = useFragment(fragment, seriesRef ?? null);
     const realm = useFragment(realmFragment, realmRef);
@@ -286,7 +286,7 @@ const SeriesPage: React.FC<SeriesPageProps> = ({ seriesRef, realmRef, basePath }
         <PageTitle title={series.title} />
         <SeriesBlockFromSeries
             showMetadata
-            basePath={basePath}
+            realmPath={realmPath}
             fragRef={series}
         />
     </div>;

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -570,7 +570,6 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, realmPath
         // but it's not clear what for.
     };
 
-    const basePath = realmPath == null ? "/!v" : `${realmPath}/v`;
     return <>
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
         <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
@@ -591,12 +590,12 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, realmPath
         {playlistRef
             ? <PlaylistBlockFromPlaylist
                 moreOfTitle
-                basePath={basePath}
+                realmPath={realmPath}
                 fragRef={playlistRef}
                 activeEventId={event.id}
             />
             : event.series && <SeriesBlockFromSeries
-                basePath={basePath}
+                realmPath={realmPath}
                 fragRef={event.series}
                 title={t("video.more-from-series", { series: event.series.title })}
                 activeEventId={event.id}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -981,7 +981,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const series = event.series;
     const tabs = {
         "main": {
-            label: t("video.share.main"),
+            label: t("share.link"),
             Icon: LuLink,
             Component: () => {
                 let url = window.location.href.replace(timeStringPattern, "");
@@ -1005,12 +1005,12 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             />}
                         />}
                     </div>
-                    <QrCodeButton target={url} label={t("video.share.main")} />
+                    <QrCodeButton target={url} label={t("share.link")} />
                 </>;
             },
         },
         "embed": {
-            label: t("video.share.embed"),
+            label: t("share.embed"),
             Icon: LuCode,
             Component: () => {
                 const ar = event.authorizedData == null
@@ -1037,7 +1037,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 return <>
                     <div>
                         <CopyableInput
-                            label={t("video.embed.copy-embed-code-to-clipboard")}
+                            label={t("share.copy-embed-code")}
                             value={embedCode}
                             multiline
                             css={{ height: 75 }}
@@ -1052,25 +1052,20 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             />}
                         />}
                     </div>
-                    <QrCodeButton target={embedCode} label={t("video.share.embed")} />
+                    <QrCodeButton target={embedCode} label={t("share.embed")} />
                 </>;
             },
         },
         ...series && {
             "rss": {
-                label: t("video.share.rss"),
+                label: t("share.rss"),
                 Icon: LuRss,
                 Component: () => {
                     const rssUrl = window.location.origin
                         + `/~rss/series/${keyOfId(series.id)}`;
                     return <>
-                        <div>
-                            <CopyableInput
-                                label={t("video.rss.copy-link-to-clipboard")}
-                                value={rssUrl}
-                            />
-                        </div>
-                        <QrCodeButton target={rssUrl} label={t("video.share.rss")} />
+                        <CopyableInput label={t("share.copy-rss")} value={rssUrl} />
+                        <QrCodeButton target={rssUrl} label={t("share.rss")} />
                     </>;
                 },
             },
@@ -1085,7 +1080,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
         }
     };
 
-    return <ShareButton {...{ tabs, onOpen }} />;
+    return <ShareButton {...{ tabs, onOpen }} height={250} />;
 };
 
 

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1,5 +1,4 @@
 import React, {
-    ReactElement,
     ReactNode,
     useEffect,
     useRef,
@@ -12,12 +11,11 @@ import {
 import { useTranslation } from "react-i18next";
 import { fetchQuery, OperationType } from "relay-runtime";
 import {
-    LuCode, LuDownload, LuInfo, LuLink, LuQrCode, LuRss, LuSettings, LuShare2, LuLockOpen,
+    LuCode, LuDownload, LuInfo, LuLink, LuRss, LuSettings, LuLockOpen,
 } from "react-icons/lu";
-import { QRCodeCanvas } from "qrcode.react";
 import {
     match, unreachable, screenWidthAtMost, screenWidthAbove, useColorScheme,
-    Floating, FloatingContainer, FloatingTrigger, WithTooltip, Card, Button, ProtoButton,
+    Floating, FloatingContainer, FloatingTrigger, WithTooltip, Card, Button,
     notNullish,
 } from "@opencast/appkit";
 import { VideoObject, WithContext } from "schema-dts";
@@ -39,7 +37,6 @@ import {
     toIsoDuration,
     useForceRerender,
     translatedConfig,
-    currentRef,
     secondsToTimeString,
     eventId,
     keyOfId,
@@ -74,12 +71,11 @@ import {
 } from "../ui/Blocks/__generated__/PlaylistBlockPlaylistData.graphql";
 import { getEventTimeInfo } from "../util/video";
 import { formatDuration } from "../ui/Video";
-import { ellipsisOverflowCss, focusStyle } from "../ui";
+import { ellipsisOverflowCss } from "../ui";
 import { realmBreadcrumbs } from "../util/realm";
 import { TrackInfo } from "./manage/Video/TechnicalDetails";
 import { COLORS } from "../color";
 import { RelativeDate } from "../ui/time";
-import { Modal, ModalHandle } from "../ui/Modal";
 import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
 import { CollapsibleDescription } from "../ui/metadata";
 import { DirectSeriesRoute, SeriesRoute } from "./Series";
@@ -94,6 +90,7 @@ import { AuthorizedBlockEvent } from "../ui/Blocks/Video";
 import {
     VideoPageAuthorizedData$data, VideoPageAuthorizedData$key,
 } from "./__generated__/VideoPageAuthorizedData.graphql";
+import { QrCodeButton, ShareButton } from "../ui/ShareButton";
 
 
 // ===========================================================================================
@@ -904,7 +901,7 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
                 {CONFIG.showDownloadButton && event.authorizedData && (
                     <DownloadButton event={event} />
                 )}
-                <ShareButton {...{ event }} />
+                <VideoShareButton {...{ event }} />
             </div>
         </div>
         <div css={{
@@ -973,260 +970,125 @@ const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     );
 };
 
-const ShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
-    type MenuState = "closed" | "main" | "embed" | "rss";
-    /* eslint-disable react/jsx-key */
-    const entries: [Exclude<MenuState, "closed">, ReactElement][] = [
-        ["main", <LuLink />],
-        ["embed", <LuCode />],
-    ];
-    if (event.series) {
-        entries.push(["rss", <LuRss />]);
-    }
-    /* eslint-enable react/jsx-key */
-
+const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const { t } = useTranslation();
-    const [menuState, setMenuState] = useState<MenuState>("closed");
     const [timestamp, setTimestamp] = useState(0);
     const [addLinkTimestamp, setAddLinkTimestamp] = useState(false);
     const [addEmbedTimestamp, setAddEmbedTimestamp] = useState(false);
-    const isDark = useColorScheme().scheme === "dark";
-    const ref = useRef(null);
-    const qrModalRef = useRef<ModalHandle>(null);
     const { paella, playerIsLoaded } = usePlayerContext();
 
     const timeStringPattern = /\?t=(\d+h)?(\d+m)?(\d+s)?/;
 
-    const isActive = (label: MenuState) => label === menuState;
+    const series = event.series;
+    const tabs = {
+        "main": {
+            label: t("video.share.main"),
+            Icon: LuLink,
+            Component: () => {
+                let url = window.location.href.replace(timeStringPattern, "");
+                url += addLinkTimestamp && timestamp
+                    ? `?t=${secondsToTimeString(timestamp)}`
+                    : "";
 
-    const tabStyle = {
-        display: "flex",
-        flexDirection: "column",
-        flex: `1 calc(100% / ${entries.length})`,
-        backgroundColor: COLORS.neutral20,
-        paddingBottom: 4,
-        cursor: "pointer",
-        alignItems: "center",
-        borderRight: `1px solid ${COLORS.neutral40}`,
-        borderTop: "none",
-        borderBottom: `1px solid ${COLORS.neutral40}`,
-        ":is(:first-child)": { borderTopLeftRadius: 4 },
-        ":is(:last-child)": {
-            borderRight: "none",
-            borderTopRightRadius: 4,
-        },
-        "& > svg": {
-            width: 32,
-            height: 32,
-            color: COLORS.primary1,
-            padding: "8px 4px 4px",
-        },
-        "&[disabled]": {
-            cursor: "default",
-            backgroundColor: isDark ? COLORS.neutral15 : COLORS.neutral05,
-            borderBottom: "none",
-            svg: { color: COLORS.primary0 },
-        },
-        ":not([disabled])": {
-            "&:hover": { backgroundColor: COLORS.neutral15 },
-        },
-        ...focusStyle({ inset: true }),
-
-        // By using the `has()` selector, these styles only get applied
-        // to non-firefox browsers. Once firefox supports that selector,
-        // this border radius stuff should get refactored.
-        ":has(svg)": {
-            "&[disabled]": {
-                borderRight: "none",
-                "+ button": {
-                    borderLeft: `1px solid ${COLORS.neutral40}`,
-                    borderBottomLeftRadius: 4,
-                },
-            },
-            ":not([disabled]):has(+ button[disabled])": {
-                borderBottomRightRadius: 4,
-                borderLeft: "none",
-            },
-        },
-    } as const;
-
-    const header = <div css={{ display: "flex" }}>
-        {entries.map(([label, icon]) => (
-            <ProtoButton
-                disabled={isActive(label)}
-                key={label}
-                onClick={() => setMenuState(label)}
-                css={tabStyle}
-            >
-                {icon}
-                {t(`video.share.${label}`)}
-            </ProtoButton>
-        ))}
-    </div>;
-
-    const ShowQRCodeButton: React.FC<{ target: string; label: MenuState }> = (
-        { target, label },
-    ) => <>
-        <Button
-            onClick={() => currentRef(qrModalRef).open()}
-            css={{ width: "max-content" }}
-        >
-            <LuQrCode />
-            {t("video.share.show-qr-code")}
-        </Button>
-        <Modal
-            ref={qrModalRef}
-            title={t("video.share.title", { title: label })}
-            css={{ minWidth: "max-content" }}
-            closeOnOutsideClick
-        >
-            <div css={{ display: "flex", justifyContent: "center" }}>
-                <QRCodeCanvas
-                    value={target}
-                    size={250}
-                    css={{
-                        margin: 16,
-                        outline: "8px solid #FFFFFF",
-                    }}
-                />
-            </div>
-        </Modal>
-    </>;
-
-    const inner = match(menuState, {
-        "closed": () => null,
-        "main": () => {
-            let url = window.location.href.replace(timeStringPattern, "");
-            url += addLinkTimestamp && timestamp
-                ? `?t=${secondsToTimeString(timestamp)}`
-                : "";
-
-            return <>
-                <div>
-                    <CopyableInput
-                        label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
-                        css={{ fontSize: 14, width: 400, marginBottom: 6 }}
-                        value={url}
-                    />
-                    {!event.isLive && <InputWithCheckbox
-                        checkboxChecked={addLinkTimestamp}
-                        setCheckboxChecked={setAddLinkTimestamp}
-                        label={t("manage.my-videos.details.set-time")}
-                        input={<TimeInput
-                            {...{ timestamp, setTimestamp }}
-                            disabled={!addLinkTimestamp}
-                        />}
-                    />}
-                </div>
-                <ShowQRCodeButton target={url} label={menuState} />
-            </>;
-        },
-        "embed": () => {
-            const ar = event.authorizedData == null
-                ? [16, 9]
-                : getPlayerAspectRatio(event.authorizedData.tracks);
-
-            const url = new URL(location.href.replace(timeStringPattern, ""));
-            url.search = addEmbedTimestamp && timestamp
-                ? `?t=${secondsToTimeString(timestamp)}`
-                : "";
-            url.pathname = EmbedVideoRoute.url({ videoId: event.id });
-
-            const embedCode = `<iframe ${[
-                'name="Tobira Player"',
-                `src="${url}"`,
-                "allow=fullscreen",
-                `style="${[
-                    "border: none;",
-                    "width: 100%;",
-                    `aspect-ratio: ${ar.join("/")};`,
-                ].join(" ")}"`,
-            ].join(" ")}></iframe>`;
-
-            return <>
-                <div>
-                    <CopyableInput
-                        label={t("video.embed.copy-embed-code-to-clipboard")}
-                        value={embedCode}
-                        multiline
-                        css={{ fontSize: 14, width: 400, height: 75, marginBottom: 6 }}
-                    />
-                    {!event.isLive && <InputWithCheckbox
-                        checkboxChecked={addEmbedTimestamp}
-                        setCheckboxChecked={setAddEmbedTimestamp}
-                        label={t("manage.my-videos.details.set-time")}
-                        input={<TimeInput
-                            {...{ timestamp, setTimestamp }}
-                            disabled={!addEmbedTimestamp}
-                        />}
-                    />}
-                </div>
-                <ShowQRCodeButton target={embedCode} label={menuState} />
-            </>;
-        },
-        "rss": () => {
-            if (event.series) {
-                const rssUrl = window.location.origin + `/~rss/series/${keyOfId(event.series.id)}`;
                 return <>
                     <div>
                         <CopyableInput
-                            label={t("video.rss.copy-link-to-clipboard")}
+                            label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
                             css={{ fontSize: 14, width: 400, marginBottom: 6 }}
-                            value={rssUrl}
+                            value={url}
                         />
+                        {!event.isLive && <InputWithCheckbox
+                            checkboxChecked={addLinkTimestamp}
+                            setCheckboxChecked={setAddLinkTimestamp}
+                            label={t("manage.my-videos.details.set-time")}
+                            input={<TimeInput
+                                {...{ timestamp, setTimestamp }}
+                                disabled={!addLinkTimestamp}
+                            />}
+                        />}
                     </div>
-                    <ShowQRCodeButton target={rssUrl} label={menuState} />
+                    <QrCodeButton target={url} label={t("video.share.main")} />
                 </>;
-            } else {
-                return null;
-            }
+            },
         },
-    });
+        "embed": {
+            label: t("video.share.embed"),
+            Icon: LuCode,
+            Component: () => {
+                const ar = event.authorizedData == null
+                    ? [16, 9]
+                    : getPlayerAspectRatio(event.authorizedData.tracks);
 
+                const url = new URL(location.href.replace(timeStringPattern, ""));
+                url.search = addEmbedTimestamp && timestamp
+                    ? `?t=${secondsToTimeString(timestamp)}`
+                    : "";
+                url.pathname = EmbedVideoRoute.url({ videoId: event.id });
 
-    return (
-        <FloatingContainer
-            ref={ref}
-            placement="top"
-            arrowSize={12}
-            ariaRole="dialog"
-            open={menuState !== "closed"}
-            onClose={() => setMenuState("closed")}
-            viewPortMargin={12}
-        >
-            <FloatingTrigger>
-                <Button onClick={() => {
-                    setMenuState(state => state === "closed" ? "main" : "closed");
-                    if (playerIsLoaded) {
-                        paella.current?.player.videoContainer.currentTime().then(res => {
-                            setTimestamp(res);
-                        });
-                    }
-                }}>
-                    <LuShare2 size={16} />
-                    {t("general.action.share")}
-                </Button>
-            </FloatingTrigger>
-            <Floating
-                padding={0}
-                backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
-                css={{
-                    height: 240,
-                    display: "flex",
-                    flexDirection: "column",
-                }}
-            >
-                {header}
-                <div css={{
-                    margin: 16,
-                    flexGrow: 1,
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "space-between",
-                }}>{inner}</div>
-            </Floating>
-        </FloatingContainer>
-    );
+                const embedCode = `<iframe ${[
+                    'name="Tobira Player"',
+                    `src="${url}"`,
+                    "allow=fullscreen",
+                    `style="${[
+                        "border: none;",
+                        "width: 100%;",
+                        `aspect-ratio: ${ar.join("/")};`,
+                    ].join(" ")}"`,
+                ].join(" ")}></iframe>`;
+
+                return <>
+                    <div>
+                        <CopyableInput
+                            label={t("video.embed.copy-embed-code-to-clipboard")}
+                            value={embedCode}
+                            multiline
+                            css={{ fontSize: 14, width: 400, height: 75, marginBottom: 6 }}
+                        />
+                        {!event.isLive && <InputWithCheckbox
+                            checkboxChecked={addEmbedTimestamp}
+                            setCheckboxChecked={setAddEmbedTimestamp}
+                            label={t("manage.my-videos.details.set-time")}
+                            input={<TimeInput
+                                {...{ timestamp, setTimestamp }}
+                                disabled={!addEmbedTimestamp}
+                            />}
+                        />}
+                    </div>
+                    <QrCodeButton target={embedCode} label={t("video.share.embed")} />
+                </>;
+            },
+        },
+        ...series && {
+            "rss": {
+                label: t("video.share.rss"),
+                Icon: LuRss,
+                Component: () => {
+                    const rssUrl = window.location.origin
+                        + `/~rss/series/${keyOfId(series.id)}`;
+                    return <>
+                        <div>
+                            <CopyableInput
+                                label={t("video.rss.copy-link-to-clipboard")}
+                                css={{ fontSize: 14, width: 400, marginBottom: 6 }}
+                                value={rssUrl}
+                            />
+                        </div>
+                        <QrCodeButton target={rssUrl} label={t("video.share.rss")} />
+                    </>;
+                },
+            },
+        },
+    };
+
+    const onOpen = () => {
+        if (playerIsLoaded) {
+            paella.current?.player.videoContainer.currentTime().then(res => {
+                setTimestamp(res);
+            });
+        }
+    };
+
+    return <ShareButton {...{ tabs, onOpen }} />;
 };
 
 

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -994,7 +994,6 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                     <div>
                         <CopyableInput
                             label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
-                            css={{ fontSize: 14, width: 400, marginBottom: 6 }}
                             value={url}
                         />
                         {!event.isLive && <InputWithCheckbox
@@ -1042,7 +1041,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             label={t("video.embed.copy-embed-code-to-clipboard")}
                             value={embedCode}
                             multiline
-                            css={{ fontSize: 14, width: 400, height: 75, marginBottom: 6 }}
+                            css={{ height: 75 }}
                         />
                         {!event.isLive && <InputWithCheckbox
                             checkboxChecked={addEmbedTimestamp}
@@ -1069,7 +1068,6 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                         <div>
                             <CopyableInput
                                 label={t("video.rss.copy-link-to-clipboard")}
-                                css={{ fontSize: 14, width: 400, marginBottom: 6 }}
                                 value={rssUrl}
                             />
                         </div>

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -153,7 +153,7 @@ const DirectLink: React.FC<Props> = ({ event }) => {
             <CopyableInput
                 label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
                 value={url.href}
-                css={{ width: "100%", fontSize: 14, marginBottom: 6 }}
+                css={{ fontSize: 14 }}
             />
             <InputWithCheckbox
                 {...{ checkboxChecked, setCheckboxChecked }}

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -291,6 +291,7 @@ type AuthorizedPlaylist implements Node {
   opencastId: String!
   title: String!
   description: String
+  creator: String!
   entries: [VideoListEntry!]!
 }
 

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -11,6 +11,7 @@ import {
     PlaylistBlockPlaylistData$key,
 } from "./__generated__/PlaylistBlockPlaylistData.graphql";
 import { Card, unreachable } from "@opencast/appkit";
+import { keyOfId } from "../../util";
 
 
 type SharedProps = {
@@ -105,6 +106,7 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
             : playlist.title)
         : undefined;
 
+    const playlistKey = keyOfId(playlist.id);
     return <VideoListBlock
         initialLayout={props.layout}
         initialOrder={
@@ -119,5 +121,13 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
         isPlaylist
         listId={playlist.id}
         listEntries={playlist.entries}
+        shareInfo={{
+            // TODO: once we have the `/path/to/realm/p/<id>` route
+            // shareUrl: props.realmPath == null
+            //     ? `/!p/${playlistKey}`
+            //     : `${props.realmPath}p/${playlistKey}`,
+            shareUrl: `/!p/${playlistKey}`,
+            rssUrl: `/~rss/playlist/${playlistKey}`,
+        }}
     />;
 };

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -36,6 +36,7 @@ const playlistFragment = graphql`
             id
             title
             description
+            creator
             entries {
                 __typename
                 ... on AuthorizedEvent { id, ...VideoListEventData }
@@ -112,6 +113,7 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
         allowOriginalOrder
         {...{ title }}
         description={(props.showMetadata && playlist.description) || undefined}
+        creators={props.showMetadata ? [playlist.creator] : undefined}
         activeEventId={props.activeEventId}
         basePath={props.basePath}
         isPlaylist

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -14,7 +14,7 @@ import { Card, unreachable } from "@opencast/appkit";
 
 
 type SharedProps = {
-    basePath: string;
+    realmPath: string | null;
     moreOfTitle?: boolean;
 };
 
@@ -115,7 +115,7 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
         description={(props.showMetadata && playlist.description) || undefined}
         creators={props.showMetadata ? [playlist.creator] : undefined}
         activeEventId={props.activeEventId}
-        basePath={props.basePath}
+        realmPath={props.realmPath}
         isPlaylist
         listId={playlist.id}
         listEntries={playlist.entries}

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Card } from "@opencast/appkit";
 import { graphql, useFragment } from "react-relay";
 
-import { isSynced } from "../../util";
+import { isSynced, keyOfId } from "../../util";
 import type { Fields } from "../../relay";
 import {
     SeriesBlockData$data, SeriesBlockData$key,
@@ -36,6 +36,7 @@ const blockFragment = graphql`
 
 const seriesFragment = graphql`
     fragment SeriesBlockSeriesData on Series {
+        id
         title
         created
         # description is only queried to get the sync status
@@ -106,6 +107,7 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
         }
     })();
 
+    const seriesKey = keyOfId(series.id);
     return <VideoListBlock
         initialLayout={props.layout}
         initialOrder={
@@ -119,5 +121,11 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
         activeEventId={props.activeEventId}
         realmPath={props.realmPath}
         listEntries={series.entries}
+        shareInfo={{
+            shareUrl: props.realmPath == null
+                ? `/!s/${seriesKey}`
+                : `${props.realmPath.replace(/\/$/u, "")}/s/${seriesKey}`,
+            rssUrl: `/~rss/series/${seriesKey}`,
+        }}
     />;
 };

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -19,7 +19,7 @@ import { VideoListBlock, VideoListBlockContainer } from "./VideoList";
 // ==============================================================================================
 
 type SharedProps = {
-    basePath: string;
+    realmPath: string | null;
 };
 
 const blockFragment = graphql`
@@ -117,7 +117,7 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
         timestamp={props.showMetadata ? series.created ?? undefined : undefined}
         creators={props.showMetadata ? creators : undefined}
         activeEventId={props.activeEventId}
-        basePath={props.basePath}
+        realmPath={props.realmPath}
         listEntries={series.entries}
     />;
 };

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -37,8 +37,10 @@ const blockFragment = graphql`
 const seriesFragment = graphql`
     fragment SeriesBlockSeriesData on Series {
         title
+        created
         # description is only queried to get the sync status
         syncedData { description }
+        metadata
         entries {
             __typename
             ...on AuthorizedEvent { id, ...VideoListEventData }
@@ -92,6 +94,17 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
             {t("series.not-ready.text")}
         </VideoListBlockContainer>;
     }
+    const creators = (() => {
+        const raw = series.metadata?.dcterms?.creator;
+
+        if (raw && Array.isArray(raw) && raw.length > 0 && typeof raw[0] === "string") {
+            return raw;
+        } else if (raw && typeof raw === "string") {
+            return [raw];
+        } else {
+            return undefined;
+        }
+    })();
 
     return <VideoListBlock
         initialLayout={props.layout}
@@ -101,6 +114,8 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
         allowOriginalOrder={false}
         title={props.title ?? (props.showTitle ? series.title : undefined)}
         description={(props.showMetadata && series.syncedData.description) || undefined}
+        timestamp={props.showMetadata ? series.created ?? undefined : undefined}
+        creators={props.showMetadata ? creators : undefined}
         activeEventId={props.activeEventId}
         basePath={props.basePath}
         listEntries={series.entries}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -19,6 +19,7 @@ import { keyframes } from "@emotion/react";
 import { IconType } from "react-icons";
 import {
     LuColumns2, LuList, LuChevronLeft, LuChevronRight, LuPlay, LuLayoutGrid, LuCircleAlert, LuInfo,
+    LuRss, LuLink,
 } from "react-icons/lu";
 import { graphql, readInlineData } from "react-relay";
 
@@ -42,6 +43,8 @@ import { COLORS } from "../../color";
 import { FloatingBaseMenu } from "../FloatingBaseMenu";
 import { isRealUser, useUser } from "../../User";
 import { LoginLink } from "../../routes/util";
+import { QrCodeButton, ShareButton } from "../ShareButton";
+import { CopyableInput } from "../Input";
 
 
 
@@ -106,6 +109,7 @@ export type VideoListBlockProps = {
     description?: string;
     timestamp?: string;
     creators?: string[];
+    shareInfo: VideoListShareButtonProps,
     isPlaylist?: boolean;
     listEntries: Entries;
 }
@@ -121,6 +125,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     description,
     timestamp,
     creators,
+    shareInfo,
     isPlaylist = false,
     listEntries,
 }) => {
@@ -164,7 +169,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     return <OrderContext.Provider value={{ eventOrder, setEventOrder, allowOriginalOrder }}>
         <VideoListBlockContainer
             showViewOptions={eventsNotEmpty}
-            {...{ title, description, timestamp, creators, initialLayout, isPlaylist }}
+            {...{ title, description, timestamp, creators, shareInfo, initialLayout, isPlaylist }}
         >
             {(mainItems.length + upcomingLiveEvents.length === 0 && !hasHiddenItems)
                 ? <div css={{ padding: 14 }}>{t("videolist-block.no-videos")}</div>
@@ -304,6 +309,7 @@ type VideoListBlockContainerProps = {
     description?: string | null;
     timestamp?: string;
     creators?: string[];
+    shareInfo?: VideoListShareButtonProps,
     children: ReactNode;
     showViewOptions: boolean;
     initialLayout?: VideoListLayout;
@@ -321,7 +327,8 @@ const LayoutContext = createContext<LayoutContext>({
 });
 
 export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = ({
-    title, description, timestamp, creators, children, showViewOptions, initialLayout = "GALLERY",
+    title, description, timestamp, creators, shareInfo, children,
+    showViewOptions, initialLayout = "GALLERY",
 }) => {
     const [layoutState, setLayoutState] = useState<VideoListLayout>(initialLayout);
     const isDark = useColorScheme().scheme === "dark";
@@ -380,7 +387,7 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
                                 {...{ description }}
                             />}
                         </div>
-                        {showViewOptions && <div css={{
+                        <div css={{
                             display: "flex",
                             alignItems: "center",
                             alignSelf: description ? "flex-end" : "flex-start",
@@ -389,9 +396,12 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
                             gap: 16,
                             padding: 5,
                         }}>
-                            <OrderMenu />
-                            <LayoutMenu />
-                        </div>}
+                            {shareInfo && <VideoListShareButton {...shareInfo} />}
+                            {showViewOptions && <>
+                                <OrderMenu />
+                                <LayoutMenu />
+                            </>}
+                        </div>
                     </div>
                 </div>
                 {hasMetadata && <hr css={{ margin: "12px 6px 20px 6px" }} />}
@@ -401,6 +411,39 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
     </LayoutContext.Provider>;
 };
 
+type VideoListShareButtonProps = {
+    shareUrl: string;
+    rssUrl: string;
+};
+
+const VideoListShareButton: React.FC<VideoListShareButtonProps> = props => {
+    const { t } = useTranslation();
+    const shareUrl = document.location.origin + props.shareUrl;
+    const rssUrl = document.location.origin + props.rssUrl;
+    const tabs = {
+        "main": {
+            label: t("share.link"),
+            Icon: LuLink,
+            Component: () => <>
+                <CopyableInput label={t("share.copy-link")} value={shareUrl} />
+                <QrCodeButton target={shareUrl} label={t("share.link")} />
+            </>,
+        },
+        "rss": {
+            label: t("share.rss"),
+            Icon: LuRss,
+            Component: () => <>
+                <CopyableInput label={t("share.copy-rss")} value={rssUrl} />
+                <QrCodeButton target={rssUrl} label={t("share.rss")} />
+            </>,
+        },
+    };
+    return <ShareButton height={180} {...{ tabs }} css={{
+        padding: 12,
+        height: 31,
+        borderRadius: 4,
+    }} />;
+};
 
 
 // ==============================================================================================

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -97,7 +97,7 @@ type Entries = Extract<
 
 export type VideoListBlockProps = {
     listId?: string;
-    basePath: string;
+    realmPath: string | null;
     activeEventId?: string;
     allowOriginalOrder: boolean;
     initialOrder: Order;
@@ -112,7 +112,7 @@ export type VideoListBlockProps = {
 
 export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     listId,
-    basePath,
+    realmPath,
     activeEventId,
     allowOriginalOrder,
     initialOrder,
@@ -143,6 +143,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
         unauthorizedItems,
     } = orderItems(items, eventOrder, i18n);
 
+    const basePath = realmPath == null ? "/!v" : `${realmPath.replace(/\/$/u, "")}/v`;
     const renderEvents = (events: readonly VideoListItem[]) => (
         <Items
             basePath={basePath}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -36,7 +36,7 @@ import {
     ThumbnailOverlayContainer,
 } from "../Video";
 import { RelativeDate } from "../time";
-import { CollapsibleDescription, SmallDescription } from "../metadata";
+import { CollapsibleDescription, DateAndCreators, SmallDescription } from "../metadata";
 import { darkModeBoxShadow, ellipsisOverflowCss, focusStyle } from "..";
 import { COLORS } from "../../color";
 import { FloatingBaseMenu } from "../FloatingBaseMenu";
@@ -104,6 +104,8 @@ export type VideoListBlockProps = {
     initialLayout?: VideoListLayout;
     title?: string;
     description?: string;
+    timestamp?: string;
+    creators?: string[];
     isPlaylist?: boolean;
     listEntries: Entries;
 }
@@ -117,6 +119,8 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     initialLayout = "GALLERY",
     title,
     description,
+    timestamp,
+    creators,
     isPlaylist = false,
     listEntries,
 }) => {
@@ -159,7 +163,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     return <OrderContext.Provider value={{ eventOrder, setEventOrder, allowOriginalOrder }}>
         <VideoListBlockContainer
             showViewOptions={eventsNotEmpty}
-            {...{ title, description, initialLayout, isPlaylist }}
+            {...{ title, description, timestamp, creators, initialLayout, isPlaylist }}
         >
             {(mainItems.length + upcomingLiveEvents.length === 0 && !hasHiddenItems)
                 ? <div css={{ padding: 14 }}>{t("videolist-block.no-videos")}</div>
@@ -297,6 +301,8 @@ const orderItems = (
 type VideoListBlockContainerProps = {
     title?: string;
     description?: string | null;
+    timestamp?: string;
+    creators?: string[];
     children: ReactNode;
     showViewOptions: boolean;
     initialLayout?: VideoListLayout;
@@ -313,11 +319,12 @@ const LayoutContext = createContext<LayoutContext>({
     setLayoutState: () => {},
 });
 
-export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
-    { title, description, children, showViewOptions, initialLayout = "GALLERY" },
-) => {
+export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = ({
+    title, description, timestamp, creators, children, showViewOptions, initialLayout = "GALLERY",
+}) => {
     const [layoutState, setLayoutState] = useState<VideoListLayout>(initialLayout);
     const isDark = useColorScheme().scheme === "dark";
+    const hasMetadata = description || timestamp || (creators && creators.length > 0);
 
     return <LayoutContext.Provider value={{ layoutState, setLayoutState }}>
         <div css={{
@@ -331,7 +338,7 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
                 <div css={{
                     display: "flex",
                     justifyContent: "space-between",
-                    ...title && description && { flexDirection: "column" },
+                    ...title && hasMetadata && { flexDirection: "column" },
                     [screenWidthAtMost(VIDEO_GRID_BREAKPOINT)]: {
                         flexWrap: "wrap",
                     },
@@ -351,11 +358,27 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
                             flexWrap: "wrap",
                         },
                     }}>
-                        {description && <CollapsibleDescription
-                            type="series"
-                            bottomPadding={32}
-                            {...{ description }}
-                        />}
+                        <div>
+                            {(timestamp || (creators && creators.length > 0)) && <DateAndCreators
+                                timestamp={timestamp}
+                                isLive={false}
+                                creators={creators}
+                                css={{
+                                    margin: "0px 12px",
+                                    gap: 16,
+                                    "> *": {
+                                        padding: "4px 6px",
+                                        borderRadius: 4,
+                                        background: COLORS.neutral15,
+                                    },
+                                }}
+                            />}
+                            {description && <CollapsibleDescription
+                                type="series"
+                                bottomPadding={32}
+                                {...{ description }}
+                            />}
+                        </div>
                         {showViewOptions && <div css={{
                             display: "flex",
                             alignItems: "center",
@@ -370,7 +393,7 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
                         </div>}
                     </div>
                 </div>
-                {description && <hr css={{ margin: "12px 6px 20px 6px" }} />}
+                {hasMetadata && <hr css={{ margin: "12px 6px 20px 6px" }} />}
             </>
             {children}
         </div>

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -82,11 +82,17 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm, edit }) =>
         {match(__typename, {
             "TitleBlock": () => <TitleBlock fragRef={block} />,
             "TextBlock": () => <TextBlockByQuery fragRef={block} />,
-            "SeriesBlock": () => <SeriesBlockFromBlock fragRef={block} {...{ basePath, edit }} />,
+            "SeriesBlock": () => <SeriesBlockFromBlock
+                fragRef={block}
+                realmPath={path}
+                {...{ edit }}
+            />,
             "VideoBlock": () => <VideoBlock fragRef={block} {...{ basePath, edit }} />,
-            "PlaylistBlock": () => (
-                <PlaylistBlockFromBlock fragRef={block} {...{ basePath, edit }} />
-            ),
+            "PlaylistBlock": () => <PlaylistBlockFromBlock
+                fragRef={block}
+                realmPath={path}
+                {...{ edit }}
+            />,
         })}
     </div>;
 };

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -268,6 +268,7 @@ export const CopyableInput: React.FC<CopyableInputProps> = ({
             position: "relative",
             height: multiline ? 95 : 34,
             maxWidth: "100%",
+            marginBottom: 6,
         }} {...rest}>
             <div css={{ position: "absolute", top: 0, right: 0, zIndex: 10 }}>
                 <WithTooltip tooltip={label} css={{ fontFamily: "var(--main-font), sans-serif" }}>
@@ -326,4 +327,3 @@ export function DisplayOptionGroup<TFieldValues extends FieldValues>(
         }
     </div>;
 }
-

--- a/frontend/src/ui/ShareButton.tsx
+++ b/frontend/src/ui/ShareButton.tsx
@@ -1,0 +1,178 @@
+import React, { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { LuQrCode, LuShare2 } from "react-icons/lu";
+import { QRCodeCanvas } from "qrcode.react";
+import {
+    useColorScheme, Floating, FloatingContainer, FloatingTrigger, Button, ProtoButton,
+} from "@opencast/appkit";
+
+import { currentRef } from "../util";
+import { focusStyle } from "../ui";
+import { COLORS } from "../color";
+import { Modal, ModalHandle } from "../ui/Modal";
+
+
+export type ShareButtonProps = {
+    tabs: Record<string, {
+        label: string;
+        Icon: React.ComponentType;
+        Component: React.ComponentType;
+    }>;
+    onOpen: () => void;
+};
+
+export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen }) => {
+    const { t } = useTranslation();
+    const [activeTab, setActiveTab] = useState<string | null>(null);
+    const isDark = useColorScheme().scheme === "dark";
+    const ref = useRef(null);
+
+    const tabStyle = {
+        display: "flex",
+        flexDirection: "column",
+        flex: `1 calc(100% / ${Object.keys(tabs).length})`,
+        backgroundColor: COLORS.neutral20,
+        paddingBottom: 4,
+        cursor: "pointer",
+        alignItems: "center",
+        borderRight: `1px solid ${COLORS.neutral40}`,
+        borderTop: "none",
+        borderBottom: `1px solid ${COLORS.neutral40}`,
+        ":is(:first-child)": { borderTopLeftRadius: 4 },
+        ":is(:last-child)": {
+            borderRight: "none",
+            borderTopRightRadius: 4,
+        },
+        "& > svg": {
+            width: 32,
+            height: 32,
+            color: COLORS.primary1,
+            padding: "8px 4px 4px",
+        },
+        "&[disabled]": {
+            cursor: "default",
+            backgroundColor: isDark ? COLORS.neutral15 : COLORS.neutral05,
+            borderBottom: "none",
+            svg: { color: COLORS.primary0 },
+        },
+        ":not([disabled])": {
+            "&:hover": { backgroundColor: COLORS.neutral15 },
+        },
+        ...focusStyle({ inset: true }),
+
+        // By using the `has()` selector, these styles only get applied
+        // to non-firefox browsers. Once firefox supports that selector,
+        // this border radius stuff should get refactored.
+        ":has(svg)": {
+            "&[disabled]": {
+                borderRight: "none",
+                "+ button": {
+                    borderLeft: `1px solid ${COLORS.neutral40}`,
+                    borderBottomLeftRadius: 4,
+                },
+            },
+            ":not([disabled]):has(+ button[disabled])": {
+                borderBottomRightRadius: 4,
+                borderLeft: "none",
+            },
+        },
+    } as const;
+
+    const header = <div css={{ display: "flex" }}>
+        {Object.entries(tabs).map(([id, { label, Icon }]) => (
+            <ProtoButton
+                disabled={id === activeTab}
+                key={id}
+                onClick={() => setActiveTab(id)}
+                css={tabStyle}
+            >
+                <Icon />
+                {label}
+            </ProtoButton>
+        ))}
+    </div>;
+
+    const TabComponent = activeTab && tabs[activeTab].Component;
+
+    return (
+        <FloatingContainer
+            ref={ref}
+            placement="top"
+            arrowSize={12}
+            ariaRole="dialog"
+            open={activeTab !== null}
+            onClose={() => setActiveTab(null)}
+            viewPortMargin={12}
+        >
+            {/* Share Button */}
+            <FloatingTrigger>
+                <Button onClick={() => {
+                    setActiveTab(state => state === null ? Object.keys(tabs)[0] : null);
+                    if (activeTab == null) {
+                        onOpen();
+                    }
+                }}>
+                    <LuShare2 size={16} />
+                    {t("general.action.share")}
+                </Button>
+            </FloatingTrigger>
+
+            {/* Share Menu */}
+            <Floating
+                padding={0}
+                backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
+                css={{
+                    height: 240,
+                    display: "flex",
+                    flexDirection: "column",
+                }}
+            >
+                {header}
+                <div css={{
+                    margin: 16,
+                    flexGrow: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "space-between",
+                }}>{TabComponent && <TabComponent />}</div>
+            </Floating>
+        </FloatingContainer>
+    );
+};
+
+type QrCodeButtonProps = {
+    target: string;
+    label: string;
+};
+
+export const QrCodeButton: React.FC<QrCodeButtonProps> = ({ target, label }) => {
+    const { t } = useTranslation();
+    const qrModalRef = useRef<ModalHandle>(null);
+
+    return <>
+        <Button
+            onClick={() => currentRef(qrModalRef).open()}
+            css={{ width: "max-content" }}
+        >
+            <LuQrCode />
+            {t("video.share.show-qr-code")}
+        </Button>
+        <Modal
+            ref={qrModalRef}
+            title={label}
+            css={{ minWidth: "max-content" }}
+            closeOnOutsideClick
+        >
+            <div css={{ display: "flex", justifyContent: "center" }}>
+                <QRCodeCanvas
+                    value={target}
+                    size={250}
+                    css={{
+                        margin: 16,
+                        outline: "8px solid #FFFFFF",
+                    }}
+                />
+            </div>
+        </Modal>
+    </>;
+};

--- a/frontend/src/ui/ShareButton.tsx
+++ b/frontend/src/ui/ShareButton.tsx
@@ -10,6 +10,7 @@ import { currentRef } from "../util";
 import { focusStyle } from "../ui";
 import { COLORS } from "../color";
 import { Modal, ModalHandle } from "../ui/Modal";
+import { Interpolation, Theme } from "@emotion/react";
 
 
 export type ShareButtonProps = {
@@ -37,24 +38,20 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen, height, 
         paddingBottom: 4,
         cursor: "pointer",
         alignItems: "center",
-        borderRight: `1px solid ${COLORS.neutral40}`,
+        border: `1px solid ${COLORS.neutral40}`,
         borderTop: "none",
-        borderBottom: `1px solid ${COLORS.neutral40}`,
-        ":is(:first-child)": { borderTopLeftRadius: 4 },
+        ":is(:first-child)": {
+            borderLeft: "none",
+            borderTopLeftRadius: 4,
+        },
         ":is(:last-child)": {
             borderRight: "none",
             borderTopRightRadius: 4,
         },
-        "& > svg": {
-            width: 32,
-            height: 32,
-            color: COLORS.primary1,
-            padding: "8px 4px 4px",
-        },
         "&[disabled]": {
             cursor: "default",
             backgroundColor: isDark ? COLORS.neutral15 : COLORS.neutral05,
-            borderBottom: "none",
+            borderColor: "transparent",
             svg: { color: COLORS.primary0 },
         },
         ":not([disabled])": {
@@ -62,23 +59,27 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen, height, 
         },
         ...focusStyle({ inset: true }),
 
-        // By using the `has()` selector, these styles only get applied
-        // to non-firefox browsers. Once firefox supports that selector,
-        // this border radius stuff should get refactored.
-        ":has(svg)": {
-            "&[disabled]": {
-                borderRight: "none",
-                "+ button": {
-                    borderLeft: `1px solid ${COLORS.neutral40}`,
-                    borderBottomLeftRadius: 4,
-                },
-            },
-            ":not([disabled]):has(+ button[disabled])": {
-                borderBottomRightRadius: 4,
-                borderLeft: "none",
-            },
+        // Get rid of double border between to non-active tabs by always
+        // hiding the left border of the right tab.
+        ":not([disabled]) + :not([disabled])": {
+            borderLeftColor: "transparent",
         },
-    } as const;
+        // Add radius to tab left of active tab.
+        ":not([disabled]):has(+ button[disabled])": {
+            borderBottomRightRadius: 4,
+        },
+        // Add radius to tab right of active tab.
+        "&[disabled] + :not([disabled])": {
+            borderBottomLeftRadius: 4,
+        },
+
+        "& > svg": {
+            width: 32,
+            height: 32,
+            color: COLORS.primary1,
+            padding: "8px 4px 4px",
+        },
+    } as const satisfies Interpolation<Theme>;
 
     const header = <div css={{ display: "flex" }}>
         {Object.entries(tabs).map(([id, { label, Icon }]) => (

--- a/frontend/src/ui/ShareButton.tsx
+++ b/frontend/src/ui/ShareButton.tsx
@@ -18,10 +18,12 @@ export type ShareButtonProps = {
         Icon: React.ComponentType;
         Component: React.ComponentType;
     }>;
-    onOpen: () => void;
+    onOpen?: () => void;
+    height: number;
+    className?: string;
 };
 
-export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen }) => {
+export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen, height, className }) => {
     const { t } = useTranslation();
     const [activeTab, setActiveTab] = useState<string | null>(null);
     const isDark = useColorScheme().scheme === "dark";
@@ -106,10 +108,10 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen }) => {
         >
             {/* Share Button */}
             <FloatingTrigger>
-                <Button onClick={() => {
+                <Button {...{ className }} onClick={() => {
                     setActiveTab(state => state === null ? Object.keys(tabs)[0] : null);
                     if (activeTab == null) {
-                        onOpen();
+                        onOpen?.();
                     }
                 }}>
                     <LuShare2 size={16} />
@@ -122,7 +124,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen }) => {
                 padding={0}
                 backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
                 css={{
-                    height: 240,
+                    height,
                     display: "flex",
                     flexDirection: "column",
                 }}
@@ -157,7 +159,7 @@ export const QrCodeButton: React.FC<QrCodeButtonProps> = ({ target, label }) => 
             css={{ width: "max-content" }}
         >
             <LuQrCode />
-            {t("video.share.show-qr-code")}
+            {t("share.show-qr-code")}
         </Button>
         <Modal
             ref={qrModalRef}

--- a/frontend/src/ui/ShareButton.tsx
+++ b/frontend/src/ui/ShareButton.tsx
@@ -134,6 +134,8 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen }) => {
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "space-between",
+                    fontSize: 14,
+                    width: 400,
                 }}>{TabComponent && <TabComponent />}</div>
             </Floating>
         </FloatingContainer>

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -5,6 +5,8 @@ import { ProtoButton, useColorScheme } from "@opencast/appkit";
 import { ellipsisOverflowCss, focusStyle } from ".";
 import { COLORS } from "../color";
 import { Creators } from "./Video";
+import { LuCalendar } from "react-icons/lu";
+import { RelativeDate } from "./time";
 
 
 export const TitleLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
@@ -30,6 +32,47 @@ export const FieldIsRequiredNote: React.FC = () => {
 /** Separates different inputs in the metadata form */
 export const InputContainer: React.FC<{ children: ReactNode }> = ({ children }) => (
     <div css={{ margin: "16px 0 " }}>{children}</div>
+);
+
+export type DateAndCreatorsProps = {
+    timestamp?: string;
+    isLive: boolean;
+    creators?: (string | JSX.Element)[];
+    className?: string;
+};
+
+/** Shows a datetime and creators in one line, each with an icon in front. */
+export const DateAndCreators: React.FC<DateAndCreatorsProps> = ({
+    timestamp, isLive, creators, className,
+}) => (
+    <div {...{ className }} css={{
+        display: "flex",
+        color: COLORS.neutral80,
+        fontSize: 12,
+        gap: 24,
+        whiteSpace: "nowrap",
+    }}>
+        {timestamp && <div css={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <LuCalendar css={{ fontSize: 15, color: COLORS.neutral60 }} />
+            <RelativeDate date={new Date(timestamp)} isLive={isLive} />
+        </div>}
+        <Creators creators={creators ?? null} css={{
+            minWidth: 0,
+            fontSize: 12,
+            svg: {
+                fontSize: 15,
+            },
+            ul: {
+                display: "inline-block",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+            },
+            li: {
+                display: "inline",
+            },
+        }} />
+    </div>
 );
 
 type SmallDescriptionProps = {

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -46,7 +46,7 @@ export const DateAndCreators: React.FC<DateAndCreatorsProps> = ({
     timestamp, isLive, creators, className,
 }) => (
     <div {...{ className }} css={{
-        display: "flex",
+        display: "inline-flex",
         color: COLORS.neutral80,
         fontSize: 12,
         gap: 24,

--- a/frontend/tests/search.spec.ts
+++ b/frontend/tests/search.spec.ts
@@ -36,6 +36,8 @@ test("Search", async ({ page, browserName, standardData, activeSearchIndex }) =>
             await expect(page).toHaveURL(new RegExp("/!v/[0-9a-zA-Z_\\-]{11}$"));
             await expect(page.getByRole("heading", { level: 1, name: videoTitle })).toBeVisible();
             await page.goBack();
+            await expect(page).toHaveURL(`~search?q=${query}`);
+            await expect(page.getByText("Search results for cat (6 hits)")).toBeVisible();
         });
     }
 
@@ -53,6 +55,7 @@ test("Search", async ({ page, browserName, standardData, activeSearchIndex }) =>
         await expect(realm).toBeVisible();
         await realm.click({ force: true });
         await expect(page).toHaveURL("/animals/cats");
+        await expect(page.getByRole("heading", { level: 1, name: "Cats" })).toBeVisible();
         await page.goBack();
     });
 
@@ -61,6 +64,7 @@ test("Search", async ({ page, browserName, standardData, activeSearchIndex }) =>
         await expect(realm).toBeVisible();
         await realm.click({ force: true });
         await expect(page).toHaveURL("/love");
+        await expect(page.getByRole("heading", { level: 1, name: "Fabulous Cats" })).toBeVisible();
         await page.goBack();
     });
 });

--- a/frontend/tests/videoPage.spec.ts
+++ b/frontend/tests/videoPage.spec.ts
@@ -31,7 +31,7 @@ test("Video page", async ({ page, standardData, browserName }) => {
     });
 
     await test.step("Share button", async () => {
-        const shareButton = page.getByRole("button", { name: "Share" });
+        const shareButton = page.getByRole("button", { name: "Share" }).first();
 
         await test.step("Button is present", async () => {
             await expect(shareButton).toBeVisible();

--- a/util/scripts/watch-frontend.sh
+++ b/util/scripts/watch-frontend.sh
@@ -26,5 +26,5 @@ mkdir -p build
     npx webpack watch --mode=development --stats=errors-warnings &
 
     # Watch the build directory to trigger a reload when webpack is done building.
-    watchexec --watch build --postpone -- $reload_command
+    (cd build && watchexec --postpone -- $reload_command)
 )


### PR DESCRIPTION
Fixes #1400 
Fixes #1390 
Fixes #1367 
Fixes #1283 

This PR touches the "videolist block" (series & playlist blocks) and adds some things to it. 

The creator (dcterms.creator) of the series/playlist is shown (if it is set) and the `created` date of the series is shown as well. That is, if the checkbox labelled "show description" in the block settings is checked. That label was changed to "show description & metadata". In the future, we might enable users to decide separately whether to show these two things, but for now it's tied together.

Further, the blocks now have a share button with a "link to series/playlist" as well as an RSS link. This PR also adds RSS feeds for playlists, because why not. The "link to series/playlist" uses the realm context if there is some.

The "series page" is now also more similar to just the series block, not using a special way to display the description anymore ([old](https://tobira.opencast.org/lectures/d-biol/2021/spring/551-1298-00L/s/KyEb0W_MAjq), [new](https://pr1405.tobira.opencast.org/lectures/d-biol/2021/spring/551-1298-00L/s/KyEb0W_MAjq)). See the commit descriptions as well for more, minor changes. 

Examples for testing:
- Check out the home page with a series block showing metadata, one not showing it, and one playlist block.
- Series with creator: [old](https://tobira.opencast.org/lectures/d-hest/2020/autumn/752-3103-00L/s/IAGEyOOTnHZ), [new](https://pr1405.tobira.opencast.org/lectures/d-hest/2020/autumn/752-3103-00L/s/IAGEyOOTnHZ)
- Series without videos: [old](https://tobira.opencast.org/speakers/collegium-helveticum/emotionen/einfuehrung/), [new](https://pr1405.tobira.opencast.org/speakers/collegium-helveticum/emotionen/einfuehrung/)
- Series direct link: [old](https://tobira.opencast.org/!s/FWSUfcLGXtV), [new](https://pr1405.tobira.opencast.org/!s/FWSUfcLGXtV)

---

This PR should be reviewed commit by commit.