### PR TITLE
Redesign realm navigation (and add `DevConfig` helper)

### DIFF
--- a/backend/src/api/model/realm/nav.rs
+++ b/backend/src/api/model/realm/nav.rs
@@ -1,0 +1,133 @@
+use juniper::GraphQLObject;
+
+use crate::{
+    api::{err::ApiResult, Context},
+    db::util::{dbargs, select},
+    model::Key,
+    prelude::*,
+};
+
+/// Information to render the navigation for a single realm.
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct RealmNav {
+    /// Elements above the list, usually current page and parent. Is either
+    /// 0, 1 or 2 elements long. Order is "reversed" in that the last element
+    /// is rendered first/topmost. The main root realm is treated as parent of
+    /// user root realms.
+    header: Vec<RealmNavItem>,
+
+    /// Main part of the nav: list of realms to navigate to. These are usually
+    /// the children of the current realm, except for non-root leaf nodes, where
+    /// it's the siblings (including itself) instead.
+    list: Vec<RealmNavItem>,
+
+    /// Dictates in what order the items in `list` should be displayed.
+    list_order: super::RealmOrder,
+}
+
+#[derive(Debug, GraphQLObject)]
+pub(crate) struct RealmNavItem {
+    /// Resolved name, like `Realm.name`.
+    name: Option<String>,
+    path: String,
+    has_children: bool,
+}
+
+impl RealmNav {
+    pub(crate) async fn load_for(realm: &super::Realm, context: &Context) -> ApiResult<Self> {
+        let (selection, mapping) = select!(
+            id,
+            full_path,
+            child_order,
+            // This causes an "index only scan" for each row, but this is extremely fast.
+            has_children: "exists(select from realms r2 where r2.parent = realms.id)",
+            name: "case \
+                when name_from_block is null then name \
+                else (\
+                    select coalesce(series.title, events.title) \
+                    from blocks \
+                    left join events on blocks.video = events.id \
+                    left join series on blocks.series = series.id \
+                    where blocks.id = name_from_block\
+                )\
+            end",
+        );
+
+        let list_filter = if realm.is_main_root() {
+            "parent = $1"
+        } else if realm.is_user_root() {
+            "parent = $1"
+        } else {
+            "case
+                -- If realm has children -> select children
+                when $2 is null or exists(select from realms where parent = $1) then parent = $1
+                -- If not -> select siblings
+                else parent = $2
+            end"
+        };
+        let sql = format!("\
+            select {selection} from realms where
+                -- grandparent
+                full_path = $3
+                -- parent
+                or id = $2
+                -- list
+                or {list_filter}
+            order by index asc");
+
+        let grandparent_path = realm.full_path.rsplitn(3, '/').nth(2);
+        let parent_key = if realm.is_user_root() { Some(Key(0)) } else { realm.parent_key };
+        let rows = context.db.query_raw(&sql, dbargs![
+            &realm.key,
+            &parent_key,
+            &grandparent_path,
+        ]).await?;
+
+        // Go through rows and collect all parts.
+        let mut parent = None;
+        let mut parent_order = None;
+        let mut grandparent = None;
+        let mut list = vec![];
+        rows.try_for_each(|row| {
+            let id = mapping.id.of::<Key>(&row);
+            let item = RealmNavItem {
+                path: mapping.full_path.of(&row),
+                name: mapping.name.of(&row),
+                has_children: mapping.has_children.of(&row),
+            };
+
+            if parent_key == Some(id) {
+                parent_order = Some(mapping.child_order.of(&row));
+                parent = Some(item);
+            } else if grandparent_path == Some(&item.path) {
+                grandparent = Some(item);
+            } else {
+                list.push(item);
+            }
+
+            std::future::ready(Ok(()))
+        }).await?;
+
+        // Check if the `list` contains children or siblings of `realm`.
+        if list.len() > 0 && list[0].path.split('/').count() == realm.full_path.split('/').count() {
+            // Siblings
+            Ok(Self {
+                header: [grandparent, parent].into_iter().flatten().collect(),
+                list,
+                list_order: parent_order.expect("no parent of siblings"),
+            })
+        } else {
+            // Children
+            let this = RealmNavItem {
+                name: realm.resolved_name.clone(),
+                path: realm.full_path.clone(),
+                has_children: true,
+            };
+            Ok(Self {
+                header: [parent, Some(this)].into_iter().flatten().collect(),
+                list,
+                list_order: realm.child_order,
+            })
+        }
+    }
+}

--- a/backend/src/api/model/realm/nav.rs
+++ b/backend/src/api/model/realm/nav.rs
@@ -53,9 +53,7 @@ impl RealmNav {
             end",
         );
 
-        let list_filter = if realm.is_main_root() {
-            "parent = $1"
-        } else if realm.is_user_root() {
+        let list_filter = if realm.is_main_root() || realm.is_user_root() {
             "parent = $1"
         } else {
             "case
@@ -123,8 +121,12 @@ impl RealmNav {
                 path: realm.full_path.clone(),
                 has_children: true,
             };
+
+            // Special case main root where we don't show "this".
+            let this = if realm.is_main_root() { None } else { Some(this) };
+
             Ok(Self {
-                header: [parent, Some(this)].into_iter().flatten().collect(),
+                header: [parent, this].into_iter().flatten().collect(),
                 list,
                 list_order: realm.child_order,
             })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { COLORS } from "./color";
 import { InitialConsent } from "./ui/InitialConsent";
 import { InitialLoading } from "./layout/Root";
 import { NotificationProvider } from "./ui/NotificationContext";
+import { DevConfig } from "./DevConfig";
 
 
 type Props = {
@@ -36,19 +37,21 @@ export const App: React.FC<Props> = ({ initialRoute, consentGiven }) => (
                     <GlobalStyle />
                     <GlobalErrorBoundary>
                         <RelayEnvironmentProvider {...{ environment }}>
-                            <Router initialRoute={initialRoute}>
-                                <GraphQLErrorBoundary>
-                                    <MenuProvider>
-                                        <NotificationProvider>
-                                            <LoadingIndicator />
-                                            <InitialConsent {...{ consentGiven }} />
-                                            <Suspense fallback={<InitialLoading />}>
-                                                <ActiveRoute />
-                                            </Suspense>
-                                        </NotificationProvider>
-                                    </MenuProvider>
-                                </GraphQLErrorBoundary>
-                            </Router>
+                            <DevConfig>
+                                <Router initialRoute={initialRoute}>
+                                    <GraphQLErrorBoundary>
+                                        <MenuProvider>
+                                            <NotificationProvider>
+                                                <LoadingIndicator />
+                                                <InitialConsent {...{ consentGiven }} />
+                                                <Suspense fallback={<InitialLoading />}>
+                                                    <ActiveRoute />
+                                                </Suspense>
+                                            </NotificationProvider>
+                                        </MenuProvider>
+                                    </GraphQLErrorBoundary>
+                                </Router>
+                            </DevConfig>
                         </RelayEnvironmentProvider>
                     </GlobalErrorBoundary>
                 </AppkitConfigProvider>

--- a/frontend/src/DevConfig.tsx
+++ b/frontend/src/DevConfig.tsx
@@ -1,0 +1,67 @@
+import { bug, match, notNullish } from "@opencast/appkit";
+import React, { PropsWithChildren, useContext, useState } from "react";
+import { COLORS } from "./color";
+
+// NOTE TO DEVELOPERS: you only need to adjust the `DevConfig` type and
+// `DEFAULT` value. Everything else should work automatically.
+
+type DevConfig = {
+    treeIcons: boolean;
+    nestedHome: boolean;
+};
+const DEFAULT: DevConfig = {
+    treeIcons: false,
+    nestedHome: false,
+};
+
+// -----
+
+const ENABLED = Object.keys(DEFAULT).length > 0;
+
+const Context = React.createContext<DevConfig | null>(null);
+
+export const useDevConfig = (): DevConfig => notNullish(useContext(Context));
+
+/**
+ * User accessible configuration for development. Intended to let people
+ * immediately switch between different design options, for example. Just for
+ * development!
+*/
+export const DevConfig: React.FC<PropsWithChildren> = ({ children }) => {
+    const [config, setConfig] = useState(DEFAULT);
+
+    if (!ENABLED) {
+        return children;
+    }
+
+    return <>
+        <div css={{
+            position: "fixed",
+            bottom: 0,
+            right: 0,
+            backgroundColor: COLORS.neutral10,
+            padding: "8px 16px",
+            border: "2px dashed orange",
+            zIndex: 250,
+        }}>
+            {Object.keys(DEFAULT).map(key => {
+                const value = DEFAULT[key as keyof typeof DEFAULT];
+                const ty = typeof value;
+                const input = match(ty, {
+                    "boolean": () => <input
+                        type="checkbox"
+                        defaultChecked={value}
+                        onChange={e => setConfig(old => ({ ...old, [key]: e.target.checked }))}
+                    />,
+                });
+
+                if (!input) {
+                    bug(`Dev config type ${ty} not yet supported`);
+                }
+
+                return <label key={key} css={{ display: "block" }}>{input} {key}</label>;
+            })}
+        </div>
+        <Context.Provider value={config}>{children}</Context.Provider>
+    </>;
+};

--- a/frontend/src/DevConfig.tsx
+++ b/frontend/src/DevConfig.tsx
@@ -5,13 +5,10 @@ import { COLORS } from "./color";
 // NOTE TO DEVELOPERS: you only need to adjust the `DevConfig` type and
 // `DEFAULT` value. Everything else should work automatically.
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type DevConfig = {
-    treeIcons: boolean;
-    nestedHome: boolean;
 };
 const DEFAULT: DevConfig = {
-    treeIcons: false,
-    nestedHome: false,
 };
 
 // -----

--- a/frontend/src/layout/Burger.tsx
+++ b/frontend/src/layout/Burger.tsx
@@ -40,29 +40,18 @@ export const BurgerMenu: React.FC<BurgerMenuProps> = ({ hide, items }) => (
                 margin: 8,
                 borderBottom: "none",
                 "a, span, button": {
-                    padding: 16,
                     borderRadius: 4,
                 },
             },
-            nav: {
-                "> a": {
-                    margin: 8,
-                    padding: "12px 4px",
-                    borderRadius: 4,
-                    "svg:first-of-type": {
-                        display: "block",
-                        fontSize: 24,
-                    },
-                    "svg:last-of-type": { display: "none" },
-                },
-                "> div": {
-                    backgroundColor: COLORS.neutral20,
-                    borderRadius: 4,
-                    border: "none",
-                    color: COLORS.primary2,
+            "div > ul > li": {
+                "a, span, button": {
                     padding: 16,
-                    margin: "0 8px",
-                    "~ ul": { marginLeft: 26 },
+                },
+            },
+            "div > nav > ul > li": {
+                "> a, > div, > button": {
+                    paddingTop: 16,
+                    paddingBottom: 16,
                 },
             },
         }}>

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { LuChevronLeft, LuChevronRight, LuCornerLeftUp } from "react-icons/lu";
+import { LuChevronRight } from "react-icons/lu";
 import { graphql, useFragment } from "react-relay";
 
 import type { NavigationData$key } from "./__generated__/NavigationData.graphql";
@@ -7,12 +7,14 @@ import { useTranslation } from "react-i18next";
 import {
     ellipsisOverflowCss,
     focusStyle,
-    LinkList,
-    LinkWithIcon,
     SIDE_BOX_BORDER_RADIUS,
 } from "../ui";
 import { MissingRealmName, sortRealms } from "../routes/util";
 import { COLORS } from "../color";
+import { Link } from "../router";
+import { match, screenWidthAbove, useColorScheme } from "@opencast/appkit";
+import { css } from "@emotion/react";
+import { useMenu } from "./MenuState";
 
 
 /** The breakpoint, in pixels, where mobile/desktop navigations are swapped. */
@@ -25,90 +27,234 @@ type Props = {
 };
 
 /**
- * Navigation for realm pages. Shows all children of the current realm, as well
- * as the current realm name and a button to the parent. The `fragRef` is a
- * reference to a realm that has the data of the `NavigationData` fragment in
- * it.
+ * Navigation for realm pages. The `fragRef` is a reference to a realm that has
+ * the data of the `NavigationData` fragment in it.
  */
-export const Nav: React.FC<Props> = ({ fragRef }) => {
+export const RealmNav: React.FC<Props> = ({ fragRef }) => {
     const { t, i18n } = useTranslation();
     const realm = useFragment(
         graphql`
             fragment NavigationData on Realm {
                 id
                 name
-                childOrder
-                isUserRoot
-                children { id name path }
-                parent { isMainRoot name path }
+                path
+                nav {
+                    header { name path }
+                    list { name path hasChildren }
+                    listOrder
+                }
             }
         `,
         fragRef,
     );
-
-    const parent = realm.isUserRoot
-        ? {
-            path: "/",
-            name: t("general.home"),
-            isMainRoot: true,
-        }
-        : realm.parent;
-    const hasRealmParent = parent != null;
+    const nav = realm.nav;
 
     // We expect all production instances to have more than the root realm. So
     // we print this information instead of an empty div to avoid confusion.
-    if (realm.children.length === 0 && !hasRealmParent) {
+    if (nav.list.length === 0 && nav.header.length === 0) {
         return <div css={{ margin: "8px 12px" }}>{t("general.no-root-children")}</div>;
     }
 
-    const children = sortRealms(realm.children, realm.childOrder, i18n.language);
+    const shared = (item: { path: string, name?: string | null }) => ({
+        label: item.path === "" ? t("general.home") : item.name ?? <MissingRealmName />,
+        active: item.path === realm.path,
+        link: item.path || "/",
+    });
+
+    return <Nav treeIcons items={[
+        // Header
+        ...nav.header.map((item, i) => ({
+            ...shared(item),
+            indent: i,
+        } satisfies NavItem)),
+
+        // Main list
+        ...sortRealms(nav.list, nav.listOrder, i18n.language).map(item => ({
+            ...shared(item),
+            indent: nav.header.length,
+            icon: item.hasChildren ? {
+                icon: <LuChevronRight />,
+                position: "right",
+            } : undefined,
+        } satisfies NavItem)),
+    ]} />;
+};
+
+
+type NavItem = {
+    label: ReactNode;
+    /** Indentation level, small positive integer */
+    indent: number;
+    active: boolean;
+    link: string;
+    icon?: {
+        position: "left" | "right";
+        icon: ReactNode;
+    };
+    closeBurgerOnClick?: boolean;
+};
+
+type NavProps = {
+    treeIcons?: boolean;
+    items: NavItem[];
+};
+
+/**
+ * TODO: docs
+ */
+export const Nav: React.FC<NavProps> = ({ items, treeIcons = false }) => {
+    const isDarkMode = useColorScheme().scheme === "dark";
+    const treeIcon = (idx: number): NavItemProps["treeIcon"] => {
+        if (!treeIcons) {
+            return undefined;
+        }
+
+        const item = items[idx];
+        const prev = items[idx - 1];
+        const next = items[idx + 1];
+
+        return {
+            incoming: item.indent > 0 && prev && prev.indent <= item.indent,
+            outgoing: !next || next.indent < item.indent ? "none" : (
+                next.indent > item.indent ? "child" : "sibling"
+            ),
+        };
+    };
+
+    const menu = useMenu();
+    const closeBurger = () => menu.state === "burger" && menu.close();
 
     return <nav>
-        {hasRealmParent && <>
-            <LinkWithIcon
-                to={parent.path}
-                iconPos="left"
-                css={{
-                    color: COLORS.neutral60,
-                    padding: "10px 14px",
-                    borderRadius: `${SIDE_BOX_BORDER_RADIUS}px ${SIDE_BOX_BORDER_RADIUS}px 0 0`,
-                    ...focusStyle({ inset: true }),
-                }}
-            >
-                {/* Show arrow and hide chevron in burger menu */}
-                <LuCornerLeftUp css={{ display: "none" }}/>
-                <LuChevronLeft />
-                {parent.isMainRoot ? t("general.home") : parent.name ?? <MissingRealmName />}
-            </LinkWithIcon>
-            <div css={{
-                padding: "8px 14px 8px 16px",
-                color: COLORS.primary2,
-                backgroundColor: COLORS.neutral20,
-                border: `2px solid ${COLORS.neutral05}`,
-                borderLeft: "none",
-                borderRight: "none",
-            }}>{realm.name ?? <MissingRealmName />}</div>
-        </>}
-        <LinkList
-            items={children.map(child => (
-                <Item
-                    key={child.id}
-                    label={child.name ?? <MissingRealmName />}
-                    link={child.path}
-                />
+        <ul css={{
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+        }}>
+            {items.map((item, i) => (
+                <li key={i} css={{
+                    backgroundColor: COLORS.neutral10, // For burger menu
+                    borderBottom: `2px solid ${COLORS.neutral05}`,
+                    "&:last-of-type": { borderBottom: "none" },
+                    [screenWidthAbove(BREAKPOINT)]: {
+                        "&:first-child > *": {
+                            borderTopRightRadius: SIDE_BOX_BORDER_RADIUS,
+                            borderTopLeftRadius: SIDE_BOX_BORDER_RADIUS,
+                        },
+                        "&:last-child > *": {
+                            borderBottomRightRadius: SIDE_BOX_BORDER_RADIUS,
+                            borderBottomLeftRadius: SIDE_BOX_BORDER_RADIUS,
+                        },
+                    },
+                }}>
+                    <NavItem
+                        {...{ item, isDarkMode }}
+                        onLinkClick={item.closeBurgerOnClick ? closeBurger : undefined}
+                        treeIcon={treeIcon(i)}
+                    />
+                </li>
             ))}
-        />
+        </ul>
     </nav>;
 };
 
-type ItemProps = {
-    label: ReactNode;
-    link: string;
+type NavItemProps = {
+    item: NavItem,
+    isDarkMode: boolean;
+    onLinkClick?: () => void;
+    treeIcon?: {
+        incoming: boolean;
+        outgoing: "none" | "sibling" | "child";
+    },
 };
 
-const Item: React.FC<ItemProps> = ({ label, link }) => (
-    <LinkWithIcon to={link} iconPos="right">
-        <div css={ellipsisOverflowCss(3)}>{label}</div>
-        <LuChevronRight />
-    </LinkWithIcon>
-);
+const NavItem: React.FC<NavItemProps> = ({ item, isDarkMode, onLinkClick, treeIcon }) => {
+    // Shared style (for active & links)
+    const style = css({
+        display: "block",
+        padding: 10,
+        paddingRight: 12,
+        paddingLeft: 16 + item.indent * 16,
+        "& > svg": {
+            fontSize: 20,
+            minWidth: 20,
+        },
+    });
+
+    const inner = <div css={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: match(item.icon?.position ?? "none", {
+            "left": () => "flex-start",
+            "right": () => "space-between",
+            "none": () => "flex-start",
+        }),
+        gap: 12,
+    }}>
+        {item.icon && item.icon.position === "left" && item.icon.icon}
+        {treeIcon && <div css={{
+            position: "absolute",
+            left: -14,
+            top: -12,
+            bottom: -12,
+            display: "flex",
+            alignItems: "center",
+        }}>
+            <svg
+                viewBox="0 0 24 44"
+                height="44px"
+                stroke="currentColor"
+                fill="none"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                css={{ color: COLORS.neutral40 }}
+            >
+                {treeIcon.incoming && <path d="M2 2v16q0 4,4 4h2" />}
+                {treeIcon.outgoing === "sibling" && <path d="M2 24v18" />}
+                {treeIcon.outgoing === "child" && <path d="M18 38v14" />}
+            </svg>
+        </div>}
+        <span css={ellipsisOverflowCss(2)}>{item.label}</span>
+        {item.icon && item.icon.position === "right" && item.icon.icon}
+    </div>;
+
+    if (item.active) {
+        const activeStyle = css({
+            fontWeight: "bold",
+            position: "relative" as const,
+            backgroundColor: COLORS.neutral15,
+        });
+
+        return <div css={[style, activeStyle]} aria-current="page">
+            <div css={{
+                position: "absolute",
+                right: 0,
+                top: 0,
+                bottom: 0,
+                width: 3,
+                backgroundColor: COLORS.neutral40,
+            }} />
+            {inner}
+        </div>;
+    } else {
+        const linkStyle = css({
+            textDecoration: "none",
+            transitionProperty: "background-color, color",
+            transitionDuration: "0.15s",
+            "&:hover, &:focus-visible": {
+                transitionDuration: "0s", // Make on hover immediate, on blur transition
+                backgroundColor: COLORS.neutral20,
+                ...isDarkMode && { color: COLORS.primary2 },
+            },
+            ...isDarkMode && { color: COLORS.primary1 },
+            ...focusStyle({ inset: true }),
+        });
+
+        return <Link
+            to={item.link}
+            onClick={onLinkClick}
+            css={[style, linkStyle]}
+        >{inner}</Link>;
+    }
+};

--- a/frontend/src/layout/Navigation.tsx
+++ b/frontend/src/layout/Navigation.tsx
@@ -52,7 +52,12 @@ export const RealmNav: React.FC<Props> = ({ fragRef }) => {
     // We expect all production instances to have more than the root realm. So
     // we print this information instead of an empty div to avoid confusion.
     if (nav.list.length === 0 && nav.header.length === 0) {
-        return <div css={{ margin: "8px 12px" }}>{t("general.no-root-children")}</div>;
+        return <Nav items={[{
+            label: t("general.no-root-children"),
+            active: true,
+            indent: 0,
+            link: "/",
+        }]} />;
     }
 
     const shared = (item: { path: string, name?: string | null }) => ({

--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -3,7 +3,7 @@ import { useTranslation, Trans } from "react-i18next";
 import { graphql } from "react-relay";
 
 import CONFIG from "../config";
-import { Nav } from "../layout/Navigation";
+import { RealmNav } from "../layout/Navigation";
 import { RootLoader } from "../layout/Root";
 import { loadQuery } from "../relay";
 import { AboutQuery } from "./__generated__/AboutQuery.graphql";
@@ -25,7 +25,7 @@ export const AboutRoute = makeRoute({
         return {
             render: () => <RootLoader
                 {...{ query, queryRef }}
-                nav={data => <Nav fragRef={data.realm} />}
+                nav={data => <RealmNav fragRef={data.realm} />}
                 render={() => <About />}
             />,
             dispose: () => queryRef.dispose(),

--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -5,7 +5,7 @@ import { unreachable } from "@opencast/appkit";
 import { loadQuery } from "../relay";
 import { makeRoute } from "../rauta";
 import { RootLoader } from "../layout/Root";
-import { Nav } from "../layout/Navigation";
+import { RealmNav } from "../layout/Navigation";
 import { PageTitle } from "../layout/header/ui";
 import { keyOfId, playlistId } from "../util";
 import { NotFound } from "./NotFound";
@@ -44,7 +44,7 @@ export const DirectPlaylistOCRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => <Nav fragRef={data.rootRealm} />}
+                nav={data => <RealmNav fragRef={data.rootRealm} />}
                 render={result => <PlaylistPage realmPath={null} playlistFrag={result.playlist} />}
             />,
             dispose: () => queryRef.dispose(),
@@ -78,7 +78,7 @@ export const DirectPlaylistRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => <Nav fragRef={data.rootRealm} />}
+                nav={data => <RealmNav fragRef={data.rootRealm} />}
                 render={result => <PlaylistPage realmPath={null} playlistFrag={result.playlist} />}
             />,
             dispose: () => queryRef.dispose(),

--- a/frontend/src/routes/Realm.tsx
+++ b/frontend/src/routes/Realm.tsx
@@ -11,8 +11,7 @@ import { Breadcrumbs } from "../ui/Breadcrumbs";
 import { Blocks } from "../ui/Blocks";
 import { RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
-import { Nav } from "../layout/Navigation";
-import { LinkList, LinkWithIcon } from "../ui";
+import { RealmNav, Nav } from "../layout/Navigation";
 import { characterClass, useTitle, useTranslatedConfig, visuallyHiddenStyle } from "../util";
 import { makeRoute } from "../rauta";
 import { MissingRealmName } from "./util";
@@ -23,7 +22,6 @@ import { displayCommitError } from "./manage/Realm/util";
 import { Spinner, boxError } from "@opencast/appkit";
 import { useRouter } from "../router";
 import { COLORS } from "../color";
-import { useMenu } from "../layout/MenuState";
 import { ManageNav } from "./manage";
 import { BREAKPOINT as NAV_BREAKPOINT } from "../layout/Navigation";
 import CONFIG from "../config";
@@ -98,7 +96,7 @@ export const RealmRoute = makeRoute({
                         return [];
                     }
 
-                    const mainNav = <Nav key="nav" fragRef={data.realm} />;
+                    const mainNav = <RealmNav key="nav" fragRef={data.realm} />;
                     return data.realm.canCurrentUserModerate
                         ? [mainNav, <RealmEditLinks key="edit-buttons" path={realmPath} />]
                         : mainNav;
@@ -264,7 +262,6 @@ const CreateUserRealm: React.FC<{ realmPath: string }> = ({ realmPath }) => {
 
 export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
     const { t } = useTranslation();
-    const menu = useMenu();
 
     /* eslint-disable react/jsx-key */
     const buttons: [string, string, ReactElement][] = [
@@ -278,19 +275,17 @@ export const RealmEditLinks: React.FC<{ path: string }> = ({ path }) => {
 
     const encodedPath = pathToQuery(path);
 
-    const items = buttons.map(([route, label, icon], i) => (
-        <LinkWithIcon key={i}
-            to={`${route}${encodedPath}`}
-            iconPos="left"
-            active={isActive(route)}
-            close={() => menu.state === "burger" && menu.close()}
-        >
-            {icon}
-            {label}
-        </LinkWithIcon>
-    ));
-
-    return <LinkList items={items} />;
+    return <Nav items={buttons.map(([route, label, icon]) => ({
+        active: isActive(route),
+        indent: 0,
+        label,
+        link: `${route}${encodedPath}`,
+        icon: {
+            position: "left",
+            icon,
+        },
+        closeBurgerOnClick: true,
+    }))} />;
 };
 
 /**

--- a/frontend/src/routes/Series.tsx
+++ b/frontend/src/routes/Series.tsx
@@ -5,7 +5,7 @@ import { loadQuery } from "../relay";
 import { makeRoute } from "../rauta";
 import { SeriesBlockFromSeries } from "../ui/Blocks/Series";
 import { InitialLoading, RootLoader } from "../layout/Root";
-import { Nav } from "../layout/Navigation";
+import { RealmNav } from "../layout/Navigation";
 import { PageTitle } from "../layout/header/ui";
 import { WaitingPage } from "../ui/Waiting";
 import { isSynced, keyOfId, seriesId } from "../util";
@@ -58,7 +58,7 @@ export const SeriesRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+                nav={data => data.realm ? <RealmNav fragRef={data.realm} /> : []}
                 render={({ series, realm }) => {
                     if (!realm || series?.isReferencedByRealm === false) {
                         return <ForwardToDirectRoute seriesId={params.seriesId} />;
@@ -109,7 +109,7 @@ export const OpencastSeriesRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+                nav={data => data.realm ? <RealmNav fragRef={data.realm} /> : []}
                 render={({ series, realm }) => {
                     if (!realm || series?.isReferencedByRealm === false) {
                         return <ForwardToDirectRoute seriesId={params.seriesId} />;
@@ -183,7 +183,7 @@ export const DirectSeriesOCRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => <Nav fragRef={data.rootRealm} />}
+                nav={data => <RealmNav fragRef={data.rootRealm} />}
                 render={result => <SeriesPage
                     seriesRef={result.series}
                     realmRef={result.rootRealm}
@@ -221,7 +221,7 @@ export const DirectSeriesRoute = makeRoute({
             render: () => <RootLoader
                 {...{ query, queryRef }}
                 noindex
-                nav={data => <Nav fragRef={data.rootRealm} />}
+                nav={data => <RealmNav fragRef={data.rootRealm} />}
                 render={result => <SeriesPage
                     seriesRef={result.series}
                     realmRef={result.rootRealm}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -23,7 +23,7 @@ import { VideoObject, WithContext } from "schema-dts";
 import { environment, loadQuery } from "../relay";
 import { InitialLoading, RootLoader } from "../layout/Root";
 import { NotFound } from "./NotFound";
-import { Nav } from "../layout/Navigation";
+import { RealmNav } from "../layout/Navigation";
 import { WaitingPage } from "../ui/Waiting";
 import { getPlayerAspectRatio, InlinePlayer, PlayerPlaceholder } from "../ui/player";
 import { SeriesBlockFromSeries } from "../ui/Blocks/Series";
@@ -145,7 +145,7 @@ export const VideoRoute = makeRoute({
         return {
             render: () => <RootLoader
                 {... { query, queryRef }}
-                nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+                nav={data => data.realm ? <RealmNav fragRef={data.realm} /> : []}
                 render={({ event, realm, playlist }) => {
                     if (!realm || (event && !event.isReferencedByRealm)) {
                         return <ForwardToDirectRoute videoId={videoId} />;
@@ -213,7 +213,7 @@ export const OpencastVideoRoute = makeRoute({
         return {
             render: () => <RootLoader
                 {... { query, queryRef }}
-                nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+                nav={data => data.realm ? <RealmNav fragRef={data.realm} /> : []}
                 render={({ event, realm, playlist }) => {
                     if (!realm || (event && !event.isReferencedByRealm)) {
                         return <ForwardToDirectOcRoute ocID={id} />;
@@ -381,7 +381,7 @@ const matchedDirectRoute = (
     render: () => <RootLoader
         {... { query, queryRef }}
         noindex
-        nav={data => data.realm ? <Nav fragRef={data.realm} /> : []}
+        nav={data => data.realm ? <RealmNav fragRef={data.realm} /> : []}
         render={({ event, realm, playlist }) => <VideoPage
             eventRef={event}
             realmRef={realm ?? unreachable("root realm doesn't exist")}

--- a/frontend/src/routes/manage/Realm/AddChild.tsx
+++ b/frontend/src/routes/manage/Realm/AddChild.tsx
@@ -19,7 +19,7 @@ import { displayCommitError, RealmSettingsContainer, realmValidations } from "./
 import { Button, boxError } from "@opencast/appkit";
 import { AddChildMutation$data } from "./__generated__/AddChildMutation.graphql";
 import { Spinner } from "@opencast/appkit";
-import { Nav } from "../../../layout/Navigation";
+import { RealmNav } from "../../../layout/Navigation";
 import { makeRoute } from "../../../rauta";
 import { ILLEGAL_CHARS, RealmEditLinks, RESERVED_CHARS } from "../../Realm";
 import { Breadcrumbs } from "../../../ui/Breadcrumbs";
@@ -52,7 +52,7 @@ export const AddChildRoute = makeRoute({
                 noindex
                 nav={data => data.parent
                     ? [
-                        <Nav key="main-nav" fragRef={data.parent} />,
+                        <RealmNav key="main-nav" fragRef={data.parent} />,
                         <RealmEditLinks key="edit-buttons" path={parent} />,
                     ]
                     : []}

--- a/frontend/src/routes/manage/Realm/ChildOrder.tsx
+++ b/frontend/src/routes/manage/Realm/ChildOrder.tsx
@@ -22,6 +22,7 @@ const fragment = graphql`
         name
         childOrder
         children { id name index }
+        ...NavigationData
     }
 `;
 

--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -14,7 +14,7 @@ import { loadQuery } from "../../../../relay";
 import { PathInvalid } from "..";
 import { NotAuthorized } from "../../../../ui/error";
 import { RealmSettingsContainer } from "../util";
-import { Nav } from "../../../../layout/Navigation";
+import { RealmNav } from "../../../../layout/Navigation";
 import { makeRoute } from "../../../../rauta";
 import { Spinner } from "@opencast/appkit";
 import { AddButtons } from "./AddButtons";
@@ -51,7 +51,7 @@ export const ManageRealmContentRoute = makeRoute({
                 noindex
                 nav={data => data.realm
                     ? [
-                        <Nav key="main-nav" fragRef={data.realm} />,
+                        <RealmNav key="main-nav" fragRef={data.realm} />,
                         <RealmEditLinks key="edit-buttons" path={path} />,
                     ]
                     : []}

--- a/frontend/src/routes/manage/Realm/index.tsx
+++ b/frontend/src/routes/manage/Realm/index.tsx
@@ -14,7 +14,7 @@ import { DangerZone } from "./DangerZone";
 import { LinkButton } from "../../../ui/LinkButton";
 import { LuCircleArrowRight, LuCirclePlus } from "react-icons/lu";
 import { Card } from "@opencast/appkit";
-import { Nav } from "../../../layout/Navigation";
+import { RealmNav } from "../../../layout/Navigation";
 import { CenteredContent } from "../../../ui";
 import { NotAuthorized } from "../../../ui/error";
 import { RealmSettingsContainer } from "./util";
@@ -52,7 +52,7 @@ export const ManageRealmRoute = makeRoute({
                 noindex
                 nav={data => data.realm
                     ? [
-                        <Nav key="main-nav" fragRef={data.realm} />,
+                        <RealmNav key="main-nav" fragRef={data.realm} />,
                         <RealmEditLinks key="edit-buttons" path={data.realm.path} />,
                     ]
                     : []}

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -684,6 +684,8 @@ type Realm implements Node {
     `null` is returned.
   """
   ownerDisplayName: String
+  "Info about the navigation UI for this realm."
+  nav: RealmNav!
   """
     Returns the acl of this realm, combining moderator and admin roles and assigns
     the respective actions that are necessary for UI purposes.
@@ -735,6 +737,32 @@ type Realm implements Node {
 "A realm name that is derived from a block of that realm."
 type RealmNameFromBlock {
   block: Block!
+}
+
+"Information to render the navigation for a single realm."
+type RealmNav {
+  """
+    Elements above the list, usually current page and parent. Is either
+    0, 1 or 2 elements long. Order is "reversed" in that the last element
+    is rendered first/topmost. The main root realm is treated as parent of
+    user root realms.
+  """
+  header: [RealmNavItem!]!
+  """
+    Main part of the nav: list of realms to navigate to. These are usually
+    the children of the current realm, except for non-root leaf nodes, where
+    it's the siblings (including itself) instead.
+  """
+  list: [RealmNavItem!]!
+  "Dictates in what order the items in `list` should be displayed."
+  listOrder: RealmOrder!
+}
+
+type RealmNavItem {
+  "Resolved name, like `Realm.name`."
+  name: String
+  path: String!
+  hasChildren: Boolean!
 }
 
 type RemovedBlock {

--- a/frontend/tests/realms.spec.ts
+++ b/frontend/tests/realms.spec.ts
@@ -31,6 +31,7 @@ for (const realmType of realmTypes) {
         });
 
         const nav = page.locator("nav").first().getByRole("listitem");
+        const navHeader = ["Home", parentPageName];
         const subPages = ["Apple", "Banana", "Cherry"];
         // User realm already has an "Apple" sub-page
         const pagesToAdd = realmType === "User realm" ? ["Banana", "Cherry"] : subPages;
@@ -41,7 +42,7 @@ for (const realmType of realmTypes) {
                 await page.getByRole("heading", { name: parentPageName, level: 1 }).waitFor();
             }
 
-            await expect(nav).toHaveText(subPages);
+            await expect(nav).toHaveText([...navHeader, ...subPages]);
         });
 
         const saveButton = page.getByRole("button", { name: "Save" });
@@ -52,14 +53,14 @@ for (const realmType of realmTypes) {
                 await page.getByText("Sort alphabetically descending").click();
                 await saveButton.nth(1).click();
 
-                await expect(nav).toHaveText(subPages.slice().reverse());
+                await expect(nav).toHaveText([...navHeader, ...subPages.slice().reverse()]);
             });
 
             await test.step("Sort alphabetically ascending", async () => {
                 await page.getByText("Sort alphabetically ascending").click();
                 await saveButton.nth(1).click();
 
-                await expect(nav).toHaveText(subPages);
+                await expect(nav).toHaveText([...navHeader, ...subPages]);
             });
 
             await test.step("Manually order", async () => {
@@ -80,7 +81,7 @@ for (const realmType of realmTypes) {
                 }
                 await saveButton.nth(1).click();
 
-                await expect(nav).toHaveText(postOrder);
+                await expect(nav).toHaveText([...navHeader, ...postOrder]);
             });
         });
 


### PR DESCRIPTION
This is my second attempt at redesigning our navigation, with the main goal of showing siblings of the current page if the page has no children. Therefore fixes https://github.com/elan-ev/tobira/issues/1391. Changes:

- Show siblings of current page if page has no children. In that case, we also show the parent *and* grandparent. This means the nav is essentially the same as one page up.
- The active entry in the UI looks a bit different now, with a slightly less intense background color, bold text and an indicator on the right side.
- Only pages that have children have the `>` icon on the right side.
- The first line of the navigation has lost its "up icon" and is not indented at all. The next entry is indented one more, and then all the children are indented two steps. All of these entries have the same height now.

This pull request is not done yet, as there are two parts missing:
- ~~The burger menu is completely broken right now~~ -> not anymore
- The management navigation does not use the new "design" -> will do that later

I opened this PR to gather feedback on this new iteration. I must say I'm pretty happy. I don't see any obvious problems with it and I think it looks quite nice! 

| [Try it out](https://pr1477.tobira.opencast.org) |
| --- |

### Open questions

There are two choices we have. And this time, you can simply try them out! In the bottom right corner of the screen, you have a new UI with two checkboxes. Toggling them will immediately change the navigation. The `nestedHome` only affects the navigation of the home page `/`.

- `nestedHome`: On the homepage, do we also want to show "Homepage" at the top, showing all other pages as children? Or keep the old behavior of only showing all children, non-indented.
- `treeIcons`: these icons make the relationship between pages clearer, resembling some folder structure. However, they add visual noise. Do we want these icons or not?