### PR TITLE
Improve accessibility in some areas

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -268,6 +268,7 @@ search:
   no-results: Keine Ergebnisse
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
   unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.
+  clear: Suchbegriff löschen
   filter:
     all: Alle
     event: Videos

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -28,6 +28,9 @@ general:
     select:
       no-options: Keine Optionen
       select-option: Option auswählen
+  seconds: Sekunden
+  minutes: Minuten
+  hours: Stunden
 
 welcome:
   title: Willkommen zu Tobira!
@@ -167,6 +170,7 @@ video:
       Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen
       (Rechtsklick - Speichern unter).
   manage: Verwalten
+  extra-buttons: Weitere Videoaktionen
   start: Anfang
   end: Ende
   ends: Endet
@@ -185,6 +189,7 @@ video:
 share:
   share-video: Video teilen
   direct-link: Direktlink
+  share-direct-link: Via Direktlink teilen
   main: Link
   embed: Einbetten
   rss: RSS
@@ -192,6 +197,11 @@ share:
   copy-link: Link in Zwischenablage kopieren
   copy-rss: RSS Link in Zwischenablage kopieren
   copy-embed-code: Einbettungscode in Zwischenablage kopieren
+  copy-direct-link-to-clipboard: Videolink in Zwischenablage kopieren
+  set-time: 'Starten bei: '
+  set-time-label: 'Videostartzeit einstellen. Aktuell: {{time}}.'
+  set-time-unit: '{{unit}} einstellen'
+  no-time: Keine
 
 playlist:
   deleted-playlist-block: Die hier referenzierte Playlist wurde gelöscht.
@@ -299,9 +309,6 @@ upload:
     a-few-seconds: wenige Sekunden
     a-minute: eine Minute
     an-hour: eine Stunde
-    seconds: Sekunden
-    minutes: Minuten
-    hours: Stunden
     time-left: '{{time}} verbleibend'
   finished: >
     Ihr Video wurde erfolgreich hochgeladen und wird nun verarbeitet. Es kann wie gewohnt
@@ -442,9 +449,6 @@ manage:
     no-videos-found: Keine Videos gefunden.
     details:
       title: Videodetails
-      share-direct-link: Via Direktlink teilen
-      set-time: 'Starten bei: '
-      copy-direct-link-to-clipboard: Videolink in Zwischenablage kopieren
       open-in-editor: Im Videoeditor öffnen
       referencing-pages: Referenzierende Seiten
       referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -128,7 +128,7 @@ video:
   created: Erstellt
   updated: Zuletzt verändert
   duration: Abspielzeit
-  link: Zur Videoseite
+  link: Videodetails
   part-of-series: Teil der Serie
   more-from-series: Mehr von „{{series}}“
   more-from-playlist: Mehr von „{{playlist}}”

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -125,6 +125,7 @@ login-page:
 video:
   video: Video
   video-page: 'Video Seite: „{{video}}“'
+  video-player: Videoplayer
   created: Erstellt
   updated: Zuletzt verändert
   duration: Abspielzeit

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -123,6 +123,7 @@ login-page:
 video:
   video: Video
   video-page: 'Video page: “{{video}}”'
+  video-player: Video player
   created: Created
   updated: Last updated
   duration: Duration

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -267,6 +267,7 @@ search:
   no-results: No results
   too-few-characters: Please type more characters to start the search.
   unavailable: The search is currently unavailable. Try again later.
+  clear: Clear search input
   filter:
     all: All
     event: Videos

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -126,7 +126,7 @@ video:
   created: Created
   updated: Last updated
   duration: Duration
-  link: Go to video page
+  link: Video details
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
   more-from-playlist: More from “{{playlist}}”

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -27,6 +27,9 @@ general:
     select:
       no-options: No options
       select-option: Select option
+  seconds: seconds
+  minutes: minutes
+  hours: hours
 
 welcome:
   title: Welcome to Tobira!
@@ -164,6 +167,7 @@ video:
     info: >
       Here you can download the video(s) in different formats/qualities (Right click - Save as).
   manage: Manage
