### PR TITLE
Make `tobira serve` gracefully shutdown HTTP server

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2601,6 +2601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3015,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,7 +41,7 @@ hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyperlocal = "0.9.1"
 http-body-util = "0.1"
 hyper-rustls = { version = "0.27.3", default-features = false, features = ["http1", "http2", "native-tokio", "logging", "tls12"] }
-hyper-util = { version = "0.1.3", features = ["client", "server", "http1", "http2"] }
+hyper-util = { version = "0.1.3", features = ["client", "server", "http1", "http2", "server-graceful", "server-auto"] }
 iso8601 = "0.6.1"
 juniper = { version = "0.16.2", default-features = false, features = ["chrono", "schema-language", "anyhow", "backtrace"] }
 meilisearch-sdk = { path = "vendor/meilisearch-sdk" }
@@ -73,7 +73,7 @@ static_assertions = "1"
 tap = "1"
 termcolor = "1.1.1"
 time = "0.3"
-tokio = { version = "1.43", features = ["fs", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.43", features = ["fs", "rt-multi-thread", "macros", "signal", "time"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.13.0"
 url = "2.4.1"


### PR DESCRIPTION
When a shutdown signal is received, the server still replies to open connections and only shuts down then. We use a fairly short timeout of 1s for that to not be too different from the old behavior. Apart from not just dropping HTTP connections, it's also nice to have a log output for shutdown.

The implementation is a tiny bit more complex because of our use of the hyper util "auto" builder. I think we can get rid of that and just use http1: since Tobira does not do TLS itself, I'm pretty sure the HTTP 2 ability of the server is never used, as protocol negotiation only happen via TLS in practice. But I didn't want to cram "remove http 2 server support" into this PR.