### PR TITLE
Add creation date to series placeholders

### DIFF
--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -174,9 +174,10 @@ impl Series {
         let selection = Self::select().with_renamed_table("series", "all_series");
         let query = format!(
             "insert into all_series ( \
-                opencast_id, title, description, state, updated, read_roles, write_roles \
+                opencast_id, title, description, state, \
+                created, updated, read_roles, write_roles \
             ) \
-            values ($1, $2, $3, 'waiting', '-infinity', $4, $5) \
+            values ($1, $2, $3, 'waiting', now(), '-infinity', $4, $5) \
             returning {selection}",
         );
 


### PR DESCRIPTION
Not showing a creation date for items that have clearly been created is a little confusing.
So even though it will be overwritten with the date from Opencast when sync happens, showing a "created in Tobira" date before that should be fine. It might even be helpful if creation on the Opencast side failed. Then the user can at least see when they attempted to create the item.