### PR TITLE
Show empty matches on timeline for events with only preview rights

### DIFF
--- a/backend/src/api/model/search/event.rs
+++ b/backend/src/api/model/search/event.rs
@@ -59,8 +59,9 @@ pub struct TextMatch {
     /// Duration of this timespan in number of milliseconds.
     pub duration: f64,
 
-    /// The text containing the match, with some context
-    pub text: String,
+    /// The text containing the match, with some context. Is `null` if the user
+    /// is not allowed to read the event, but only preview it.
+    pub text: Option<String>,
 
     /// Source of this text.
     pub ty: TextAssetType,
@@ -90,18 +91,18 @@ impl SearchEvent {
         let mut text_matches = Vec::new();
         let read_roles = decode_acl(&src.read_roles);
         let user_can_read = context.auth.overlaps_roles(read_roles);
-        if user_can_read {
-            src.slide_texts.resolve_matches(
-                match_ranges_for(match_positions, "slide_texts.texts"),
-                &mut text_matches,
-                TextAssetType::SlideText,
-            );
-            src.caption_texts.resolve_matches(
-                match_ranges_for(match_positions, "caption_texts.texts"),
-                &mut text_matches,
-                TextAssetType::Caption,
-            );
-        }
+        src.slide_texts.resolve_matches(
+            match_ranges_for(match_positions, "slide_texts.texts"),
+            &mut text_matches,
+            TextAssetType::SlideText,
+            user_can_read,
+        );
+        src.caption_texts.resolve_matches(
+            match_ranges_for(match_positions, "caption_texts.texts"),
+            &mut text_matches,
+            TextAssetType::Caption,
+            user_can_read,
+        );
 
         let matches = SearchEventMatches {
             title: field_matches_for(match_positions, "title"),

--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from "react-relay";
 import {
     LuCalendarRange,
+    LuLock,
     LuPanelsTopLeft,
     LuVolume2,
     LuX,
@@ -793,15 +794,17 @@ const TextMatchTooltip: React.FC<TextMatchTooltipProps> = ({ previewImage, textM
             alignItems: "center",
             justifyContent: "center",
         }}>
-            <div css={{
-                padding: 1,
-                fontSize: 13,
-                lineHeight: 1.3,
-                ...ellipsisOverflowCss(2),
-                mark: highlightCss(COLORS.neutral90),
-            }}>
-                …{highlightText(textMatch.text, textMatch.highlights)}…
-            </div>
+            {textMatch.text
+                ? <div css={{
+                    padding: 1,
+                    fontSize: 13,
+                    lineHeight: 1.3,
+                    ...ellipsisOverflowCss(2),
+                    mark: highlightCss(COLORS.neutral90),
+                }}>
+                    …{highlightText(textMatch.text, textMatch.highlights)}…
+                </div>
+                : <LuLock />}
         </div>
         <div css={{ marginTop: 2 }}>
             {`(${startDuration} – ${endDuration})`}

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -1054,8 +1054,11 @@ type TextMatch {
   start: Float!
   "Duration of this timespan in number of milliseconds."
   duration: Float!
-  "The text containing the match, with some context"
-  text: String!
+  """
+    The text containing the match, with some context. Is `null` if the user
+    is not allowed to read the event, but only preview it.
+  """
+  text: String
   "Source of this text."
   ty: TextAssetType!
   "Parts of `text` that should be highlighted."


### PR DESCRIPTION
Before, no timeline was shown at all, which was confusing as it's not clear why the event is even shown in the results. With this commit, everything is still shown, except for the actual text. Of course this reveals some information about the transcript, but I don't see a way how this could get abused or how anyone would consider "knowing a specific term was used at a specific time" a leak of private data.

Fixes #1544

Hint: review with "hide whitespace changes"!