### PR TITLE
Add workflow activity check to event ACL mutations

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -677,7 +677,7 @@ api-remote-errors:
     not-allowed: Sie haben nicht die Berechtigung, diese Videoaktion durchzuführen.
     workflow:
       not-allowed: Sie haben nicht die Berechtigung, die Workflowaktivität für dieses Video abzufragen.
-      active-acl: $t(manage.access.workflow-active)
+      active-acl: $t(acl.workflow-active)
       active-metadata: $t(metadata-form.event-workflow-active)
   series:
     not-found: "Aktion fehlgeschlagen: Serie nicht gefunden."

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -641,7 +641,7 @@ api-remote-errors:
     not-allowed: You are not allowed to perform this video action.
     workflow:
       not-allowed: You are not allowed to inquire about workflow activity of this video.
-      active-acl: $t(manage.acl.workflow-active)
+      active-acl: $t(acl.workflow-active)
       active-metadata: $t(metadata-form.event-workflow-active)
   series:
     not-found: "Action failed: series not found."

--- a/frontend/src/routes/manage/Video/VideoAccess.tsx
+++ b/frontend/src/routes/manage/Video/VideoAccess.tsx
@@ -15,6 +15,7 @@ import { VideoAccessAclMutation } from "./__generated__/VideoAccessAclMutation.g
 import { NoteWithTooltip } from "../../../ui";
 import { Link } from "../../../router";
 import { ManageSeriesAccessRoute } from "../Series/SeriesAccess";
+import { Inertable } from "../../../util";
 
 
 export const ManageVideoAccessRoute = makeManageVideoRoute(
@@ -47,6 +48,7 @@ const updateVideoAcl = graphql`
         updateEventAcl(id: $id, acl: $acl) {
             ...on AuthorizedEvent {
                 acl { role actions info { label implies large } }
+                hasActiveWorkflows
             }
         }
     }
@@ -84,7 +86,7 @@ const EventAclEditor: React.FC<EventAclPageProps> = ({ event, data }) => {
         });
     };
 
-    return <>
+    return <Inertable isInert={event.hasActiveWorkflows || aclLockedToSeries || editingBlocked}>
         {event.hasActiveWorkflows && <Card kind="info" css={{ marginBottom: 20 }}>
             <Trans i18nKey="acl.workflow-active" />
         </Card>}
@@ -102,6 +104,6 @@ const EventAclEditor: React.FC<EventAclPageProps> = ({ event, data }) => {
             data,
             editingBlocked,
         }} />
-    </>;
+    </Inertable>;
 };
 


### PR DESCRIPTION
Editing event ACL will now immediatly return the workflow activity to block further edits.