### PR TITLE
Add `auth.hide_login_button` config

### DIFF
--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -17,6 +17,11 @@ pub(crate) struct AuthConfig {
     #[config(default = "none")]
     pub(crate) source: AuthSource,
 
+    /// Whether to hide the login button in the header. Useful when only admins
+    /// are supposed to log into Tobira by visiting the login page directly.
+    #[config(default = false)]
+    pub(crate) hide_login_button: bool,
+
     /// Link of the login button. If not set, the login button internally
     /// (not via `<a>`, but through JavaScript) links to Tobira's own login page.
     pub(crate) login_link: Option<String>,

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -267,6 +267,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         },
         "auth": {
             "usesTobiraSessions": config.auth.source == AuthSource::TobiraSession,
+            "hideLoginButton": config.auth.hide_login_button,
             "loginLink": config.auth.login_link,
             "logoutLink": config.auth.logout_link,
             "userIdLabel": config.auth.login_page.user_id_label,

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -225,6 +225,12 @@
 # Default value: "none"
 #source = "none"
 
+# Whether to hide the login button in the header. Useful when only admins
+# are supposed to log into Tobira by visiting the login page directly.
+#
+# Default value: false
+#hide_login_button = false
+
 # Link of the login button. If not set, the login button internally
 # (not via `<a>`, but through JavaScript) links to Tobira's own login page.
 #login_link =

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -52,6 +52,7 @@ type InitialConsent = {
 
 type AuthConfig = {
     usesTobiraSessions: boolean;
+    hideLoginButton: boolean;
     loginLink: string | null;
     logoutLink: string | null;
     userIdLabel: TranslatedString | null;

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -46,12 +46,14 @@ export const UserBox: React.FC = () => {
 
     let boxContent;
     if (user === "unknown") {
-        boxContent = <Spinner css={iconCss} />;
+        // If the login button is hidden, then almost no user logs in, so
+        // showing a brief spinner is annoying.
+        boxContent = CONFIG.auth.hideLoginButton ? null : <Spinner css={iconCss} />;
     } else if (user === "error") {
         // TODO: tooltip
         boxContent = <LuTriangleAlert css={iconCss} />;
     } else if (user === "none") {
-        boxContent = <LoggedOut />;
+        boxContent = CONFIG.auth.hideLoginButton ? null : <LoggedOut />;
     } else {
         boxContent = <LoggedIn {...{ t, user }} />;
     }


### PR DESCRIPTION
This is useful for use-cases where normal users are not supposed to login and it's expected that only a handful of admins log in. Those admins can type the direct link to the login page. And showing a login button kind of suggests to normal users that they can login, which is confusing if they in fact cannot.

UOS requested this. CC @lkiesow 