### PR TITLE
Allow changing built-in group info (e.g. label of ROLE_USER)

### DIFF
--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -20,9 +20,11 @@ pub(crate) struct AclItem {
     /// `annotate`). This is a set, i.e. no duplicate elements.
     pub actions: Vec<String>,
 
-    /// Additional info we have about the role. Is `null` if the role is unknown
-    /// or is `ROLE_ANONYMOUS`, `ROLE_ADMIN` or `ROLE_USER`, as those are
-    /// handled in a special way in the frontend.
+    /// Additional info we have about the role. Is `null` if the role is
+    /// unknown. For the built-in roles `ROLE_ANONYMOUS`, `ROLE_ADMIN` and
+    /// `ROLE_USER`, this might be `null` as well (in which case there is
+    /// special handling in the frontend), but might be non-null if custom info
+    /// is configured.
     pub info: Option<RoleInfo>,
 }
 

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -47,6 +47,9 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
     "ROLE_STAFF": { "label": { "en": "Staff", "de": "Angestellte" }, "implies": [], "large": true },
     "ROLE_LECTURER": { "label": { "en": "Lecturers", "de": "Vortragende" }, "implies": ["ROLE_STAFF"], "large": true },
     "ROLE_TOBIRA_MODERATOR": { "label": { "en": "Moderators", "de": "Moderierende" }, "implies": ["ROLE_STAFF"], "large": false }
+
+    // You can also overwrite the label of built-in groups, if you so desire
+    // "ROLE_USER": { "label": { "en": "...", "de": "..." }, "implies": [], "large": true },
 }
 ```
 

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -43,13 +43,13 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
 
 ```json
 {
-    "ROLE_STUDENT": { "label": { "en": "Students", "de": "Studierende" }, "implies": [], "large": true },
-    "ROLE_STAFF": { "label": { "en": "Staff", "de": "Angestellte" }, "implies": [], "large": true },
-    "ROLE_LECTURER": { "label": { "en": "Lecturers", "de": "Vortragende" }, "implies": ["ROLE_STAFF"], "large": true },
-    "ROLE_TOBIRA_MODERATOR": { "label": { "en": "Moderators", "de": "Moderierende" }, "implies": ["ROLE_STAFF"], "large": false }
+    "ROLE_STUDENT": { "label": { "default": "Students", "de": "Studierende" }, "implies": [], "large": true },
+    "ROLE_STAFF": { "label": { "default": "Staff", "de": "Angestellte" }, "implies": [], "large": true },
+    "ROLE_LECTURER": { "label": { "default": "Lecturers", "de": "Vortragende" }, "implies": ["ROLE_STAFF"], "large": true },
+    "ROLE_TOBIRA_MODERATOR": { "label": { "default": "Moderators", "de": "Moderierende" }, "implies": ["ROLE_STAFF"], "large": false }
 
     // You can also overwrite the label of built-in groups, if you so desire
-    // "ROLE_USER": { "label": { "en": "...", "de": "..." }, "implies": [], "large": true },
+    // "ROLE_USER": { "label": { "default": "...", "de": "..." }, "implies": [], "large": true },
 }
 ```
 

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -86,7 +86,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclSelector
             acl={selections}
             onChange={setSelections}
-            addAnonymous={false}
+            disallowAnonymous
             {...{ knownRoles, inheritedAcl, ownerDisplayName }}
             permissionLevels={MODERATE_ADMIN_ACTIONS}
         />
@@ -107,4 +107,3 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         {boxError(commitError)}
     </>;
 };
-

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -226,9 +226,11 @@ type AclItem {
   """
   actions: [String!]!
   """
-    Additional info we have about the role. Is `null` if the role is unknown
-    or is `ROLE_ANONYMOUS`, `ROLE_ADMIN` or `ROLE_USER`, as those are
-    handled in a special way in the frontend.
+    Additional info we have about the role. Is `null` if the role is
+    unknown. For the built-in roles `ROLE_ANONYMOUS`, `ROLE_ADMIN` and
+    `ROLE_USER`, this might be `null` as well (in which case there is
+    special handling in the frontend), but might be non-null if custom info
+    is configured.
   """
   info: RoleInfo
 }


### PR DESCRIPTION
Closes #1388

Luckily, this didn't require that much work. The database did not disallow these entries in `known_groups`, neither does the subcommand `known-groups upsert`. So it was simply a matter of making the frontend use the custom info if it is provided. The `acl` API docs were also adjusted to match the actual behavior. It is not quite possible to override info for ROLE_ADMIN yet, as that special group has quite a few extra behaviors attached to it, but ROLE_USER and ROLE_ANONYMOUS can be defined as any other group.