### PR TITLE
Fix "slice into UTF8 codepoint" bug in search index

### DIFF
--- a/backend/src/search/event.rs
+++ b/backend/src/search/event.rs
@@ -825,7 +825,7 @@ impl<'a> FromSql<'a> for TextSearchIndex {
             // example. Having duplicates is not useful for search. The `4096`
             // limit is just there to avoid quadratic blowup in case there are
             // lots of texts in the same span.
-            if buf[..min(buf.len(), 4096)].contains(s) {
+            if buf[..ceil_char_boundary(buf, 4096)].contains(s) {
                 continue;
             }
 


### PR DESCRIPTION
When updating or rebuilding the search index, a rare bug could occur where the code would cut into an UTF8 codepoint.