### PR TITLE
Make build-container-image runnable again

### DIFF
--- a/util/containers/Dockerfile
+++ b/util/containers/Dockerfile
@@ -35,7 +35,6 @@ COPY backend/Cargo.toml backend/Cargo.lock /build/backend/
 COPY <<EOF /build/backend/src/main.rs
 fn main() {}
 EOF
-RUN cargo build --target "${RUST_TARGET}" --release
 
 COPY --from=frontend-build /build/build /build/frontend/build
 COPY backend .

--- a/util/containers/Dockerfile
+++ b/util/containers/Dockerfile
@@ -32,9 +32,11 @@ ARG RUST_TARGET
 RUN rustup target add "${RUST_TARGET}"
 
 COPY backend/Cargo.toml backend/Cargo.lock /build/backend/
+COPY backend/vendor /build/backend/vendor
 COPY <<EOF /build/backend/src/main.rs
 fn main() {}
 EOF
+RUN cargo build --target "${RUST_TARGET}" --release
 
 COPY --from=frontend-build /build/build /build/frontend/build
 COPY backend .

--- a/util/scripts/build-container-image.sh
+++ b/util/scripts/build-container-image.sh
@@ -16,7 +16,6 @@ GIT_COMMIT_HASH="$(git rev-parse --short HEAD || echo "unknown")"
 VERSION="$(sed -n -E 's/^version = "([^"]+)"$/\1/p' backend/Cargo.toml)"
 
 docker buildx build \
-  --network "host" \
   --platform "${CONTAINER_PLATFORM}" \
   --build-arg "NODE_VERSION=${NODE_VERSION}" \
   --build-arg "RUST_VERSION=${RUST_VERSION}" \

--- a/util/scripts/build-container-image.sh
+++ b/util/scripts/build-container-image.sh
@@ -5,8 +5,8 @@ set -e
 basedir=$(dirname "$0")
 cd "$basedir"/../..
 
-NODE_VERSION=19.3
-RUST_VERSION=1.66
+NODE_VERSION=22.15
+RUST_VERSION=1.86
 
 CONTAINER_PLATFORM="${CONTAINER_PLATFORM:-linux/amd64}"
 RUST_TARGET="${RUST_TARGET:-x86_64-unknown-linux-musl}"
@@ -16,6 +16,7 @@ GIT_COMMIT_HASH="$(git rev-parse --short HEAD || echo "unknown")"
 VERSION="$(sed -n -E 's/^version = "([^"]+)"$/\1/p' backend/Cargo.toml)"
 
 docker buildx build \
+  --network "host" \
   --platform "${CONTAINER_PLATFORM}" \
   --build-arg "NODE_VERSION=${NODE_VERSION}" \
   --build-arg "RUST_VERSION=${RUST_VERSION}" \


### PR DESCRIPTION
`./x.sh build-container-image` fails with the current state of the repository. Both the Dockerfile and build-container-image.sh were not updated since they got added 3 years ago.

So far I have only tested the build command. This passes after the changes and builds the container.

### Changes made:

#### 1. Bump Node.js to current lts version (22.15)

Not a necessary change, but probably a reasonable one. Node.js 19 went EoL with version 19.9.0 in June 2023.

Switched to the current LTS version. In October, Node.js 24 will enter LTS. Another change could considered then. Alternatively, there is also the lts tag for docker.io/node if no version pinning is strictly required 

#### 2. Bump Rust version to > 1.80

Rust version 1.66 is incompatible. At least 1.80 is required to compile without problems. Bumped to the latest version (1.86)

#### 3. Add `--network "host"` to the build command

Without that flag, it fails to fetch the alpine package indices on my system

#### 4. Removed duplicate line in Dockerfile that caused problems

`RUN cargo build --target "${RUST_TARGET}" --release` was present twice in the Dockerfile. The first occurrence is before all dependencies are copied, thus failing