### PR TITLE
Add keyboard shortcuts for general functions and video player

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,12 @@ jobs:
     - name: Generate GraphQL query types
       working-directory: frontend
       run: npx relay-compiler
-    - name: Lint frontend
-      working-directory: frontend
-      run: npx eslint --max-warnings 0 .
     - name: Build frontend
       working-directory: frontend
       run: npx webpack --mode=${{ env.ci_webpack_flags }}
+    - name: Lint frontend
+      working-directory: frontend
+      run: npx eslint --max-warnings 0 .
     - name: Typecheck frontend
       working-directory: frontend
       run: npx tsc

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "react-beforeunload": "^2.6.0",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.56.3",
+        "react-hotkeys-hook": "^5.1.0",
         "react-i18next": "^15.5.1",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
@@ -9096,6 +9097,19 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.1.0.tgz",
+      "integrity": "sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-i18next": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "react-beforeunload": "^2.6.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.56.3",
+    "react-hotkeys-hook": "^5.1.0",
     "react-i18next": "^15.5.1",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode, StrictMode, Suspense } from "react";
+import { HotkeysProvider } from "react-hotkeys-hook";
 import { RelayEnvironmentProvider } from "react-relay/hooks";
 import { CacheProvider } from "@emotion/react";
 import createEmotionCache from "@emotion/cache";
+
 
 import { GlobalErrorBoundary } from "./util/err";
 import { environment } from "./relay";
@@ -37,21 +39,23 @@ export const App: React.FC<Props> = ({ initialRoute, consentGiven }) => (
                     <GlobalStyle />
                     <GlobalErrorBoundary>
                         <RelayEnvironmentProvider {...{ environment }}>
-                            <DevConfig>
-                                <Router initialRoute={initialRoute}>
-                                    <GraphQLErrorBoundary>
-                                        <MenuProvider>
-                                            <NotificationProvider>
-                                                <LoadingIndicator />
-                                                <InitialConsent {...{ consentGiven }} />
-                                                <Suspense fallback={<InitialLoading />}>
-                                                    <ActiveRoute />
-                                                </Suspense>
-                                            </NotificationProvider>
-                                        </MenuProvider>
-                                    </GraphQLErrorBoundary>
-                                </Router>
-                            </DevConfig>
+                            <HotkeysProvider initiallyActiveScopes={["general"]}>
+                                <DevConfig>
+                                    <Router initialRoute={initialRoute}>
+                                        <GraphQLErrorBoundary>
+                                            <MenuProvider>
+                                                <NotificationProvider>
+                                                    <LoadingIndicator />
+                                                    <InitialConsent {...{ consentGiven }} />
+                                                    <Suspense fallback={<InitialLoading />}>
+                                                        <ActiveRoute />
+                                                    </Suspense>
+                                                </NotificationProvider>
+                                            </MenuProvider>
+                                        </GraphQLErrorBoundary>
+                                    </Router>
+                                </DevConfig>
+                            </HotkeysProvider>
                         </RelayEnvironmentProvider>
                     </GlobalErrorBoundary>
                 </AppkitConfigProvider>

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -128,4 +128,8 @@ const GLOBAL_STYLE = css({
             color: COLORS.neutral70,
         },
     },
+    // Disable background scroll when a modal with this class is open.
+    "body:has(.disable-background-scroll)": {
+        overflow: "hidden",
+    },
 });

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,5 +1,5 @@
 import i18n from "i18next";
-import type { ResourceLanguage } from "i18next";
+import type { DefaultNamespace, ParseKeys, ResourceLanguage } from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
@@ -14,6 +14,8 @@ export const languages = {
     fr: { translation: frTranslations as ResourceLanguage },
     it: { translation: itTranslations as ResourceLanguage },
 };
+
+export type TranslationKey = ParseKeys<DefaultNamespace, Record<string, unknown>>;
 
 // TODO: wait for `init` to complete before rendering?
 void i18n

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -418,6 +418,18 @@ player:
     title: Optionen
     label: Optionen anzeigen
 
+shortcuts:
+  title: Tastenkürzel
+  sequence-separator: oder
+  general:
+    title: Allgemein
+    show-overview: Diese Übersicht anzeigen
+    close-modal: Dialog schließen
+    tab: Durch Elemente navigieren
+    search: Suchfeld fokussieren
+  keys:
+    escape: Esc
+
 manage:
   dashboard:
     title: Dashboard

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -427,8 +427,23 @@ shortcuts:
     close-modal: Dialog schließen
     tab: Durch Elemente navigieren
     search: Suchfeld fokussieren
+  player:
+    title: Videoplayer
+    play: Abspielen/pausieren
+    mute: Stummschaltung ein/aus
+    captions: Untertitel ein/aus
+    fullscreen: Vollbildmodus ein/aus
+    rewind: "{{seconds}} Sekunden zurückspulen"
+    fast-forward: "{{seconds}} Sekunden vorspulen"
+    frame-backward: Zum vorherigen Frame springen
+    frame-forward: Zum nächsten Frame springen
+    volume-down: Lautstärke verringern
+    volume-up: Lautstärke erhöhen
+    slow-down: Wiedergabegeschwindigkeit verringern
+    speed-up: Wiedergabegeschwindigkeit erhöhen
   keys:
     escape: Esc
+    space: Leertaste
 
 manage:
   dashboard:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -394,6 +394,18 @@ player:
     title: Options
     label: Show options
 
+shortcuts:
+  title: Shortcuts
+  sequence-separator: or
+  general:
+    title: General
+    show-overview: Show this overview
+    close-modal: Close modal
+    tab: Navigate through elements
+    search: Focus search input
+  keys:
+    escape: Esc
+
 manage:
   dashboard:
     title: Dashboard

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -403,8 +403,23 @@ shortcuts:
     close-modal: Close modal
     tab: Navigate through elements
     search: Focus search input
