### PR TITLE
Add config option to disable video removal in series management

### DIFF
--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -135,6 +135,12 @@ pub(crate) struct GeneralConfig {
     /// content in your Tobira is safe for all audiences.
     #[config(default = true)]
     pub explicit_rss_content: bool,
+
+    /// Whether users can remove events from a series they have write access for.
+    /// Should to be disabled when the connected Opencast requires events to always
+    /// be part of a series, as removing wouldn't work in that case.
+    #[config(default = true)]
+    pub allow_series_event_removal: bool,
 }
 
 const INTERNAL_RESERVED_PATHS: &[&str] = &["favicon.ico", "robots.txt", ".well-known"];

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -314,6 +314,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         "usersSearchable": config.general.users_searchable,
         "allowAclEdit": config.general.allow_acl_edit,
         "lockAclToSeries": config.general.lock_acl_to_series,
+        "allowSeriesEventRemoval": config.general.allow_series_event_removal,
         "footerLinks": config.general.footer_links,
         "metadataLabels": config.general.metadata,
         "paellaPluginConfig": config.player.paella_plugin_config,

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -151,6 +151,13 @@
 # Default value: true
 #explicit_rss_content = true
 
+# Whether users can remove events from a series they have write access for.
+# Should to be disabled when the connected Opencast requires events to always
+# be part of a series, as removing wouldn't work in that case.
+#
+# Default value: true
+#allow_series_event_removal = true
+
 
 [db]
 # The username of the database user.

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -29,6 +29,7 @@ type Config = {
     usersSearchable: boolean;
     allowAclEdit: boolean;
     lockAclToSeries: boolean;
+    allowSeriesEventRemoval: boolean;
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
     metadataLabels: Record<string, Record<string, MetadataLabel>>;

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -508,6 +508,7 @@ manage:
     no-content: Keine Videos
     no-of-videos_one: '{{count}} Videos'
     no-of-videos_other: '{{count}} Videos'
+    removing-disabled: Entfernen von Videos ist deaktiviert.
     edit:
       add-video: Video hinzufügen
       to-be-added: wird hinzugefügt

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -485,6 +485,7 @@ manage:
     no-content: No videos
     no-of-videos_one: '{{count}} video'
     no-of-videos_other: '{{count}} videos'
+    removing-disabled: Removing videos is disabled.
     edit:
       add-video: Add video
       to-be-added: will be added

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -509,6 +509,7 @@ manage:
     no-content: pas de vidéos
     no-of-videos_one: '{{count}} Vidéos'
     no-of-videos_other: '{{count}} Vidéos'
+    removing-disabled: La suppression des vidéos est désactivée. # needs verification
     edit:
       add-video: Ajouter une vidéo
       to-be-added: sera ajouté

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -500,6 +500,7 @@ manage:
     no-content: Nessun video
     no-of-videos_one: '{{count}} video'
     no-of-videos_other: '{{count}} video'
+    removing-disabled: La rimozione dei video è disabilitata. # needs verification
     edit:
       add-video: Aggiungere video
       to-be-added: sarà aggiunto

--- a/frontend/src/routes/manage/Shared/EditVideoList.tsx
+++ b/frontend/src/routes/manage/Shared/EditVideoList.tsx
@@ -7,6 +7,7 @@ import {
     boxError,
     bug,
     Button,
+    Card,
     Floating,
     FloatingContainer,
     FloatingHandle,
@@ -32,6 +33,7 @@ import { useNavBlocker } from "../../util";
 import { UploadRoute } from "../../Upload";
 import { LinkButton } from "../../../ui/LinkButton";
 import { isRealUser, useUser } from "../../../User";
+import CONFIG from "../../../config";
 
 
 type Entry = Series["entries"][number];
@@ -107,6 +109,9 @@ export const ManageVideoListContent = <TMutation extends VideoListMutationParams
         {description && <p css={{ marginBottom: 8, maxWidth: 750, fontSize: 14 }}>
             {description}
         </p>}
+        {!CONFIG.allowSeriesEventRemoval && <Card kind="info">
+            {t("manage.video-list.removing-disabled")}
+        </Card>}
         <div css={{ margin: "24px auto 16px", display: "flex", gap: 12, flexWrap: "wrap" }}>
             <AddVideoMenu {...{ setEvents, events }} />
             {/* // Todo: Omit upload button when adding this route for playlists */}
@@ -375,7 +380,7 @@ const EventEntry: React.FC<EventEntryProps> = ({ event, onChange }) => {
                                 ({t("manage.video-list.edit.cannot-be-removed")})
                             </i>}
                             <Button
-                                disabled={!event.canWrite}
+                                disabled={!event.canWrite || !CONFIG.allowSeriesEventRemoval}
                                 kind="danger"
                                 css={buttonStyle}
                                 onClick={onChange}


### PR DESCRIPTION
This is a temporary solution to deal with the fact that Opencast can be configured in a way that makes it mandatory for a video to always be part of a series. If that is configured, removing a video doesn't work (see #1529).
Until we add the necessary API and interface directly move a video to another series instead of just removing it, it's best to just let admins use this option to disable video removal.
For that, `general.allow_series_event_removal = false` needs to be set.

The UI will then show a note and the `remove` buttons will be disabled:

<img width="559" height="268" alt="Bildschirmfoto 2025-09-01 um 14 34 14" src="https://github.com/user-attachments/assets/7592a8dd-ea41-434a-9c37-4d6f1513d35a" />
  