### PR TITLE
Update paella-user-tracking to 1.42.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.1",
         "paella-slide-plugins": "1.50.1",
-        "paella-user-tracking": "1.42.5",
+        "paella-user-tracking": "1.42.6",
         "paella-zoom-plugin": "1.41.3",
         "qrcode.react": "^4.2.0",
         "raw-loader": "^4.0.2",
@@ -8513,9 +8513,9 @@
       }
     },
     "node_modules/paella-user-tracking": {
-      "version": "1.42.5",
-      "resolved": "https://registry.npmjs.org/paella-user-tracking/-/paella-user-tracking-1.42.5.tgz",
-      "integrity": "sha512-dUZZMQOc+Jr7emYxsX7kheuKURsRBIk04CD126EFnEcEfOY/GaBK1ypNBq0f7IGdVGMFKZfnfsPrlJJyt6UCQA==",
+      "version": "1.42.6",
+      "resolved": "https://registry.npmjs.org/paella-user-tracking/-/paella-user-tracking-1.42.6.tgz",
+      "integrity": "sha512-g8aCPTs3GmyW6TmQMDp+dlZH+hWa5RR8pRBi8f9hpAxdxWWdv6NzWv2YLYjDwCl356aozAwN/Ge5DVdFgvNQCg==",
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
         "paella-core": "^1.42.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.1",
     "paella-slide-plugins": "1.50.1",
-    "paella-user-tracking": "1.42.5",
+    "paella-user-tracking": "1.42.6",
     "paella-zoom-plugin": "1.41.3",
     "qrcode.react": "^4.2.0",
     "raw-loader": "^4.0.2",


### PR DESCRIPTION
The new version of the paella-user-tracking plugin introduces the config parameter `disableAlwaysUseSendBeacon` to improve user tracking with Matomo.