### PR TITLE
Move thumbnail query to API fn

### DIFF
--- a/backend/src/api/util.rs
+++ b/backend/src/api/util.rs
@@ -29,6 +29,8 @@ impl<T> LazyLoad<T> {
         }
     }
 
+    // Currently unused, but might come in handy again at some point.
+    #[allow(dead_code)]
     pub fn as_ref(&self) -> LazyLoad<&T> {
         match self {
             LazyLoad::Loaded(t) => LazyLoad::Loaded(t),


### PR DESCRIPTION
This way it doesn't load the thumbnails for every single series query.