### PR TITLE
Fix "global page admins" appearing in ACL UI for events/series

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -350,7 +350,7 @@ acl:
     admins: Administration
     everyone: Alle
     logged-in-users: Eingeloggte Nutzende
-    global-page-admins: Globale Seitenadministration
+    global-page-admins: "Globale Seiten\u00ADadministration"
   table:
     group: Gruppe
     user: Person

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -196,7 +196,9 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
     const isDark = useColorScheme().scheme === "dark";
     const user = useUser();
     const { t, i18n } = useTranslation();
-    const { change, knownGroups, groupDag, permissionLevels, ownerDisplayName } = useAclContext();
+    const {
+        change, knownGroups, groupDag, permissionLevels, ownerDisplayName, itemType,
+    } = useAclContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
     const userIsOwner = isRealUser(user) && user.displayName === ownerDisplayName;
     const [error, setError] = useState<ReactNode>(null);
@@ -251,6 +253,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
     const userIsGlobalPageAdmin = isRealUser(user)
         && user.roles.includes(COMMON_ROLES.TOBIRA_GLOBAL_PAGE_ADMIN);
     const showGlobalPageAdminEntry = kind === "group"
+        && itemType === "realm"
         && !entries.some(e => e.role === COMMON_ROLES.TOBIRA_GLOBAL_PAGE_ADMIN)
         && userIsGlobalPageAdmin;
 


### PR DESCRIPTION
This only makes sense for realm ACL, as there global page admins magically have access. Before this commit, for users that were global page admins, the entry was also shown in the ACL UI for events and series.

You can test that easily on the deployment with user `gustav` (same password as `admin`). He cannot upload but just check out any video he has access to like https://tobira.opencast.org/~manage/videos/P-R1lPy_-q_/access. Check the same on this PR's deployment to see the entry disappear.

CC @oas777 