### PR TITLE
Fix broken series blocks when series gets deleted

### DIFF
--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -201,8 +201,7 @@ impl SeriesBlock {
     async fn series(&self, context: &Context) -> ApiResult<Option<Series>> {
         match self.series {
             None => Ok(None),
-            // `unwrap` is okay here because of our foreign key constraint
-            Some(series_id) => Ok(Some(Series::load_by_id(series_id, context).await?.unwrap())),
+            Some(series_id) => Series::load_by_id(series_id, context).await,
         }
     }
 


### PR DESCRIPTION
Fixes #1476

The ability to delete series from Tobira introduced a bug where blocks referencing that series would be broken. That previous change introduced the table `all_series` with a `deleted` flag. That way, the foreign key we had (and is referenced in the deleted comment) became useless. Fixing this is easy fortunately.