### PR TITLE
Add share button to video details page

### DIFF
--- a/frontend/src/routes/manage/Shared/Details.tsx
+++ b/frontend/src/routes/manage/Shared/Details.tsx
@@ -11,10 +11,9 @@ import { COLORS } from "../../../color";
 import { PageTitle } from "../../../layout/header/ui";
 import { Breadcrumbs } from "../../../ui/Breadcrumbs";
 import { NotAuthorized } from "../../../ui/error";
-import { CopyableInput, TimeInputWithCheckbox } from "../../../ui/Input";
 import { MetadataFields, MetadataForm, SubmitButtonWithStatus } from "../../../ui/metadata";
 import { useUser, isRealUser } from "../../../User";
-import { OcEntity, Inertable, isSynced, OpencastEntity, secondsToTimeString } from "../../../util";
+import { OcEntity, Inertable, isSynced, OpencastEntity } from "../../../util";
 import { PAGE_WIDTH } from "./Nav";
 import { displayCommitError } from "../Realm/util";
 import { ConfirmationModal, ConfirmationModalHandle } from "../../../ui/Modal";
@@ -22,11 +21,6 @@ import { Link, useRouter } from "../../../router";
 import { useNotification } from "../../../ui/NotificationContext";
 import { preciseDateTime, preferredLocaleForLang } from "../../../ui/time";
 
-
-type UrlProps = {
-    url: URL;
-    withTimestamp?: boolean;
-};
 
 type Item = OpencastEntity & {
     id: string;
@@ -121,31 +115,6 @@ const DateValue: React.FC<DateValueProps> = ({ label, date }) => <>
 </>;
 
 
-export const DirectLink: React.FC<UrlProps> = ({ url, withTimestamp }) => {
-    const { t } = useTranslation();
-    const [timestamp, setTimestamp] = useState(0);
-    const [checkboxChecked, setCheckboxChecked] = useState(false);
-
-    const linkUrl = url;
-    if (withTimestamp && timestamp && checkboxChecked) {
-        linkUrl.searchParams.set("t", secondsToTimeString(timestamp));
-    }
-
-    return <div css={{ marginBottom: 40, maxWidth: 750 }}>
-        <div css={{ marginBottom: 4 }}>
-            {t("share.share-direct-link") + ":"}
-        </div>
-        <CopyableInput
-            label={t("share.copy-direct-link-to-clipboard")}
-            value={linkUrl.href}
-            css={{ fontSize: 14 }}
-        />
-        {withTimestamp && <TimeInputWithCheckbox {...{
-            timestamp, setTimestamp, checkboxChecked, setCheckboxChecked,
-        }} />}
-    </div>;
-};
-
 type MetadataInput = {
     title: string;
     description?: string | null;
@@ -221,7 +190,7 @@ export const MetadataSection = <TMutation extends MetadataMutationParams>({
 
 
 export const ButtonSection: React.FC<PropsWithChildren> = ({ children }) => (
-    <div css={{ display: "flex", gap: 12, marginBottom: 16 }}>
+    <div css={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 16 }}>
         {children}
     </div>
 );

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -105,8 +105,9 @@ const query = graphql`
                     audioOnly
                 }
                 authorizedData {
-                    tracks { flavor resolution mimetype uri }
+                    tracks { flavor isMaster resolution mimetype uri }
                     captions { uri lang }
+                    segments { startTime uri }
                 }
                 series {
                     id

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -9,13 +9,12 @@ import { isRealUser, useUser } from "../../../User";
 import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
 import { Inertable, isSynced, translatedConfig } from "../../../util";
-import { DirectVideoRoute, VideoRoute } from "../../Video";
+import { DirectVideoRoute, VideoRoute, VideoShareButton } from "../../Video";
 import { ManageVideosRoute } from ".";
 import CONFIG from "../../../config";
 import {
     UpdatedCreatedInfo,
     DetailsPage,
-    DirectLink,
     MetadataSection,
     DeleteButton,
     ButtonSection,
@@ -43,9 +42,6 @@ export const ManageVideoDetailsRoute = makeManageVideoRoute(
                 updated: event.syncedData?.updated,
             }} />,
             <VideoButtonSection key="button-section" event={authEvent} />,
-            <DirectLink key="direct-link" withTimestamp={!event.isLive} url={
-                new URL(DirectVideoRoute.url({ videoId: authEvent.id }), document.baseURI)
-            } />,
             <VideoMetadataSection key="metadata" event={event} />,
             <div key="host-realms" css={{ marginBottom: 32 }}>
                 <HostRealms kind="video" hostRealms={authEvent.hostRealms} itemLink={realmPath => (
@@ -93,8 +89,15 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
         return <NotAuthorized />;
     }
 
-    return <Inertable isInert={!isSynced(event) || event.workflowStatus !== "IDLE"}>
-        <ButtonSection>
+    return <ButtonSection>
+        <VideoShareButton
+            {...{ event }}
+            videoLink={new URL(DirectVideoRoute.url({ videoId: event.id }), document.baseURI).href}
+        />
+        <Inertable
+            isInert={!isSynced(event) || event.workflowStatus !== "IDLE"}
+            css={{ display: "flex", flexWrap: "wrap", gap: 12 }}
+        >
             {user.canUseEditor && !event.isLive && event.canWrite && (
                 <ExternalLink
                     service="EDITOR"
@@ -116,8 +119,8 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
                 returnPath="/~manage/videos"
                 commit={commit}
             />
-        </ButtonSection>
-    </Inertable>;
+        </Inertable>
+    </ButtonSection>;
 };
 
 const VideoMetadataSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => {


### PR DESCRIPTION
We added that to series details recently as well, and while it's still planned to redesign these pages, this makes it easier to get to the embed and rss links coming from the video overview for now.