### PR TITLE
Fix keyboard navigation in share modal tabs

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -983,7 +983,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
         "main": {
             label: t("share.link"),
             Icon: LuLink,
-            Component: () => {
+            render: () => {
                 let url = window.location.href.replace(timeStringPattern, "");
                 url += addLinkTimestamp && timestamp
                     ? `?t=${secondsToTimeString(timestamp)}`
@@ -1012,7 +1012,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
         "embed": {
             label: t("share.embed"),
             Icon: LuCode,
-            Component: () => {
+            render: () => {
                 const ar = event.authorizedData == null
                     ? [16, 9]
                     : getPlayerAspectRatio(event.authorizedData.tracks);
@@ -1060,7 +1060,7 @@ const VideoShareButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
             "rss": {
                 label: t("share.rss"),
                 Icon: LuRss,
-                Component: () => {
+                render: () => {
                     const rssUrl = window.location.origin
                         + `/~rss/series/${keyOfId(series.id)}`;
                     return <>

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -424,7 +424,7 @@ const VideoListShareButton: React.FC<VideoListShareButtonProps> = props => {
         "main": {
             label: t("share.link"),
             Icon: LuLink,
-            Component: () => <>
+            render: () => <>
                 <CopyableInput label={t("share.copy-link")} value={shareUrl} />
                 <QrCodeButton target={shareUrl} label={t("share.link")} />
             </>,
@@ -432,7 +432,7 @@ const VideoListShareButton: React.FC<VideoListShareButtonProps> = props => {
         "rss": {
             label: t("share.rss"),
             Icon: LuRss,
-            Component: () => <>
+            render: () => <>
                 <CopyableInput label={t("share.copy-rss")} value={rssUrl} />
                 <QrCodeButton target={rssUrl} label={t("share.rss")} />
             </>,

--- a/frontend/src/ui/ShareButton.tsx
+++ b/frontend/src/ui/ShareButton.tsx
@@ -17,7 +17,7 @@ export type ShareButtonProps = {
     tabs: Record<string, {
         label: string;
         Icon: React.ComponentType;
-        Component: React.ComponentType;
+        render: () => React.ReactNode;
     }>;
     onOpen?: () => void;
     height: number;
@@ -95,8 +95,6 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen, height, 
         ))}
     </div>;
 
-    const TabComponent = activeTab && tabs[activeTab].Component;
-
     return (
         <FloatingContainer
             ref={ref}
@@ -139,7 +137,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ tabs, onOpen, height, 
                     justifyContent: "space-between",
                     fontSize: 14,
                     width: 400,
-                }}>{TabComponent && <TabComponent />}</div>
+                }}>{activeTab && tabs[activeTab].render()}</div>
             </Floating>
         </FloatingContainer>
     );


### PR DESCRIPTION
The ability to enter a starting time using only keyboard navigation got a little mangled in a recent refactor. This restores the previous behaviour.