### PR TITLE
Undo some eslint/webpack related updates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "react-transition-group": "^4.4.5",
         "relay-compiler": "^16.2.0",
         "relay-config": "^12.0.1",
-        "webpack": "^5.99.8",
+        "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
         "yaml": "^2.8.0",
         "yaml-loader": "^0.8.1"
@@ -63,7 +63,7 @@
         "@types/react-transition-group": "^4.4.12",
         "@types/webpack-env": "^1.18.8",
         "eslint": "^9.26.0",
-        "eslint-webpack-plugin": "^5.0.1",
+        "eslint-webpack-plugin": "^4.2.0",
         "fork-ts-checker-webpack-plugin": "^9.1.0",
         "html-webpack-plugin": "^5.6.3",
         "postgres": "^3.4.5",
@@ -5288,20 +5288,20 @@
       }
     },
     "node_modules/eslint-webpack-plugin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-5.0.1.tgz",
-      "integrity": "sha512-Ur100Vi+z0uP7j4Z8Ccah0pXmNHhl3f7P2hCYZj3mZCOSc33G5c1R/vZ4KCapwWikPgRyD4dkangx6JW3KaVFQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-rsfpFQ01AWQbqtjgPRr2usVRxhWDuG0YDYcG8DJOteD3EFnpeuYuOwk0PQiN7PRBTqS6ElNdtPZPggj8If9WnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint": "^9.6.1",
+        "@types/eslint": "^8.56.10",
         "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.8",
+        "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
-        "schema-utils": "^4.3.0"
+        "schema-utils": "^4.2.0"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5310,6 +5310,17 @@
       "peerDependencies": {
         "eslint": "^8.0.0 || ^9.0.0",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/eslint-webpack-plugin/node_modules/@types/eslint": {
+      "version": "8.56.12",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
       }
     },
     "node_modules/espree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "react-transition-group": "^4.4.5",
     "relay-compiler": "^16.2.0",
     "relay-config": "^12.0.1",
-    "webpack": "^5.99.8",
+    "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
     "yaml": "^2.8.0",
     "yaml-loader": "^0.8.1"
@@ -79,7 +79,7 @@
     "@types/react-transition-group": "^4.4.12",
     "@types/webpack-env": "^1.18.8",
     "eslint": "^9.26.0",
-    "eslint-webpack-plugin": "^5.0.1",
+    "eslint-webpack-plugin": "^4.2.0",
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "html-webpack-plugin": "^5.6.3",
     "postgres": "^3.4.5",


### PR DESCRIPTION
I was semi-constantly getting some false eslint/webpack errors about `@typescript-eslint/restrict-plus-operands`. Not sure if both downgrades are needed or if they even help in the long run, or if the issue will pop up again, but at least they won't break anything.