### PR TITLE
Fix incorrect language/locale being used when not explicitly set

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -24,6 +24,7 @@ void i18n
     .init({
         resources: languages,
         fallbackLng: "en",
+        supportedLngs: Object.keys(languages),
         interpolation: {
             escapeValue: false,
         },


### PR DESCRIPTION
We use `i18n.language` in many places across the codebase, e.g. for pretty dates. Turns out: that is not necessarily one of our supported languages! If a new user who never chose a language explicitly in Tobira comes along, `i18n.language` is their preferred browser language. I could have changed all `i18n.language` to `i18n.resolvedLanguage`, which seems to be what we want. But it's also fine to explicitly set the supported languages, to force i18n to set `i18n.language` to one of those. If the user has a different one, `fallbackLng` is used.

CC @oas777 this fixes the problem the Greek person encountered.