+  player:
+    title: Video player
+    play: Play/pause
+    mute: Mute/unmute
+    captions: Toggle captions
+    fullscreen: Toggle fullscreen
+    rewind: Rewind {{seconds}} seconds
+    fast-forward: Skip {{seconds}} seconds
+    frame-backward: Go back one frame
+    frame-forward: Go forward one frame
+    volume-down: Decrease volume
+    volume-up: Increase volume
+    slow-down: Decrease playback speed
+    speed-up: Increase playback speed
   keys:
     escape: Esc
+    space: Spacebar
 
 manage:
   dashboard:

--- a/frontend/src/layout/header/UserBox.tsx
+++ b/frontend/src/layout/header/UserBox.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     LuTriangleAlert, LuLogIn, LuMoon, LuSun, LuFolder, LuFilm,
     LuUpload, LuVideo, LuLogOut, LuChevronDown, LuUserCheck,
-    LuCirclePlus,
+    LuCirclePlus, LuKeyboard,
 } from "react-icons/lu";
 import { HiOutlineFire, HiOutlineTranslate } from "react-icons/hi";
 import {
@@ -29,6 +29,8 @@ import { CREDENTIALS_STORAGE_KEY } from "../../routes/Video";
 import { ManageSeriesRoute } from "../../routes/manage/Series";
 import SeriesIcon from "../../icons/series.svg";
 import { CreateSeriesRoute } from "../../routes/manage/Series/Create";
+import { SHORTCUTS, ShortcutsOverview, useShortcut } from "../../ui/Shortcuts";
+import { ModalHandle } from "../../ui/Modal";
 
 
 
@@ -59,6 +61,7 @@ export const UserBox: React.FC = () => {
     }
 
     return <>
+        <ShortcutsButton />
         <LanguageSettings />
         <ColorSchemeSettings />
         {boxContent}
@@ -103,6 +106,24 @@ const LoggedOut: React.FC = () => {
             <span>{t("user.login")}</span>
         </LoginLink>
     );
+};
+
+const ShortcutsButton: React.FC = () => {
+    const { t } = useTranslation();
+    const modalRef = useRef<ModalHandle>(null);
+    const openModal = () => modalRef.current?.open();
+    useShortcut(
+        SHORTCUTS.general.showOverview.keys,
+        openModal,
+        { useKey: true },
+    );
+
+    return <div css={{ [screenWidthAtMost(BREAKPOINT_MEDIUM)]: { display: "none" } }}>
+        <ActionIcon title={t("shortcuts.title")} onClick={openModal}>
+            <LuKeyboard />
+        </ActionIcon>
+        <ShortcutsOverview {...{ modalRef }} />
+    </div>;
 };
 
 /** Header button and associated floating menu to choose between color schemes */

--- a/frontend/src/routes/Embed.tsx
+++ b/frontend/src/routes/Embed.tsx
@@ -18,8 +18,9 @@ import { b64regex } from "./util";
 import { EmbedQuery } from "./__generated__/EmbedQuery.graphql";
 import { EmbedDirectOpencastQuery } from "./__generated__/EmbedDirectOpencastQuery.graphql";
 import { EmbedEventData$key } from "./__generated__/EmbedEventData.graphql";
-import { PlayerContextProvider } from "../ui/player/PlayerContext";
+import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
 import { PreviewPlaceholder, useEventWithAuthData } from "./Video";
+import { PlayerShortcuts } from "../ui/player/PlayerShortcuts";
 
 export const EmbedVideoRoute = makeRoute({
     url: ({ videoId }: { videoId: string }) => `/~embed/!v/${keyOfId(videoId)}`,
@@ -95,6 +96,7 @@ const matchedEmbedRoute = (
             </PlayerPlaceholder>
         }>
             <PlayerContextProvider>
+                <EmbedPageShortcuts />
                 <Embed query={query} queryRef={queryRef} />
             </PlayerContextProvider>
         </Suspense>
@@ -198,6 +200,12 @@ export const BlockEmbedRoute = makeRoute({
         };
     },
 });