+  extra-buttons: Additional video actions
   start: Start
   end: End
   ends: Ends
@@ -183,6 +187,7 @@ video:
 share:
   share-video: Share video
   direct-link: Direct link
+  share-direct-link: Share via direct link
   link: Link
   embed: Embed
   rss: RSS
@@ -190,6 +195,11 @@ share:
   copy-link: Copy link to clipboard
   copy-rss: Copy RSS link to clipboard
   copy-embed-code: Copy embed code to clipboard
+  copy-direct-link-to-clipboard: Copy video link to clipboard
+  set-time: 'Start at: '
+  set-time-label: 'Set video start time. Current time: {{time}}.'
+  set-time-unit: Set {{unit}}
+  no-time: None
 
 playlist:
   deleted-playlist-block: The playlist referenced here was deleted.
@@ -297,9 +307,6 @@ upload:
     a-few-seconds: a few seconds
     a-minute: a minute
     an-hour: an hour
-    seconds: seconds
-    minutes: minutes
-    hours: hours
     time-left: '{{time}} left'
   finished: >
     Your video was uploaded successfully and is now being processed. It can be
@@ -423,9 +430,6 @@ manage:
     no-videos-found: No videos found.
     details:
       title: Video details
-      share-direct-link: Share via direct link
-      set-time: 'Start at: '
-      copy-direct-link-to-clipboard: Copy video link to clipboard
       open-in-editor: Open in video editor
       referencing-pages: Referencing pages
       referencing-pages-explanation: 'This video is referenced on the following pages:'

