### PR TITLE
Remove download menu note

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -172,9 +172,6 @@ video:
     title: Download
     presenter: Video (Sprecher:in)
     slides: Video (Präsentation)
-    info: >
-      Hier können Sie das/die Video(s) in unterschiedlichen Formaten/Auflösungen herunterladen
-      (Rechtsklick - Speichern unter).
   extra-buttons: Weitere Videoaktionen
   start: Anfang
   end: Ende

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -170,8 +170,6 @@ video:
     title: Download
     presenter: Video (speaker)
     slides: Video (presentation)
-    info: >
-      Here you can download the video(s) in different formats/qualities (Right click - Save as).
   extra-buttons: Additional video actions
   start: Start
   end: End

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -173,9 +173,6 @@ video:
     title: Télécharger
     presenter: Vidéo (Intervenant(s))
     slides: Vidéo (présentation)
-    info: >
-      Ici, vous pouvez télécharger les vidéos dans différents formats (Cic droit
-      - Enregistrer sous).
   extra-buttons: Actions vidéo supplémentaires
   start: Début
   end: Fin

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -169,9 +169,6 @@ video:
     title: Download
     presenter: Video (relatore/relatrice)
     slides: Video (presentazione)
-    info: >
-      Qui è possibile scaricare il/i video in diversi formati/qualità (clic
-      destro - Salva con nome).
   extra-buttons: Ulteriori azioni video
   start: Inizio
   end: Fine

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -954,12 +954,6 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
 };
 
 
-const PopoverHeading: React.FC<React.PropsWithChildren> = ({ children }) => (
-    <strong css={{ fontSize: 18, display: "block", marginBottom: 16 }}>
-        {children}
-    </strong>
-);
-
 const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const { t } = useTranslation();
     const ref = useRef(null);
@@ -984,10 +978,9 @@ const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
                 backgroundColor={isDark ? COLORS.neutral15 : COLORS.neutral05}
                 padding={[8, 16, 16, 16]}
             >
-                <PopoverHeading>{t("video.download.title")}</PopoverHeading>
-                <Card kind="info" iconPos="left" css={{ maxWidth: 400, fontSize: 14 }}>
-                    {t("video.download.info")}
-                </Card>
+                <strong css={{ fontSize: 18, display: "block", marginBottom: 8 }}>
+                    {t("video.download.title")}
+                </strong>
                 <TrackInfo event={event} translateFlavors />
             </Floating>
         </FloatingContainer>

--- a/frontend/src/ui/Video.tsx
+++ b/frontend/src/ui/Video.tsx
@@ -387,7 +387,7 @@ export const TrackInfo: React.FC<TrackInfoProps> = (
 
     const isSingleFlavor = flavors.size === 1;
 
-    return <ul css={{ fontSize: 15, marginTop: 8, paddingLeft: 24 }}>
+    return <ul css={{ fontSize: 15, marginBottom: 4, paddingLeft: 24 }}>
         {Array.from(flavors, ([flavor, tracks]) => {
             const trackItems = tracks
                 .sort((a, b) => (a.resolution?.[0] ?? 0) - (b.resolution?.[0] ?? 0))


### PR DESCRIPTION
The information wasn't really necessary and removing it makes the menu a little smaller, which is nice.
Also removes some margins/padding.

Closes #1564