### PR TITLE
Fix shrinking "info" icon for "missing access" note in videolist block

### DIFF
--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -216,7 +216,7 @@ const HiddenItemsInfo: React.FC<PropsWithChildren> = ({ children }) => <div css=
     gap: 16,
     alignItems: "center",
 }}>
-    <LuInfo size={18} />
+    <LuInfo size={18} css={{ flexShrink: 0 }} />
     {children}
 </div>;
 


### PR DESCRIPTION
See here (not logged in) and reduce screen width: https://tobira.opencast.org/lectures/d-infk/2020/spring/263-0008-00L

<img width="656" height="242" alt="image" src="https://github.com/user-attachments/assets/18161eb0-8ffc-4382-91aa-491fd59c3c7b" />
