### PR TITLE
Add shortcut to hide/show player UI

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -441,6 +441,7 @@ shortcuts:
     volume-up: Lautstärke erhöhen
     slow-down: Wiedergabegeschwindigkeit verringern
     speed-up: Wiedergabegeschwindigkeit erhöhen
+    hide-ui: Bedienelemente aus/einblenden
   keys:
     escape: Esc
     space: Leertaste

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -417,6 +417,7 @@ shortcuts:
     volume-up: Increase volume
     slow-down: Decrease playback speed
     speed-up: Increase playback speed
+    hide-ui: Hide/show user interface
   keys:
     escape: Esc
     space: Spacebar

--- a/frontend/src/typings/paella-core.d.ts
+++ b/frontend/src/typings/paella-core.d.ts
@@ -34,6 +34,7 @@ declare module "paella-core" {
         public enterFullscreen(): Promise<void>;
         public exitFullscreen(): Promise<void>;
 
+        public containerElement: HTMLElement;
         public captionsCanvas: CaptionsCanvas;
     }
 

--- a/frontend/src/ui/Shortcuts.tsx
+++ b/frontend/src/ui/Shortcuts.tsx
@@ -98,6 +98,10 @@ export const SHORTCUTS = {
             keys: "shift+period",
             translation: "shortcuts.player.speed-up",
         },
+        hideUI: {
+            keys: "h",
+            translation: "shortcuts.player.hide-ui",
+        },
     },
 } as const satisfies Record<string, Record<string, ShortcutProps>>;
 

--- a/frontend/src/ui/player/PlayerShortcuts.tsx
+++ b/frontend/src/ui/player/PlayerShortcuts.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import { SHORTCUTS, useShortcut } from "../Shortcuts";
 import { FRAME_DURATION, SKIP_INTERVAL, SPEEDS } from "./consts";
+import { UI_HIDDEN_CLASS } from "./Paella";
 
 
 export const isSpaceOnInteractiveElement = (e: KeyboardEvent): boolean => (
@@ -111,6 +112,9 @@ export const SHORTCUT_ACTIONS = {
     speedUp: {
         callback: player => async () => await adjustSpeed(player, 1),
     },
+    hideUI: {
+        callback: player => () => toggleUiVisibility(player),
+    },
 } satisfies Record<PlayerAction, PlayerShortcuts>;
 
 
@@ -171,3 +175,9 @@ export const adjustSpeed = async (
     const newSpeed = SPEEDS[newIdx];
     await player.videoContainer.setPlaybackRate(newSpeed);
 };
+
+
+const toggleUiVisibility = (player: Paella) => {
+    player.containerElement.classList.toggle(UI_HIDDEN_CLASS);
+};
+


### PR DESCRIPTION
The UI can now be hidden and subsequently shown again by pressing `h`. When hidden, any mouse activity inside the video container will also pop the UI back in, preserving the default behaviour.

This doesn't use built in paella functions like `hideUserInterface()` because that only works when the player is not paused, so this implements a css solution instead.

Closes https://github.com/elan-ev/tobira/issues/1480