### PR TITLE
Send `lng` parameter to Editor

### DIFF
--- a/frontend/src/relay/auth.tsx
+++ b/frontend/src/relay/auth.tsx
@@ -34,6 +34,7 @@ export type ExternalLinkProps = PropsWithChildren<{
         id: string;
         callbackUrl: string;
         callbackSystem: string;
+        lng: string;
     };
 })>;
 

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -103,6 +103,8 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
                         id: event.opencastId,
                         callbackUrl: document.location.href,
                         callbackSystem: translatedConfig(CONFIG.siteTitle, i18n),
+                        // Editor has two german variants and doesn't work with just "de".
+                        lng: i18n.language === "de" ? "de-de" : i18n.language,
                     }}
                     fallback="button"
                     css={buttonStyle(config, "normal", isHighContrast)}


### PR DESCRIPTION
With this, the editor will use the language that is currently selected in Tobira.

Closes #1570 