+
+const EmbedPageShortcuts: React.FC = () => {
+    const { paella } = usePlayerContext();
+    const player = paella.current?.player ?? null;
+    return <PlayerShortcuts activePlayer={{ current: player }} />;
+};
 
 class ErrorBoundary extends GlobalErrorBoundary {
     public render(): ReactNode {

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -91,6 +91,7 @@ import {
     VideoPageAuthorizedData$data, VideoPageAuthorizedData$key,
 } from "./__generated__/VideoPageAuthorizedData.graphql";
 import { QrCodeButton, ShareButton } from "../ui/ShareButton";
+import { PlayerShortcuts } from "../ui/player/PlayerShortcuts";
 
 
 // ===========================================================================================
@@ -574,6 +575,7 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, realmPath
         <Breadcrumbs path={breadcrumbs} tail={event.title} />
         <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
         <PlayerContextProvider>
+            <VideoPageShortcuts />
             <section aria-label={t("video.video-player")}>
                 {event.authorizedData
                     ? <InlinePlayer
@@ -1249,4 +1251,10 @@ const isValidLink = (s: string): boolean => {
     }
 
     return true;
+};
+
+const VideoPageShortcuts: React.FC = () => {
+    const { paella } = usePlayerContext();
+    const player = paella.current?.player ?? null;
+    return <PlayerShortcuts activePlayer={{ current: player }} />;
 };

--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -28,6 +28,12 @@ declare module "paella-core" {
         public skin: Skin;
 
         public unload(): Promise<void>;
+
+        public isFullscreen: boolean;
+        public enterFullscreen(): Promise<void>;
+        public exitFullscreen(): Promise<void>;
+
+        public captionsCanvas: CaptionsCanvas;
     }
 
     export interface InitParams {
@@ -71,9 +77,24 @@ declare module "paella-core" {
     }
 
     export interface VideoContainer {
+        lastVolume: number;
+
         setCurrentTime: (t: number) => Promise<void>;
         currentTime: () => Promise<number>;
-        pause: () => void;
+        pause: () => Promise<void>;
+        play: () => Promise<void>;
+        paused: () => Promise<boolean>;
+        volume: () => Promise<number>;
+        setVolume: (volume: number) => Promise<void>;
+        playbackRate: () => Promise<number>;
+        setPlaybackRate: (rate: number) => Promise<void>;
+    }
+
+    interface CaptionsCanvas {
+        isVisible: boolean;
+        captions: Caption[];
+        disableCaptions: () => void;
+        enableCaptions: (searchOptions: { label?: string; index?: number; lang?: string }) => void;
     }
 
     export type PluginConfig = Record<string, unknown> & {

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -12,7 +12,8 @@ import { TitleBlock } from "./Title";
 import { TextBlockByQuery } from "./Text";
 import { SeriesBlockFromBlock } from "./Series";
 import { VideoBlock } from "./Video";
-import { PlayerGroupProvider } from "../player/PlayerGroupContext";
+import { PlayerGroupProvider, usePlayerGroupContext } from "../player/PlayerGroupContext";
+import { PlayerShortcuts } from "../player/PlayerShortcuts";
 import { PlaylistBlockFromBlock } from "./Playlist";
 import { COLORS } from "../../color";
 
@@ -43,6 +44,7 @@ export const Blocks: React.FC<BlocksProps> = ({ realm }) => {
             rowGap: 32,
         }}>
             <PlayerGroupProvider>
+                <PlayerGroupShortcuts />
                 {realmWithBlocks.blocks.map(
                     block => <Block key={block.id} realm={realmWithBlocks} block={block} />,
                 )}
@@ -50,6 +52,12 @@ export const Blocks: React.FC<BlocksProps> = ({ realm }) => {
         </div>
     );
 };
+
+const PlayerGroupShortcuts: React.FC = () => {
+    const { activePlayer } = usePlayerGroupContext();
+    return <PlayerShortcuts activePlayer={activePlayer} />;
+};
+
 
 type BlockProps = {
     realm: BlocksRealmData$key;

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -191,63 +191,65 @@ export const ShortcutsOverview: React.FC<{ modalRef: React.RefObject<ModalHandle
     const { t } = useTranslation();
     const groups: (keyof typeof SHORTCUTS)[] = ["general", "player"];
 
-    return <Modal ref={modalRef} title={t("shortcuts.title")} closeOnOutsideClick css={{
-        maxWidth: 1000,
-        "& > div": {
-            maxHeight: "80vh",
-            overflow: "auto",
-        },
-    }}>
-        {groups.map(group => (
-            <section key={group} css={{
-                margin: "32px 0",
-                ":first-of-type": {
-                    marginTop: 16,
-                },
-            }}>
-                <h2 css={{ fontSize: 18, marginBottom: 8 }}>
-                    {t(`shortcuts.${group}.title`)}
-                </h2>
-                <div css={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
-                    {Object.entries(SHORTCUTS[group]).map((
-                        [name, shortcut]: [string, ShortcutProps],
-                    ) => <div
-                        key={group + name}
-                        css={{
-                            width: "calc(33.33% - 24px / 3)",
-                            [screenWidthAtMost(1080)]: {
-                                width: "calc(50% - 12px / 2)",
-                            },
-                            [screenWidthAtMost(720)]: {
-                                width: "100%",
-                            },
-                            backgroundColor: COLORS.neutral10,
-                            borderRadius: 4,
-                            padding: "10px 16px",
-                            display: "inline-flex",
-                            flexDirection: "column",
-                            alignItems: "start",
-                            gap: 8,
-                        }}
-                    >
-                        <div css={{ overflowWrap: "anywhere" }}>
-                            {typeof shortcut.translation === "string"
-                                ? t(shortcut.translation)
-                                : t(shortcut.translation.key, shortcut.translation.options)}
-                        </div>
-                        <div css={{ display: "flex", gap: 8, alignItems: "center" }}>
-                            {shortcut.keys.split(";").map((combination: string, i: number) =>
-                                <React.Fragment key={i}>
-                                    {i > 0 && t("shortcuts.sequence-separator")}
-                                    <ShortcutKeys shortcut={combination.trim()} />
-                                </React.Fragment>)
-                            }
-                        </div>
-                    </div>)}
-                </div>
-            </section>
-        ))}
-    </Modal>;
+    return (
+        <Modal ref={modalRef} title={t("shortcuts.title")} closeOnOutsideClick css={{
+            maxWidth: 1000,
+            "& > div": {
+                maxHeight: "80vh",
+                overflow: "auto",
+            },
+        }}>
+            {groups.map(group => (
+                <section key={group} css={{
+                    margin: "32px 0",
+                    ":first-of-type": {
+                        marginTop: 16,
+                    },
+                }}>
+                    <h2 css={{ fontSize: 18, marginBottom: 8 }}>
+                        {t(`shortcuts.${group}.title`)}
+                    </h2>
+                    <div css={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+                        {Object.entries(SHORTCUTS[group]).map((
+                            [name, shortcut]: [string, ShortcutProps],
+                        ) => <div
+                            key={group + name}
+                            css={{
+                                width: "calc(33.33% - 24px / 3)",
+                                [screenWidthAtMost(1000)]: {
+                                    width: "calc(50% - 12px / 2)",
+                                },
+                                [screenWidthAtMost(720)]: {
+                                    width: "100%",
+                                },
+                                backgroundColor: COLORS.neutral10,
+                                borderRadius: 4,
+                                padding: "10px 16px",
+                                display: "inline-flex",
+                                flexDirection: "column",
+                                alignItems: "start",
+                                gap: 8,
+                            }}
+                        >
+                            <div css={{ overflowWrap: "anywhere" }}>
+                                {typeof shortcut.translation === "string"
+                                    ? t(shortcut.translation)
+                                    : t(shortcut.translation.key, shortcut.translation.options)}
+                            </div>
+                            <div css={{ display: "flex", gap: 8, alignItems: "center" }}>
+                                {shortcut.keys.split(";").map((combination: string, i: number) =>
+                                    <React.Fragment key={i}>
+                                        {i > 0 && t("shortcuts.sequence-separator")}
+                                        <ShortcutKeys shortcut={combination.trim()} />
+                                    </React.Fragment>)
+                                }
+                            </div>
+                        </div>)}
+                    </div>
+                </section>
+            ))}
+        </Modal>
+    );
 };
 
 

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -192,13 +192,19 @@ export const ShortcutsOverview: React.FC<{ modalRef: React.RefObject<ModalHandle
     const groups: (keyof typeof SHORTCUTS)[] = ["general", "player"];
 
     return (
-        <Modal ref={modalRef} title={t("shortcuts.title")} closeOnOutsideClick css={{
-            maxWidth: 1000,
-            "& > div": {
-                maxHeight: "80vh",
-                overflow: "auto",
-            },
-        }}>
+        <Modal
+            className="disable-background-scroll"
+            ref={modalRef}
+            title={t("shortcuts.title")}
+            closeOnOutsideClick
+            css={{
+                maxWidth: 1000,
+                "& > div": {
+                    maxHeight: "80vh",
+                    overflow: "auto",
+                },
+            }}
+        >
             {groups.map(group => (
                 <section key={group} css={{
                     margin: "32px 0",

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -13,17 +13,13 @@ import { match, screenWidthAtMost, useColorScheme } from "@opencast/appkit";
 
 import { Modal, ModalHandle } from "./Modal";
 import { COLORS } from "../color";
-import { adjustSpeed, jumpFrame } from "./player/PlayerShortcuts";
 import { SKIP_INTERVAL } from "./player/consts";
-import { Paella } from "paella-core";
 import { TranslationKey } from "../i18n";
 
 
 export type ShortcutProps = {
     keys: string,
     translation: TranslationKey | { key: TranslationKey; options?: Record<string, unknown> };
-    playerCallback?: (activePlayer: Paella) => HotkeyCallback,
-    options?: Options,
 }
 
 export const SHORTCUTS = {
@@ -50,82 +46,24 @@ export const SHORTCUTS = {
         play: {
             keys: "k; space",
             translation: "shortcuts.player.play",
-            playerCallback: player => async () => {
-                const isPaused = await player.videoContainer.paused();
-                if (isPaused) {
-                    await player.videoContainer.play();
-                } else {
-                    await player.videoContainer.pause();
-                }
-            },
-            options: {
-                scopes: ["player"],
-                // Don't trigger when a button is focused. This way, users can still
-                // use the space bar to control other elements by default.
-                ignoreEventWhen: e => (e.key !== "k" && (
-                    e.target instanceof HTMLButtonElement
-                        || e.target instanceof HTMLInputElement
-                )),
-                // But still disable scrolling with space.
-                preventDefault: e => !(e.key !== "k" && (
-                    e.target instanceof HTMLButtonElement
-                        || e.target instanceof HTMLInputElement
-                )),
-            },
         },
         mute: {
             keys: "m",
             translation: "shortcuts.player.mute",
-            playerCallback: player => async () => {
-                const vol = await player.videoContainer.volume();
-                let newVol = 0;
-                if (vol > 0) {
-                    player.videoContainer.lastVolume = vol;
-                    newVol = 0;
-                } else {
-                    newVol = player.videoContainer.lastVolume || 1;
-                }
-
-                await player.videoContainer.setVolume(newVol);
-            },
         },
         captions: {
             keys: "c",
             translation: "shortcuts.player.captions",
-            playerCallback: player => () => {
-                if (player.captionsCanvas.isVisible) {
-                    // TODO: cycle through captions before disabling?
-                    player.captionsCanvas.disableCaptions();
-                } else {
-                    const availableCaptions = player.captionsCanvas.captions;
-                    if (availableCaptions && availableCaptions.length > 0) {
-                        player.captionsCanvas.enableCaptions({ index: 0 });
-                    }
-                }
-            },
         },
         fullscreen: {
             keys: "f",
             translation: "shortcuts.player.fullscreen",
-            playerCallback: player => async () => {
-                if (player.isFullscreen) {
-                    await player.exitFullscreen();
-                } else {
-                    await player.enterFullscreen();
-                }
-            },
         },
         rewind: {
             keys: "j; left",
             translation: {
                 key: "shortcuts.player.rewind",
                 options: { seconds: SKIP_INTERVAL },
-            },
-            playerCallback: player => async () => {
-                const currentTime = await player.videoContainer.currentTime();
-                await player.videoContainer.setCurrentTime(
-                    Math.max(0, currentTime - SKIP_INTERVAL),
-                );
             },
         },
         fastForward: {
@@ -134,52 +72,30 @@ export const SHORTCUTS = {
                 key: "shortcuts.player.fast-forward",
                 options: { seconds: SKIP_INTERVAL },
             },
-            playerCallback: player => async () => {
-                const currentTime = await player.videoContainer.currentTime();
-                await player.videoContainer.setCurrentTime(currentTime + SKIP_INTERVAL);
-            },
         },
         frameBackward: {
             keys: "comma",
             translation: "shortcuts.player.frame-backward",
-            playerCallback: player => async () => await jumpFrame(player, -1),
         },
         frameForward: {
             keys: "period",
             translation: "shortcuts.player.frame-forward",
-            playerCallback: player => async () => await jumpFrame(player, 1),
         },
         volumeDown: {
             keys: "shift+down",
             translation: "shortcuts.player.volume-down",
-            playerCallback: player => async () => {
-                const currentVolume = await player.videoContainer.volume();
-                await player.videoContainer.setVolume(
-                    Math.max(0, currentVolume - 0.1),
-                );
-            },
-            options: { preventDefault: true },
         },
         volumeUp: {
             keys: "shift+up",
             translation: "shortcuts.player.volume-up",
-            playerCallback: player => async () => {
-                const currentVolume = await player.videoContainer.volume();
-                await player.videoContainer.setVolume(
-                    Math.min(1, currentVolume + 0.1),
-                );
-            },
-            options: { preventDefault: true },
         },
         slowDown: {
             keys: "shift+comma",
             translation: "shortcuts.player.slow-down",
-            playerCallback: player => async () => await adjustSpeed(player, -1),
         },
         speedUp: {
             keys: "shift+period",
             translation: "shortcuts.player.speed-up",
-            playerCallback: player => async () => await adjustSpeed(player, 1),
         },
     },
 } as const satisfies Record<string, Record<string, ShortcutProps>>;

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -10,18 +10,18 @@ import {
     LuArrowUp,
 } from "react-icons/lu";
 import { match, screenWidthAtMost, useColorScheme } from "@opencast/appkit";
-import { ParseKeys, TOptions } from "i18next";
 
 import { Modal, ModalHandle } from "./Modal";
 import { COLORS } from "../color";
 import { adjustSpeed, jumpFrame } from "./player/PlayerShortcuts";
 import { SKIP_INTERVAL } from "./player/consts";
 import { Paella } from "paella-core";
+import { TranslationKey } from "../i18n";
 
 
 export type ShortcutProps = {
     keys: string,
-    translation: ParseKeys | { key: ParseKeys; options?: TOptions },
+    translation: TranslationKey | { key: TranslationKey; options?: Record<string, unknown> };
     playerCallback?: (activePlayer: Paella) => HotkeyCallback,
     options?: Options,
 }

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -59,6 +59,7 @@ export const SHORTCUTS = {
                 }
             },
             options: {
+                scopes: ["player"],
                 // Don't trigger when a button is focused. This way, users can still
                 // use the space bar to control other elements by default.
                 ignoreEventWhen: e => (e.key !== "k" && (

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Options, useHotkeys, HotkeyCallback } from "react-hotkeys-hook";
+import { LuArrowRightToLine } from "react-icons/lu";
+import { match, screenWidthAtMost, useColorScheme } from "@opencast/appkit";
+import { ParseKeys } from "i18next";
+
+import { Modal, ModalHandle } from "./Modal";
+import { COLORS } from "../color";
+
+
+export type ShortcutProps = {
+    keys: string,
+    translation: ParseKeys,
+}
+
+export const SHORTCUTS = {
+    general: {
+        showOverview: {
+            keys: "?",
+            translation: "shortcuts.general.show-overview",
+        },
+        closeModal: {
+            keys: "escape",
+            translation: "shortcuts.general.close-modal",
+        },
+        tab: {
+            keys: "tab",
+            translation: "shortcuts.general.tab",
+        },
+        search: {
+            keys: "s; /",
+            translation: "shortcuts.general.search",
+        },
+    },
+} as const satisfies Record<string, Record<string, ShortcutProps>>;
+
+
+export const ShortcutsOverview: React.FC<{ modalRef: React.RefObject<ModalHandle> }> = ({
+    modalRef,
+}) => {
+    const { t } = useTranslation();
+    const groups: (keyof typeof SHORTCUTS)[] = ["general"];
+    return <Modal ref={modalRef} title={t("shortcuts.title")} closeOnOutsideClick css={{
+        maxWidth: 1000,
+        "& > div": {
+            maxHeight: "80vh",
+            overflow: "auto",
+        },
+    }}>
+        {groups.map(group => (
+            <section key={group} css={{
+                margin: "32px 0",
+                ":first-of-type": {
+                    marginTop: 16,
+                },
+            }}>
+                <h2 css={{ fontSize: 18, marginBottom: 8 }}>
+                    {t(`shortcuts.${group}.title`)}
+                </h2>
+                <div css={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+                    {Object.entries(SHORTCUTS[group]).map((
+                        [name, shortcut]: [string, ShortcutProps],
+                    ) => <div
+                        key={group + name}
+                        css={{
+                            width: "calc(33.33% - 24px / 3)",
+                            [screenWidthAtMost(1080)]: {
+                                width: "calc(50% - 12px / 2)",
+                            },
+                            [screenWidthAtMost(720)]: {
+                                width: "100%",
+                            },
+                            backgroundColor: COLORS.neutral10,
+                            borderRadius: 4,
+                            padding: "10px 16px",
+                            display: "inline-flex",
+                            flexDirection: "column",
+                            alignItems: "start",
+                            gap: 8,
+                        }}
+                    >
+                        <div css={{ overflowWrap: "anywhere" }}>
+                            {t(shortcut.translation)}
+                        </div>
+                        <div css={{ display: "flex", gap: 8, alignItems: "center" }}>
+                            {shortcut.keys.split(";").map((combination: string, i: number) =>
+                                <React.Fragment key={i}>
+                                    {i > 0 && t("shortcuts.sequence-separator")}
+                                    <ShortcutKeys shortcut={combination.trim()} />
+                                </React.Fragment>)
+                            }
+                        </div>
+                    </div>)}
+                </div>
+            </section>
+        ))}
+    </Modal>;
+};
+
+
+const ShortcutKeys: React.FC<{ shortcut: string }> = ({ shortcut }) => {
+    const { t } = useTranslation();
+
+    return <div css={{ display: "flex", alignItems: "center", gap: 4, color: COLORS.neutral70 }}>
+        {shortcut.split("+").map((key, i) => {
+            const child = match(key, {
+                "escape": () => <>{t("shortcuts.keys.escape")}</>,
+                "tab": () => <LuArrowRightToLine size={20} title={key} />,
+            }) ?? <>{key}</>;
+            return (
+                <React.Fragment key={shortcut + key}>
+                    {i !== 0 && "+"}
+                    <SingleKey monofont={key === "l"}>{child}</SingleKey>
+                </React.Fragment>
+            );
+        })}
+    </div>;
+};
+
+
+type SingleKeyProps = React.PropsWithChildren<{
+  /** Whether to use `monospace` font for this one. Basically only useful for lowercase l. */
+  monofont: boolean;
+}>;
+
+const SingleKey: React.FC<SingleKeyProps> = ({ monofont, children }) => {
+    const isLight = useColorScheme().scheme === "light";
+
+    return (
+        <div css={{
+            border: `1px solid ${COLORS.neutral50}`,
+            borderRadius: 4,
+            padding: "2px 6px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: 36,
+            minWidth: 36,
+            fontSize: 16,
+            boxShadow: "0 0 6px var(--shadow-color)",
+            backgroundColor: isLight ? COLORS.neutral05 : COLORS.neutral15,
+            color: isLight ? COLORS.neutral80 : COLORS.neutral90,
+            cursor: "default",
+            ...monofont && { fontFamily: "monospace" },
+        }}>
+            {children}
+        </div>
+    );
+};
+
+
+export const useShortcut = (
+    keys: string,
+    callback: HotkeyCallback,
+    options: Omit<Options, "delimiter"> = {},
+    deps: unknown[] = [],
+) => useHotkeys(keys, callback, { delimiter: ";", ...options }, deps);

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -31,7 +31,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
     const { t, i18n } = useTranslation();
     const ref = useRef<HTMLDivElement>(null);
     const { paella, setPlayerIsLoaded } = usePlayerContext();
-    const { players, register, unregister } = usePlayerGroupContext();
+    const { players, register, unregister, setActivePlayer } = usePlayerGroupContext();
 
     useEffect(() => {
         // If the ref is not set yet (which should not usually happen), we do
@@ -153,25 +153,24 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
             });
 
 
-            if (!event.isLive) {
+            player.bindEvent("paella:playerLoaded", () => {
+                setPlayerIsLoaded(true);
+                register(player);
                 const time = new URL(window.location.href).searchParams.get("t");
-                player.bindEvent("paella:playerLoaded", () => {
-                    setPlayerIsLoaded(true);
-                    if (time) {
+                if (!event.isLive && time) {
                         player.videoContainer.setCurrentTime(timeStringToSeconds(time));
                     }
                 });
             }
 
             player.bindEvent("paella:play", () => {
-                players?.forEach(playerInstance => {
+                setActivePlayer(player);
+                players.forEach((playerInstance: Paella) => {
                     if (playerInstance && playerInstance !== player) {
                         playerInstance.videoContainer.pause();
                     }
                 });
             });
-
-            register(player);
 
             const loadPromise = player.skin.loadSkin("/~assets/paella/theme.json")
                 .then(() => player.loadManifest());

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -15,6 +15,7 @@ import { usePlayerContext } from "./PlayerContext";
 import { usePlayerGroupContext } from "./PlayerGroupContext";
 import CONFIG from "../../config";
 import i18n from "../../i18n";
+import { SKIP_INTERVAL } from "./consts";
 
 
 type PaellaPlayerProps = {
@@ -486,7 +487,7 @@ const PAELLA_CONFIG = {
             enabled: true,
             side: "left",
             order: 2,
-            time: 10,
+            time: SKIP_INTERVAL,
             suffix: false,
             tabIndex: 2,
         },
@@ -494,7 +495,7 @@ const PAELLA_CONFIG = {
             enabled: true,
             side: "left",
             order: 3,
-            time: 10,
+            time: SKIP_INTERVAL,
             suffix: false,
             tabIndex: 3,
         },

--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -7,6 +7,7 @@ import getUserTrackingPluginsContext from "paella-user-tracking";
 import getSlidePluginsContext from "paella-slide-plugins";
 import { Global } from "@emotion/react";
 import { useTranslation } from "react-i18next";
+import { useHotkeysContext } from "react-hotkeys-hook";
 
 import { isHlsTrack, PlayerEvent, Track } from ".";
 import { SPEEDS, TRANSLATIONS } from "./consts";
@@ -32,6 +33,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
     const ref = useRef<HTMLDivElement>(null);
     const { paella, setPlayerIsLoaded } = usePlayerContext();
     const { players, register, unregister, setActivePlayer } = usePlayerGroupContext();
+    const { enableScope, disableScope } = useHotkeysContext();
 
     useEffect(() => {
         // If the ref is not set yet (which should not usually happen), we do
@@ -155,13 +157,13 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
 
             player.bindEvent("paella:playerLoaded", () => {
                 setPlayerIsLoaded(true);
+                enableScope("player");
                 register(player);
                 const time = new URL(window.location.href).searchParams.get("t");
                 if (!event.isLive && time) {
-                        player.videoContainer.setCurrentTime(timeStringToSeconds(time));
-                    }
-                });
-            }
+                    player.videoContainer.setCurrentTime(timeStringToSeconds(time));
+                }
+            });
 
             player.bindEvent("paella:play", () => {
                 setActivePlayer(player);
@@ -184,6 +186,7 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
             paellaSnapshot.loadPromise.then(() => {
                 paellaSnapshot.player.unload();
             });
+            disableScope("player");
         };
     }, [event, t]);
 

--- a/frontend/src/ui/player/PlayerGroupContext.tsx
+++ b/frontend/src/ui/player/PlayerGroupContext.tsx
@@ -1,34 +1,60 @@
 import { Paella } from "paella-core";
-import React, { createContext, useContext, PropsWithChildren } from "react";
+import React, {
+    createContext,
+    useContext,
+    PropsWithChildren,
+    useRef,
+} from "react";
+
 
 type PlayerGroupContext = {
-    players: Set<Paella> | null;
+    players: Set<Paella>;
+    activePlayer: React.MutableRefObject<Paella | null>;
+    setActivePlayer: (player: Paella) => void;
     register: (player: Paella) => void;
     unregister: (player: Paella) => void;
 }
 
 const PlayerGroupContext = createContext<PlayerGroupContext>({
-    players: null,
+    players: new Set<Paella>(),
+    activePlayer: { current: null },
+    setActivePlayer: () => {},
     register: () => {},
     unregister: () => {},
 });
 
 export const PlayerGroupProvider: React.FC<PropsWithChildren> = ({ children }) => {
-    const players = new Set<Paella>(null);
+    const players = new Set<Paella>();
+    const activePlayer = useRef<Paella | null>(null);
 
     const register = (player: Paella) => {
         players.add(player);
+        if (!activePlayer.current) {
+            activePlayer.current = player;
+        }
     };
 
     const unregister = (player: Paella) => {
         players.delete(player);
+        if (activePlayer.current === player) {
+            activePlayer.current = players.size > 0 ? [...players][0] : null;
+        }
     };
 
-    return (
-        <PlayerGroupContext.Provider value={{ players, register, unregister }}>
-            {children}
-        </PlayerGroupContext.Provider>
-    );
+    const setActivePlayer = (player: Paella) => {
+        activePlayer.current = player;
+    };
+
+
+    return <PlayerGroupContext.Provider value={{
+        players,
+        activePlayer,
+        setActivePlayer,
+        register,
+        unregister,
+    }}>
+        {children}
+    </PlayerGroupContext.Provider>;
 };
 
 export const usePlayerGroupContext = () => useContext(PlayerGroupContext);

--- a/frontend/src/ui/player/PlayerShortcuts.tsx
+++ b/frontend/src/ui/player/PlayerShortcuts.tsx
@@ -1,0 +1,53 @@
+import { Paella } from "paella-core";
+import { HotkeyCallback } from "react-hotkeys-hook";
+
+import { ShortcutProps, SHORTCUTS, useShortcut } from "../Shortcuts";
+import { FRAME_DURATION, SPEEDS } from "./consts";
+
+
+export const PlayerShortcuts: React.FC<{ activePlayer: React.MutableRefObject<Paella | null> }> = ({
+    activePlayer,
+}) => <>
+    {Object.entries(SHORTCUTS.player).forEach(([, shortcut]: [unknown, ShortcutProps]) => {
+        const hotkeyCallback: HotkeyCallback = (event, handler) => {
+            if (shortcut.playerCallback && activePlayer.current) {
+                const playerCallback = shortcut.playerCallback(activePlayer.current);
+                return playerCallback(event, handler);
+            }
+        };
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useShortcut(
+            shortcut.keys,
+            hotkeyCallback,
+            shortcut.options,
+            [activePlayer.current],
+        );
+    })}
+</>;
+
+
+export const jumpFrame = async (
+    player: Paella,
+    direction: 1 | -1,
+): Promise<void> => {
+    if (await player.videoContainer.paused()) {
+        const currentTime = await player.videoContainer.currentTime();
+        const newTime = Math.max(0, currentTime + (direction * FRAME_DURATION));
+        await player.videoContainer.setCurrentTime(newTime);
+    }
+};
+
+export const adjustSpeed = async (
+    player: Paella,
+    direction: 1 | -1,
+): Promise<void> => {
+    const currentSpeed = await player.videoContainer.playbackRate();
+    const idx = SPEEDS.indexOf(currentSpeed);
+    if (idx === -1) {
+        return;
+    }
+    const newIdx = Math.max(0, Math.min(SPEEDS.length - 1, idx + direction));
+    const newSpeed = SPEEDS[newIdx];
+    await player.videoContainer.setPlaybackRate(newSpeed);
+};

--- a/frontend/src/ui/player/PlayerShortcuts.tsx
+++ b/frontend/src/ui/player/PlayerShortcuts.tsx
@@ -1,31 +1,141 @@
 import { Paella } from "paella-core";
-import { HotkeyCallback } from "react-hotkeys-hook";
+import { HotkeyCallback, Options } from "react-hotkeys-hook";
 
 import { ShortcutProps, SHORTCUTS, useShortcut } from "../Shortcuts";
-import { FRAME_DURATION, SPEEDS } from "./consts";
+import { FRAME_DURATION, SKIP_INTERVAL, SPEEDS } from "./consts";
+
+
+type PlayerShortcuts = {
+    callback: (activePlayer: Paella) => HotkeyCallback;
+    options?: Options,
+}
+type PlayerAction = keyof typeof SHORTCUTS["player"];
+export const SHORTCUT_ACTIONS = {
+    play: {
+        callback: player => async () => {
+            const isPaused = await player.videoContainer.paused();
+            if (isPaused) {
+                await player.videoContainer.play();
+            } else {
+                await player.videoContainer.pause();
+            }
+        },
+        options: {
+            scopes: ["player"],
+            // Don't trigger when a button is focused. This way, users can still
+            // use the space bar to control other elements by default.
+            ignoreEventWhen: e => (e.key !== "k" && (
+                e.target instanceof HTMLButtonElement
+                    || e.target instanceof HTMLInputElement
+            )),
+            // But still disable scrolling with space.
+            preventDefault: true,
+        },
+    },
+    mute: {
+        callback: player => async () => {
+            const vol = await player.videoContainer.volume();
+            let newVol = 0;
+            if (vol > 0) {
+                player.videoContainer.lastVolume = vol;
+                newVol = 0;
+            } else {
+                newVol = player.videoContainer.lastVolume || 1;
+            }
+            await player.videoContainer.setVolume(newVol);
+        },
+    },
+    captions: {
+        callback: player => () => {
+            if (player.captionsCanvas.isVisible) {
+                // TODO: cycle through captions before disabling?
+                player.captionsCanvas.disableCaptions();
+            } else {
+                const availableCaptions = player.captionsCanvas.captions;
+                if (availableCaptions && availableCaptions.length > 0) {
+                    player.captionsCanvas.enableCaptions({ index: 0 });
+                }
+            }
+        },
+    },
+    fullscreen: {
+        callback: player => async () => {
+            if (player.isFullscreen) {
+                await player.exitFullscreen();
+            } else {
+                await player.enterFullscreen();
+            }
+        },
+    },
+    rewind: {
+        callback: player => async () => {
+            const currentTime = await player.videoContainer.currentTime();
+            await player.videoContainer.setCurrentTime(
+                Math.max(0, currentTime - SKIP_INTERVAL),
+            );
+        },
+    },
+    fastForward: {
+        callback: player => async () => {
+            const currentTime = await player.videoContainer.currentTime();
+            await player.videoContainer.setCurrentTime(currentTime + SKIP_INTERVAL);
+        },
+    },
+    frameBackward: {
+        callback: player => async () => await jumpFrame(player, -1),
+    },
+    frameForward: {
+        callback: player => async () => await jumpFrame(player, 1),
+    },
+    volumeDown: {
+        callback: player => async () => {
+            const currentVolume = await player.videoContainer.volume();
+            await player.videoContainer.setVolume(
+                Math.max(0, currentVolume - 0.1),
+            );
+        },
+    },
+    volumeUp: {
+        callback: player => async () => {
+            const currentVolume = await player.videoContainer.volume();
+            await player.videoContainer.setVolume(
+                Math.min(1, currentVolume + 0.1),
+            );
+        },
+    },
+    slowDown: {
+        callback: player => async () => await adjustSpeed(player, -1),
+    },
+    speedUp: {
+        callback: player => async () => await adjustSpeed(player, 1),
+    },
+} satisfies Record<PlayerAction, PlayerShortcuts>;
+
 
 
 export const PlayerShortcuts: React.FC<{ activePlayer: React.MutableRefObject<Paella | null> }> = ({
     activePlayer,
-}) => <>
-    {Object.entries(SHORTCUTS.player).forEach(([, shortcut]: [unknown, ShortcutProps]) => {
-        const hotkeyCallback: HotkeyCallback = (event, handler) => {
-            if (shortcut.playerCallback && activePlayer.current) {
-                const playerCallback = shortcut.playerCallback(activePlayer.current);
-                return playerCallback(event, handler);
+}) => <>{(Object.entries(SHORTCUTS.player) as [PlayerAction, ShortcutProps][]).forEach(
+    ([key, shortcut]) => {
+        const action = SHORTCUT_ACTIONS[key];
+        const hotkeyCallback: HotkeyCallback = () => {
+            if (activePlayer.current) {
+                const playerCallback = action.callback(activePlayer.current);
+                playerCallback();
             }
         };
 
+        // Since SHORTCUTS.player is static, the loop always iterates over
+        // the same unchanging array and disabling the hook rule is safe.
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useShortcut(
             shortcut.keys,
             hotkeyCallback,
-            shortcut.options,
+            "options" in action ? action.options : undefined,
             [activePlayer.current],
         );
-    })}
-</>;
-
+    },
+)}</>;
 
 export const jumpFrame = async (
     player: Paella,

--- a/frontend/src/ui/player/consts.tsx
+++ b/frontend/src/ui/player/consts.tsx
@@ -1,6 +1,16 @@
 /** Offered playback speeds. */
 export const SPEEDS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2, 2.5];
 
+/** The interval in seconds at which the player should skip forwards/backwards. */
+export const SKIP_INTERVAL = 10;
+
+/** Fixed framerate for single frame skips. */
+export const FRAME_RATE = 25;
+
+/** Duration of a single frame in seconds. */
+export const FRAME_DURATION = 1 / FRAME_RATE;
+
+
 export const TRANSLATIONS: Record<string, Record<string, string>> = {
     it: {
         // From paella-core


### PR DESCRIPTION
This adds the following shortcuts:
<img width="1013" height="832" alt="Bildschirmfoto 2025-07-29 um 14 49 10" src="https://github.com/user-attachments/assets/90774074-bc08-4f0c-acd1-3c6233c4bd9c" />

Note that right now, the play shortcut cannot be used to **start** a video yet, only to pause and resume play. I do realize that this is suboptimal and am looking for a solution.

Also, the "general" section is pretty bare bones, but I could imagine adding some more shortcuts, for example for changing the language or color scheme. On the other hand I would not add shortcuts for every single conceivable action.

Review commit by commit.

Resolves #1416 