### PR TITLE
Clean up translations

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -8,6 +8,7 @@ general:
   home: Startseite
   homepage: Startseite
   page: Seite
+  password: Password
   leave-page-confirmation: >
     Seite verlassen? Vorgenommene Änderungen sind möglicherweise noch nicht gespeichert!
   action:
@@ -15,8 +16,9 @@ general:
     cancel: Abbrechen
     save: Speichern
     back: Zurück
-    goto-homepage: Zur Startseite
     share: Teilen
+    are-you-sure: Sind Sie sich sicher?
+    cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
   version-information: Version
   logo-alt: Startseite von „{{title}}“
   no-root-children: Noch keine Seiten
@@ -32,6 +34,8 @@ general:
   seconds: Sekunden
   minutes: Minuten
   hours: Stunden
+  none: Keine
+  title: Titel
 
 welcome:
   title: Willkommen zu Tobira!
@@ -92,7 +96,7 @@ invalid-url:
     Stelle, die diesen veröffentlicht hat.
 
 about-tobira:
-  title: Informationen über „Tobira“
+  title: Informationen über Tobira
   body: >
     Dieses Videoportal nutzt Tobira, eine Videoportal-Software für
     Opencast. Es erlaubt seinen Nutzern, alle Videos und Serien aus der
@@ -100,9 +104,6 @@ about-tobira:
     organisieren. Tobira, wie auch Opencast selber, ist kostenlose
     Open-Source-Software. Weitere Informationen und die Möglichkeit,
     Fehler zu melden, gibt es im <1>GitHub-Repository des Projekts</1>.
-
-footer:
-  about-tobira: Über Tobira
 
 main-menu:
   label: Menü
@@ -116,29 +117,28 @@ user:
   login: Anmelden
   logout: Abmelden
   settings: Nutzereinstellungen
-  manage-content: Verwalten
+  manage: Verwalten
 
 login-page:
   heading: Anmeldung
   user-id: Nutzerkennung
-  password: Passwort
   bad-credentials: 'Anmeldung fehlgeschlagen: Falsche Anmeldedaten.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
   already-logged-in: Sie sind bereits angemeldet.
 
 video:
-  video: Video
+  singular: Video
+  plural: Videos
   video-page: 'Video Seite: „{{video}}“'
   video-player: Videoplayer
   duration: Abspielzeit
-  link: Videodetails
+  details: Videodetails
   part-of-series: Teil der Serie
   more-from-series: Mehr von „{{series}}“
   more-from-playlist: Mehr von „{{playlist}}”
-  deleted-video-block: Das hier referenzierte Video wurde gelöscht.
-  not-allowed-video-block: Sie sind nicht autorisiert, das hier eingebettete Video zu sehen.
-  preview: Vorschau
-  preview-only: Sie brauchen zusätzliche Berichtigungen, um dieses Video anzuschauen.
+  deleted-block: Das hier referenzierte Video wurde gelöscht.
+  not-allowed-block: Sie sind nicht autorisiert, das hier eingebettete Video zu sehen.
+  preview-only: Sie benötigen zusätzliche Berechtigungen, um dieses Video anzusehen.
   not-ready:
     title: Video noch nicht verarbeitet
     text: >
@@ -168,7 +168,6 @@ video:
     info: >
       Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen
       (Rechtsklick - Speichern unter).
-  manage: Verwalten
   extra-buttons: Weitere Videoaktionen
   start: Anfang
   end: Ende
@@ -176,20 +175,37 @@ video:
   password:
     heading: Geschütztes Video
     sub-heading: Zugriff zu diesem Video ist beschränkt.
+    no-preview-permission: $t(api-remote-errors.view.event)
     body: >
       Bitte geben Sie die Zugangsdaten ein, die Sie für dieses Videos erhalten haben.
       Beachten Sie, dass diese nicht Ihren Logindaten für dieses Portal entsprechen.
     label:
       id: Kennung
-      password: Passwort
       submit: Freischalten
     invalid-credentials: Ungültige Zugangsdaten.
 
+series:
+  singular: Serie
+  plural: Serien
+  series-page: 'Serienseite: “{{series}}”'
+  deleted-block: Die hier referenzierte Serie wurde gelöscht.
+  entry-of-series-thumbnail: "Vorschlaubild für Teil von „{{series}}“"
+  not-ready:
+    title: Serie noch nicht synchronisiert
+    text: >
+      Die Daten der gewünschten Serie wurden leider noch nicht vollständig übertragen. Dies sollte
+      in Kürze automatisch passieren. Versuchen Sie es in wenigen Minuten noch einmal!
+    label: nicht synchronisiert
+
+playlist:
+  singular: Playlist
+  deleted-block: Die hier referenzierte Playlist wurde gelöscht.
+  not-allowed: Sie sind nicht autorisiert, diese Playlist zu sehen.
+  not-allowed-block: Sie sind nicht autorisiert, die hier eingebettete Playlist zu sehen.
+
 share:
-  share-video: Video teilen
-  direct-link: Direktlink
   share-direct-link: Via Direktlink teilen
-  main: Link
+  link: Link
   embed: Einbetten
   rss: RSS
   show-qr-code: QR Code anzeigen
@@ -200,36 +216,15 @@ share:
   set-time: 'Starten bei: '
   set-time-label: 'Videostartzeit einstellen. Aktuell: {{time}}.'
   set-time-unit: '{{unit}} einstellen'
-  no-time: Keine
 
-playlist:
-  deleted-playlist-block: Die hier referenzierte Playlist wurde gelöscht.
-  not-allowed-playlist-block: Sie sind nicht autorisiert, die hier eingebettete Playlist zu sehen.
-
-series:
-  series: Serie
-  deleted: Gelöschte Serie
-  deleted-series-block: Die hier referenzierte Serie wurde gelöscht.
-  entry-of-series-thumbnail: "Vorschlaubild für Teil von „{{series}}“"
-  not-ready:
-    title: Serie noch nicht synchronisiert
-    text: >
-      Die Daten der gewünschten Serie wurden leider noch nicht vollständig übertragen. Dies sollte
-      in Kürze automatisch passieren. Versuchen Sie es in wenigen Minuten noch einmal!
-    label: nicht synchronisiert
-
-videolist-block:
+video-list-block:
   upcoming-live-streams: "Anstehende Livestreams ({{count}})"
-  missing-video: Video nicht gefunden
-  no-videos: Keine Videos
   unauthorized: Fehlende Berechtigung
   hidden-items:
     unauthorized_one: Für ein Video fehlen Ihnen die Zugriffsrechte.
     unauthorized_other: 'Für {{count}} Videos fehlen Ihnen die Zugriffsrechte.'
     missing_one: Ein Video wurde nicht gefunden.
     missing_other: '{{count}} Videos wurden nicht gefunden.'
-  videos:
-    heading: Videos
   settings:
     order: Reihenfolge
     order-label: Video Reihenfolge auswählen
@@ -259,8 +254,8 @@ realm:
       Dies ist eine persönliche Nutzerseite, die allein von {{user}} gepflegt wird.
       Für alle Inhalte ist {{user}} verantwortlich.
     create:
+      title: Persönliche Seite erstellen
       currently-none: Sie haben zurzeit keine persönliche Seite.
-      heading: Persönliche Seite erstellen
       what-you-can-do: >
         Auf Ihrer persönlichen Seite können Sie frei Videos, Text und andere Elemente anordnen,
         um so Inhalte besser präsentieren und teilen zu können.
@@ -270,7 +265,6 @@ realm:
         Alle, die diesen Link oder Ihren Benutzernamen kennen, können Ihre Seite besuchen.
         Ihre Seite wird jedoch nicht in der Hauptnavigation dieses Videoportals auftauchen.
         Sie können Ihre Seite später jederzeit wieder löschen.
-      button: Persönliche Seite erstellen
 
 search:
   input-label: Suche
@@ -280,13 +274,13 @@ search:
   too-few-characters: Tippen Sie weitere Zeichen, um die Suche zu starten.
   unavailable: Die Suchfunktion ist zurzeit nicht verfügbar. Versuchen Sie es später erneut.
   clear: Suchbegriff löschen
-  filter:
-    all: Alle
-    event: Videos
-    realm: Seiten
-    series: Serien
   select-time-frame: Zeitraum auswählen
   clear-time-frame: Zeitraum zurücksetzen
+  filter:
+    all: Alle
+    event: '$t(video.plural)'
+    realm: Seiten
+    series: '$t(series.plural)'
 
 upload:
   title: Video hochladen
@@ -324,129 +318,178 @@ upload:
       Andere Serien sind daher hier nicht auswählbar.
   errors:
     failed-to-upload: Hochladen fehlgeschlagen.
-    unknown: Während des Dateiuploads ist ein unbekannter Fehler aufgetreten.
     opencast-server-error: Opencast-Server-Fehler (unerwartete Antwort).
     opencast-unreachable: 'Netzwerkfehler: Opencast kann nicht erreicht werden.'
     jwt-invalid: 'Interner Fremdauthentifizierungsfehler: Opencast hat das Hochladen nicht autorisiert.'
     failed-fetching-series-acl: Abruf der Serienzugangsberechtigungen fehlgeschlagen.
 
-metadata-form:
-  title: Titel
-  description: Beschreibung
-  required: Pflichtfeld
-  save: Metadaten speichern
-  errors:
-    field-required: Dieses Feld darf nicht leer sein.
-  event-workflow-active: >
-    Änderung der Metadaten ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
+acl:
+  title: Zugriffsrechte
+  authorized-groups: Autorisierte Gruppen
+  authorized-users: Autorisierte Personen
+  editing-disabled: Bearbeitung der Zugangsberechtigungen ist deaktiviert.
+  workflow-active: >
+    Änderung der Berechtigungen ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
     <br />
     Bitte versuchen Sie es später nochmal.
-acl:
-  unknown-user-note: unbekannt
-  no-entries: Keine Einträge
-  admin-user: Admin
+  locked-to-series: >
+    Die Berechtigungen dieses Videos werden durch seine <1>Serie</1> bestimmt und können daher nicht bearbeitet werden.
+  users-no-options:
+    initial-searchable: Nach Name suchen oder exakten Nutzernamen/exakte E-Mail angeben
+    none-found-searchable: Keine Personen gefunden
+    initial-not-searchable: Geben Sie Nutzernamen oder E-Mail an, um Personen hinzuzufügen
+    none-found-not-searchable: Keine Person mit diesem Nutzernamen bzw. dieser E-Mail gefunden
+  select:
+    groups: Gruppen hinzufügen
+    users: Personen hinzufügen
+    create: '{{item}} erstellen'
   groups:
     admins: Administration
     everyone: Alle
     logged-in-users: Eingeloggte Nutzende
     global-page-admins: Globale Seitenadministration
+  table:
+    group: Gruppe
+    user: Person
+    yourself: Sie
+    admin-user: Admin
+    unknown-user-note: unbekannt
+    no-entries: Keine Einträge
+    subset-warning: 'Diese Auswahl ist bereits in den folgenden Gruppen enthalten: {{groups}}.'
+    inherited: 'Geerbte Berechtigungen:'
+    inherited-tooltip: >
+      Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden an alle Unterseiten
+      vererbt.
+    permissions:
+      title: Berechtigung
+      read: Lesen
+      write: Lesen und schreiben
+      moderate: Moderation
+      admin: Seitenadmin
+      unknown: Unbekanntes Berechtigungsschema
+      unknown-description: Dieses Berechtigungsschema ist nicht bekannt.
+      video-read-description_one: Kann das Video anschauen und Metadaten sehen.
+      video-read-description_other: Können das Video anschauen und Metadaten sehen.
+      video-write-description_one: >
+        Kann außerdem das Video editieren, löschen und Metadaten sowie andere Videodetails verändern.
+      video-write-description_other: >
+        Können außerdem das Video editieren, löschen und Metadaten sowie andere Videodetails verändern.
+      series-read-description: Nutzbar als Vorlage für Videos dieser Serie.
+      series-write-description_one: >
+        Kann Serie löschen, Metadaten ändern und Videos zur Serie hinzufügen oder entfernen.
+      series-write-description_other: >
+        Können Serie löschen, Metadaten ändern und Videos zur Serie hinzufügen oder entfernen.
+      realm-moderate-description_one: >
+        Kann Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
+        der Unterseiten bearbeiten.
+      realm-moderate-description_other: >
+        Können Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
+        der Unterseiten bearbeiten.
+      realm-admin-description_one: >
+        Kann moderieren, Seiten löschen und Berechtigungen bearbeiten.
+      realm-admin-description_other: >
+        Können moderieren, Seiten löschen und Berechtigungen bearbeiten.
+      write-access: Schreibzugriff
+      moderate-access: Moderationsrechte
+      admin-access: Adminrechte
+      large-group-warning: Sie geben einer großen Gruppe {{val}}. Ist das beabsichtigt?
+  unlisted:
+      note: Dieses Video ist ungelistet.
+      explanation: >
+        Ein ungelistetes Video ist nur über seinen direkten Link oder seine Serie aufrufbar.
+  reset-modal:
+    label: Zurücksetzen
+    title: Änderungen zurücksetzen?
+    body: Von Ihnen getätigte Änderungen werden zurückgesetzt.
+  save-modal:
+    title: Eigenen Zugriff entfernen?
+    disclaimer-write: Die aktuelle Auswahl wird Ihren Schreibzugriff entfernen.
+      Ohne diesen werden Sie keine weiteren Änderungen vornehmen können.
+    disclaimer-admin: Die aktuelle Auswahl wird ihre Verwaltungsrechte entfernen.
+      Ohne diese werden Sie keine weiteren Änderungen an diesen Berechtigungen und dem Seitenpfad
+      vornehmen können, und die Seite kann von Ihnen nicht mehr gelöscht werden.
+    confirm: Bestätigen
 
 manage:
-  access:
-    authorized-groups: Autorisierte Gruppen
-    authorized-users: Autorisierte Personen
-    editing-disabled: Bearbeitung der Zugangsberechtigungen ist deaktiviert.
-    workflow-active: >
-      Änderung der Berechtigungen ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
-      <br />
-      Bitte versuchen Sie es später nochmal.
-    locked-to-series: >
-      Die Berechtigungen dieses Videos werden durch seine <1>Serie</1> bestimmt und können daher nicht bearbeitet werden.
-    users-no-options:
-      initial-searchable: Nach Name suchen oder exakten Nutzernamen/exakte E-Mail angeben
-      none-found-searchable: Keine Personen gefunden
-      initial-not-searchable: Geben Sie Nutzernamen oder E-Mail an, um Personen hinzuzufügen
-      none-found-not-searchable: Keine Person mit diesem Nutzernamen bzw. dieser E-Mail gefunden
-    select:
-      groups: Gruppen hinzufügen
-      users: Personen hinzufügen
-      create: '{{item}} erstellen'
-    table:
-      group: Gruppe
-      user: Person
-      yourself: Sie
-      subset-warning: 'Diese Auswahl ist bereits in den folgenden Gruppen enthalten: {{groups}}.'
-      inherited: 'Geerbte Berechtigungen:'
-      inherited-tooltip: >
-        Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden an alle Unterseiten
-        vererbt.
-      actions:
-        title: Berechtigung
-        read: Lesen
-        write: Lesen und schreiben
-        moderate: Moderation
-        unknown: Unbekanntes Berechtigungsschema
-        admin: Seitenadmin
-        unknown-description: Dieses Berechtigungsschema ist nicht bekannt.
-        video-read-description_one: Kann das Video anschauen und Metadaten sehen.
-        video-read-description_other: Können das Video anschauen und Metadaten sehen.
-        video-write-description_one: >
-          Kann außerdem das Video editieren, löschen und Metadaten sowie andere Videodetails verändern.
-        video-write-description_other: >
-          Können außerdem das Video editieren, löschen und Metadaten sowie andere Videodetails verändern.
-        series-read-description: Nutzbar als Vorlage für Videos dieser Serie.
-        series-write-description_one: >
-          Kann Serie löschen, Metadaten ändern und Videos zur Serie hinzufügen oder entfernen.
-        series-write-description_other: >
-          Können Serie löschen, Metadaten ändern und Videos zur Serie hinzufügen oder entfernen.
-        realm-moderate-description_one: >
-          Kann Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
-          der Unterseiten bearbeiten.
-        realm-moderate-description_other: >
-          Können Unterseiten hinzufügen, Inhalte und den Namen der Seite sowie die Reihenfolge
-          der Unterseiten bearbeiten.
-        realm-admin-description_one: >
-          Kann moderieren, Seiten löschen und Berechtigungen bearbeiten.
-        realm-admin-description_other: >
-          Können moderieren, Seiten löschen und Berechtigungen bearbeiten.
-        write-access: Schreibzugriff
-        moderate-access: Moderationsrechte
-        admin-access: Adminrechte
-        large-group-warning: Sie geben einer großen Gruppe {{val}}. Ist das beabsichtigt?
-    unlisted:
-        note: Dieses Video ist ungelistet.
-        explanation: >
-          Ein ungelistetes Video ist nur über seinen direkten Link oder seine Serie aufrufbar.
-    reset-modal:
-      label: Zurücksetzen
-      title: Änderungen zurücksetzen?
-      body: Von Ihnen getätigte Änderungen werden zurückgesetzt.
-    save-modal:
-      title: Eigenen Zugriff entfernen?
-      disclaimer-write: Die aktuelle Auswahl wird Ihren Schreibzugriff entfernen.
-        Ohne diesen werden Sie keine weiteren Änderungen vornehmen können.
-      disclaimer-admin: Die aktuelle Auswahl wird ihre Verwaltungsrechte entfernen.
-        Ohne diese werden Sie keine weiteren Änderungen an diesen Berechtigungen und dem Seitenpfad
-        vornehmen können, und die Seite kann von Ihnen nicht mehr gelöscht werden.
-      confirm: Bestätigen
-
   dashboard:
     title: Dashboard
-    upload-tile: Hier können Sie Videos von Ihrem Computer hochladen.
-    studio-tile-title: Video aufnehmen
-    studio-tile-body: >
-      Erstellen Sie Videos, indem Sie Ihren Bildschirm, Ihre Webcam
-      und Ihr Mikrofonsignal aufzeichnen.
-    my-videos-tile: Hier finden Sie Ihre Videos und können diese verwalten und bearbeiten.
-    user-realm-tile: >
-      Auf Ihren persönlichen Seiten können Sie Videos, Text und andere Elemente anordnen.
-    manage-pages-tile-title: Seiten verwalten
-    manage-pages-tile-body: >
+    studio-title: Video aufnehmen
+    manage-pages-title: Seiten verwalten
+    manage-pages-body: >
       Um Seiten zu bearbeiten, umzubenennen und zu löschen, navigieren Sie zu der gewünschten
       Seite. Solange Sie angemeldet sind und die benötigten Rechte haben, gibt es dort entsprechende
       Seitenverwaltungs-Buttons in der Seitenleiste bzw. im Menu.
 
