### PR TITLE
Fix variables inside French translation

### DIFF
--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -137,7 +137,7 @@ login-page:
 video:
   singular: Vidéo
   plural: Vidéos
-  video-page: 'Page vidéo: « {{vidéo}} »'
+  video-page: 'Page vidéo: « {{video}} »'
   video-player: Videoplayer
   duration: Durée de lecture
   details: Détails de la vidéo
@@ -153,7 +153,7 @@ video:
       Cette vidéo n'a pas encore été entièrement traitée. Cela devrait bientôt
       se faire automatiquement. Réessayez plus tard.
     label: pas encore traité
-  thumbnail-for: Vignette pour « {{vidéo}} »
+  thumbnail-for: Vignette pour « {{video}} »
   live: En direct
   upcoming: À venir
   ended: Terminé
@@ -196,7 +196,7 @@ video:
 series:
   singular: Série
   plural: Séries
-  series-page: 'Page de la série : « {{séries}} »'
+  series-page: 'Page de la série : « {{series}} »'
   deleted-block: La série référencée ici a été supprimée.
   entry-of-series-thumbnail: Vignette pour l'entrée de « {{series}} »
   not-ready:


### PR DESCRIPTION
All these seem to be only used in alt-text and aria-labels, that's probably why no one noticed.