### PR TITLE
Add caching for Paella SVG icons

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -32,6 +32,7 @@ type Config = {
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;
+    paellaSettingsIcon: string;
     logos: LogoConfig;
     plyr: PlyrConfig;
     upload: UploadConfig;

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -358,7 +358,7 @@ const PAELLA_CONFIG = {
             enabled: true,
             groupName: "optionsContainer",
             description: "Options",
-            icon: "icons/settings.svg",
+            icon: CONFIG.paellaSettingsIcon.replace(/^\/~assets\/paella/, ""),
             order: 6,
             side: "right",
             tabIndex: 6,


### PR DESCRIPTION
I noticed that these icons are downloaded every time, which takes a lot of time. Not sure why we never did that before. I guess I assumed the paths are hardcoded deep inside Paella, but no: we can just replace them in `theme.json`.