-  item-table:
+  video:
+    table: Meine Videos
+    details:
+      delete: Video löschen
+      confirm-delete: Video löschen?
+      open-in-editor: Im Videoeditor öffnen
+      referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'
+      no-referencing-pages: Dieses Video wird von keiner Seite referenziert.
+    technical-details:
+      title: Technische Details
+      tracks: Video-/Audiospuren
+      video: $t(video.singular)
+      audio: Audio
+      unknown-mimetype: Unbekannter MIME-Type
+      opencast-id: Opencast-ID
+      copy-oc-id-to-clipboard: Opencast-ID in Zwischenablage kopieren
+      further-info: Weitere Informationen
+      synced: Synchronisiert?
+      part-of: 'Teil von:'
+      is-live: Live?
+
+  series:
+    created-note: Serie wurde erstellt.
+    table:
+      title: Meine Serien
+      create: Serie erstellen
+    details:
+      title: Seriendetails
+      delete: Serie löschen
+      confirm-delete: Serie löschen?
+      referencing-pages-explanation: 'Diese Serie wird von den folgenden Seiten referenziert:'
+      no-referencing-pages: Diese Serie wird von keiner Seite referenziert.
+      delete-note: >
+        In der Serie enthaltene Videos werden nicht gelöscht und können einer anderen Serie
+        zugeordnet werden.
+      edit-note: >
+        Sie können neue Videos als Teil dieser Serie hochladen und bestehende Videos, auf welche
+        Sie Schreibzugriff haben, hinzufügen oder entfernen.
+        Es können nur Videos hinzugefügt werden, die in keiner anderen Serie enthalten sind.
+        Hier entfernte Videos werden nicht gelöscht, sondern nur aus der Serie entfernt.
+
+  video-list:
+    no-content: Keine Videos
+    no-of-videos_one: '{{count}} Videos'
+    no-of-videos_other: '{{count}} Videos'
+    edit:
+      add-video: Video hinzufügen
+      to-be-added: wird hinzugefügt
+      remove: Entfernen
+      to-be-removed: wird entfernt
+      cannot-be-removed: "Nicht entfernbar: Fehlender Schreibzugriff"
+      undo: Rückgängig
+      save: Änderungen speichern
+      error: Es gab einen Fehler beim Speichern der Änderungen.
+
+  details:
+    referencing-pages: Referenzierende Seiten
+
+  metadata-form:
+    description: Beschreibung
+    required: Pflichtfeld
+    save: Metadaten speichern
+    errors:
+      field-required: Dieses Feld darf nicht leer sein.
+    event-workflow-active: >
+      Änderung der Metadaten ist zurzeit nicht möglich, da das Video im Hintergrund verarbeitet wird.
+      <br />
+      Bitte versuchen Sie es später nochmal.
+
+  table:
     page-showing-ids: '{{start}}–{{end}} von {{total}}'
     navigation:
       first: Erste Seite
@@ -457,31 +500,13 @@ manage:
       description: 'Sortieren nach {{title}}, {{direction}}'
       ascending: aufsteigend
       descending: absteigend
-      title: Titel
       created: Erstellt
       updated: Aktualisiert
-      series: Serie
-    no-series: Keine
     no-series-title: Fehlender Titel
     no-entries-found: Keine Einträge gefunden.
     missing-date: Unbekannt
-
-  shared:
-    created: Erstellt
     updated: Zuletzt verändert
-    item:
-      video: Video
-      series: Serie
-    details:
-      #share-direct-link: Via Direktlink teilen
-      #copy-direct-link-to-clipboard: Videolink in Zwischenablage kopieren
-      referencing-pages: Referenzierende Seiten
-    acl:
-      title: Zugriffsrechte
-    delete:
-      title: '{{item}} löschen'
-      confirm: '{{item}} löschen?'
-      cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
+    deletion:
       failed: Löschen fehlgeschlagen.
       failed-maybe: Löschen möglicherweise fehlgeschlagen.
       pending: Löschvorgang ausstehend.
@@ -494,64 +519,6 @@ manage:
           Der Löschvorgang dieses Eintrags in Opencast wurde angesetzt und es wird
           nach dessen Erfolg hier entfernt.
 
-  video-list:
-    content: Videos
-    no-content: Keine Videos
-    no-of-videos_one: '{{count}} Videos'
-    no-of-videos_other: '{{count}} Videos'
-    edit:
-      add-video: Video hinzufügen
-      upload: Video hochladen
-      to-be-added: wird hinzugefügt
-      remove: Entfernen
-      to-be-removed: wird entfernt
-      cannot-be-removed: "Nicht entfernbar: Fehlender Schreibzugriff"
-      undo: Rückgängig
-      save: Änderungen speichern
-    error: Es gab einen Fehler beim Speichern der Änderungen.
-
-  my-series:
-    title: Meine Serien
-    details:
-      title: Seriendetails
-      referencing-pages-explanation: 'Diese Serie wird von den folgenden Seiten referenziert:'
-      no-referencing-pages: Diese Serie wird von keiner Seite referenziert.
-      created-note: Serie wurde erstellt.
-      edit-note: >
-        Sie können neue Videos als Teil dieser Serie hochladen und bestehende Videos, auf welche
-        Sie Schreibzugriff haben, hinzufügen oder entfernen.
-        Es können nur Videos hinzugefügt werden, die in keiner anderen Serie enthalten sind.
-        Hier entfernte Videos werden nicht gelöscht, sondern nur aus der Serie entfernt.
-    delete-note: >
-      In der Serie enthaltene Videos werden nicht gelöscht und können einer anderen Serie
-      zugeordnet werden.
-    create:
-      title: Serie erstellen
-
-  my-videos:
-    title: Meine Videos
-    details:
-      title: Videodetails
-      #set-time: 'Starten bei: '
-      open-in-editor: Im Videoeditor öffnen
-      referencing-pages: Referenzierende Seiten
-      referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'
-      no-referencing-pages: Dieses Video wird von keiner Seite referenziert.
-    technical-details:
-      title: Technische Details
-      tracks: Video-/Audiospuren
-      video: Video
-      audio: Audio
-      unknown-mimetype: Unbekannter MIME-Type
-      opencast-id: Opencast-ID
-      copy-oc-id-to-clipboard: Opencast-ID in Zwischenablage kopieren
-      further-info: Weitere Informationen
-      synced: Synchronisiert?
-      part-of: 'Teil von:'
-      is-live: Live?
-
-  are-you-sure: Sind Sie sich sicher?
-
   realm:
     invalid-path: >
       Fehler: ungültiger Pfad zur Seite. Wurde die Seite gelöscht oder ihr Pfad geändert?
@@ -559,7 +526,7 @@ manage:
     heading-root: Einstellungen zur Startseite
     descendants-count: Diese Seite besitzt {{count}} direkte und indirekte Unterseiten.
     view-page: Zur Seite
-
+    permissions: Berechtigungen verwalten
     name-must-not-be-empty: Name darf nicht leer sein.
     path-must-not-be-empty: Pfadsegment darf nicht leer sein.
     path-too-short: Pfadsegment muss mindestens zwei Zeichen lang sein.
@@ -569,7 +536,6 @@ manage:
       Pfadsegment darf nicht folgende Zeichen enthalten: {{illegalChars}}
     reserved-char-in-path: >
       Pfadsegment darf nicht mit den folgenden Zeichen beginnen: {{reservedChars}}
-
     general:
       page-name: Seitenname
       name-directly: Direkt benennen
@@ -581,7 +547,6 @@ manage:
       no-name: Keinen Namen anzeigen
       no-blocks: Auf dieser Seite befinden sich keine verknüpfbaren Videos/Serien.
       rename-failed: Änderung des Namen fehlgeschlagen.
-
     children:
       heading: Reihenfolge Unterseiten
       sort-alphabetically-asc: Alphabetisch aufsteigend sortieren
@@ -590,10 +555,6 @@ manage:
       failed: Änderung fehlgeschlagen.
       move-up: Hoch schieben
       move-down: Runter schieben
-
-    permissions:
-      heading: Berechtigungen verwalten
-
     danger-zone:
       heading: Gefahrenbereich
       root-note: >
@@ -603,7 +564,7 @@ manage:
         heading: Pfad ändern
         button: Pfadsegment ändern
         failed: Änderung des Pfades fehlgeschlagen.
-        cannot-userrealm: Der Pfad Ihrer persönlichen Seite kann nicht geändert werden.
+        cannot-user-realm: Der Pfad Ihrer persönlichen Seite kann nicht geändert werden.
         warning: >
           Wichtig: Wenn Sie den Pfad ändern, invalidieren Sie damit alle bisherigen
           Links zu dieser Seite, zu allen direkten und indirekten Unterseiten, und
@@ -611,90 +572,35 @@ manage:
           dann nicht mehr. Das betrifft persönliche Browser-Lesezeichen wie auch
           bereits veröffentlichte Links.
       delete:
-        heading: Seite löschen
+        title: Seite löschen
         button: Diese Seite und <strong>{{numSubPages}}</strong> Unterseiten löschen
-        button-single: Seite löschen
-        cannot-be-undone: Diese Aktion kann <strong>nicht</strong> rückgängig gemacht werden!
         confirm-removal: Seite löschen?
-        failed: Löschung fehlgeschlagen.
+        failed: Löschen der Seite ist fehlgeschlagen.
         warning: >
           Wenn Sie diese Seite löschen, werden automatisch alle direkten und
           indirekten Unterseiten sowie alle Inhalte dieser Seiten
           mitgelöscht. Die Löschung kann nicht wieder rückgängig gemacht werden!
-
     content:
       heading: Seite „{{realm}}“ bearbeiten
       heading-root: Startseite bearbeiten
       view-page: Seite ansehen
-
       add: Hier einen neuen Block einfügen
       add-popup-title: Neu hinzufügen
-      add-title: Titel
+      add-title: $t(general.title)
       add-text: Text
-      add-series: Serie
-      add-video: Video
-      add-playlist: Playlist
-
+      add-series: $t(series.singular)
+      add-video: '$t(video.singular)'
+      add-playlist: $t(playlist.singular)
       move-down: Block nach unten verschieben
       move-up: Block nach oben verschieben
       edit: Block bearbeiten
       remove: Block entfernen
       confirm-removal: Block entfernen?
-
       cannot-remove-block: Block nicht entfernbar
       cannot-remove-name-source-block: >
         Entfernen nicht möglich, da diese Seite ihren Namen von diesem Block
         bezieht. Um den Block zu entfernen, müssen Sie zuerst den Seitennamen in
         den Seiteneinstellungen ändern.
-
-      title:
-        content: Titel
-
-      text:
-        content: Hier können Sie Ihren Text einfügen. Sie können auch Markdown verwenden.
-
-      series:
-        series:
-          heading: Serie
-          invalid: Bitte eine Serie auswählen
-          findable-series-note: >
-            Sie können hier nur Serien wählen, die gelistet sind oder auf die
-            Sie Schreibzugriff haben.
-        metadata:
-          heading: Metadaten
-
-      playlist:
-        playlist:
-          heading: Playlist
-          invalid: Bitte eine Playlist auswählen
-          findable-playlist-note: >
-            Sie können hier nur Playlisten wählen, die gelistet sind oder auf die
-            Sie Schreibzugriff haben.
-        metadata:
-          heading: Metadaten
-
-      event:
-        event:
-          heading: Video
-          invalid: Bitte ein Video auswählen
-          findable-events-note: >
-            Sie können hier nur Videos wählen, die gelistet sind oder auf die
-            Sie Schreibzugriff haben.
-          no-read-access-to-current: >
-            Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.
-
-      show-title: Titel anzeigen
-      show-link: Link zur Videoseite anzeigen
-      show-description: Beschreibung und Metadaten anzeigen
-      display-options: Anzeigeoptionen
-
-      cancel: Verwerfen
-      confirm-cancel: Änderungen verwerfen?
-      cancel-warning: Ihre Änderungen wurden noch nicht gespeichert!
-
-      removing-failed: Entfernen ist fehlgeschlagen.
-      moving-failed: Verschieben ist fehlgeschlagen.
-      saving-failed: Speichern Ihrer Änderungen ist fehlgeschlagen.
 
   add-child:
     heading: Seite hinzufügen
@@ -714,18 +620,47 @@ manage:
       Pfadsegmente dürfen weder Leerzeichen noch <code>{{illegalChars}}</code> enthalten und nicht
       mit <code>{{reservedChars}}</code> beginnen.
 
+  block:
+    text: Hier können Sie Ihren Text einfügen. Sie können auch Markdown verwenden.
+    series:
+      invalid: Bitte eine Serie auswählen
+      findable-series-note: >
+        Sie können hier nur Serien wählen, die gelistet sind oder auf die
+        Sie Schreibzugriff haben.
+    playlist:
+      invalid: Bitte eine Playlist auswählen
+      findable-playlist-note: >
+        Sie können hier nur Playlisten wählen, die gelistet sind oder auf die
+        Sie Schreibzugriff haben.
+    event:
+      invalid: Bitte ein Video auswählen
+      findable-events-note: >
+        Sie können hier nur Videos wählen, die gelistet sind oder auf die
+        Sie Schreibzugriff haben.
+      no-read-access-to-current: >
+        Sie haben keinen Lesezugriff zu dem derzeit verlinkten Video.
+    options:
+      show-title: Titel anzeigen
+      show-link: Link zur Videoseite anzeigen
+      show-description: Beschreibung und Metadaten anzeigen
+    metadata: Metadaten
+    cancel: Verwerfen
+    confirm-cancel: Änderungen verwerfen?
+    cancel-warning: Ihre Änderungen wurden noch nicht gespeichert!
+    removing-failed: Entfernen ist fehlgeschlagen.
+    moving-failed: Verschieben ist fehlgeschlagen.
+    saving-failed: Speichern Ihrer Änderungen ist fehlgeschlagen.
+
+embed:
+  not-supported: Diese Seite kann nicht eingebettet werden.
+
 
 # These errors map the `key` field of an API error response to a nice message.
 api-remote-errors:
   view:
     event: Sie sind nicht autorisiert, dieses Video zu sehen.
-    playlist: Sie sind nicht autorisiert, diese Playlist zu sehen.
-  upload:
-    not-logged-in: Sie müssen angemeldet sein, um Videos hochzuladen.
-    not-authorized: $t(upload.not-authorized)
   mutation:
     not-logged-in: Sie müssen eingeloggt sein, um diese Aktion auszuführen.
-    not-a-tobira-admin: Sie müssen Tobira Admin sein, um diese Aktion auszuführen.
   realm:
     path-is-reserved: Dieser Pfad ist reserviert und kann nicht für Seiten genutzt werden.
     path-collision: Eine Seite mit diesem Pfad existiert bereits.
@@ -747,6 +682,3 @@ api-remote-errors:
   series:
     not-found: "Aktion fehlgeschlagen: Serie nicht gefunden."
     not-allowed: Sie haben nicht die Berechtigung, diese Serienaktion durchzuführen.
-
-embed:
-  not-supported: Diese Seite kann nicht eingebettet werden.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -8,14 +8,16 @@ general:
   home: Home
   homepage: Homepage
   page: Page
+  password: Password
   leave-page-confirmation: Leave page? Changes you made may not be saved!
   action:
     close: Close
     cancel: Cancel
     save: Save
     back: Back
-    goto-homepage: Go to homepage
     share: Share
+    are-you-sure: Are you sure?
+    cannot-be-undone: This action <strong>cannot</strong> be undone!
   version-information: Version
   logo-alt: Homepage of “{{title}}”
   no-root-children: No pages yet
@@ -31,6 +33,8 @@ general:
   seconds: seconds
   minutes: minutes
   hours: hours
+  none: None
+  title: Title
 
 welcome:
   title: Welcome to Tobira!
@@ -91,16 +95,13 @@ invalid-url:
     responsible for publishing that link.
 
 about-tobira:
-  title: About “Tobira”
+  title: About Tobira
   body: >
     This video portal is powered by Tobira, a video portal software for
     Opencast. It allows its users to browse, watch and organize all videos
     and series of the connected Opencast instance. Tobira, like Opencast, is
     free open source software. For more information and to report bugs, please
     visit <1>its GitHub repository</1>.
-
-footer:
-  about-tobira: About Tobira
 
 main-menu:
   label: Menu
@@ -114,28 +115,27 @@ user:
   login: Login
   logout: Log out
   settings: User settings
-  manage-content: Manage
+  manage: Manage
 
 login-page:
-  heading: Login
+  heading: $t(user.login)
   user-id: User ID
-  password: Password
   bad-credentials: 'Login failed: invalid credentials.'
   unexpected-response: '$t(errors.unexpected-response) $t(errors.not-your-fault)'
   already-logged-in: You are already logged in.
 
 video:
-  video: Video
+  singular: Video
+  plural: Videos
   video-page: 'Video page: “{{video}}”'
   video-player: Video player
   duration: Duration
-  link: Video details
+  details: Video details
   part-of-series: Part of series
   more-from-series: More from “{{series}}”
   more-from-playlist: More from “{{playlist}}”
-  deleted-video-block: The video referenced here was deleted.
-  not-allowed-video-block: You are not allowed to view the video embedded here.
-  preview: Preview
+  deleted-block: The video referenced here was deleted.
+  not-allowed-block: You are not allowed to view the video embedded here.
   preview-only: You need additional permissions to watch this video.
   not-ready:
     title: Video not processed yet
@@ -165,7 +165,6 @@ video:
     slides: Video (presentation)
     info: >
       Here you can download the video(s) in different formats/qualities (Right click - Save as).
-  manage: Manage
   extra-buttons: Additional video actions
   start: Start
   end: End
@@ -179,13 +178,29 @@ video:
       please note that these are not your login credentials.
     label:
       id: Identifier
-      password: Password
       submit: Verify
     invalid-credentials: Invalid credentials.
 
+series:
+  singular: Series
+  plural: Series
+  series-page: 'Series page: “{{series}}”'
+  deleted-block: The series referenced here was deleted.
+  entry-of-series-thumbnail: "Thumbnail for entry of “{{series}}”"
+  not-ready:
+    title: Series not synchronized yet
+    text: >
+      The data of the requested series has not been fully transferred yet. This should
+      happen automatically soon. Try again in a few minutes.
+    label: not synchronized
+
+playlist:
+  singular: Playlist
+  deleted-block: The playlist referenced here was deleted.
+  not-allowed: You are not authorized to view this playlist.
+  not-allowed-block: You are not authorized to view the playlist embedded here.
+
 share:
