### PR TITLE
Fix frontend watching & reloading

### DIFF
--- a/util/scripts/watch-frontend.sh
+++ b/util/scripts/watch-frontend.sh
@@ -26,5 +26,5 @@ mkdir -p build
     npx webpack watch --mode=development --stats=errors-warnings &
 
     # Watch the build directory to trigger a reload when webpack is done building.
-    watchexec --watch build --postpone -- $reload_command
+    (cd build && watchexec --postpone -- $reload_command)
 )


### PR DESCRIPTION
For me (Linux), this somehow stopped to work. Both of these things should do the same, but the old version doesn't detect changes for me anymore. Since the new version still works for everyone else, we just change it.