### PR TITLE
Adjust webpack config for node 23/24

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "incremental": true,
 
     "target": "es2020",
-    "module": "CommonJS",
+    "module": "preserve",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { CallableOption } from "webpack-cli";
+import type { CallableOption } from "webpack-cli";
 import YAML from "yaml";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
@@ -7,7 +7,9 @@ import ESLintPlugin from "eslint-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import * as fs from "fs";
+import { fileURLToPath } from "url";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const APP_PATH = path.join(__dirname, "src");
 const OUT_PATH = path.join(__dirname, "build");
 const PAELLA_SKIN_PATH = path.join(__dirname, "node_modules", "paella-skins", "skins", "opencast");


### PR DESCRIPTION
Node 23.6+ ships a native TS+ESM loader which requires specific type-only imports and drops CJS globals.

This requires a change in our webpack which makes it no longer work with older node versions without errors or warnings. To work around that, this commit adds a CJS wrapper for the config, with which it should work for all recent node versions (at least 22/23/24) without any errors or warnings.