### PR TITLE
Add RSS link to series details

### DIFF
--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -37,8 +37,7 @@ general:
   yesterday-at: Ieri alle {{time}}
   tomorrow-at: Domani alle {{time}}
   weekday-at: '{{weekday}} alle {{time}}'
-  date-at: |
-    {{date}} alle {{time}}
+  date-at: '{{date}} alle {{time}}'
   none: Nessuno
   title: Titolo
 

--- a/frontend/src/routes/manage/Series/SeriesDetails.tsx
+++ b/frontend/src/routes/manage/Series/SeriesDetails.tsx
@@ -4,12 +4,11 @@ import { graphql, useMutation } from "react-relay";
 import i18n from "../../../i18n";
 import { makeManageSeriesRoute, Series } from "./Shared";
 import { ManageSeriesRoute } from ".";
-import { DirectSeriesRoute, SeriesRoute } from "../../Series";
+import { SeriesRoute } from "../../Series";
 import { Link } from "../../../router";
 import {
     UpdatedCreatedInfo,
     DetailsPage,
-    DirectLink,
     MetadataSection,
     DeleteButton,
     HostRealms,
@@ -21,8 +20,9 @@ import {
 import { useNotification } from "../../../ui/NotificationContext";
 import { ManageVideoListContent } from "../Shared/EditVideoList";
 import { SeriesDetailsContentMutation } from "./__generated__/SeriesDetailsContentMutation.graphql";
-import { Inertable, isSynced } from "../../../util";
+import { Inertable, isSynced, keyOfId } from "../../../util";
 import { NotReadyNote } from "../../util";
+import { VideoListShareButton } from "../../../ui/Blocks/VideoList";
 
 
 const updateSeriesMetadata = graphql`
@@ -72,9 +72,6 @@ export const ManageSeriesDetailsRoute = makeManageSeriesRoute(
             <SeriesNoteSection key="series-note" {...{ series }} />,
             <UpdatedCreatedInfo key="date-info" item={series} />,
             <SeriesButtonSection key="button-section" {...{ series }} />,
-            <DirectLink key="direct-link" url={
-                new URL(DirectSeriesRoute.url({ seriesId: series.id }), document.baseURI)
-            } />,
             <SeriesMetadataSection key="metadata" series={series} />,
             <SeriesContentSection key="content" series={series} />,
             <div key="host-realms" css={{ marginBottom: 32 }}>
@@ -100,7 +97,14 @@ const SeriesButtonSection: React.FC<{ series: Series }> = ({ series }) => {
     const { t } = useTranslation();
     const [commit] = useMutation<SeriesDetailsDeleteMutation>(deleteSeriesMutation);
 
+    const seriesKey = keyOfId(series.id);
+    const shareInfo = {
+        shareUrl: `/!s/${seriesKey}`,
+        rssUrl: `/~rss/series/${seriesKey}`,
+    };
+
     return <div css={{ display: "flex", gap: 12, marginBottom: 16 }}>
+        <VideoListShareButton {...shareInfo} css={{ height: 40, borderRadius: 8 }} />
         <DeleteButton
             item={series}
             kind="series"

--- a/frontend/src/routes/manage/Shared/Details.tsx
+++ b/frontend/src/routes/manage/Shared/Details.tsx
@@ -146,7 +146,6 @@ export const DirectLink: React.FC<UrlProps> = ({ url, withTimestamp }) => {
     </div>;
 };
 
-
 type MetadataInput = {
     title: string;
     description?: string | null;

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -421,31 +421,36 @@ export const VideoListBlockContainer: React.FC<VideoListBlockContainerProps> = (
 type VideoListShareButtonProps = {
     shareUrl: string;
     rssUrl: string;
+    className?: string;
 };
 
-const VideoListShareButton: React.FC<VideoListShareButtonProps> = props => {
+export const VideoListShareButton: React.FC<VideoListShareButtonProps> = ({
+    shareUrl, rssUrl, className,
+}) => {
     const { t } = useTranslation();
-    const shareUrl = document.location.origin + props.shareUrl;
-    const rssUrl = document.location.origin + props.rssUrl;
+
+    const directLinkUrl = document.location.origin + shareUrl;
+    const rssLinkUrl = document.location.origin + rssUrl;
+
     const tabs = {
         "main": {
             label: t("share.link"),
             Icon: LuLink,
             render: () => <>
-                <CopyableInput label={t("share.copy-link")} value={shareUrl} />
-                <QrCodeButton target={shareUrl} label={t("share.link")} />
+                <CopyableInput label={t("share.copy-link")} value={directLinkUrl} />
+                <QrCodeButton label={t("share.link")} target={directLinkUrl} />
             </>,
         },
         "rss": {
             label: t("share.rss"),
             Icon: LuRss,
             render: () => <>
-                <CopyableInput label={t("share.copy-rss")} value={rssUrl} />
-                <QrCodeButton target={rssUrl} label={t("share.rss")} />
+                <CopyableInput label={t("share.copy-rss")} value={rssLinkUrl} />
+                <QrCodeButton label={t("share.rss")} target={rssLinkUrl} />
             </>,
         },
     };
-    return <ShareButton height={180} {...{ tabs }} css={{
+    return <ShareButton height={180} {...{ tabs, className }} css={{
         padding: 12,
         height: 31,
         borderRadius: 4,


### PR DESCRIPTION
So people won't need to take the detour via the actual series page anymore.

This is just temporary however, since we plan on rebuilding the details pages anyway at some point.

Until then, we might still consider to just use the share menu to combine both links (RSS and direct), or at least add a variation of the QR code button, though that would need design considerations and possibly some soon-to-be redundant work.