### PR TITLE
Add formatting guide & live preview to text block editor

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -626,7 +626,27 @@ manage:
       mit <code>{{reservedChars}}</code> beginnen.
 
   block:
-    text: Hier können Sie Ihren Text einfügen. Sie können auch Markdown verwenden.
+    text:
+      placeholder: Hier können Sie Ihren Text einfügen. Sie können auch Markdown verwenden.
+      formatting:
+          guide: Formatierungshilfe
+          description: >
+              Sie können Markdown zur Formatierung nutzen. Die folgende Tabelle
+              listet alle unterstützten Funktionen. Bilder können hier nicht
+              hochgeladen werden: Sie müssen diese vorher auf anderem Wege
+              hochladen. Eine leere Zeile beginnt einen neuen Paragraphen.
+          result: Ergebnis
+          italic: Kursiv
+          bold: Fett
+          monospace: Monospace
+          link: Link
+          quote: Zitat
+          code-block: Codeblock
+          external-image: Externes Bild
+          hr: Trennlinie
+          bullet-points: Stichpunkte
+          ordered-list: Nummerierte Liste
+
     series:
       invalid: Bitte eine Serie auswählen
       findable-series-note: >

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -628,6 +628,7 @@ manage:
   block:
     text:
       placeholder: Hier können Sie Ihren Text einfügen. Sie können auch Markdown verwenden.
+      preview: Vorschau
       formatting:
           guide: Formatierungshilfe
           description: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -595,6 +595,7 @@ manage:
   block:
     text:
       placeholder: You can add your text content here. You can also use Markdown.
+      preview: Preview
       formatting:
           guide: Formatting guide
           description: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -593,7 +593,26 @@ manage:
       and they must not start with <code>{{reservedChars}}</code>.
 
   block:
-    text: You can add your text content here. You can also use Markdown.
+    text:
+      placeholder: You can add your text content here. You can also use Markdown.
+      formatting:
+          guide: Formatting guide
+          description: >
+              You can use Markdown for simple formatting. Below you can find all
+              supported features. Note that images cannot be uploaded here: you
+              must first upload them via different means. Use an empty line to
+              start a new paragraph.
+          result: Result
+          italic: Italic
+          bold: Bold
+          monospace: Monospace
+          link: Link
+          quote: Quote
+          code-block: Code block
+          external-image: External image
+          hr: Separator
+          bullet-points: Bullet points
+          ordered-list: Ordered list
     series:
       invalid: Please select a series
       findable-series-note: >

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -663,9 +663,10 @@ manage:
       pas commencer par <code>{{reservedChars}}</code>.
 
   block:
-    text: >
-      Vous pouvez insérer votre texte ici. Vous pouvez également utiliser la
-      fonction Markdown.
+    text:
+      placeholder: >
+        Vous pouvez insérer votre texte ici. Vous pouvez également utiliser la
+        fonction Markdown.
     series:
       invalid: Veuillez sélectionner une série
       findable-series-note: >

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -654,9 +654,10 @@ manage:
       e non devono iniziare con <code>{{reservedChars}}</code>.
 
   block:
-    text: >
-      Qui si può aggiungere il contenuto del testo. È anche possibile utilizzare
-      Markdown.
+    text:
+      placeholder: >
+        Qui si può aggiungere il contenuto del testo. È anche possibile utilizzare
+        Markdown.
     series:
       invalid: Si prega di selezionare una serie
       findable-series-note: >

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { startTransition, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
 import { Controller } from "react-hook-form";
@@ -57,6 +57,7 @@ export const EditTextBlock: React.FC<EditTextBlockProps> = ({ block: blockRef })
     const map = (data: TextFormData) => data;
     const defaultValues = { content };
 
+    const [previewText, setPreviewText] = useState(defaultValues.content);
 
     return <EditModeForm {...{ defaultValues, map, save, create }}>
         <FormattingGuide />
@@ -67,8 +68,20 @@ export const EditTextBlock: React.FC<EditTextBlockProps> = ({ block: blockRef })
                 placeholder={t("manage.block.text.placeholder")}
                 css={{ display: "block" }}
                 {...field}
+                onChange={e => {
+                    const value = e.currentTarget.value;
+                    startTransition(() => setPreviewText(value));
+                    field.onChange(e);
+                }}
             />}
         />
