### PR TITLE
Remove unused GraphQL fields in videolist blocks

### DIFF
--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -67,9 +67,6 @@ export const videoListEventFragment = graphql`
             endTime
             audioOnly
         }
-        authorizedData {
-            tracks { resolution }
-        }
     }
 `;
 type Event = VideoListEventData$data;


### PR DESCRIPTION
This is not used anymore.

On the homepage of our test deployment, this reduces the size of the graphql request from 27.5KB to 24.3KB.