### PR TITLE
Remove redundant instances of `ts-expect-error`

### DIFF
--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -73,7 +73,7 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
             // Use a message fitting to the exact error key, if it is present.
             const translationKey = err.key ? `api-remote-errors.${err.key}` : null;
             if (translationKey && i18n.exists(translationKey)) {
-                // more strictly than just `string` or `ParseKeys` for the `<Trans>`
+                // More strictly than just `string` or `ParseKeys` for the `<Trans>`
                 // component.
                 const msg = <Trans i18nKey={translationKey} />;
                 causes.add(msg);

--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -73,7 +73,6 @@ export const errorDisplayInfo = (error: unknown, i18n: i18n): ErrorDisplayInfo =
             // Use a message fitting to the exact error key, if it is present.
             const translationKey = err.key ? `api-remote-errors.${err.key}` : null;
             if (translationKey && i18n.exists(translationKey)) {
-                // @ts-expect-error: Dynamically passed i18next keys need to be typed
                 // more strictly than just `string` or `ParseKeys` for the `<Trans>`
                 // component.
                 const msg = <Trans i18nKey={translationKey} />;

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -116,7 +116,6 @@ const config: CallableOption = (_env, argv) => ({
                     // To guard against updates.
                     throw new Error("Paella skin CSS changed! Adjust webpack config.");
                 }
-                // @ts-expect-error replaceAll requires a newer es standard, but
                 // that's trick to configure for this file.
                 const out = file.replace(fontDecl, "").replaceAll("font-family: roboto;", "");
                 fs.writeFileSync(outPath, out);

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -116,7 +116,7 @@ const config: CallableOption = (_env, argv) => ({
                     // To guard against updates.
                     throw new Error("Paella skin CSS changed! Adjust webpack config.");
                 }
-                // that's trick to configure for this file.
+                // That's a trick to configure for this file.
                 const out = file.replace(fontDecl, "").replaceAll("font-family: roboto;", "");
                 fs.writeFileSync(outPath, out);
             });


### PR DESCRIPTION
These probably got “fixed” by some TypeScript update?