-  share-video: Share video
-  direct-link: Direct link
   share-direct-link: Share via direct link
   link: Link
   embed: Embed
@@ -198,37 +213,15 @@ share:
   set-time: 'Start at: '
   set-time-label: 'Set video start time. Current time: {{time}}.'
   set-time-unit: Set {{unit}}
-  no-time: None
 
-playlist:
-  deleted-playlist-block: The playlist referenced here was deleted.
-  not-allowed-playlist-block: You are not allowed to view the playlist embedded here.
-
-series:
-  series: Series
-  series-page: 'Series page: “{{series}}”'
-  deleted: Deleted series
-  deleted-series-block: The series referenced here was deleted.
-  entry-of-series-thumbnail: "Thumbnail for entry of “{{series}}”"
-  not-ready:
-    title: Series not synchronized yet
-    text: >
-      The data of the requested series has not been fully transferred yet. This should
-      happen automatically soon. Try again in a few minutes.
-    label: not synchronized
-
-videolist-block:
+video-list-block:
   upcoming-live-streams: "Upcoming live streams ({{count}})"
-  missing-video: Video not found
-  no-videos: No videos
   unauthorized: Missing permissions
   hidden-items:
     unauthorized_one: One video requires additional permissions to view.
     unauthorized_other: '{{count}} videos require additional permissions to view.'
     missing_one: One video is missing.
     missing_other: '{{count}} videos are missing.'
-  videos:
-    heading: Videos
   settings:
     order: Order
     order-label: Choose video order
@@ -258,8 +251,8 @@ realm:
       This is a personal user page which is managed by {{user}}.
       They are responsible for all contents.
     create:
+      title: Create your own page
       currently-none: You don't currently have a personal page.
-      heading: Create your own page
       what-you-can-do: >
         On your personal page, you can freely arrange videos, text, and other elements.
         This allows you to better present and share your content.
@@ -269,8 +262,6 @@ realm:
         Anyone who has this link or knows your username can visit your page.
         However, it will not appear anywhere in main navigation of this video portal.
         You can always delete your page later, should you change your mind.
-      button: Create your own page
-
 
 search:
   input-label: Search
@@ -280,13 +271,13 @@ search:
   too-few-characters: Please type more characters to start the search.
   unavailable: The search is currently unavailable. Try again later.
   clear: Clear search input
-  filter:
-    all: All
-    event: Videos
-    realm: Pages
-    series: Series
   select-time-frame: Select time frame
   clear-time-frame: Clear time frame
+  filter:
+    all: All
+    event: '$t(video.plural)'
+    realm: Pages
+    series: '$t(series.plural)'
 
 upload:
   title: Upload video
@@ -321,111 +312,160 @@ upload:
       Other series are therefore not listed as selectable here.
   errors:
     failed-to-upload: Failed to upload video.
-    unknown: Unknown error occurred during video upload.
     opencast-server-error: Opencast server error (unexpected response).
     opencast-unreachable: 'Network error: Opencast cannot be reached.'
     jwt-invalid: 'Internal cross-authentication error: Opencast did not authorize the upload.'
     failed-fetching-series-acl: Failed to fetch series acl.
 
-metadata-form:
-  title: Title
-  description: Description
-  required: required
-  save: Save metadata
-  errors:
-    field-required: This field is required (cannot be empty).
-  event-workflow-active: >
-      Changing the metadata is not possible at this time, since the video is being processed in the background.
-      <br />
-      Please try again later.
-
 acl:
-  unknown-user-note: unknown
-  no-entries: No entries
-  admin-user: Admin
+  title: Access policy
+  authorized-groups: Authorized groups
+  authorized-users: Authorized users
+  editing-disabled: Access policy editing is disabled.
+  workflow-active: >
+    Changing the access policy is not possible at this time, since the video is being processed in the background.
+    <br />
+    Please try again later.
+  locked-to-series: The access policy of this video is determined by its <1>series</1> and can't be edited.
+  users-no-options:
+    initial-searchable: Type to search for users by name (or enter exact email/username)
+    none-found-searchable: No user found
+    initial-not-searchable: Enter username or email of the person you want to add
+    none-found-not-searchable: No user with that username/email found
+  select:
+    groups: Add groups
+    users: Add users
+    create: 'Create {{item}}'
   groups:
     admins: Administrators
     everyone: Everyone
     logged-in-users: Logged in users
     global-page-admins: Global page admins
+  table:
+    group: Group
+    user: User
+    yourself: You
+    admin-user: Admin
+    unknown-user-note: unknown
+    no-entries: No entries
+    subset-warning: 'This selection is already included in the following group(s): {{groups}}.'
+    inherited: 'Inherited permissions:'
+    inherited-tooltip: >
+      The following permissions were granted in a higher level page and are inherited to all subpages.
+    permissions:
+      title: Actions
+      read: Read
+      write: Read and write
+      moderate: Moderator
+      admin: Page admin
+      unknown: Unknown permission
+      unknown-description: This permission isn't known.
+      video-read-description: Can watch the video and view metadata.
+      video-write-description: Can also edit and delete the video, metadata and other details.
+      series-read-description: Usable as template for videos in this series.
+      series-write-description: Can delete the series, change metadata and add or remove videos.
+      realm-moderate-description: Can edit content, add subpages and change the name and subpage order.
+      realm-admin-description: Can moderate, delete pages and edit permissions.
+      write-access: write-access
+      moderate-access: moderating-rights
+      admin-access: page admin-rights
+      large-group-warning: You are giving {{val}} to a large group. Is this intentional?
+  unlisted:
+    note: This video is unlisted.
+    explanation: >
+      An unlisted video can only be found by sharing its direct link or via its series.
+  reset-modal:
+    label: Reset
+    title: Reset changes?
+    body: The changes you have made will be reset.
+  save-modal:
+    title: Remove own access?
+    disclaimer-write: The current selection will remove your write-access.
+      Without this, you will lose the ability to make any further edits.
+    disclaimer-admin: The current selection will remove your page admin-rights.
+      Without these, you can no longer edit these permissions, change the realm path, or delete the page.
+    confirm: Confirm
 
 manage:
-  access:
-    authorized-groups: Authorized groups
-    authorized-users: Authorized users
-    editing-disabled: Access policy editing is disabled.
-    workflow-active: >
-      Changing the access policy is not possible at this time, since the video is being processed in the background.
-      <br />
-      Please try again later.
-    locked-to-series: >
-      The access policy of this video is determined by its <1>series</1> and can't be edited.
-    users-no-options:
-      initial-searchable: Type to search for users by name (or enter exact email/username)
-      none-found-searchable: No user found
-      initial-not-searchable: Enter username or email of the person you want to add
-      none-found-not-searchable: No user with that username/email found
-    select:
-      groups: Add groups
-      users: Add users
-      create: 'Create {{item}}'
-    table:
-      group: Group
-      user: User
-      yourself: You
-      subset-warning: 'This selection is already included in the following group(s): {{groups}}.'
-      inherited: 'Inherited permissions:'
-      inherited-tooltip: >
-        The following permissions were granted in a higher level page and are inherited to all subpages.
-      actions:
-        title: Actions
-        read: Read
-        write: Read and write
-        moderate: Moderator
-        admin: Page admin
-        unknown: Unknown permission
-        unknown-description: This permission isn't known.
-        video-read-description: Can watch the video and view metadata.
-        video-write-description: Can also edit and delete the video, metadata and other details.
-        series-read-description: Usable as template for videos in this series.
-        series-write-description: Can delete the series, change metadata and add or remove videos.
-        realm-moderate-description: Can edit content, add subpages and change the name and subpage order.
-        realm-admin-description: Can moderate, delete pages and edit permissions.
-        write-access: write-access
-        moderate-access: moderating-rights
-        admin-access: page admin-rights
-        large-group-warning: You are giving {{val}} to a large group. Is this intentional?
-    unlisted:
-      note: This video is unlisted.
-      explanation: >
-        An unlisted video can only be found by sharing its direct link or via its series.
-    reset-modal:
-      label: Reset
-      title: Reset changes?
-      body: The changes you have made will be reset.
-    save-modal:
-      title: Remove own access?
-      disclaimer-write: The current selection will remove your write-access.
-        Without this, you will lose the ability to make any further edits.
-      disclaimer-admin: The current selection will remove your page admin-rights.
-        Without these, you can no longer edit these permissions, change the realm path, or delete the page.
-      confirm: Confirm
-
   dashboard:
     title: Dashboard
-    upload-tile: Here you can upload a new video from your computer.
-    studio-tile-title: Record video
-    studio-tile-body: >
-      Create videos by recording your screen, webcam and microphone.
-    my-videos-tile: Here you can view and edit your videos.
-    user-realm-tile: >
-      On your personal pages, you can arrange videos, text, and other elements.
-    manage-pages-tile-title: Manage pages
-    manage-pages-tile-body: >
+    studio-title: Record video
+    manage-pages-title: Manage pages
+    manage-pages-body: >
       To rename, modify, and delete pages, navigate to the page in question. If you
       are logged in and have the necessary permissions, page management buttons will appear.
 
-  item-table:
+  video:
+    table: My videos
+    details:
+      delete: Delete video
+      confirm-delete: Delete video?
+      open-in-editor: Open in video editor
+      referencing-pages-explanation: 'This video is referenced on the following pages:'
+      no-referencing-pages: No pages reference this video.
+    technical-details:
+      title: Technical details
+      tracks: Video/audio tracks
+      video: $t(video.singular)
+      audio: Audio
+      unknown-mimetype: Unknown MIME type
+      opencast-id: Opencast ID
+      copy-oc-id-to-clipboard: Copy Opencast-ID to clipboard
+      further-info: Further information
+      synced: Synchronized?
+      part-of: 'Part of:'
+      is-live: Live?
+
+  series:
+    created-note: Series has been created.
+    table:
+      title: My series
+      create: Create series
+    details:
+      title: Series details
+      delete: Delete series
+      confirm-delete: Delete series?
+      referencing-pages-explanation: 'This series is referenced on the following pages:'
+      no-referencing-pages: No pages reference this series.
+      delete-note: >
+        Videos in this series will not be deleted.
+        They will remain in the system and can be added to another series.
+      edit-note: >
+        You can upload new videos as part of this series and add or remove existing videos that you
+        have write access for.
+        You may only add videos that are not part of any other series.
+        Removing a video from this list does not delete the video itself but just removes it from
+        this series.
+
+  video-list:
+    no-content: No videos
+    no-of-videos_one: '{{count}} video'
+    no-of-videos_other: '{{count}} videos'
+    edit:
+      add-video: Add video
+      to-be-added: will be added
+      remove: Remove
+      to-be-removed: will be removed
+      cannot-be-removed: "Can't be removed: Missing write access"
+      undo: Undo
+      save: Save changes
+      error: Failed to update series content.
+
+  details:
+    referencing-pages: Referencing pages
+
+  metadata-form:
+    description: Description
+    required: required
+    save: Save metadata
+    errors:
+      field-required: This field is required (cannot be empty).
+    event-workflow-active: >
+      Changing the metadata is not possible at this time, since the video is being processed in the background.
+      <br />
+      Please try again later.
+
+  table:
     page-showing-ids: '{{start}}–{{end}} of {{total}}'
     navigation:
       first: First page
@@ -436,118 +476,37 @@ manage:
       description: 'Sort by {{title}}, {{direction}}'
       ascending: ascending
       descending: descending
-      title: Title
       created: Created
       updated: Updated
-      series: Series
-    no-series: None
     no-series-title: Missing title
     no-entries-found: No entries found.
     missing-date: Unknown
-
-  shared:
-    created: Created
     updated: Last updated
-    item:
-      video: video
-      series: series
-    details:
-      #share-direct-link: Share via direct link
-      #copy-direct-link-to-clipboard: Copy link to clipboard
-      referencing-pages: Referencing pages
-    acl:
-      title: Access policy
-    delete:
-      title: Delete {{item}}
-      confirm: Delete {{item}}?
-      cannot-be-undone: This action <strong>cannot</strong> be undone!
-      failed: Deleting the {{item}} failed.
-      failed-maybe: Deleting the {{item}} possibly failed.
-      in-progress: '“{{itemTitle}}” is being deleted.'
+    deletion:
+      failed: Deletion failed.
+      failed-maybe: Deletion possibly failed.
       pending: Deletion is pending.
+      in-progress: '“{{itemTitle}}” is being deleted.'
       tooltip:
         failed: >
           The deletion of this entry was requested {{time}} but still has not happened, so it might have failed.
         pending: >
           The deletion of this entry was requested in Opencast and it will be removed from this list upon success.
 
-  video-list:
-    content: Videos
-    no-content: No videos
-    no-of-videos_one: '{{count}} video'
-    no-of-videos_other: '{{count}} videos'
-    edit:
-      add-video: Add video
-      to-be-added: will be added
-      upload: Upload video
-      remove: Remove
-      to-be-removed: will be removed
-      cannot-be-removed: "Can't be removed: Missing write access"
-      undo: Undo
-      save: Save changes
-    error: Failed to update series content.
-
-  my-series:
-    title: My series
-    details:
-      title: Series details
-      referencing-pages-explanation: 'This series is referenced on the following pages:'
-      no-referencing-pages: No pages reference this series.
-      created-note: Series has been created.
-      edit-note: >
-        You can upload new videos as part of this series and add or remove existing videos that you
-        have write access for.
-        You may only add videos that are not part of any other series.
-        Removing a video from this list does not delete the video itself but just removes it from
-        this series.
-    delete-note: >
-      Videos in this series will not be deleted.
-      They will remain in the system and can be added to another series.
-    create:
-      title: Create series
-
-  my-videos:
-    title: My videos
-    details:
-      title: Video details
-      #set-time: 'Start at: '
-      open-in-editor: Open in video editor
-      referencing-pages: Referencing pages
-      referencing-pages-explanation: 'This video is referenced on the following pages:'
-      no-referencing-pages: No pages reference this video.
-    technical-details:
-      title: Technical details
-      tracks: Video/audio tracks
-      video: Video
-      audio: Audio
-      unknown-mimetype: Unknown MIME type
-      opencast-id: Opencast ID
-      copy-oc-id-to-clipboard: Copy Opencast-ID to clipboard
-      further-info: Further information
-      synced: Synchronized?
-      part-of: 'Part of:'
-      is-live: Live?
-
-  are-you-sure: Are you sure?
-
   realm:
-    invalid-path: >
-      Error: invalid path to page. Was the page deleted or its path changed?
+    invalid-path: 'Error: invalid path to page. Was the page deleted or its path changed?'
     heading: Settings of page “{{realm}}”
     heading-root: Homepage settings
     descendants-count: This page has {{count}} direct and indirect subpages.
     view-page: Go to page
-
+    permissions: Manage permissions
     name-must-not-be-empty: Name must not be empty.
     path-must-not-be-empty: Path segment must not be empty.
     path-too-short: Path segment must be at least two characters long.
     no-control-in-path: Path segments may not include control characters.
     no-space-in-path: Path segments may not include whitespace characters.
-    illegal-chars-in-path: >
-      Path segment may not include the following characters: {{illegalChars}}
-    reserved-char-in-path: >
-      Path segment may not start with the following characters: {{reservedChars}}
-
+    illegal-chars-in-path: 'Path segment may not include the following characters: {{illegalChars}}'
+    reserved-char-in-path: 'Path segment may not start with the following characters: {{reservedChars}}'
     general:
       page-name: Page name
       name-directly: Name directly
@@ -558,7 +517,6 @@ manage:
       no-name: Omit name
       no-blocks: There are no linkable video/series on this page.
       rename-failed: Failed to change the name.
-
     children:
       heading: Order of subpages
       sort-alphabetically-asc: Sort alphabetically ascending
@@ -567,10 +525,6 @@ manage:
       failed: Changing the order failed.
       move-up: Move up
       move-down: Move down
-
-    permissions:
-      heading: Manage permissions
-
     danger-zone:
       heading: Danger zone
       root-note: The homepage cannot be deleted or moved, nor can its path be changed.
@@ -578,94 +532,42 @@ manage:
         heading: Change path
         button: Change path segment
         failed: Changing the path failed.
-        cannot-userrealm: The path of your personal page cannot be changed.
+        cannot-user-realm: The path of your personal page cannot be changed.
         warning: >
           Important: Changing the path of this page invalidates all links to
           this page, to all direct or indirect subpages, and to all videos
           linked on any of those pages. Old links, e.g. in personal
           browser-bookmarks or published somewhere, won't work anymore.
       delete:
-        heading: Delete page
+        title: Delete page
         button: Delete this page and <strong>{{numSubPages}}</strong> subpages
-        button-single: Delete page
-        cannot-be-undone: This action <strong>cannot</strong> be undone!
         confirm-removal: Delete page?
         failed: Deleting the page failed.
         warning: >
           Deleting this page will also automatically delete all direct and
           indirect subpages, as well as all content of these pages. This
           cannot be undone!
-
     content:
       heading: Edit page “{{realm}}”
       heading-root: Edit homepage
       view-page: View page
-
       add: Insert a new block here
       add-popup-title: Add new
-      add-title: Title
+      add-title: $t(general.title)
       add-text: Text
-      add-series: Series
-      add-video: Video
-      add-playlist: Playlist
-
+      add-series: $t(series.singular)
+      add-video: '$t(video.singular)'
+      add-playlist: $t(playlist.singular)
       move-down: Move block down
       move-up: Move block up
       edit: Edit block
       remove: Remove block
       confirm-removal: Remove block?
-
       cannot-remove-block: Cannot remove block
       cannot-remove-name-source-block: >
         Removal not possible as the current page derives its name from this
         block. In order to remove this block, change the name of this page in
         the page settings.
-
-      title:
-        content: Title
-
-      text:
-        content: You can add your text content here. You can also use Markdown.
-
-      series:
-        series:
-          heading: Series
-          invalid: Please select a series
-          findable-series-note: >
-            You can only select series here which are listed or which you have write-access to.
-        metadata:
-          heading: Metadata
-
-      playlist:
-        playlist:
-          heading: Playlist
-          invalid: Please select a playlist
-          findable-playlist-note: >
-            You can only select playlists here which are listed or which you have write-access to.
-        metadata:
-          heading: Metadata
-
-      event:
-        event:
-          heading: Event
-          invalid: Please select an event
-          findable-events-note: >
-            You can only select videos here which are listed or which you have write-access to.
-          no-read-access-to-current: >
-            You do not have read access to the video that is currently referenced here.
-
-      show-title: Show title
-      show-link: Show link to video page
-      show-description: Show description and metadata
-      display-options: Display options
-
-      cancel: Discard
-      confirm-cancel: Discard changes?
-      cancel-warning: Your changes have not yet been saved!
-
-      removing-failed: Removing failed.
-      moving-failed: Moving failed.
-      saving-failed: Saving your changes failed.
 
   add-child:
     heading: Add page