+        <strong css={{ marginTop: 24, display: "block" }}>
+            {t("manage.block.text.preview")}{":"}
+        </strong>
+        <hr css={{ }} />
+        <div css={{ padding: "0 4px" }}>
+            <RenderMarkdown>{previewText}</RenderMarkdown>
+        </div>
     </EditModeForm>;
 };
 

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
@@ -14,6 +14,8 @@ import type {
 import type {
     TextEditSaveMutation,
 } from "./__generated__/TextEditSaveMutation.graphql";
+import { COLORS } from "../../../../../../color";
+import { RenderMarkdown } from "../../../../../../ui/Blocks/Text";
 
 
 type TextFormData = {
@@ -57,14 +59,133 @@ export const EditTextBlock: React.FC<EditTextBlockProps> = ({ block: blockRef })
 
 
     return <EditModeForm {...{ defaultValues, map, save, create }}>
+        <FormattingGuide />
         <Controller
             name="content"
             defaultValue={content}
             render={({ field }) => <TextArea
-                placeholder={t("manage.block.text")}
+                placeholder={t("manage.block.text.placeholder")}
                 css={{ display: "block" }}
                 {...field}
             />}
         />
     </EditModeForm>;
+};
+
+const FormattingGuide: React.FC = () => {
+    const { t } = useTranslation();
+
+    const rows: [string, string][] = [
+        [
+            t("manage.block.text.formatting.bold"),
+            "The **lazy** dog",
+        ],
+        [
+            t("manage.block.text.formatting.italic"),
+            "The *lazy* dog",
+        ],
+        [
+            t("manage.block.text.formatting.link"),
+            "[Lazy dog](https://example.com)",
+        ],
+        [
+            t("manage.block.text.formatting.bullet-points"),
+            "- Lazy dog\n- Quick brown fox",
+        ],
+        [
+            t("manage.block.text.formatting.ordered-list"),
+            "1. Lazy dog\n2. Quick brown fox",
+        ],
+        [
+            t("manage.block.text.formatting.external-image"),
+            "![Alt text](https://example.com/image.jpg)",
+        ],
+        [
+            t("manage.block.text.formatting.quote"),
+            "> To 🐝 or not to 🐝. ― Shakespeare",
+        ],
+        [
+            t("manage.block.text.formatting.hr"),
+            "---",
+        ],
+        [
+            t("manage.block.text.formatting.monospace"),
+            "E-Mail: `test@example.com`",
+        ],
+        [
+            t("manage.block.text.formatting.code-block"),
+            "```\nfn main() {}\n```",
+        ],
+    ];
+
+    return (
+        <details css={{
+            border: `1px solid ${COLORS.neutral40}`,
+            borderRadius: 4,
+            padding: "6px 8px",
+            margin: "16px 0",
+            fontSize: 14,
+            code: {
+                backgroundColor: COLORS.neutral15,
+                borderRadius: 4,
+                padding: 2,
+            },
+        }}>
+            <summary css={{ cursor: "pointer", fontWeight: "bold" }}>
+                {t("manage.block.text.formatting.guide")}
+            </summary>
+            <p css={{ margin: "16px 8px", maxWidth: "80ch" }}>
+                {t("manage.block.text.formatting.description")}
+            </p>
+            <div css={{ overflowX: "auto" }}>
+                <table css={{
+                    width: "100%",
+                    maxWidth: 930,
+                    borderCollapse: "collapse",
+                    "> thead > tr, > tbody > tr:not(:last-child)": {
+                        borderBottom: `1px solid ${COLORS.neutral15}`,
+                    },
+                    th: {
+                        textAlign: "left",
+                    },
+                    "th, td": {
+                        padding: "8px 12px",
+                    },
+                }}>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Markdown</th>
+                            <th>{t("manage.block.text.formatting.result")}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map(([label, markdown], i) => <tr key={i}>
+                            <td css={{ fontWeight: "bold" }}>{label}</td>
+                            <td css={{
+                                fontFamily: "monospace",
+                                whiteSpace: "pre-line",
+                            }}>{markdown}</td>
+                            <td css={{
+                                "& > *": {
+                                    margin: 0,
+                                },
+                                "img": {
+                                    height: 30,
+                                },
+                            }}>
+                                <RenderMarkdown>
+                                    {markdown.replace(
+                                        "https://example.com/image.jpg",
+                                        "/~assets/favicon.svg",
+                                    )}
+                                </RenderMarkdown>
+                            </td>
+                        </tr>)}
+                    </tbody>
+                </table>
+            </div>
+        </details>
+
+    );
 };

--- a/frontend/src/ui/Blocks/Text.tsx
+++ b/frontend/src/ui/Blocks/Text.tsx
@@ -48,8 +48,8 @@ const MARKDOWN_COMPONENTS: Options["components"] = {
         {...props}
     />,
     a: ({ node, href, ...props }) => <Link to={href ?? ""} {...props} />,
-    ul: ({ node, ...props }) => <ul css={{ maxWidth: 800 }} {...props} />,
-    ol: ({ node, ...props }) => <ol css={{ maxWidth: 800 }} {...props} />,
+    ul: ({ node, ...props }) => <ul css={{ maxWidth: 800, paddingLeft: 32 }} {...props} />,
+    ol: ({ node, ...props }) => <ol css={{ maxWidth: 800, paddingLeft: 32 }} {...props} />,
     blockquote: ({ node, ...props }) => <blockquote
         css={{
             borderLeft: `4px solid ${COLORS.neutral25}`,
@@ -96,8 +96,12 @@ export const TextBlock: React.FC<Props> = ({ content }) => (
             outlineOffset: 1,
         },
     }}>
-        <ReactMarkdown allowedElements={ALLOWED_MARKDOWN_TAGS} components={MARKDOWN_COMPONENTS}>
-            {content}
-        </ReactMarkdown>
+        <RenderMarkdown>{content}</RenderMarkdown>
     </div>
+);
+
+export const RenderMarkdown: React.FC<{ children: string }> = ({ children }) => (
+    <ReactMarkdown allowedElements={ALLOWED_MARKDOWN_TAGS} components={MARKDOWN_COMPONENTS}>
+        {children}
+    </ReactMarkdown>
 );


### PR DESCRIPTION
CC #446

The formatting guide explains markdown and lists all supported features. The live preview shows the rendered markdown below the text box.

Can be reviewed commit by commit.