### PR TITLE
Slightly improve error message for TranslatedString in config

### DIFF
--- a/backend/src/model/translated_string.rs
+++ b/backend/src/model/translated_string.rs
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for TranslatedString {
         let map = <HashMap<LangKey, String>>::deserialize(deserializer).map_err(|e| {
             let hint = "\
                 this is a 'translated label', a lang -> string map is expected, \
-                e.g. '{ default = \"Dog\", de = \"Hund\" }'";
+                e.g. `value = { default = \"Dog\", de = \"Hund\" }`";
             D::Error::custom(format!("{e} (HINT: {hint})"))
         })?;
         map.try_into().map_err(|e| D::Error::custom(e))


### PR DESCRIPTION
The single quotes were confusing because people would copy them into the config file and then get an error. I replaced them with backticks and also includes `value = ` which hopefully gives more context. At that point in the code, we don't know the actual name of the config field, so `value` is best we can do.

Fixes #1619