@@ -685,23 +587,49 @@ manage:
       Path segments must not contain whitespace nor <code>{{illegalChars}}</code>
       and they must not start with <code>{{reservedChars}}</code>.
 
+  block:
+    text: You can add your text content here. You can also use Markdown.
+    series:
+      invalid: Please select a series
+      findable-series-note: >
+        You can only select series here which are listed or which you have write-access to.
+    playlist:
+      invalid: Please select a playlist
+      findable-playlist-note: >
+        You can only select playlists here which are listed or which you have write-access to.
+    event:
+      invalid: Please select a video
+      findable-events-note: >
+        You can only select videos here which are listed or which you have write-access to.
+      no-read-access-to-current: >
+        You do not have read access to the video that is currently referenced here.
+    options:
+      show-title: Show title
+      show-link: Show link to video page
+      show-description: Show description and metadata
+    metadata: Metadata
+    cancel: Discard
+    confirm-cancel: Discard changes?
+    cancel-warning: Your changes have not yet been saved!
+    removing-failed: Removing failed.
+    moving-failed: Moving failed.
+    saving-failed: Saving your changes failed.
+
+embed:
+  not-supported: This page can't be embedded.
+
 
 # These errors map the `key` field of an API error response to a nice message.
 api-remote-errors:
   view:
     event: You are not authorized to view this video.
-    playlist: You are not authorized to view this playlist.
-  upload:
-    not-logged-in: You have to be logged in to upload videos.
-    not-authorized: $t(upload.not-authorized)
   mutation:
     not-logged-in: You have to be logged in to perform this action.
-    not-a-tobira-admin: You have to be a Tobira admin to perform this action.
   realm:
     path-is-reserved: The chosen path is reserved and cannot be used for pages.
     path-collision: A page with this path already exists.
     no-moderator-rights: You are not allowed to modify this page.
-    no-page-admin-rights: You are not allowed to carry out this action.
+    no-page-admin-rights: You are not allowed to perform this action.
     cannot-create-user-realm: You are not allowed to create your own page.
     user-realm-already-exists: Your own page already exists.
     username-not-valid-as-path: >
@@ -709,15 +637,12 @@ api-remote-errors:
       thus you cannot create your own page. Contact a system administrator for
       further assistance.
   event:
-    not-found: "Action failed: event not found."
-    not-allowed: You are not allowed to perform this event action.
+    not-found: "Action failed: Video not found."
+    not-allowed: You are not allowed to perform this video action.
     workflow:
       not-allowed: You are not allowed to inquire about workflow activity of this video.
-      active-acl: $t(manage.access.workflow-active)
+      active-acl: $t(manage.acl.workflow-active)
       active-metadata: $t(metadata-form.event-workflow-active)
   series:
     not-found: "Action failed: series not found."
     not-allowed: You are not allowed to perform this series action.
