### PR TITLE
Sort groups alphabetically in selector & add `sortKey` for more control

### DIFF
--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -19,19 +19,21 @@ pub struct KnownGroup {
     pub(crate) role: String,
     pub(crate) label: TranslatedString,
     pub(crate) implies: Vec<String>,
+    pub(crate) sort_key: Option<String>,
     pub(crate) large: bool,
 }
 
 impl_from_db!(
     KnownGroup,
     select: {
-        known_groups.{ role, label, implies, large },
+        known_groups.{ role, label, implies, sort_key, large },
     },
     |row| {
         KnownGroup {
             role: row.role(),
             label: row.label(),
             implies: row.implies(),
+            sort_key: row.sort_key(),
             large: row.large(),
         }
     },

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -378,4 +378,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     43: "search-views-without-deletions",
     44: "redo-events-no-null-tracks-constraint",
     45: "custom-user-realm-path",
+    46: "known-groups-sort-key",
 ];

--- a/backend/src/db/migrations/46-known-groups-sort-key.sql
+++ b/backend/src/db/migrations/46-known-groups-sort-key.sql
@@ -1,0 +1,4 @@
+-- Add sort_key to known groups to give admins more control over sorting.
+
+alter table known_groups
+    add column sort_key text;

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -43,7 +43,7 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
 
 ```json
 {
-    "ROLE_STUDENT": { "label": { "default": "Students", "de": "Studierende" }, "implies": [], "large": true },
+    "ROLE_STUDENT": { "label": { "default": "Students", "de": "Studierende" }, "implies": [], "sortKey": "_c", "large": true },
     "ROLE_STAFF": { "label": { "default": "Staff", "de": "Angestellte" }, "implies": [], "large": true },
     "ROLE_LECTURER": { "label": { "default": "Lecturers", "de": "Vortragende" }, "implies": ["ROLE_STAFF"], "large": true },
     "ROLE_TOBIRA_MODERATOR": { "label": { "default": "Moderators", "de": "Moderierende" }, "implies": ["ROLE_STAFF"], "large": false }
@@ -63,6 +63,10 @@ Field explanation:
   All roles automatically imply `ROLE_USER` and `ROLE_ANONYMOUS`.
 - `large`: set to `true` if this group is considered so large that giving write access to it is unusual enough to show a warning in the ACL interface.
   `ROLE_USER` and `ROLE_ANONYMOUS` are both considered large.
+- `sortKey`: optional, used to sort entries in the group selector.
+  Entries with same `sortKey` are sorted alphabetically.
+  Entries without `sortKey` are sorted last.
+  By default, `ROLE_ANONYMOUS` has sortKey "_a" and `ROLE_USER` has "_b".
 
 Note that `upsert` is idempotent, so you can simply call this as part of your Ansible script, for example.
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -371,6 +371,7 @@ type KnownGroup {
   role: String!
   label: TranslatedString!
   implies: [String!]!
+  sortKey: String
   large: Boolean!
 }
 


### PR DESCRIPTION
Before, they weren't sorted at all, meaning they would be shown in the arbitrary database order. Now they are sorted alphabetically. But there is a `sortKey` which gives admins control over the order of groups. With that, ROLE_ANONYMOUS and ROLE_USER are sorted first by default.

Fixes #1288 