### PR TITLE
Fix Rust warnings for Rust 1.89

### DIFF
--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -55,7 +55,7 @@ impl SessionId {
 
     /// Returns a cookie for a `set-cookie` header in order to store the session
     /// ID in the client's cookie jar.
-    pub(crate) fn set_cookie(&self, session_duration: Duration) -> Cookie {
+    pub(crate) fn set_cookie(&self, session_duration: Duration) -> Cookie<'_> {
         Cookie::build((SESSION_COOKIE, base64encode(self.0.expose_secret())))
 
             // Only send via HTTPS as it contains sensitive information.

--- a/backend/vendor/meilisearch-sdk/src/client.rs
+++ b/backend/vendor/meilisearch-sdk/src/client.rs
@@ -202,7 +202,7 @@ impl<Http: HttpClient> Client<Http> {
     ///
     /// [1]: https://www.meilisearch.com/docs/learn/multi_search/multi_search_vs_federated_search#what-is-federated-search
     #[must_use]
-    pub fn multi_search(&self) -> MultiSearchQuery<Http> {
+    pub fn multi_search(&self) -> MultiSearchQuery<'_, '_, Http> {
         MultiSearchQuery::new(self)
     }
 

--- a/backend/vendor/meilisearch-sdk/src/documents.rs
+++ b/backend/vendor/meilisearch-sdk/src/documents.rs
@@ -86,7 +86,7 @@ pub struct DocumentQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentQuery<'_, Http> {
         DocumentQuery {
             index,
             fields: None,
@@ -200,7 +200,7 @@ pub struct DocumentsQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentsQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentsQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentsQuery<'_, Http> {
         DocumentsQuery {
             index,
             offset: None,
@@ -332,7 +332,7 @@ pub struct DocumentDeletionQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> DocumentDeletionQuery<'a, Http> {
     #[must_use]
-    pub fn new(index: &Index<Http>) -> DocumentDeletionQuery<Http> {
+    pub fn new(index: &Index<Http>) -> DocumentDeletionQuery<'_, Http> {
         DocumentDeletionQuery {
             index,
             filter: None,

--- a/backend/vendor/meilisearch-sdk/src/indexes.rs
+++ b/backend/vendor/meilisearch-sdk/src/indexes.rs
@@ -275,7 +275,7 @@ impl<Http: HttpClient> Index<Http> {
     /// # });
     /// ```
     #[must_use]
-    pub fn search(&self) -> SearchQuery<Http> {
+    pub fn search(&self) -> SearchQuery<'_, Http> {
         SearchQuery::new(self)
     }
 
@@ -1676,7 +1676,7 @@ pub struct IndexUpdater<'a, Http: HttpClient> {
 }
 
 impl<'a, Http: HttpClient> IndexUpdater<'a, Http> {
-    pub fn new(uid: impl AsRef<str>, client: &Client<Http>) -> IndexUpdater<Http> {
+    pub fn new(uid: impl AsRef<str>, client: &Client<Http>) -> IndexUpdater<'_, Http> {
         IndexUpdater {
             client,
             primary_key: None,
@@ -1858,7 +1858,7 @@ pub struct IndexesQuery<'a, Http: HttpClient> {
 
 impl<'a, Http: HttpClient> IndexesQuery<'a, Http> {
     #[must_use]
-    pub fn new(client: &Client<Http>) -> IndexesQuery<Http> {
+    pub fn new(client: &Client<Http>) -> IndexesQuery<'_, Http> {
         IndexesQuery {
             client,
             offset: None,


### PR DESCRIPTION
See https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Most changes are in the vendored Meili. This will be changed soon anyway, but this was now the easiest to just fix it.