### PR TITLE
Fix Paella popup menus not working in iOS fake fullscreen

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -231,7 +231,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
             ".paella-fallback-fullscreen": {
                 position: "fixed !important" as "fixed",
                 inset: "0 !important",
-                zIndex: "500000 !important",
+                zIndex: "499 !important",
             },
         }} />
         <div


### PR DESCRIPTION
Noticed by Olaf [here](https://github.com/elan-ev/tobira/pull/1447#issuecomment-2921930037)

Of course, just randomly changing z-index numbers is not a great solution, but there is not really a better one! With 499, paella is still above everything else Tobira, while letting the menus (with z-index 500) stay on top.