--- a/frontend/src/layout/header/Search.tsx
+++ b/frontend/src/layout/header/Search.tsx
@@ -164,6 +164,7 @@ export const SearchField: React.FC<SearchFieldProps> = ({ variant }) => {
                 </label>
             </form>
             <ProtoButton
+                aria-label={t("search.clear")}
                 // Just clear the search input
                 onClick={() => {
                     const input = currentRef(ref);

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -13,7 +13,7 @@ import { RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
 import { Nav } from "../layout/Navigation";
 import { LinkList, LinkWithIcon } from "../ui";
-import { characterClass, useTitle, useTranslatedConfig } from "../util";
+import { characterClass, useTitle, useTranslatedConfig, visuallyHiddenStyle } from "../util";
 import { makeRoute } from "../rauta";
 import { MissingRealmName } from "./util";
 import { realmBreadcrumbs } from "../util/realm";
@@ -161,14 +161,7 @@ const RealmPage: React.FC<Props> = ({ realm }) => {
             </div>
         ) : (
             // If there is no heading, this visually hidden <h1> is added for screen readers.
-            realm.isMainRoot && <h1 css={{
-                clipPath: "inset(50%)",
-                height: 1,
-                overflow: "hidden",
-                position: "absolute",
-                whiteSpace: "nowrap",
-                width: 1,
-            }}>{siteTitle}</h1>
+            realm.isMainRoot && <h1 css={visuallyHiddenStyle}>{siteTitle}</h1>
         )}
         <Blocks realm={realm} />
     </>;

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -520,16 +520,16 @@ const UploadState: React.FC<{ state: NonFinishedUploadState }> = ({ state }) => 
         } else if (secondsLeft < 4) {
             prettyTime = t("upload.time-estimate.a-few-seconds");
         } else if (secondsLeft < 45) {
-            prettyTime = `${secondsLeft} ${t("upload.time-estimate.seconds")}`;
+            prettyTime = `${secondsLeft} ${t("general.seconds")}`;
         } else if (secondsLeft < 90) {
             prettyTime = t("upload.time-estimate.a-minute");
         } else if (secondsLeft < 45 * 60) {
-            prettyTime = `${Math.round(secondsLeft / 60)} ${t("upload.time-estimate.minutes")}`;
+            prettyTime = `${Math.round(secondsLeft / 60)} ${t("general.minutes")}`;
         } else if (secondsLeft < 90 * 60) {
             prettyTime = t("upload.time-estimate.an-hour");
         } else if (secondsLeft < 24 * 60 * 60) {
             const hours = Math.round(secondsLeft / (60 * 60));
-            prettyTime = `${hours} ${t("upload.time-estimate.hours")}`;
+            prettyTime = `${hours} ${t("general.hours")}`;
         } else {
             prettyTime = null;
         }

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -52,7 +52,7 @@ import { Link, useRouter } from "../router";
 import { isRealUser, useUser } from "../User";
 import { b64regex } from "./util";
 import { ErrorPage } from "../ui/error";
-import { CopyableInput, InputWithCheckbox, TimeInput } from "../ui/Input";
+import { CopyableInput, TimeInputWithCheckbox } from "../ui/Input";
 import { VideoPageInRealmQuery } from "./__generated__/VideoPageInRealmQuery.graphql";
 import {
     VideoPageEventData$data,
@@ -882,7 +882,7 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
                 <VideoDate {...{ event }} />
             </div>
             {/* Buttons */}
-            <div css={{
+            <section aria-label={t("video.extra-buttons")} css={{
                 display: "flex",
                 gap: 8,
                 flexWrap: "wrap",
@@ -901,7 +901,7 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
                     <DownloadButton event={event} />
                 )}
                 <VideoShareButton {...{ event }} />
-            </div>
+            </section>
         </div>
         <div css={{
             display: "flex",
@@ -992,17 +992,13 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 return <>
                     <div>
                         <CopyableInput
-                            label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
+                            label={t("share.copy-direct-link-to-clipboard")}
                             value={url}
                         />
-                        {!event.isLive && <InputWithCheckbox
+                        {!event.isLive && <TimeInputWithCheckbox
                             checkboxChecked={addLinkTimestamp}
                             setCheckboxChecked={setAddLinkTimestamp}
-                            label={t("manage.my-videos.details.set-time")}
-                            input={<TimeInput
-                                {...{ timestamp, setTimestamp }}
-                                disabled={!addLinkTimestamp}
-                            />}
+                            {...{ timestamp, setTimestamp }}
                         />}
                     </div>
                     <QrCodeButton target={url} label={t("share.link")} />
@@ -1042,14 +1038,10 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                             multiline
                             css={{ height: 75 }}
                         />
-                        {!event.isLive && <InputWithCheckbox
+                        {!event.isLive && <TimeInputWithCheckbox
                             checkboxChecked={addEmbedTimestamp}
                             setCheckboxChecked={setAddEmbedTimestamp}
-                            label={t("manage.my-videos.details.set-time")}
-                            input={<TimeInput
-                                {...{ timestamp, setTimestamp }}
-                                disabled={!addEmbedTimestamp}
-                            />}
+                            {...{ timestamp, setTimestamp }}
                         />}
                     </div>
                     <QrCodeButton target={embedCode} label={t("share.embed")} />

--- a/frontend/src/routes/manage/Video/Details.tsx
+++ b/frontend/src/routes/manage/Video/Details.tsx
@@ -4,7 +4,7 @@ import { useId, useRef, useState } from "react";
 import { Link, useRouter } from "../../../router";
 import { NotAuthorized } from "../../../ui/error";
 import { Form } from "../../../ui/Form";
-import { CopyableInput, Input, InputWithCheckbox, TextArea, TimeInput } from "../../../ui/Input";
+import { CopyableInput, Input, TextArea, TimeInputWithCheckbox } from "../../../ui/Input";
 import { InputContainer, TitleLabel } from "../../../ui/metadata";
 import { isRealUser, useUser } from "../../../User";
 import { Breadcrumbs } from "../../../ui/Breadcrumbs";
@@ -148,18 +148,16 @@ const DirectLink: React.FC<Props> = ({ event }) => {
     return (
         <div css={{ marginBottom: 40 }}>
             <div css={{ marginBottom: 4 }}>
-                {t("manage.my-videos.details.share-direct-link") + ":"}
+                {t("share.share-direct-link") + ":"}
             </div>
             <CopyableInput
-                label={t("manage.my-videos.details.copy-direct-link-to-clipboard")}
+                label={t("share.copy-direct-link-to-clipboard")}
                 value={url.href}
                 css={{ fontSize: 14 }}
             />
-            <InputWithCheckbox
-                {...{ checkboxChecked, setCheckboxChecked }}
-                label={t("manage.my-videos.details.set-time")}
-                input={<TimeInput {...{ timestamp, setTimestamp }} disabled={!checkboxChecked} />}
-            />
+            {!event.isLive && <TimeInputWithCheckbox {...{
+                timestamp, setTimestamp, checkboxChecked, setCheckboxChecked,
+            }} />}
         </div>
     );
 };

--- a/frontend/src/ui/player/PlayerContext.tsx
+++ b/frontend/src/ui/player/PlayerContext.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { PaellaState } from "./Paella";
 import { bug } from "@opencast/appkit";
+import { useTranslation } from "react-i18next";
 
 type PlayerContext = {
     paella: MutableRefObject<PaellaState | undefined>;
@@ -20,11 +21,14 @@ type PlayerContext = {
 const PlayerContext = createContext<PlayerContext | null>(null);
 
 export const PlayerContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
+    const { t } = useTranslation();
     const paella = useRef<PaellaState>();
     const [playerIsLoaded, setPlayerIsLoaded] = useState(false);
 
     return <PlayerContext.Provider value={{ paella, playerIsLoaded, setPlayerIsLoaded }}>
-        {children}
+        <section aria-label={t("video.video-player")}>
+            {children}
+        </section>
     </PlayerContext.Provider>;
 };
 

--- a/frontend/src/util/index.ts
+++ b/frontend/src/util/index.ts
@@ -6,6 +6,7 @@ import { bug, match, useColorScheme } from "@opencast/appkit";
 import CONFIG, { TranslatedString } from "../config";
 import { TimeUnit } from "../ui/Input";
 import { CREDENTIALS_STORAGE_KEY } from "../routes/Video";
+import { css } from "@emotion/react";
 
 
 /**
@@ -286,3 +287,12 @@ export const useLogoConfig = () => {
 
     return { wide, narrow };
 };
+
+export const visuallyHiddenStyle = css({
+    clipPath: "inset(50%)",
+    height: 1,
+    overflow: "hidden",
+    position: "absolute",
+    whiteSpace: "nowrap",
+    width: 1,
+});

--- a/frontend/tests/blocks.spec.ts
+++ b/frontend/tests/blocks.spec.ts
@@ -103,7 +103,7 @@ for (const realmType of realmTypes) {
                 await test.step("Video blocks", async () => {
                     const editButton = page
                         .locator("div")
-                        .filter({ hasText: "Go to video" })
+                        .filter({ hasText: "Video details" })
                         .filter({ hasNotText: "Fabulous Cats" })
                         .first()
                         .getByLabel("Edit block");
@@ -135,7 +135,7 @@ for (const realmType of realmTypes) {
                         await page.getByLabel("Show link to video page").setChecked(false);
                         await saveButton.click();
 
-                        await expect(page.getByRole("link", { name: "Go to video page" }))
+                        await expect(page.getByRole("link", { name: "Video details" }))
                             .toBeHidden();
                     });
                 });


### PR DESCRIPTION
This addresses some points made in a recent accessibility assessment from a third party. Their report was done with JAWS and mentioned a couple of things that I couldn't reproduce/test with voiceover on macOS. Other things related to floating menus and their triggers need to be addressed in [opencast/appkit](https://github.com/opencast/appkit). Yet some more suggestions from the review could be considered as more related to design decisions that we need to discuss before they get implemented. Last but not least, accessibility issues related to our paella integration will be fixed in a standalone PR where we will probably disable paellas builtin hotkeys and swap in our own (see https://github.com/elan-ev/tobira/issues/1416).