-
-embed:
-  not-supported: This page can't be embedded.

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -38,7 +38,7 @@ export const Footer: React.FC = () => {
                 {CONFIG.footerLinks.map((entry, i) => {
                     if (entry === "about") {
                         return <li key={i}>
-                            <Link to={AboutRoute.url}>{t("footer.about-tobira")}</Link>
+                            <Link to={AboutRoute.url}>{t("about-tobira.title")}</Link>
                         </li>;
                     } else if (entry === "graphiql") {
                         return <li key={i}>

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -210,7 +210,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
         {
             icon: <LuFolder />,
             wrapper: <Link to={ManageRoute.url} />,
-            children: t("user.manage-content"),
+            children: t("user.manage"),
             css: { minWidth: 200 },
         },
         ...user.canCreateUserRealm ? [{
@@ -222,7 +222,7 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
         {
             icon: <LuFilm />,
             wrapper: <Link to={ManageVideosRoute.url} />,
-            children: t("manage.my-videos.title"),
+            children: t("manage.video.table"),
             css: indent,
         },
         ...user.canUpload ? [{
@@ -242,19 +242,19 @@ const LoggedIn: React.FC<LoggedInProps> = ({ user }) => {
                 fallback="link"
             />,
             keepOpenAfterClick: true,
-            children: t("manage.dashboard.studio-tile-title"),
+            children: t("manage.dashboard.studio-title"),
             css: { ...indent, width: "100%" },
         }] : [],
         {
             icon: <SeriesIcon />,
             wrapper: <Link to={ManageSeriesRoute.url} />,
-            children: t("manage.my-series.title"),
+            children: t("manage.series.table.title"),
             css: indent,
         },
         ...user.canCreateSeries ? [{
             icon: <LuCirclePlus />,
             wrapper: <Link to={CreateSeriesRoute.url} />,
-            children: t("manage.my-series.create.title"),
+            children: t("manage.series.table.create"),
             css: indent,
         }] : [],
 

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -174,7 +174,7 @@ const LoginBox: React.FC = () => {
                     : t("login-page.user-id"),
                 password: CONFIG.auth.passwordLabel
                     ? translatedConfig(CONFIG.auth.passwordLabel, i18n)
-                    : t("login-page.password"),
+                    : t("general.password"),
                 submit: t("user.login"),
             }}
         >

--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -119,7 +119,7 @@ const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag, realmPath }) 
     }
 
     if (playlist.__typename === "NotAllowed") {
-        return <ErrorPage title={t("api-remote-errors.view.playlist")} />;
+        return <ErrorPage title={t("playlist.not-allowed")} />;
     }
     if (playlist.__typename !== "AuthorizedPlaylist") {
         return unreachable();
@@ -136,7 +136,7 @@ const PlaylistPage: React.FC<PlaylistPageProps> = ({ playlistFrag, realmPath }) 
         <p css={{ maxWidth: "90ch" }}>{playlist.description}</p>
         <div css={{ marginTop: 12 }}>
             <PlaylistBlockFromPlaylist
-                title={t("videolist-block.videos.heading")}
+                title={t("video.singular")}
                 realmPath={realmPath}
                 fragRef={playlist}
             />

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -226,7 +226,7 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
     };
 
     return <>
-        <Breadcrumbs path={[]} tail={<i>{t("realm.user-realm.create.heading")}</i>} />
+        <Breadcrumbs path={[]} tail={<i>{t("realm.user-realm.create.title")}</i>} />
         <div css={{
             width: "80ch",
             maxWidth: "100%",
@@ -248,13 +248,13 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
             <Card kind="info" css={{ marginBottom: 32 }}>
                 {t("realm.user-realm.create.currently-none")}
             </Card>
-            <h1>{t("realm.user-realm.create.heading")}</h1>
+            <h1>{t("realm.user-realm.create.title")}</h1>
             <p>{t("realm.user-realm.create.what-you-can-do")}</p>
             <p>{t("realm.user-realm.create.available-at")}</p>
             <code css={{ textAlign: "center" }}>{window.location.origin + realmPath}</code>
             <p>{t("realm.user-realm.create.find-and-delete")}</p>
             <Button kind="call-to-action"css={{ marginTop: 32 }} onClick={onSubmit}>
-                {t("realm.user-realm.create.button")}
+                {t("realm.user-realm.create.title")}
             </Button>
             {isInFlight && <div css={{ marginTop: 16 }}><Spinner size={20} /></div>}
             {boxError(error)}

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -277,7 +277,7 @@ const SeriesPage: React.FC<SeriesPageProps> = ({ seriesRef, realmRef, realmPath 
     // anything.
     const breadcrumbs = realm.isMainRoot ? [] : realmBreadcrumbs(t, realm.ancestors.concat(realm));
     const tail = series.title === realm.name
-        ? <i>{t("series.series")}</i>
+        ? <i>{t("series.singular")}</i>
         : series.title;
 
     return <div css={{ display: "flex", flexDirection: "column" }}>

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -120,7 +120,7 @@ const Upload: React.FC<Props> = ({ uploadQueryData, seriesUrlParamSet }) => {
             flexDirection: "column",
         }}>
             <Breadcrumbs
-                path={[{ label: t("user.manage-content"), link: ManageRoute.url }]}
+                path={[{ label: t("user.manage"), link: ManageRoute.url }]}
                 tail={t("upload.title")}
             />
             <PageTitle title={t("upload.title")} />
@@ -806,7 +806,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({
         },
         rules: {
             required: CONFIG.upload.requireSeries
-                ? t("metadata-form.errors.field-required")
+                ? t("manage.metadata-form.errors.field-required")
                 : false,
         },
     });
@@ -822,7 +822,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({
             {/* Series */}
             <InputContainer css={{ maxWidth: 750 }}>
                 <label htmlFor={seriesFieldId}>
-                    {t("series.series")}
+                    {t("series.singular")}
                     {CONFIG.upload.requireSeries && <FieldIsRequiredNote />}
                     <WithTooltip
                         tooltip={t("upload.metadata.note-writable-series")}
@@ -858,7 +858,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({
                     marginTop: 32,
                     marginBottom: 12,
                     fontSize: 22,
-                }}>{t("manage.shared.acl.title")}</h2>
+                }}>{t("acl.title")}</h2>
                 {boxError(aclError)}
                 {aclLoading && <Spinner size={20} />}
                 {lockToSeries && (
@@ -867,7 +867,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({
                         fontSize: 14,
                         marginBottom: 10,
                     }}>
-                        <Trans i18nKey="manage.access.locked-to-series">
+                        <Trans i18nKey="acl.locked-to-series">
                             <>series</>
                         </Trans>
                     </Card>

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -634,7 +634,7 @@ export const PreviewPlaceholder: React.FC<ProtectedPlayerProps> = ({
 export const CREDENTIALS_STORAGE_KEY = "tobira-video-credentials-";
 
 const ProtectedPlayer: React.FC<ProtectedPlayerProps> = ({ event, embedded, refetch }) => {
-    const { t } = useTranslation(undefined, { keyPrefix: "video.password" });
+    const { t } = useTranslation();
     const isDark = useColorScheme().scheme === "dark";
     const user = useUser();
     const [authState, setAuthState] = useState<AuthenticationFormState>("idle");
@@ -733,11 +733,11 @@ const ProtectedPlayer: React.FC<ProtectedPlayerProps> = ({ event, embedded, refe
                 setAuthState("idle");
             },
             eventAuthError: () => {
-                setAuthError(t("no-preview-permission"));
+                setAuthError(t("video.password.no-preview-permission"));
                 setAuthState("idle");
             },
             incorrectCredentials: () => {
-                setAuthError(t("invalid-credentials"));
+                setAuthError(t("video.password.invalid-credentials"));
                 setAuthState("idle");
             },
         });
@@ -760,7 +760,7 @@ const ProtectedPlayer: React.FC<ProtectedPlayerProps> = ({ event, embedded, refe
                 [screenWidthAbove(BREAKPOINT_MEDIUM)]: {
                     textAlign: "left",
                 },
-            }}>{t("heading")}</h2>
+            }}>{t("video.password.heading")}</h2>
             <div css={{
                 display: "flex",
                 [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
@@ -778,9 +778,9 @@ const ProtectedPlayer: React.FC<ProtectedPlayerProps> = ({ event, embedded, refe
                         error={null}
                         SubmitIcon={LuLockOpen}
                         labels={{
-                            user: t("label.id"),
-                            password: t("label.password"),
-                            submit: t("label.submit"),
+                            user: t("video.password.label.id"),
+                            password: t("general.password"),
+                            submit: t("video.password.label.submit"),
                         }}
                         css={{
                             "&": { backgroundColor: "transparent" },
@@ -894,7 +894,7 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
                         ...shrinkOnMobile,
                     }}>
                         <LuSettings size={16} />
-                        {t("video.manage")}
+                        {t("user.manage")}
                     </LinkButton>
                 )}
                 {CONFIG.showDownloadButton && event.authorizedData && (
@@ -1132,7 +1132,7 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
             }
             {updatedFull && <>
                 <br/>
-                <i>{t("manage.shared.updated")}</i>: {updatedFull}
+                <i>{t("manage.table.updated")}</i>: {updatedFull}
             </>}
         </>;
 
@@ -1154,11 +1154,11 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
         tooltip = <>
             {startedDate
                 ? <><i>{t("video.started")}</i>: {startFull}</>
-                : <><i>{t("manage.shared.created")}</i>: {createdFull}</>
+                : <><i>{t("manage.table.columns.created")}</i>: {createdFull}</>
             }
             {updatedFull && <>
                 <br/>
-                <i>{t("manage.shared.updated")}</i>: {updatedFull}
+                <i>{t("manage.table.updated")}</i>: {updatedFull}
             </>}
         </>;
 

--- a/frontend/src/routes/manage/Realm/Content/Block.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Block.tsx
@@ -60,7 +60,7 @@ export const EditBlock: React.FC<Props> = ({
         onCompleted?.();
     };
 
-    type ActionErrorKeys = `manage.realm.content.${"moving" | "saving"}-failed`;
+    type ActionErrorKeys = `manage.block.${"moving" | "saving"}-failed`;
     const onBlockError = (error: Error, action: ActionErrorKeys) => {
         setError(displayCommitError(error, t(action)));
         onError?.(error, action, index);
@@ -121,7 +121,7 @@ export const EditBlock: React.FC<Props> = ({
                         setError(null);
                     }}
                     onSave={onBlockCommit}
-                    onError={error => onBlockError(error, "manage.realm.content.saving-failed")}
+                    onError={error => onBlockError(error, "manage.block.saving-failed")}
                     onCompleted={() => {
                         onBlockCompleted();
                         commitLocalUpdate(relayEnv, store => {

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Playlist.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Playlist.tsx
@@ -84,16 +84,16 @@ export const EditPlaylistBlock: React.FC<EditPlaylistBlockProps> = ({ block: blo
 
     return <EditModeForm create={create} save={save} map={(data: PlaylistFormData) => data}>
         <Heading>
-            {t("manage.realm.content.playlist.playlist.heading")}
+            {t("playlist.singular")}
             {isRealUser(user) && !user.canFindUnlisted && <InfoTooltip
-                info={t("manage.realm.content.playlist.playlist.findable-playlist-note")}
+                info={t("manage.block.playlist.findable-playlist-note")}
             />}
         </Heading>
         {"playlist" in errors && <div css={{ margin: "8px 0" }}>
-            <Card kind="error">{t("manage.realm.content.playlist.playlist.invalid")}</Card>
+            <Card kind="error">{t("manage.block.playlist.invalid")}</Card>
         </div>}
         {playlist?.__typename === "NotAllowed" && <Card kind="error" css={{ margin: "8px 0" }}>
-            {t("playlist.not-allowed-playlist-block")}
+            {t("playlist.not-allowed-block")}
         </Card>}
         <VideoListSelector
             type="playlist"

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Series.tsx
@@ -82,13 +82,13 @@ export const EditSeriesBlock: React.FC<EditSeriesBlockProps> = ({ block: blockRe
 
     return <EditModeForm create={create} save={save} map={(data: SeriesFormData) => data}>
         <Heading>
-            {t("manage.realm.content.series.series.heading")}
+            {t("series.singular")}
             {isRealUser(user) && !user.canFindUnlisted && <InfoTooltip
-                info={t("manage.realm.content.series.series.findable-series-note")}
+                info={t("manage.block.series.findable-series-note")}
             />}
         </Heading>
         {"series" in errors && <div css={{ margin: "8px 0" }}>
-            <Card kind="error">{t("manage.realm.content.series.series.invalid")}</Card>
+            <Card kind="error">{t("manage.block.series.invalid")}</Card>
         </div>}
         <VideoListSelector
             type="series"

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
@@ -57,7 +57,7 @@ export const EditTextBlock: React.FC<EditTextBlockProps> = ({ block: blockRef })
 
     return <EditModeForm create={create} save={save} map={(data: TextFormData) => data}>
         <TextArea
-            placeholder={t("manage.realm.content.text.content")}
+            placeholder={t("manage.block.text")}
             defaultValue={content}
             css={{ display: "block" }}
             {...form.register("content")}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Title.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Title.tsx
@@ -57,7 +57,7 @@ export const EditTitleBlock: React.FC<EditTitleBlockProps> = ({ block: blockRef 
 
     return <EditModeForm create={create} save={save} map={(data: TitleFormData) => data}>
         <h3><Input
-            placeholder={t("manage.realm.content.title.content")}
+            placeholder={t("general.title")}
             defaultValue={content}
             css={{ display: "block", width: "100%" }}
             {...form.register("content")}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -85,16 +85,16 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
 
     return <EditModeForm create={create} save={save} map={(data: VideoFormData) => data}>
         <Heading>
-            {t("manage.realm.content.event.event.heading")}
+            {t("video.singular")}
             {isRealUser(user) && !user.canFindUnlisted && <InfoTooltip
-                info={t("manage.realm.content.event.event.findable-events-note")}
+                info={t("manage.block.event.findable-events-note")}
             />}
         </Heading>
         {"event" in errors && <div css={{ margin: "8px 0" }}>
-            <Card kind="error">{t("manage.realm.content.event.event.invalid")}</Card>
+            <Card kind="error">{t("manage.block.event.invalid")}</Card>
         </div>}
         {event?.__typename === "NotAllowed" && <Card kind="error" css={{ margin: "8px 0" }}>
-            {t("manage.realm.content.event.event.no-read-access-to-current")}
+            {t("manage.block.event.no-read-access-to-current")}
         </Card>}
         <Controller
             defaultValue={currentEvent?.id}
@@ -111,12 +111,12 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
         <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
             {
                 option: "showTitle",
-                title: t("manage.realm.content.show-title"),
+                title: t("manage.block.options.show-title"),
                 checked: showTitle,
             },
             {
                 option: "showLink",
-                title: t("manage.realm.content.show-link"),
+                title: t("manage.block.options.show-link"),
                 checked: showLink,
             },
         ]} />

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/index.tsx
@@ -154,12 +154,12 @@ export const EditModeForm = <FormData extends object, ApiData extends object>(
             </form>
         </FocusTrap>
         <ConfirmationModal
-            title={t("manage.realm.content.confirm-cancel")}
-            buttonContent={t("manage.realm.content.cancel")}
+            title={t("manage.block.confirm-cancel")}
+            buttonContent={t("manage.block.cancel")}
             onSubmit={onCancel}
             ref={modalRef}
         >
-            <p>{t("manage.realm.content.cancel-warning")}</p>
+            <p>{t("manage.block.cancel-warning")}</p>
         </ConfirmationModal>
     </FormProvider>;
 };
@@ -182,7 +182,7 @@ const EditModeButtons: React.FC<EditModeButtonsProps> = ({ onCancel }) => {
             kind="danger"
             onClick={onCancel}
         >
-            {t("manage.realm.content.cancel")}
+            {t("manage.block.cancel")}
         </Button>
         <Button kind="call-to-action" type="submit">
             {t("general.action.save")}

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/util.tsx
@@ -120,25 +120,25 @@ export function VideoListFormFields<TFieldValues extends FieldValues>({
     const optionProps = [
         {
             option: "order",
-            title: t("videolist-block.settings.new-to-old"),
+            title: t("video-list-block.settings.new-to-old"),
             checked: order === "NEW_TO_OLD",
             value: "NEW_TO_OLD",
         },
         {
             option: "order",
-            title: t("videolist-block.settings.old-to-new"),
+            title: t("video-list-block.settings.old-to-new"),
             checked: order === "OLD_TO_NEW",
             value: "OLD_TO_NEW",
         },
         {
             option: "order",
-            title: t("videolist-block.settings.a-z"),
+            title: t("video-list-block.settings.a-z"),
             checked: order === "AZ",
             value: "AZ",
         },
         {
             option: "order",
-            title: t("videolist-block.settings.z-a"),
+            title: t("video-list-block.settings.z-a"),
             checked: order === "ZA",
             value: "ZA",
         },
@@ -146,7 +146,7 @@ export function VideoListFormFields<TFieldValues extends FieldValues>({
     if (allowOriginalOrder) {
         optionProps.unshift({
             option: "order",
-            title: t("videolist-block.settings.original"),
+            title: t("video-list-block.settings.original"),
             checked: order === "ORIGINAL",
             value: "ORIGINAL",
         });
@@ -175,30 +175,30 @@ export function VideoListFormFields<TFieldValues extends FieldValues>({
                 role="group"
                 aria-labelledby={headingId + "-order"}
             >
-                <Heading id={headingId + "-order"}>{t("videolist-block.settings.order")}</Heading>
+                <Heading id={headingId + "-order"}>{t("video-list-block.settings.order")}</Heading>
                 <DisplayOptionGroup type="radio" {...{ form, optionProps }} />
             </div>
             <div
                 role="group"
                 aria-labelledby={headingId + "-view"}
             >
-                <Heading id={headingId + "-view"}>{t("videolist-block.settings.layout")}</Heading>
+                <Heading id={headingId + "-view"}>{t("video-list-block.settings.layout")}</Heading>
                 <DisplayOptionGroup type="radio" {...{ form }} optionProps={[
                     {
                         option: "layout",
-                        title: t("videolist-block.settings.slider"),
+                        title: t("video-list-block.settings.slider"),
                         checked: layout === "SLIDER",
                         value: "SLIDER",
                     },
                     {
                         option: "layout",
-                        title: t("videolist-block.settings.gallery"),
+                        title: t("video-list-block.settings.gallery"),
                         checked: layout === "GALLERY",
                         value: "GALLERY",
                     },
                     {
                         option: "layout",
-                        title: t("videolist-block.settings.list"),
+                        title: t("video-list-block.settings.list"),
                         checked: layout === "LIST",
                         value: "LIST",
                     },
@@ -209,17 +209,17 @@ export function VideoListFormFields<TFieldValues extends FieldValues>({
                 aria-labelledby={headingId + "-metadata"}
             >
                 <Heading id={headingId + "-metadata"}>
-                    {t("manage.realm.content.series.metadata.heading")}
+                    {t("manage.block.metadata")}
                 </Heading>
                 <DisplayOptionGroup type="checkbox" {...{ form }} optionProps={[
                     {
                         option: "showTitle",
-                        title: t("manage.realm.content.show-title"),
+                        title: t("manage.block.options.show-title"),
                         checked: showTitle,
                     },
                     {
                         option: "showMetadata",
-                        title: t("manage.realm.content.show-description"),
+                        title: t("manage.block.options.show-description"),
                         checked: showMetadata,
                     },
                 ]} />

--- a/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/RemoveButton.tsx
@@ -51,7 +51,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
             },
             onError: error => {
                 currentRef(modalRef).reportError(
-                    displayCommitError(error, t("manage.realm.content.removing-failed")),
+                    displayCommitError(error, t("manage.block.removing-failed")),
                 );
             },
         });
@@ -94,7 +94,7 @@ export const RemoveButton: React.FC<Props> = ({ block: blockRef, onConfirm, name
             ref={modalRef}
         >
             <p>
-                <Trans i18nKey="manage.realm.danger-zone.delete.cannot-be-undone" />
+                <Trans i18nKey="general.action.cannot-be-undone" />
             </p>
         </ConfirmationModal>
     </>;

--- a/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/index.tsx
@@ -17,7 +17,7 @@ type Props = {
     index: number;
     onCommit?: () => void;
     onCompleted?: () => void;
-    onError?: (error: Error, action: "manage.realm.content.moving-failed") => void;
+    onError?: (error: Error, action: "manage.block.moving-failed") => void;
     onEdit?: () => void;
 };
 
@@ -47,7 +47,7 @@ export const EditButtons: React.FC<Props> = ({
     const { blocks } = realm;
 
     const onMoveError = (error: Error) => {
-        onError?.(error, "manage.realm.content.moving-failed");
+        onError?.(error, "manage.block.moving-failed");
     };
 
     return <ButtonGroup>

--- a/frontend/src/routes/manage/Realm/DangerZone.tsx
+++ b/frontend/src/routes/manage/Realm/DangerZone.tsx
@@ -111,7 +111,7 @@ const ChangePath: React.FC<InnerProps> = ({ realm }) => {
         return <>
             <h3>{t("manage.realm.danger-zone.change-path.heading")}</h3>
             <p css={{ fontSize: 14 }}>
-                {t("manage.realm.danger-zone.change-path.cannot-userrealm")}
+                {t("manage.realm.danger-zone.change-path.cannot-user-realm")}
             </p>
         </>;
     }
@@ -204,7 +204,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
     };
 
     const buttonContent = realm.numberOfDescendants === 0
-        ? t("manage.realm.danger-zone.delete.button-single")
+        ? t("manage.realm.danger-zone.delete.title")
         : <span>
             <Trans i18nKey="manage.realm.danger-zone.delete.button">
                 {{ numSubPages: realm.numberOfDescendants }}
@@ -212,7 +212,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
         </span>;
 
     return <>
-        <h3>{t("manage.realm.danger-zone.delete.heading")}</h3>
+        <h3>{t("manage.realm.danger-zone.delete.title")}</h3>
         <p css={{ fontSize: 14 }}>
             {t("manage.realm.danger-zone.delete.warning")}
         </p>
@@ -230,7 +230,7 @@ const RemoveRealm: React.FC<InnerProps> = ({ realm }) => {
             ref={modalRef}
         >
             <p>
-                <Trans i18nKey="manage.realm.danger-zone.delete.cannot-be-undone" />
+                <Trans i18nKey="general.action.cannot-be-undone" />
             </p>
         </ConfirmationModal>
     </>;

--- a/frontend/src/routes/manage/Realm/General.tsx
+++ b/frontend/src/routes/manage/Realm/General.tsx
@@ -142,9 +142,9 @@ export const NameForm: React.FC<NameFormProps> = ({ realm }) => {
             // still pending, or are deleted.
             let label;
             if (block.event?.title != null) {
-                label = t("video.video") + ": " + block.event.title;
+                label = t("video.singular") + ": " + block.event.title;
             } else if (block.series?.title != null) {
-                label = t("series.series") + ": " + block.series.title;
+                label = t("series.singular") + ": " + block.series.title;
             } else {
                 return null;
             }

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -82,7 +82,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     };
 
     return <>
-        <h2>{t("manage.realm.permissions.heading")}</h2>
+        <h2>{t("manage.realm.permissions")}</h2>
         <AclSelector
             itemType="realm"
             acl={selections}

--- a/frontend/src/routes/manage/Series/Create.tsx
+++ b/frontend/src/routes/manage/Series/Create.tsx
@@ -117,7 +117,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
                 setSuccess(true);
                 setNotification({
                     kind: "info",
-                    message: () => t("manage.my-series.details.created-note"),
+                    message: () => t("manage.series.created-note"),
                     scope: returnPath,
                 });
                 router.goto(returnPath);
@@ -130,7 +130,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
     const onSubmit = handleSubmit(data => createSeries(data));
 
     return <>
-        <PageTitle title={t("manage.my-series.create.title")} />
+        <PageTitle title={t("manage.series.table.create")} />
         <Form
             noValidate
             onSubmit={e => e.preventDefault()}
@@ -153,7 +153,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
                     css={{ width: 400, maxWidth: "100%" }}
                     autoFocus
                     {...register("title", {
-                        required: t("metadata-form.errors.field-required") as string,
+                        required: t("manage.metadata-form.errors.field-required") as string,
                     })}
                 />
                 {boxError(errors.title?.message)}
@@ -161,7 +161,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
 
             {/* Description */}
             <InputContainer css={{ maxWidth: 750 }}>
-                <label htmlFor={descriptionFieldId}>{t("metadata-form.description")}</label>
+                <label htmlFor={descriptionFieldId}>{t("manage.metadata-form.description")}</label>
                 <TextArea id={descriptionFieldId} {...register("description")} />
             </InputContainer>
 
@@ -171,7 +171,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
                     marginTop: 32,
                     marginBottom: 12,
                     fontSize: 22,
-                }}>{t("manage.shared.acl.title")}</h2>
+                }}>{t("acl.title")}</h2>
                 <Controller
                     name="acl"
                     control={control}
@@ -188,7 +188,7 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
 
             {/* Submit button */}
             <SubmitButtonWithStatus
-                label={t("manage.my-series.create.title")}
+                label={t("manage.series.table.create")}
                 onClick={onSubmit}
                 disabled={!!commitError || inFlight || !isValid}
                 success={success && !isDirty}

--- a/frontend/src/routes/manage/Series/SeriesAccess.tsx
+++ b/frontend/src/routes/manage/Series/SeriesAccess.tsx
@@ -18,7 +18,7 @@ export const ManageSeriesAccessRoute = makeManageSeriesRoute(
     "/access",
     (series, data) => (
         <AclPage note={!isSynced(series) && <NotReadyNote kind="series" />} breadcrumbTails={[
-            { label: i18n.t("manage.my-series.title"), link: ManageSeriesRoute.url },
+            { label: i18n.t("manage.series.table.title"), link: ManageSeriesRoute.url },
             { label: series.title, link: ManageSeriesDetailsRoute.url({ seriesId: series.id }) },
         ]}>
             <SeriesAclEditor {...{ series, data }} />

--- a/frontend/src/routes/manage/Series/SeriesDetails.tsx
+++ b/frontend/src/routes/manage/Series/SeriesDetails.tsx
@@ -60,10 +60,10 @@ export const ManageSeriesDetailsRoute = makeManageSeriesRoute(
     "",
     series => <DetailsPage
         kind="series"
-        pageTitle="manage.my-series.details.title"
+        pageTitle="manage.series.details.title"
         item={series}
         breadcrumb={{
-            label: i18n.t("manage.my-series.title"),
+            label: i18n.t("manage.series.table.title"),
             link: ManageSeriesRoute.url,
         }}
         sections={series => [
@@ -78,7 +78,7 @@ export const ManageSeriesDetailsRoute = makeManageSeriesRoute(
             <div key="host-realms" css={{ marginBottom: 32 }}>
                 <HostRealms kind="series" hostRealms={series.hostRealms} itemLink={realmPath => (
                     <Link to={SeriesRoute.url({ realmPath: realmPath, seriesId: series.id })}>
-                        {i18n.t("series.series")}
+                        {i18n.t("series.singular")}
                     </Link>
                 )}/>
             </div>,
@@ -103,7 +103,7 @@ const SeriesButtonSection: React.FC<{ series: Series }> = ({ series }) => {
             commit={commit}
         >
             <br />
-            <p>{t("manage.my-series.delete-note")}</p>
+            <p>{t("manage.series.details.delete-note")}</p>
         </DeleteButton>
     </div>;
 };
@@ -125,7 +125,7 @@ const SeriesContentSection: React.FC<{ series: Series }> = ({ series }) => {
         listId={series.id}
         listEntries={[...series.entries]}
         getUpdatedEntries={data => [...data.updateSeriesContent.entries]}
-        description={t("manage.my-series.details.edit-note")}
+        description={t("manage.series.details.edit-note")}
         {...{ commit, inFlight }}
     />;
 };

--- a/frontend/src/routes/manage/Series/Shared.tsx
+++ b/frontend/src/routes/manage/Series/Shared.tsx
@@ -52,7 +52,7 @@ export const makeManageSeriesRoute = (
                         <ReturnLink
                             key={1}
                             url={ManageSeriesRoute.url}
-                            title="manage.my-series.title"
+                            title="manage.series.table.title"
                         />,
                         <ManageSeriesNav key={2} series={data.series} active={page} />,
                     ] : []}
@@ -118,7 +118,7 @@ const ManageSeriesNav: React.FC<ManageSeriesNavProps> = ({ series, active }) => 
         {
             url: `/~manage/series/${id}`,
             page: "details",
-            body: <><LuPenLine />{t("manage.my-series.details.title")}</>,
+            body: <><LuPenLine />{t("manage.series.details.title")}</>,
         },
     ];
 
@@ -126,7 +126,7 @@ const ManageSeriesNav: React.FC<ManageSeriesNavProps> = ({ series, active }) => 
         navEntries.splice(1, 0, {
             url: `/~manage/series/${id}/access`,
             page: "acl",
-            body: <><LuShieldCheck />{t("manage.shared.acl.title")}</>,
+            body: <><LuShieldCheck />{t("acl.title")}</>,
         });
     }
 

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -50,7 +50,7 @@ export const ManageSeriesRoute = makeRoute({
                     : <ManageItems
                         vars={vars}
                         connection={data.currentUser.mySeries}
-                        titleKey="manage.my-series.title"
+                        titleKey="manage.series.table.title"
                         additionalColumns={seriesColumns}
                         RenderRow={SeriesRow}
                     >
@@ -98,7 +98,7 @@ const CreateSeriesLink: React.FC = () => {
     return (!isRealUser(user) || !user.canCreateSeries)
         ? null
         : <LinkButton to={CREATE_SERIES_PATH} css={{ width: "fit-content" }}>
-            {t("manage.my-series.create.title")}
+            {t("manage.series.table.create")}
             <LuCirclePlus />
         </LinkButton>;
 };
@@ -111,7 +111,7 @@ export type SingleSeries = Series[number];
 const seriesColumns: ColumnProps<SingleSeries>[] = [
     {
         key: "EVENT_COUNT",
-        label: "manage.video-list.content",
+        label: "video.plural",
         headerWidth: 112,
         column: ({ item }) => <td css={{ fontSize: 14 }}>
             {i18n.t("manage.video-list.no-of-videos", { count: item.numVideos })}
@@ -119,12 +119,12 @@ const seriesColumns: ColumnProps<SingleSeries>[] = [
     },
     {
         key: "UPDATED",
-        label: "manage.item-table.columns.updated",
+        label: "manage.table.columns.updated",
         column: ({ item }) => <DateColumn date={item.updated} />,
     },
     {
         key: "CREATED",
-        label: "manage.item-table.columns.created",
+        label: "manage.table.columns.created",
         column: ({ item }) => <DateColumn date={item.created} />,
     },
 ];

--- a/frontend/src/routes/manage/Shared/Access.tsx
+++ b/frontend/src/routes/manage/Shared/Access.tsx
@@ -40,18 +40,18 @@ export const AclPage: React.FC<AclPageProps> = ({ children, note, breadcrumbTail
     }
 
     const breadcrumbs = [
-        { label: t("user.manage-content"), link: ManageRoute.url },
+        { label: t("user.manage"), link: ManageRoute.url },
         ...breadcrumbTails,
     ];
 
     return <>
-        <Breadcrumbs path={breadcrumbs} tail={t("manage.shared.acl.title")} />
-        <PageTitle title={t("manage.shared.acl.title")} />
+        <Breadcrumbs path={breadcrumbs} tail={t("acl.title")} />
+        <PageTitle title={t("acl.title")} />
         {note}
         <br />
         {CONFIG.allowAclEdit
             ? children
-            : <Card kind="info">{t("manage.access.editing-disabled")}</Card>
+            : <Card kind="info">{t("acl.editing-disabled")}</Card>
         }
     </>;
 };

--- a/frontend/src/routes/manage/Shared/Details.tsx
+++ b/frontend/src/routes/manage/Shared/Details.tsx
@@ -54,7 +54,7 @@ export const DetailsPage = <T extends Item>({
 }: PageProps<T>) => {
     const { t } = useTranslation();
     const breadcrumbs = [
-        { label: t("user.manage-content"), link: ManageRoute.url },
+        { label: t("user.manage"), link: ManageRoute.url },
         breadcrumb,
     ];
 
@@ -102,10 +102,10 @@ export const UpdatedCreatedInfo: React.FC<UpdatedCreatedInfoProps> = ({ item }) 
         <div css={{ marginBottom: 16, fontSize: 14 }}>
             {created && (
                 <span css={{ "&:not(:last-child):after": { content: "'•'", margin: "0 12px" } }}>
-                    <DateValue label={t("manage.shared.created")} value={created} />
+                    <DateValue label={t("manage.table.columns.created")} value={created} />
                 </span>
             )}
-            {updated && <DateValue label={t("manage.shared.updated")} value={updated} />}
+            {updated && <DateValue label={t("manage.table.updated")} value={updated} />}
         </div>
     );
 };
@@ -207,7 +207,7 @@ export const MetadataSection = <TMutation extends MetadataMutationParams>({
                 <MetadataFields />
                 {/* Submit */}
                 <SubmitButtonWithStatus
-                    label={t("metadata-form.save")}
+                    label={t("manage.metadata-form.save")}
                     onClick={onSubmit}
                     disabled={!!commitError || !isValid || !isDirty || inFlight}
                     success={success && !isDirty}
@@ -248,7 +248,7 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
     const modalRef = useRef<ConfirmationModalHandle>(null);
     const router = useRouter();
 
-    const i18nKey = t(`manage.shared.item.${kind}`);
+    const buttonText = t(`manage.${kind}.details.delete`);
 
     const onSubmit = () => {
         commit({
@@ -259,14 +259,14 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
                 setNotification({
                     kind: "info",
                     message: i18n => i18n.t(
-                        "manage.shared.delete.in-progress", { itemTitle: item.title },
+                        "manage.table.deletion.in-progress", { itemTitle: item.title },
                     ),
                     scope: returnPath,
                 });
                 router.goto(returnPath);
             },
             onError: error => {
-                const failedAction = t("manage.shared.delete.failed", { item: kind });
+                const failedAction = t("manage.table.deletion.failed");
                 currentRef(modalRef).reportError(displayCommitError(error, failedAction));
             },
         });
@@ -275,16 +275,16 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
     return <Inertable isInert={!isSynced(item)}>
         <Button kind="danger" onClick={() => currentRef(modalRef).open()}>
             <span css={{ whiteSpace: "normal", textWrap: "balance" }}>
-                {t("manage.shared.delete.title", { item: i18nKey })}
+                {buttonText}
             </span>
         </Button>
         <ConfirmationModal
-            title={t("manage.shared.delete.confirm", { item: i18nKey })}
-            buttonContent={t("manage.shared.delete.title", { item: i18nKey })}
+            title={t(`manage.${kind}.details.confirm-delete`)}
+            buttonContent={buttonText}
             onSubmit={onSubmit}
             ref={modalRef}
         >
-            <p><Trans i18nKey="manage.shared.delete.cannot-be-undone" /></p>
+            <p><Trans i18nKey="general.action.cannot-be-undone" /></p>
             {children}
         </ConfirmationModal>
     </Inertable>;
@@ -298,7 +298,7 @@ type HostRealmsProps = {
         readonly path: string;
     }[];
     itemLink: (path: string) => ReactNode;
-    kind: "videos" | "series";
+    kind: OcEntity;
 };
 
 export const HostRealms: React.FC<HostRealmsProps> = ({ hostRealms, itemLink, kind }) => {
@@ -306,12 +306,12 @@ export const HostRealms: React.FC<HostRealmsProps> = ({ hostRealms, itemLink, ki
 
     return <>
         <h2 css={{ fontSize: 20, marginBottom: 8 }}>
-            {t("manage.shared.details.referencing-pages")}
+            {t("manage.details.referencing-pages")}
         </h2>
         {hostRealms.length === 0
-            ? <i>{t(`manage.my-${kind}.details.no-referencing-pages`)}</i>
+            ? <i>{t(`manage.${kind}.details.no-referencing-pages`)}</i>
             : <>
-                <p>{t(`manage.my-${kind}.details.referencing-pages-explanation`)}</p>
+                <p>{t(`manage.${kind}.details.referencing-pages-explanation`)}</p>
                 <ul>{hostRealms.map(realm => (
                     <li key={realm.id}>
                         {realm.isMainRoot ? <i>{t("general.homepage")}</i> : realm.name}

--- a/frontend/src/routes/manage/Shared/EditVideoList.tsx
+++ b/frontend/src/routes/manage/Shared/EditVideoList.tsx
@@ -87,7 +87,7 @@ export const ManageVideoListContent = <TMutation extends VideoListMutationParams
         },
         onError: e => {
             setSuccess(false);
-            setCommitError(displayCommitError(e, t("manage.video-list.error")));
+            setCommitError(displayCommitError(e, t("manage.video-list.edit.error")));
         },
     });
 
@@ -95,7 +95,7 @@ export const ManageVideoListContent = <TMutation extends VideoListMutationParams
     return <Inertable isInert={inFlight || !!commitError} css={{ marginBottom: 32, maxWidth: 750 }}>
         <div css={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
             <h2 css={{ fontSize: 20 }}>
-                {t("manage.video-list.content")}
+                {t("video.singular")}
             </h2>
             <i css={{ fontSize: 14, color: COLORS.neutral50 }}>
                 ({listEntries.length > 0
@@ -112,7 +112,7 @@ export const ManageVideoListContent = <TMutation extends VideoListMutationParams
             {/* // Todo: Omit upload button when adding this route for playlists */}
             {user.canUpload && <LinkButton to={UploadRoute.url({ seriesId: keyOfId(listId) })} >
                 <LuUpload />
-                {t("manage.video-list.edit.upload")}
+                {t("upload.title")}
             </LinkButton>}
         </div>
         {events.length > 0 && <>

--- a/frontend/src/routes/manage/Shared/Table.tsx
+++ b/frontend/src/routes/manage/Shared/Table.tsx
@@ -74,7 +74,7 @@ export const ManageItems = <T extends Item>({
         inner = <div css={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 32 }}>
             <Notification />
             <Card kind="info" css={{ width: "fit-content", marginTop: 16 }}>
-                {t("manage.item-table.no-entries-found")}
+                {t("manage.table.no-entries-found")}
             </Card>
         </div>;
     } else {
@@ -106,7 +106,7 @@ export const ManageItems = <T extends Item>({
             height: "100%",
         }}>
             <Breadcrumbs tail={title} path={[{
-                label: t("user.manage-content"),
+                label: t("user.manage"),
                 link: ManageRoute.url,
             }]} />
             <PageTitle title={title} css={{ marginBottom: 32 }} />
@@ -212,7 +212,7 @@ const ItemTable = <T extends Item>({
                     <th></th>
                     {/* Title */}
                     <ColumnHeader
-                        label={t("manage.item-table.columns.title")}
+                        label={t("general.title")}
                         sortKey="TITLE"
                         {...{ vars }}
                     />
@@ -266,7 +266,7 @@ export const DateColumn: React.FC<{ date?: string | null }> = ({ date }) => {
         {parsedDate
             ? <RelativeDate date={parsedDate} />
             : <i css={greyColor}>
-                {t("manage.item-table.missing-date")}
+                {t("manage.table.missing-date")}
             </i>
         }
     </td>;
@@ -353,10 +353,7 @@ export const TableRow = <T extends TableRowItem>({ item, ...props }: TableRowPro
             </div>
             {/* Description */}
             {deletionIsPending
-                ? <PendingDeletionBody
-                    itemType={props.itemType}
-                    {...{ deletionFailed, deletionDate }}
-                />
+                ? <PendingDeletionBody {...{ deletionFailed, deletionDate }} />
                 : <SmallDescription
                     css={{ ...descriptionStyle }}
                     text={item.description}
@@ -370,11 +367,11 @@ export const TableRow = <T extends TableRowItem>({ item, ...props }: TableRowPro
 type PendingDeleteBodyProps = {
     deletionFailed: boolean;
     deletionDate: Date;
-    itemType: OcEntity;
 }
 
 const PendingDeletionBody: React.FC<PendingDeleteBodyProps> = ({
-    deletionFailed, deletionDate, itemType,
+    deletionFailed,
+    deletionDate,
 }) => {
     const isDark = useColorScheme().scheme === "dark";
     const { t } = useTranslation();
@@ -391,12 +388,12 @@ const PendingDeletionBody: React.FC<PendingDeleteBodyProps> = ({
             padding: "0 4px",
         }}>
             <span css={{ fontStyle: "italic" }}>
-                {t(`manage.shared.delete.${
+                {t(`manage.table.deletion.${
                     deletionFailed ? "failed-maybe" : "pending"
-                }`, { item: itemType })}
+                }`)}
             </span>
             <IconWithTooltip
-                tooltip={t(`manage.shared.delete.tooltip.${
+                tooltip={t(`manage.table.deletion.tooltip.${
                     deletionFailed ? "failed" : "pending"
                 }`, { time: relative })}
                 mode={deletionFailed ? "warning" : "info"}
@@ -419,9 +416,9 @@ const ColumnHeader: React.FC<ColumnHeaderProps> = ({ label, sortKey, vars }) => 
     return <th>
         <Link
             aria-label={
-                t("manage.item-table.columns.description", {
+                t("manage.table.columns.description", {
                     title: label,
-                    direction: t(`manage.item-table.columns.${directionTransKey}`),
+                    direction: t(`manage.table.columns.${directionTransKey}`),
                 })
             }
             to={varsToLink({
@@ -470,7 +467,7 @@ const PageNavigation = <T, >({ connection, vars }: SharedManageProps<T>) => {
             gap: 48,
         }}>
             <div>
-                {t("manage.item-table.page-showing-ids", {
+                {t("manage.table.page-showing-ids", {
                     start: page * LIMIT - LIMIT + 1,
                     end: Math.min(page * LIMIT, total),
                     total,
@@ -481,25 +478,25 @@ const PageNavigation = <T, >({ connection, vars }: SharedManageProps<T>) => {
                 <PageLink
                     vars={{ ...vars, page: 1 }}
                     disabled={!pageInfo.hasPrevPage}
-                    label={t("manage.item-table.navigation.first")}
+                    label={t("manage.table.navigation.first")}
                 ><FirstPage /></PageLink>
                 {/* Previous page */}
                 <PageLink
                     vars={{ ...vars, page: page - 1 }}
                     disabled={!pageInfo.hasPrevPage}
-                    label={t("manage.item-table.navigation.previous")}
+                    label={t("manage.table.navigation.previous")}
                 ><LuChevronLeft /></PageLink>
                 {/* Next page */}
                 <PageLink
                     vars={{ ...vars, page: page + 1 }}
                     disabled={!pageInfo.hasNextPage}
-                    label={t("manage.item-table.navigation.next")}
+                    label={t("manage.table.navigation.next")}
                 ><LuChevronRight /></PageLink>
                 {/* Last page */}
                 <PageLink
                     vars={{ ...vars, page: Math.ceil(total / LIMIT) }}
                     disabled={!pageInfo.hasNextPage}
-                    label={t("manage.item-table.navigation.last")}
+                    label={t("manage.table.navigation.last")}
                 ><LastPage /></PageLink>
             </div>
         </div>

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -55,7 +55,7 @@ export const makeManageVideoRoute = (
                         <ReturnLink
                             key={1}
                             url={ManageVideosRoute.url}
-                            title="manage.my-videos.title"
+                            title="manage.video.table"
                         />,
                         <ManageVideoNav key={2} event={data.event} active={page} />,
                     ]}
@@ -141,12 +141,12 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         {
             url: `/~manage/videos/${id}`,
             page: "details",
-            body: <><LuPenLine />{t("manage.my-videos.details.title")}</>,
+            body: <><LuPenLine />{t("video.details")}</>,
         },
         {
             url: `/~manage/videos/${id}/technical-details`,
             page: "technical-details",
-            body: <><LuInfo />{t("manage.my-videos.technical-details.title")}</>,
+            body: <><LuInfo />{t("manage.video.technical-details.title")}</>,
         },
     ];
 
@@ -154,7 +154,7 @@ const ManageVideoNav: React.FC<ManageVideoNavProps> = ({ event, active }) => {
         navEntries.splice(1, 0, {
             url: `/~manage/videos/${id}/access`,
             page: "acl",
-            body: <><LuShieldCheck />{t("manage.shared.acl.title")}</>,
+            body: <><LuShieldCheck />{t("acl.title")}</>,
         });
     }
 

--- a/frontend/src/routes/manage/Video/TechnicalDetails.tsx
+++ b/frontend/src/routes/manage/Video/TechnicalDetails.tsx
@@ -36,8 +36,8 @@ const Page: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
 
     const breadcrumbs = [
-        { label: t("user.manage-content"), link: ManageRoute.url },
-        { label: t("manage.my-videos.title"), link: ManageVideosRoute.url },
+        { label: t("user.manage"), link: ManageRoute.url },
+        { label: t("manage.video.table"), link: ManageVideosRoute.url },
         { label: event.title, link: ManageVideoDetailsRoute.url({ videoId: event.id }) },
     ];
 
@@ -47,8 +47,8 @@ const Page: React.FC<Props> = ({ event }) => {
     }
 
     return <>
-        <Breadcrumbs path={breadcrumbs} tail={t("manage.my-videos.technical-details.title")} />
-        <PageTitle title={t("manage.my-videos.technical-details.title")} />
+        <Breadcrumbs path={breadcrumbs} tail={t("manage.video.technical-details.title")} />
+        <PageTitle title={t("manage.video.technical-details.title")} />
         <div css={{
             maxWidth: PAGE_WIDTH,
             "& > section:not(:last-child)": {
@@ -70,9 +70,9 @@ const OpencastId: React.FC<Props> = ({ event }) => {
     const { t } = useTranslation();
 
     return <section>
-        <h2>{t("manage.my-videos.technical-details.opencast-id")}</h2>
+        <h2>{t("manage.video.technical-details.opencast-id")}</h2>
         <CopyableInput
-            label={t("manage.my-videos.technical-details.copy-oc-id-to-clipboard")}
+            label={t("manage.video.technical-details.copy-oc-id-to-clipboard")}
             value={event.opencastId}
             css={{ width: 400, fontSize: 14 }}
         />
@@ -119,7 +119,7 @@ export const TrackInfo: React.FC<TrackInfoProps> = (
     const isSingleFlavor = flavors.size === 1;
 
     return <section css={className}>
-        <h2>{t("manage.my-videos.technical-details.tracks")}</h2>
+        <h2>{t("manage.video.technical-details.tracks")}</h2>
         <ul css={{ fontSize: 15, marginTop: 8, paddingLeft: 24 }}>
             {Array.from(flavors, ([flavor, tracks]) => {
                 const trackItems = tracks
@@ -144,7 +144,7 @@ const TrackItem: React.FC<SingleTrackInfo> = ({ mimetype, resolution, uri }) => 
     const type = mimetype && mimetype.split("/")[0];
     const subtype = mimetype && mimetype.split("/")[1];
     const typeTranslation = (type === "audio" || type === "video")
-        ? t(`manage.my-videos.technical-details.${type}`)
+        ? t(`manage.video.technical-details.${type}`)
         : type;
 
     const resolutionString = (type && " ")
@@ -157,7 +157,7 @@ const TrackItem: React.FC<SingleTrackInfo> = ({ mimetype, resolution, uri }) => 
             <a href={uri}>
                 {type
                     ? <>{typeTranslation}</>
-                    : <i>{t("manage.my-videos.technical-details.unknown-mimetype")}</i>
+                    : <i>{t("manage.video.technical-details.unknown-mimetype")}</i>
                 }
                 {(resolution || subtype) && resolutionString}
             </a>
@@ -181,15 +181,15 @@ const FurtherInfo: React.FC<Props> = ({ event }) => {
     };
 
     return <section>
-        <h2>{t("manage.my-videos.technical-details.further-info")}</h2>
+        <h2>{t("manage.video.technical-details.further-info")}</h2>
         <ul>
-            <SingleInfo label={t("manage.my-videos.technical-details.synced")}>
+            <SingleInfo label={t("manage.video.technical-details.synced")}>
                 {boolToYesNo(event.syncedData !== null)}
             </SingleInfo>
-            <SingleInfo label={t("manage.my-videos.technical-details.part-of")}>
+            <SingleInfo label={t("manage.video.technical-details.part-of")}>
                 <code css={{ fontSize: 15 }}>{event.series?.opencastId ?? "null"}</code>
             </SingleInfo>
-            <SingleInfo label={t("manage.my-videos.technical-details.is-live")}>
+            <SingleInfo label={t("manage.video.technical-details.is-live")}>
                 {boolToYesNo(event.isLive)}
             </SingleInfo>
             {event.syncedData && <>

--- a/frontend/src/routes/manage/Video/VideoAccess.tsx
+++ b/frontend/src/routes/manage/Video/VideoAccess.tsx
@@ -22,7 +22,7 @@ export const ManageVideoAccessRoute = makeManageVideoRoute(
     "/access",
     (event, data) => (
         <AclPage note={<UnlistedNote />} breadcrumbTails={[
-            { label: i18n.t("manage.my-videos.title"), link: ManageVideosRoute.url },
+            { label: i18n.t("manage.video.table"), link: ManageVideosRoute.url },
             { label: event.title, link: ManageVideoDetailsRoute.url({ videoId: event.id }) },
         ]}>
             <EventAclEditor {...{ event, data }} />
@@ -36,8 +36,8 @@ const UnlistedNote: React.FC = () => {
     const { t } = useTranslation();
 
     return <NoteWithTooltip
-        note={t("manage.access.unlisted.note")}
-        tooltip={t("manage.access.unlisted.explanation")}
+        note={t("acl.unlisted.note")}
+        tooltip={t("acl.unlisted.explanation")}
     />;
 };
 
@@ -86,11 +86,11 @@ const EventAclEditor: React.FC<EventAclPageProps> = ({ event, data }) => {
 
     return <>
         {event.hasActiveWorkflows && <Card kind="info" css={{ marginBottom: 20 }}>
-            <Trans i18nKey="manage.access.workflow-active" />
+            <Trans i18nKey="acl.workflow-active" />
         </Card>}
         {aclLockedToSeries && (
             <Card kind="info" iconPos="left" css={{ fontSize: 14, marginBottom: 10 }}>
-                <Trans i18nKey="manage.access.locked-to-series">
+                <Trans i18nKey="acl.locked-to-series">
                     series
                     <Link to={ManageSeriesAccessRoute.url({ seriesId: event.series.id })} />
                 </Trans>

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -30,10 +30,10 @@ export const ManageVideoDetailsRoute = makeManageVideoRoute(
     "",
     authEvent => <DetailsPage
         kind="video"
-        pageTitle="manage.my-videos.details.title"
+        pageTitle="video.details"
         item={{ ...authEvent, updated: authEvent.syncedData?.updated }}
         breadcrumb={{
-            label: i18n.t("manage.my-videos.title"),
+            label: i18n.t("manage.video.table"),
             link: ManageVideosRoute.url,
         }}
         sections={event => [
@@ -47,9 +47,9 @@ export const ManageVideoDetailsRoute = makeManageVideoRoute(
             } />,
             <VideoMetadataSection key="metadata" event={event} />,
             <div key="host-realms" css={{ marginBottom: 32 }}>
-                <HostRealms kind="videos" hostRealms={authEvent.hostRealms} itemLink={realmPath => (
+                <HostRealms kind="video" hostRealms={authEvent.hostRealms} itemLink={realmPath => (
                     <Link to={VideoRoute.url({ realmPath: realmPath, videoID: authEvent.id })}>
-                        {i18n.t("video.video")}
+                        {i18n.t("video.singular")}
                     </Link>
                 )}/>
             </div>,
@@ -94,7 +94,7 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
                 fallback="button"
                 css={buttonStyle(config, "normal", isHighContrast)}
             >
-                {t("manage.my-videos.details.open-in-editor")}
+                {t("manage.video.details.open-in-editor")}
             </ExternalLink>
         )}
         <DeleteButton
@@ -111,7 +111,7 @@ const VideoMetadataSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) =
 
     return <>
         {event.hasActiveWorkflows && <Card kind="info" css={{ marginBottom: -14 }}>
-            <Trans i18nKey="metadata-form.event-workflow-active" />
+            <Trans i18nKey="manage.metadata-form.event-workflow-active" />
         </Card>}
         <MetadataSection
             disabled={event.hasActiveWorkflows}

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -49,7 +49,7 @@ export const ManageVideosRoute = makeRoute({
                     : <ManageItems
                         vars={vars}
                         connection={data.currentUser.myVideos}
-                        titleKey="manage.my-videos.title"
+                        titleKey="manage.video.table"
                         additionalColumns={videoColumns}
                         RenderRow={EventRow}
                     />
@@ -105,7 +105,7 @@ export type Event = Events[number];
 const videoColumns: ColumnProps<Event>[] = [
     {
         key: "SERIES",
-        label: "manage.item-table.columns.series",
+        label: "series.singular",
         headerWidth: 175,
         column: ({ item }) => <SeriesColumn
             title={item.series?.title}
@@ -114,12 +114,12 @@ const videoColumns: ColumnProps<Event>[] = [
     },
     {
         key: "UPDATED",
-        label: "manage.item-table.columns.updated",
+        label: "manage.table.columns.updated",
         column: ({ item }) => <DateColumn date={item.syncedData?.updated} />,
     },
     {
         key: "CREATED",
-        label: "manage.item-table.columns.created",
+        label: "manage.table.columns.created",
         column: ({ item }) => <DateColumn date={item.created} />,
     },
 ];
@@ -135,10 +135,10 @@ const SeriesColumn: React.FC<SeriesColumnProps> = ({ title, seriesId }) => {
     const titleLink = seriesId
         ? <Link to={DirectSeriesRoute.url({ seriesId })} css={{ textDecoration: "none" }}>
             {title && title.trim().length > 0 ? title : <i>
-                {t("manage.item-table.no-series-title")}
+                {t("manage.table.no-series-title")}
             </i>}
         </Link>
-        : <i css={{ color: COLORS.neutral60 }}>{t("manage.item-table.no-series")}</i>;
+        : <i css={{ color: COLORS.neutral60 }}>{t("general.none")}</i>;
 
     return (
         <td css={{

--- a/frontend/src/routes/manage/index.tsx
+++ b/frontend/src/routes/manage/index.tsx
@@ -64,11 +64,11 @@ const Manage: React.FC = () => {
     }
 
     return <>
-        <Breadcrumbs path={[]} tail={t("user.manage-content")} />
+        <Breadcrumbs path={[]} tail={t("user.manage")} />
         <PageTitle title={t("manage.dashboard.title")} />
         <div css={{ maxWidth: "80ch", fontSize: 14, h2: { marginBottom: 8, fontSize: 18 } }}>
-            <h2>{t("manage.dashboard.manage-pages-tile-title")}</h2>
-            {t("manage.dashboard.manage-pages-tile-body")}
+            <h2>{t("manage.dashboard.manage-pages-title")}</h2>
+            {t("manage.dashboard.manage-pages-body")}
         </div>
     </>;
 };
@@ -99,20 +99,20 @@ export const ManageNav: React.FC<ManageNavProps> = ({ active }) => {
         entries.push([`/@${user.username}`, t("realm.user-realm.my-page"), <HiOutlineFire />]);
     }
 
-    entries.push([ManageVideosRoute.url, t("manage.my-videos.title"), <LuFilm />]);
+    entries.push([ManageVideosRoute.url, t("manage.video.table"), <LuFilm />]);
 
     if (isRealUser(user) && user.canUpload) {
         entries.push([UploadPath, t("upload.title"), <LuUpload />]);
     }
 
     if (isRealUser(user) && user.canUseStudio) {
-        entries.push(["STUDIO", t("manage.dashboard.studio-tile-title"), <LuVideo />]);
+        entries.push(["STUDIO", t("manage.dashboard.studio-title"), <LuVideo />]);
     }
 
-    entries.push([ManageSeriesRoute.url, t("manage.my-series.title"), <SeriesIcon />]);
+    entries.push([ManageSeriesRoute.url, t("manage.series.table.title"), <SeriesIcon />]);
 
     if (isRealUser(user) && user.canCreateSeries) {
-        entries.push([CreateSeriesRoute.url, t("manage.my-series.create.title"), <LuCirclePlus />]);
+        entries.push([CreateSeriesRoute.url, t("manage.series.table.create"), <LuCirclePlus />]);
     }
     /* eslint-enable react/jsx-key */
 

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -664,12 +664,22 @@ const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
             = notNullish(permissionLevels.all[newOption]).actions;
     });
 
+    const getI18nKey = (itemType: AclSubject, actionOption: PermissionLevel): ParseKeys => {
+        if (actionOption === "unknown") {
+            return "acl.table.permissions.unknown-description";
+        }
+        if (actionOption === "admin" || actionOption === "moderate") {
+            return `acl.table.permissions.realm-${actionOption}-description`;
+        }
+        if (itemType === "video" || itemType === "series") {
+            return `acl.table.permissions.${itemType}-${actionOption}-description`;
+        }
+        return "acl.table.permissions.unknown-description";
+    };
+
     const description = (actionOption: PermissionLevel) => t(
-        `acl.table.permissions.${itemType}-${actionOption}-description`,
-        {
-            count: kind === "user" ? 1 : 2,
-            defaultValue: t("acl.table.permissions.unknown-description"),
-        },
+        getI18nKey(itemType, actionOption),
+        { count: kind === "user" ? 1 : 2 },
     );
 
     return (

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -295,14 +295,14 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         isMulti: true,
         isSearchable: true,
         backspaceRemovesValue: false,
-        placeholder: t(`manage.access.select.${kind}s`),
+        placeholder: t(`acl.select.${kind}s`),
         // TODO: for users, this should say "type to search" or "enter
         // username, email, ... to add user" depending on the
         // users_searchable config.
         noOptionsMessage: kind === "group"
             ? () => t("general.form.select.no-options")
             : ({ inputValue }: { inputValue: string }) => (
-                t(`manage.access.users-no-options.${
+                t(`acl.users-no-options.${
                     inputValue.length === 0 ? "initial" : "none-found"
                 }-${CONFIG.usersSearchable ? "" : "not-"}searchable`)
             ),
@@ -311,7 +311,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             const validRole = /^ROLE_\w+/.test(input);
             return kind === "group" ? (validRole && !validUserRole) : validUserRole;
         },
-        formatCreateLabel: (input: string) => t("manage.access.select.create", { item: input }),
+        formatCreateLabel: (input: string) => t("acl.select.create", { item: input }),
         value: entries.map(e => ({ role: e.role, label: e.label })),
         getOptionValue: (option: SelectOption) => option.role,
         onCreateOption: handleCreate,
@@ -331,7 +331,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             flexBasis: 280,
         },
     }}>
-        <strong>{t(`manage.access.authorized-${kind}s`)}</strong>
+        <strong>{t(`acl.authorized-${kind}s`)}</strong>
         {error && <Card kind="error" css={{ marginBottom: 8 }}>{error}</Card>}
         {kind === "group"
             ? <CreatableSelect
@@ -368,14 +368,14 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         }
         <div>
             <Table header={<>
-                <th>{t(`manage.access.table.${kind}`)}</th>
-                <th>{t("manage.access.table.actions.title")}</th>
+                <th>{t(`acl.table.${kind}`)}</th>
+                <th>{t("acl.table.permissions.title")}</th>
                 <th></th></>
             }>
                 {/* Placeholder if there are no entries */}
                 {noEntries && <tr>
                     <td colSpan={3} css={{ textAlign: "center", fontStyle: "italic" }}>
-                        {t("acl.no-entries")}
+                        {t("acl.table.no-entries")}
                     </td>
                 </tr>}
 
@@ -402,7 +402,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                 */}
                 {showUserEntry && <TableRow
                     labelCol={!userIsOwner ? <>{ownerDisplayName}</> : <>
-                        <i>{t("manage.access.table.yourself")}</i>
+                        <i>{t("acl.table.yourself")}</i>
                             &nbsp;({ownerDisplayName})
                     </>}
                     actionCol={<UnchangeableAllActions />}
@@ -417,10 +417,10 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                         justifyContent: "space-between",
                         paddingRight: 12,
                     }}>
-                        {t("manage.access.table.inherited")}
+                        {t("acl.table.inherited")}
                         <IconWithTooltip
                             mode="info"
-                            tooltip={t("manage.access.table.inherited-tooltip")}
+                            tooltip={t("acl.table.inherited-tooltip")}
                         />
                     </span>
                 </th>
@@ -542,7 +542,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
 
     let label: JSX.Element;
     if (isUser) {
-        label = <span><i>{t("manage.access.table.yourself")}</i>&nbsp;({item.label})</span>;
+        label = <span><i>{t("acl.table.yourself")}</i>&nbsp;({item.label})</span>;
     } else if (kind === "user" && isUserRole(item.label)) {
         // We strip the user role prefix (we take the longest prefix that
         // matches, though in almost all cases just a single one will match).
@@ -552,7 +552,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
         const name = item.role.slice(Math.max(...prefixes.map(p => p.length)))
             .toLocaleLowerCase(i18n.resolvedLanguage)
             .replace("_", " ");
-        label = <span>{name} (<i>{t("acl.unknown-user-note")}</i>)</span>;
+        label = <span>{name} (<i>{t("acl.table.unknown-user-note")}</i>)</span>;
     } else {
         label = <>{item.label}</>;
     }
@@ -561,7 +561,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
         labelCol={<>
             {label}
             {isSubset && <IconWithTooltip mode="info" tooltip={
-                t("manage.access.table.subset-warning", { groups: supersets.join(", ") })
+                t("acl.table.subset-warning", { groups: supersets.join(", ") })
             } />}
         </>}
         mutedLabel={isSubset || inherited}
@@ -572,8 +572,8 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
                 {item.large && noteworthyAccessType
                     ? <IconWithTooltip
                         mode="warning"
-                        tooltip={t("manage.access.table.actions.large-group-warning", {
-                            val: t(`manage.access.table.actions.${noteworthyAccessType}-access`),
+                        tooltip={t("acl.table.permissions.large-group-warning", {
+                            val: t(`acl.table.permissions.${noteworthyAccessType}-access`),
                         })}
                     />
                     : <div css={{ width: 22 }} />
@@ -648,7 +648,7 @@ const UnchangeableAllActions: React.FC<{ permission?: PermissionLevel }> = ({ pe
     const { t } = useTranslation();
     const { permissionLevels } = useAclContext();
     const label = permission ?? permissionLevels.highest;
-    return <span css={{ marginLeft: 8 }}>{t(`manage.access.table.actions.${label}`)}</span>;
+    return <span css={{ marginLeft: 8 }}>{t(`acl.table.permissions.${label}`)}</span>;
 };
 
 const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
@@ -665,18 +665,18 @@ const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
     });
 
     const description = (actionOption: PermissionLevel) => t(
-        `manage.access.table.actions.${itemType}-${actionOption}-description`,
+        `acl.table.permissions.${itemType}-${actionOption}-description`,
         {
             count: kind === "user" ? 1 : 2,
-            defaultValue: t("manage.access.table.actions.unknown-description"),
+            defaultValue: t("acl.table.permissions.unknown-description"),
         },
     );
 
     return (
         <FloatingBaseMenu
             ref={ref}
-            label={t("manage.access.table.actions.title")}
-            triggerContent={<>{t(`manage.access.table.actions.${currentActionOption}`)}</>}
+            label={t("acl.table.permissions.title")}
+            triggerContent={<>{t(`acl.table.permissions.${currentActionOption}`)}</>}
             triggerStyles={{
                 width: "100%",
                 gap: 0,
@@ -705,7 +705,7 @@ const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
                         {allLabels.map(actionOption => <ActionMenuItem
                             key={actionOption}
                             disabled={actionOption === currentActionOption}
-                            label={t(`manage.access.table.actions.${actionOption}`)}
+                            label={t(`acl.table.permissions.${actionOption}`)}
                             description={description(actionOption)}
                             onClick={() => changeOption(actionOption)}
                             close={() => ref.current?.close()}
@@ -845,10 +845,10 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
                 onClick={() => currentRef(resetModalRef).open()}
                 css={{ ...!buttonsDisabled && { ":hover": { color: COLORS.danger0 } } }}
             >
-                {t("manage.access.reset-modal.label")}
+                {t("acl.reset-modal.label")}
             </Button>
-            <Modal ref={resetModalRef} title={t("manage.access.reset-modal.title")}>
-                <p>{t("manage.access.reset-modal.body")}</p>
+            <Modal ref={resetModalRef} title={t("acl.reset-modal.title")}>
+                <p>{t("acl.reset-modal.body")}</p>
                 <div css={{
                     display: "flex",
                     gap: 12,
@@ -862,7 +862,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
                     <Button kind="danger" onClick={() => {
                         setSelections(initialAcl);
                         currentRef(resetModalRef).close?.();
-                    }}>{t("manage.access.reset-modal.label")}</Button>
+                    }}>{t("acl.reset-modal.label")}</Button>
                 </div>
             </Modal>
 
@@ -880,11 +880,11 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
             {inFlight && <div css={{ marginTop: 16 }}><Spinner size={20} /></div>}
             <ConfirmationModal
                 ref={saveModalRef}
-                title={t("manage.access.save-modal.title")}
-                buttonContent={t("manage.access.save-modal.confirm")}
+                title={t("acl.save-modal.title")}
+                buttonContent={t("acl.save-modal.confirm")}
                 onSubmit={() => submit(selections)}
             >
-                <p>{t(`manage.access.save-modal.disclaimer-${kind}`)}</p>
+                <p>{t(`acl.save-modal.disclaimer-${kind}`)}</p>
             </ConfirmationModal>
         </div>
     );
@@ -900,7 +900,7 @@ type TranslatedLabel = { default: string } & Record<string, string | undefined>;
 /** Returns a label for the role, if known to Tobira. */
 const getLabel = (role: string, label: TranslatedLabel | undefined, i18n: i18n) => {
     if (role === COMMON_ROLES.USER_ADMIN) {
-        return i18n.t("acl.admin-user");
+        return i18n.t("acl.table.admin-user");
     }
     if (label) {
         return label[i18n.language] ?? label.default;

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -57,7 +57,7 @@ export const PlaylistBlockFromBlock: React.FC<FromBlockProps> = ({ fragRef, ...r
     const { t } = useTranslation();
     const { playlist, ...block } = useFragment(blockFragment, fragRef);
     return playlist == null && rest.editMode
-        ? <Card kind="error">{t("playlist.deleted-playlist-block")}</Card>
+        ? <Card kind="error">{t("playlist.deleted-block")}</Card>
         : playlist != null && <PlaylistBlockFromPlaylist fragRef={playlist} {...rest} {...block} />;
 };
 
@@ -88,13 +88,13 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
 
     if (!playlist) {
         return <VideoListBlockContainer showViewOptions={false}>
-            {t("playlist.deleted-playlist-block")}
+            {t("playlist.deleted-block")}
         </VideoListBlockContainer>;
     }
 
     if (playlist.__typename === "NotAllowed") {
         return <VideoListBlockContainer showViewOptions={false}>
-            {t("playlist.not-allowed-playlist-block")}
+            {t("playlist.not-allowed-block")}
         </VideoListBlockContainer>;
     }
     if (playlist.__typename !== "AuthorizedPlaylist") {

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -60,7 +60,7 @@ export const SeriesBlockFromBlock: React.FC<FromBlockProps> = ({ fragRef, ...res
     const { series, ...block } = useFragment(blockFragment, fragRef);
 
     return series == null && rest.editMode
-        ? <Card kind="error">{t("series.deleted-series-block")}</Card>
+        ? <Card kind="error">{t("series.deleted-block")}</Card>
         : series != null && <SeriesBlockFromSeries fragRef={series} {...rest} {...block} />;
 };
 

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -57,7 +57,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
     const [event, refetch] = useEventWithAuthData(protoEvent);
 
     if (event == null && edit) {
-        return <Card kind="error">{t("video.deleted-video-block")}</Card>;
+        return <Card kind="error">{t("video.deleted-block")}</Card>;
     }
 
     if (event == null) {
@@ -65,7 +65,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
     }
 
     if (event.__typename === "NotAllowed") {
-        return <Card kind="error">{t("video.not-allowed-video-block")}</Card>;
+        return <Card kind="error">{t("video.not-allowed-block")}</Card>;
     }
     if (event.__typename !== "AuthorizedEvent") {
         return unreachable();
@@ -96,7 +96,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                 outlineOffset: 1,
             }}
         >
-            {t("video.link")}
+            {t("video.details")}
             <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
         </Link>}
     </div>;

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -174,7 +174,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
             {...{ title, description, timestamp, creators, shareInfo, initialLayout, isPlaylist }}
         >
             {(mainItems.length + upcomingLiveEvents.length === 0 && !hasHiddenItems)
-                ? <div css={{ padding: 14 }}>{t("videolist-block.no-videos")}</div>
+                ? <div css={{ padding: 14 }}>{t("manage.video-list.no-content")}</div>
                 : <>
                     {upcomingLiveEvents.length > 1 && (
                         <UpcomingEventsGrid count={upcomingLiveEvents.length}>
@@ -186,11 +186,11 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
             }
             {hasHiddenItems && <div css={{ marginTop: 16 }}>
                 {missingItems > 0 && editMode && <HiddenItemsInfo>
-                    {t("videolist-block.hidden-items.missing", { count: missingItems })}
+                    {t("video-list-block.hidden-items.missing", { count: missingItems })}
                 </HiddenItemsInfo>}
                 {unauthorizedItems > 0 && <HiddenItemsInfo>
                     <span>
-                        {t("videolist-block.hidden-items.unauthorized", {
+                        {t("video-list-block.hidden-items.unauthorized", {
                             count: unauthorizedItems,
                         })}
                         &nbsp;
@@ -456,19 +456,19 @@ const VideoListShareButton: React.FC<VideoListShareButtonProps> = props => {
 const OrderMenu: React.FC = () => {
     const { t } = useTranslation();
     const ref = useRef<FloatingHandle>(null);
-    const order = useContext(OrderContext) ?? bug("order context not defined for videolist block");
+    const order = useContext(OrderContext) ?? bug("order context not defined for video-list block");
 
     const triggerContent = match(order.eventOrder, {
-        "ORIGINAL": () => t("videolist-block.settings.original"),
-        "NEW_TO_OLD": () => t("videolist-block.settings.new-to-old"),
-        "OLD_TO_NEW": () => t("videolist-block.settings.old-to-new"),
-        "AZ": () => t("videolist-block.settings.a-z"),
-        "ZA": () => t("videolist-block.settings.z-a"),
+        "ORIGINAL": () => t("video-list-block.settings.original"),
+        "NEW_TO_OLD": () => t("video-list-block.settings.new-to-old"),
+        "OLD_TO_NEW": () => t("video-list-block.settings.old-to-new"),
+        "AZ": () => t("video-list-block.settings.a-z"),
+        "ZA": () => t("video-list-block.settings.z-a"),
     });
 
     return <FloatingBaseMenu
         {...{ ref }}
-        label={t("videolist-block.settings.order-label")}
+        label={t("video-list-block.settings.order-label")}
         triggerContent={<>{triggerContent}</>}
         list={<List type="order" close={() => ref.current?.close()} />}
     />;
@@ -496,7 +496,7 @@ const LayoutMenu: React.FC = () => {
 
     return <FloatingBaseMenu
         {...{ ref, triggerContent }}
-        label={t("videolist-block.settings.layout-label")}
+        label={t("video-list-block.settings.layout-label")}
         list={<List type="layout" close={() => ref.current?.close()} />}
     />;
 };
@@ -561,12 +561,12 @@ const List: React.FC<ListProps> = ({ type, close }) => {
 
     const sharedProps = (key: LayoutTranslationKey | OrderTranslationKey) => ({
         close: close,
-        label: t(`videolist-block.settings.${key}`),
+        label: t(`video-list-block.settings.${key}`),
     });
 
     const list = match(type, {
         layout: () => <>
-            <div>{t("videolist-block.settings.layout")}</div>
+            <div>{t("video-list-block.settings.layout")}</div>
             <ul role="menu" onBlur={handleBlur}>
                 {layoutItems.map(([layout, translationKey, icon], index) => <MenuItem
                     key={`${itemId}-${layout}`}
@@ -579,7 +579,7 @@ const List: React.FC<ListProps> = ({ type, close }) => {
             </ul>
         </>,
         order: () => <>
-            <div>{t("videolist-block.settings.order")}</div>
+            <div>{t("video-list-block.settings.order")}</div>
             <ul role="menu" onBlur={handleBlur}>
                 {orderItems.map(([order, orderKey], index) => <MenuItem
                     key={`${itemId}-${order}`}
@@ -892,12 +892,12 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items, listId }) => {
                 />
             ))}
             {leftVisible && <ProtoButton
-                aria-label={t("videolist-block.slider.scroll-left")}
+                aria-label={t("video-list-block.slider.scroll-left")}
                 onClick={() => scroll(-scrollDistance)}
                 css={{ left: 8, ...buttonCss }}
             ><LuChevronLeft /></ProtoButton>}
             {rightVisible && <ProtoButton
-                aria-label={t("videolist-block.slider.scroll-right")}
+                aria-label={t("video-list-block.slider.scroll-right")}
                 onClick={() => scroll(scrollDistance)}
                 css={{ right: 8, ...buttonCss }}
             ><LuChevronRight /></ProtoButton>}
@@ -936,7 +936,7 @@ const UpcomingEventsGrid: React.FC<UpcomingEventsGridProps> = ({ count, children
                 ...focusStyle({}),
             }}>
                 <span css={{ marginLeft: 4 }}>
-                    {t("videolist-block.upcoming-live-streams", { count })}
+                    {t("video-list-block.upcoming-live-streams", { count })}
                 </span>
             </summary>
             {children}
@@ -1008,9 +1008,9 @@ const Item: React.FC<ItemProps> = ({
             color: COLORS.neutral80,
         } as const;
         if (item === "missing") {
-            return <i css={placeholderStyle}>{t("videolist-block.missing-video")}</i>;
+            return <i css={placeholderStyle}>{t("not-found.video-not-found")}</i>;
         } else if (item === "unauthorized") {
-            return <i css={placeholderStyle}>{t("videolist-block.unauthorized")}</i>;
+            return <i css={placeholderStyle}>{t("video-list-block.unauthorized")}</i>;
         } else {
             return item.title;
         }

--- a/frontend/src/ui/EventSelector.tsx
+++ b/frontend/src/ui/EventSelector.tsx
@@ -137,7 +137,7 @@ const formatOption = (event: Option, t: TFunction) => (
             <div css={{ ...ellipsisOverflowCss(1) }}>{event.title}</div>
             <Creators creators={event.creators} />
             {event.series?.title && <div css={{ fontSize: 14 }}>
-                <i>{t("series.series")}</i>{": "}
+                <i>{t("series.singular")}</i>{": "}
                 {event.series?.title}
             </div>}
         </div>

--- a/frontend/src/ui/Input.tsx
+++ b/frontend/src/ui/Input.tsx
@@ -119,9 +119,7 @@ export const TimeInputWithCheckbox: React.FC<TimeInputWithCheckboxProps> = ({
 
     return (
         <div aria-label={t("share.set-time-label", {
-            time: timestamp > 0
-                ? secondsToTimeString(timestamp)
-                : t("share.no-time"),
+            time: timestamp > 0 ? secondsToTimeString(timestamp) : t("general.none"),
         })}>
             <InputWithCheckbox
                 {...{ checkboxChecked, setCheckboxChecked }}

--- a/frontend/src/ui/Modal.tsx
+++ b/frontend/src/ui/Modal.tsx
@@ -35,7 +35,7 @@ export const ConfirmationModal
             text={{
                 cancel: t("general.action.cancel"),
                 close: t("general.action.close"),
-                areYouSure: t("manage.are-you-sure"),
+                areYouSure: t("general.action.are-you-sure"),
             }}
             {...props}
         />;

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -23,12 +23,10 @@ import { RelativeDate } from "./time";
 
 export const TitleLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
     const { t } = useTranslation();
-    return (
-        <label {...{ htmlFor }}>
-            {t("metadata-form.title")}
-            <FieldIsRequiredNote />
-        </label>
-    );
+    return <label {...{ htmlFor }}>
+        {t("general.title")}
+        <FieldIsRequiredNote />
+    </label>;
 };
 
 export const FieldIsRequiredNote: React.FC = () => {
@@ -36,7 +34,7 @@ export const FieldIsRequiredNote: React.FC = () => {
 
     return <span css={{ fontWeight: "normal" }}>
         {" ("}
-        <em>{t("metadata-form.required")}</em>
+        <em>{t("manage.metadata-form.required")}</em>
         {")"}
     </span>;
 };
@@ -339,7 +337,7 @@ export const MetadataFields: React.FC<MetadataFieldsProps> = ({ disabled = false
                 error={!!errors.title}
                 css={{ width: 400, maxWidth: "100%" }}
                 {...register("title", {
-                    required: t("metadata-form.errors.field-required") as string,
+                    required: t("manage.metadata-form.errors.field-required") as string,
                 })}
             />
             {boxError(errors.title?.message as string)}
@@ -348,7 +346,7 @@ export const MetadataFields: React.FC<MetadataFieldsProps> = ({ disabled = false
         {/* Description */}
         <InputContainer>
             <label htmlFor={descriptionFieldId}>
-                {t("metadata-form.description")}
+                {t("manage.metadata-form.description")}
             </label>
             <TextArea
                 id={descriptionFieldId}

--- a/util/scripts/i18n/compare-keys.js
+++ b/util/scripts/i18n/compare-keys.js
@@ -1,0 +1,144 @@
+/**
+ * Script to compare i18next translation keys in two YAML files.
+ *
+ * Run with `node util/scripts/i18n/compare-keys.js` from the project root.
+ * Use the `-o` or `--check-order` flag to check the key order.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+
+
+// Check for flags
+const args = process.argv.slice(2);
+const checkOrder = args.includes("-o") || args.includes("--check-order");
+
+const LANG_A = {
+  name: "en",
+  file: path.join(__dirname, "../../../frontend/src/i18n/locales/en.yaml"),
+};
+const LANG_B = {
+  name: "de",
+  file: path.join(__dirname, "../../../frontend/src/i18n/locales/de.yaml"),
+};
+
+const loadYamlObject = (filepath) => {
+  let raw;
+  try {
+    raw = fs.readFileSync(filepath, "utf8");
+  } catch (err) {
+    console.error(`❌ Cannot read ${filepath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  let doc;
+  try {
+    doc = yaml.load(raw);
+    if (typeof doc !== "object" || doc === null) {
+      throw new Error("Parsed YAML is not an object");
+    }
+  } catch (err) {
+    console.error(`❌ Error parsing ${filepath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  return doc;
+};
+
+// Recursively walk through parsed YAML in insertion order to build array of dotted key‐paths.
+// e.g. { common: { hello: "Hello", world: "World" }, cat: { dog: "mouse" } }
+// → ["common.hello", "common.world", "cat.dog"]
+const collectKeyPaths = (obj, prefix = []) => {
+  const result = [];
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    const pathSoFar = prefix.concat(key);
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      result.push(...collectKeyPaths(value, pathSoFar));
+    } else {
+      result.push(pathSoFar.join("."));
+    }
+  }
+  return result;
+};
+
+const diffArrays = (a, b) => {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const onlyInA = [...setA].filter((k) => !setB.has(k));
+  const onlyInB = [...setB].filter((k) => !setA.has(k));
+  return [onlyInA, onlyInB];
+};
+
+const findOrderDifferences = (keysA, keysB) => {
+  // Only consider keys present in both files
+  const setA = new Set(keysA);
+  const setB = new Set(keysB);
+  const commonKeys = keysA.filter(k => setB.has(k));
+  const orderInA = commonKeys;
+  const orderInB = keysB.filter(k => setA.has(k));
+  const mismatches = [];
+  for (let i = 0; i < Math.min(orderInA.length, orderInB.length); i++) {
+    if (orderInA[i] !== orderInB[i]) {
+      mismatches.push({ keyA: orderInA[i], keyB: orderInB[i], index: i });
+    }
+  }
+  return mismatches;
+};
+
+(() => {
+  console.log("Loading keys from translation files…\n");
+
+  const aKeys = collectKeyPaths(loadYamlObject(LANG_A.file));
+  const bKeys = collectKeyPaths(loadYamlObject(LANG_B.file));
+
+  console.log(`  • ${aKeys.length} keys in "${LANG_A.name}.yaml"`);
+  console.log(`  • ${bKeys.length} keys in "${LANG_B.name}.yaml"\n`);
+
+  // 1) Check for missing keys in either file
+  const [onlyInA, onlyInB] = diffArrays(aKeys, bKeys);
+
+  let hasError = false;
+
+  if (onlyInA.length > 0) {
+    console.error(`❌ Keys present in ${LANG_A.name}.yaml but missing in "${LANG_B.name}.yaml":`);
+    onlyInA.forEach((k) => console.error(`    • ${k}`));
+    console.error("");
+    hasError = true;
+  }
+
+  if (onlyInB.length > 0) {
+    console.error(`❌ Keys present in ${LANG_B.name}.yaml but missing in "${LANG_A.name}.yaml":`);
+    onlyInB.forEach((k) => console.error(`    • ${k}`));
+    console.error("");
+    hasError = true;
+  }
+
+  // 2) Check ordering if the flag is present, but only for keys present in both files
+  if (checkOrder) {
+    console.log("\n🔄 Checking key order…");
+    const orderMismatches = findOrderDifferences(aKeys, bKeys);
+
+    if (orderMismatches.length === 0) {
+      console.log("✅ Key order matches exactly for all keys that exist in both files.");
+    } else {
+      console.error(`❌ Found ${orderMismatches.length} key order mismatches:`);
+      orderMismatches.forEach(({ keyA, keyB, index }) => {
+        console.error(`    • At position ${index}: ${LANG_A.name}: "${keyA}" vs ${LANG_B.name}: "${keyB}"`);
+      });
+      hasError = true;
+    }
+  } else {
+    console.log("\n🔄 Skipping key order check. Use the -o or --check-order flag to enable it.");
+  }
+
+  if (hasError) {
+    console.error("\n❗ Translation key check FAILED.");
+    process.exit(1);
+  } else {
+    console.log("\n✅ All keys match and are in the same order. No differences found.");
+    process.exit(0);
+  }
+})();
+

--- a/util/scripts/i18n/find-duplicate-keys.js
+++ b/util/scripts/i18n/find-duplicate-keys.js
@@ -1,0 +1,44 @@
+/**
+ * Script to find duplicated i18next translation values in a YAML file.
+ *
+ * Make sure to have the necessary dependencies installed
+ * (you can just dump them afterwards) and that the path below point
+ * to the translation files that you want to compare (relative to project root).
+ *
+ * Run with `node util/scripts/i18n/find-duplicate-keys.js` from the project root.
+ */
+
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+
+const doc = yaml.load(fs.readFileSync("frontend/src/i18n/locales/en.yaml", "utf8"));
+
+// Flatten keys to { keyPath: value } map
+const flatten = (obj, prefix = "", res = {})  =>{
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object") {
+      flatten(v, path, res);
+    } else {
+      res[path] = v;
+    }
+  }
+  return res;
+}
+
+const flat = flatten(doc);
+
+// Group keys by value
+const byValue = Object.entries(flat).reduce((acc, [key, value]) => {
+  acc[value] = acc[value] || [];
+  acc[value].push(key);
+  return acc;
+}, {});
+
+// Print only those values that map to multiple keys
+for (const [value, keys] of Object.entries(byValue)) {
+  if (keys.length > 1) {
+    console.log(`"${value}" → ${keys.join(", ")}`);
+  }
+}

--- a/util/scripts/i18n/find-unused-keys.js
+++ b/util/scripts/i18n/find-unused-keys.js
@@ -1,0 +1,145 @@
+/**
+ * Script to find unused i18next translation keys.
+ * Removes each key from the translation file one by one,
+ * runs a type-check, and reports which keys were never referenced in the code.
+ *
+ * Make sure to have the necessary dependencies installed
+ * (you can just dump them afterwards) and that the path below point
+ * to the translation files that you want to compare.
+ *
+ * Run with `node util/scripts/i18n/find-unused-keys.js` from the project root.
+ *
+ * Some notes:
+ * - This is very inefficient performance wise and will probably
+ * take between one and two hours to run with the current translation file.
+ *
+ * - It will not work with keys that have both a `_one` and `_other` variant
+ * and are used with a {{count}} variable, as it will only remove one of them at a time.
+ * There are currently three in total which you will have to check manually.
+ *
+ * - It will report false positives for keys that are only used in backend (`api-remote-errors`).
+ *
+ * - If the script fails or is interrupted, it will **not** restore the original translation file,
+ * so make sure to have a backup before running it.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
+const yaml = require("js-yaml");
+
+
+const TRANSLATION_FILE = path.join(__dirname, "../../../frontend/src/i18n/locales/en.yaml");
+
+// Type-check command
+const CHECK_CMD = "(cd frontend && npx webpack --mode=development --stats=errors-warnings)";
+
+// ────────────────────────────────────────────────────────────────────────────────
+
+// Helper to recursively collect all nested key-paths.
+const collectKeyPaths = (obj, prefix = []) => {
+  const results = [];
+  Object.entries(obj).forEach(([k, v]) => {
+    const currentPath = prefix.concat(k);
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      results.push(...collectKeyPaths(v, currentPath));
+    } else {
+      results.push(currentPath);
+    }
+  });
+  return results;
+}
+
+// Helper to recursively delete nested keys.
+const deleteKeyAtPath = (obj, pathArray) => {
+  if (pathArray.length === 0) return;
+  const [first, ...rest] = pathArray;
+  if (!(first in obj)) return;
+  if (rest.length === 0) {
+    delete obj[first];
+  } else if (obj[first] && typeof obj[first] === "object") {
+    deleteKeyAtPath(obj[first], rest);
+    if (Object.keys(obj[first]).length === 0) {
+      delete obj[first];
+    }
+  }
+}
+
+
+// Main script execution
+(async () => {
+  // 1) Read and parse the original YAML
+  let rawYaml;
+  try {
+    rawYaml = fs.readFileSync(TRANSLATION_FILE, "utf8");
+  } catch (err) {
+    console.error(`❌ Cannot read ${TRANSLATION_FILE}: ${err.message}`);
+    process.exit(1);
+  }
+
+  let originalDoc;
+  try {
+    originalDoc = yaml.load(rawYaml);
+    if (typeof originalDoc !== "object" || originalDoc === null) {
+      throw new Error("Parsed YAML is not an object.");
+    }
+  } catch (err) {
+    console.error(`❌ Error parsing ${TRANSLATION_FILE}: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Save the original file content to restore it later
+  const originalFileContent = rawYaml;
+
+  // 2) Collect all key paths (e.g. [["common","hello"], ["home","title"], …])
+  const allKeyPaths = collectKeyPaths(originalDoc);
+
+  if (allKeyPaths.length === 0) {
+    console.log("No translation keys found in", TRANSLATION_FILE);
+    process.exit(0);
+  }
+
+  console.log(`🔍 Found ${allKeyPaths.length} translation keys. Checking usage…\n`);
+
+  // 3) For each key, remove it from a fresh clone of the original file and run a type-check.
+  const unusedKeys = [];
+  for (let i = 0; i < allKeyPaths.length; i++) {
+    const keyPath = allKeyPaths[i];
+    const keyString = keyPath.join(".");
+
+    const workingCopy = JSON.parse(JSON.stringify(originalDoc));
+    deleteKeyAtPath(workingCopy, keyPath);
+
+    const newYaml = yaml.dump(workingCopy);
+    fs.writeFileSync(TRANSLATION_FILE, newYaml, "utf8");
+
+    let hasError = false;
+    try {
+      child_process.execSync(CHECK_CMD, { stdio: "ignore" });
+      // Exit code 0: no TS error ⇒ key is unused.
+    } catch (err) {
+      // Non-zero exit code: TS error (missing key) ⇒ key is used somewhere.
+      hasError = true;
+    }
+
+    if (!hasError) {
+      unusedKeys.push(keyString);
+      console.log(`  [UNUSED]  ${keyString}`);
+    } else {
+      process.stdout.write(`  [USED]    ${keyString}\r`);
+      console.log(`  [USED]    ${keyString}`);
+    }
+  }
+
+  // 4) Restore original YAML file.
+  fs.writeFileSync(TRANSLATION_FILE, originalFileContent, "utf8");
+
+  // 5) Print summary.
+  console.log("\n────────────────────────────────────────────────");
+  if (unusedKeys.length === 0) {
+    console.log("✅ No unused translations detected.");
+  } else {
+    console.log(`✅ Found ${unusedKeys.length} unused keys:`);
+    unusedKeys.forEach((k) => console.log(`    • ${k}`));
+  }
+})();


### PR DESCRIPTION
This removes duplicate and unused keys, and generally restructures chunks of translation keys by reordering them and also removing some excessive nesting in some cases.

This also removes any non-count or name related interpolation (there were only two or three). Such interpolations are considered bad practice as they can be problematic for translations in multiple languages, especially when multiple articles need to be considered that just aren't present in english.

I ran three scripts to check/find stuff:
- 1. duplicate translation values
- 2. unused translation keys
- 3. equality of `en` and `de` keys

I double checked and corrected anything reported by these scripts manually.
Note that there are some cases where the german translations need additional plural cases that would be redundant in the english file.

This is mainly a refactor PR and will not profit from a thorough review.
<sub>We can always argue about specific names for keys or were they should be placed, but please trust me this once when I say that this is an overall improvement.</sub>