### PR TITLE
Fix issue with eslint-webpack-plugin

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -94,7 +94,7 @@ const config: CallableOption = (_env, argv) => ({
         }),
         new ESLintPlugin({
             extensions: ["ts", "tsx", "js"],
-            configType: "flat",
+            failOnError: false,
         }),
         new CopyPlugin({
             patterns: [


### PR DESCRIPTION
After an upgrade to 5.x, the plugin would
kill our dev script. This is fixed by adjusting
the config.

I also removed `configType: "flat"` since that is
the default now.