### PR TITLE
Improve realm nav by showing siblings when there are no children

### DIFF
--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -19,12 +19,14 @@ use super::block::BlockValue;
 
 
 mod mutations;
+mod nav;
 
 pub(crate) use mutations::{
     ChildIndex, NewRealm, RemovedRealm, UpdateRealm, UpdatedPermissions,
     UpdatedRealmName, RealmSpecifier, RealmLineageComponent, CreateRealmLineageOutcome,
     RemoveMountedSeriesOutcome,
 };
+pub(crate) use nav::RealmNav;
 
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromSql, ToSql, GraphQLEnum)]
@@ -286,6 +288,11 @@ impl Realm {
     /// `null` is returned.
     fn owner_display_name(&self) -> Option<&str> {
         self.owner_display_name.as_deref()
+    }
+
+    /// Info about the navigation UI for this realm.
+    async fn nav(&self, context: &Context) -> ApiResult<RealmNav> {
+        RealmNav::load_for(self, context).await
     }
 
     /// Returns the acl of this realm, combining moderator and admin roles and assigns

--- a/backend/src/api/model/realm/nav.rs
+++ b/backend/src/api/model/realm/nav.rs
@@ -1,0 +1,113 @@
+use juniper::GraphQLObject;
+
+use crate::{
+    api::{err::ApiResult, Context},
+    db::util::{dbargs, select},
+    model::Key,
+    prelude::*,
+};
+
+
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct RealmNav {
+    /// The "go up" part of the navigation, i.e. the logical parent. This is
+    /// almost always also the actual parent, except for user root realms,
+    /// which have no actual parent, but for which this field points to the
+    /// main root realm. Is `null` for only the main root realm.
+    up: Option<RealmNavItem>,
+
+    /// Whether the name of the current realm should be shown in an extra
+    /// section in the nav. This is `true` except for the main root and leaf
+    /// nodes.
+    show_self: bool,
+
+    /// Main part of the navigation: list of realms to navigate to. These are
+    /// usually the children of the realm, except for leaf nodes (except root
+    /// realms), where it's the siblings (including itself) instead.
+    list: Vec<RealmNavItem>,
+
+    /// Dictates in what order the items in `list` should be displayed.
+    list_order: super::RealmOrder,
+}
+
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct RealmNavItem {
+    /// Resolved name, like `Realm.name`.
+    name: Option<String>,
+    path: String,
+}
+
+impl RealmNav {
+    pub(crate) async fn load_for(realm: &super::Realm, context: &Context) -> ApiResult<Self> {
+        let (selection, mapping) = select!(
+            id,
+            full_path,
+            name: "case \
+          		when name_from_block is null then name \
+          		else (\
+         			select coalesce(series.title, events.title) \
+         			from blocks \
+         			left join events on blocks.video = events.id \
+         			left join series on blocks.series = series.id \
+         			where blocks.id = name_from_block\
+          		)\
+           	end",
+        );
+        let sql = format!("\
+            select {selection} --full_path, realms.resolved_name
+           	from realms
+           	where id = $2
+           	or parent = case
+          		when exists(select from realms where parent = $1) then $1
+          		else $2
+           	end
+            order by index asc");
+
+        let mut list = vec![];
+        let mut up = None;
+        let mut show_self = true;
+        context.db.query_raw(&sql, dbargs![&realm.key, &realm.parent_key])
+            .await?
+            .try_for_each(|row| {
+                let id = mapping.id.of::<Key>(&row);
+                let item = RealmNavItem {
+                    path: mapping.full_path.of(&row),
+                    name: mapping.name.of(&row),
+                };
+                if Some(id) == realm.parent_key {
+                    up = Some(item)
+                } else {
+                    list.push(item);
+                }
+
+                if id == realm.key {
+                    show_self = false;
+                }
+
+                std::future::ready(Ok(()))
+            })
+            .await?;
+
+        if realm.is_user_root() {
+            up = Some(RealmNavItem {
+                path: "".into(),
+                name: None,
+            });
+        }
+
+        Ok(Self {
+            up,
+            show_self,
+            list_order: realm.child_order,
+            list,
+        })
+    }
+}
+
+// #[derive(Debug, GraphQLObject)]
+// pub(crate) struct RealmNavListItem {
+//     /// Resolved name, like `Realm.name`.
+//     name: Option<String>,
+//     path: String,
+
+// }

--- a/frontend/src/layout/Burger.tsx
+++ b/frontend/src/layout/Burger.tsx
@@ -43,6 +43,9 @@ export const BurgerMenu: React.FC<BurgerMenuProps> = ({ hide, items }) => (
                     padding: 16,
                     borderRadius: 4,
                 },
+                "a > div": {
+                    padding: 0,
+                },
             },
             nav: {
                 "> a": {

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -22,6 +22,7 @@ const fragment = graphql`
         name
         childOrder
         children { id name index }
+        ... NavigationData
     }
 `;
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -636,6 +636,8 @@ type Realm implements Node {
     `null` is returned.
   """
   ownerDisplayName: String
+  "Info about the navigation UI for this realm."
+  nav: RealmNav!
   """
     Returns the acl of this realm, combining moderator and admin roles and assigns
     the respective actions that are necessary for UI purposes.
@@ -687,6 +689,36 @@ type Realm implements Node {
 "A realm name that is derived from a block of that realm."
 type RealmNameFromBlock {
   block: Block!
+}
+
+type RealmNav {
+  """
+    The "go up" part of the navigation, i.e. the logical parent. This is
+    almost always also the actual parent, except for user root realms,
+    which have no actual parent, but for which this field points to the
+    main root realm. Is `null` for only the main root realm.
+  """
+  up: RealmNavItem
+  """
+    Whether the name of the current realm should be shown in an extra
+    section in the nav. This is `true` except for the main root and leaf
+    nodes.
+  """
+  showSelf: Boolean!
+  """
+    Main part of the navigation: list of realms to navigate to. These are
+    usually the children of the realm, except for leaf nodes (except root
+    realms), where it's the siblings (including itself) instead.
+  """
+  list: [RealmNavItem!]!
+  "Dictates in what order the items in `list` should be displayed."
+  listOrder: RealmOrder!
+}
+
+type RealmNavItem {
+  "Resolved name, like `Realm.name`."
+  name: String
+  path: String!
 }
 
 type RemovedBlock {


### PR DESCRIPTION
Fixes #1391

Before, the navigation of leaf realms was fairly useless, only allowing you to go up, never showing more links, making browsing less inviting. With this commit, the siblings are shown instead in these situations. To visually distinguish this "special last level" from the others, in intermediate layers (where children are shown), all children are indented a bit. Also, the "current realm" name is not shown as second line in the nav on the last level (no children), as that would show the realm name twice.

For testers: Make sure you test desktop mode and burger menu, each for all possible kinds of realms: main root realm, no children, parent and children, user root realm, user non-root realm.

Open questions:
- When navigating from [the second lowest level](https://pr1413.tobira.opencast.org/live/events) to [the lowest level](https://pr1413.tobira.opencast.org/live/events/live-3), the "list" in the navigation stays the same, but since the "current page" part disappears, the whole list "jumps" up. Is that a problem or annoying? How would one solve it? 
- Does it look fine/OK in the "no children" case, that there is no special separation between the parent page and the first sibling?

---

Technical notes:

The API and backend was also changed as otherwise, the frontend would have needed to request the children and siblings all the time, adding more traffic and another SQL query. The API `Realm` got a new field `nav` that delivers exactly the information needed to show the navigation, loading everything in one SQL query (which is one less than before).

Some of the code is a bit uhg, since we still have the problem explained in #840. But this PR was unfortunately not the right time to fix it.