### PR TITLE
Add embed url to share button

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -216,6 +216,7 @@ share:
   show-qr-code: QR Code anzeigen
   copy-link: Link in Zwischenablage kopieren
   copy-rss: RSS Link in Zwischenablage kopieren
+  copy-embed-url: Einbettungs-URL in Zwischenablage kopieren
   copy-embed-code: Einbettungscode in Zwischenablage kopieren
   copy-direct-link-to-clipboard: Videolink in Zwischenablage kopieren
   set-time: 'Starten bei: '

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -214,6 +214,7 @@ share:
   show-qr-code: Show QR code
   copy-link: Copy link to clipboard
   copy-rss: Copy RSS link to clipboard
+  copy-embed-url: Copy embed url to clipboard
   copy-embed-code: Copy embed code to clipboard
   copy-direct-link-to-clipboard: Copy video link to clipboard
   set-time: 'Start at: '

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -218,6 +218,7 @@ share:
   show-qr-code: Afficher le code QR
   copy-link: Copier le lien dans le presse-papiers
   copy-rss: Copier le lien RSS dans le presse-papiers
+  copy-embed-url: Copier l’URL d’intégration dans le presse-papiers # verify
   copy-embed-code: Copier le code d’intégration dans le presse-papiers
   copy-direct-link-to-clipboard: Copier le lien vidéo dans le presse-papiers
   set-time: 'Commencer à :'

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -214,6 +214,7 @@ share:
   show-qr-code: Mostra QR Code
   copy-link: Copia il link negli appunti
   copy-rss: Copia il link RSS negli appunti
+  copy-embed-url: Copia l'URL incorporato negli appunti # verify
   copy-embed-code: Copia il codice incorporato negli appunti
   copy-direct-link-to-clipboard: Copia il link del video negli appunti
   set-time: 'Iniziare da:'

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1072,18 +1072,17 @@ export const VideoShareButton: React.FC<VideoShareButtonProps> = ({
                 return <>
                     <div>
                         <CopyableInput
-                            label={t("share.copy-embed-code")}
-                            value={embedCode}
-                            multiline
-                            css={{ height: 75 }}
+                            label={t("share.copy-embed-url")}
+                            value={url.toString()}
+                            css={{ marginBottom: 14 }}
                         />
-                        {!event.isLive && <TimeInputWithCheckbox
-                            checkboxChecked={addEmbedTimestamp}
-                            setCheckboxChecked={setAddEmbedTimestamp}
-                            {...{ timestamp, setTimestamp }}
-                        />}
+                        <CopyableInput label={t("share.copy-embed-code")} value={embedCode} />
                     </div>
-                    <QrCodeButton target={embedCode} label={t("share.embed")} />
+                    {!event.isLive && <TimeInputWithCheckbox
+                        checkboxChecked={addEmbedTimestamp}
+                        setCheckboxChecked={setAddEmbedTimestamp}
+                        {...{ timestamp, setTimestamp }}
+                    />}
                 </>;
             },
         },


### PR DESCRIPTION
It was requested to supply an easy way to get the embed url without having to manually copy it from the iframe code.
So this adds a second "copyable input" line to the embed tab of the share menu.

In order to not blow up the vertical space needed by the menu, I shrunk the <iframe> copy thing a bit, which should be fine. It was larger because that would make it easier to get to the url in the first place (I think). It's still scrollable.

This is just a(n admittedly low-effort) proposition, but I'm not sure if there is or needs to be a nicer way.

Closes #1597 