### PR TITLE
Make relay cache expire after 30min

### DIFF
--- a/frontend/src/relay/index.ts
+++ b/frontend/src/relay/index.ts
@@ -13,7 +13,9 @@ import { NetworkError } from "../util/err";
 
 
 export const environment = new Environment({
-    store: new Store(new RecordSource()),
+    store: new Store(new RecordSource(), {
+        queryCacheExpirationTime: 30 * 60 * 1000,
+    }),
     network: Network.create(
         async ({ text: query }, variables) => {
             const response = await fetch("/graphql", {


### PR DESCRIPTION
Fixes #1433

Of course, the exact expiration time is up for debate. On one side, reducing this as much as possible prevents more situations where people expect navigation to result in fresh data. One situation we absolutely want to avoid is people coming back on another day, navigating around only to see cached results. On the other hand, caching speeds up navigation, especially when users click around a lot and return to intermediate pages often. It also reduces server load.

The relay docs example have 5min:
https://relay.dev/docs/guided-tour/reusing-cached-data/staleness-of-data/#query-cache-expiration-time

I figured 30min is fine for now, we can always reduce it further in the future.