### PR TITLE
Filter groups in ACL selector

### DIFF
--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -47,6 +47,16 @@ impl KnownGroup {
             .await?
             .pipe(Ok)
     }
+
+    pub(crate) async fn load_for_user(context: &Context) -> ApiResult<Vec<Self>> {
+        let selection = Self::select();
+        let user_roles = context.auth.state.roles().into_iter().collect::<Vec<_>>();
+        let query = format!("select {selection} from known_groups where role = any($1)");
+
+        context.db.query_mapped(&query, dbargs![&user_roles], |row| Self::from_row_start(&row))
+            .await?
+            .pipe(Ok)
+    }
 }
 
 // ===== Users ===============================================================

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -1,7 +1,7 @@
 use juniper::graphql_object;
 
 
-use crate::{auth::{AuthState, User}, model::OpencastId};
+use crate::{auth::{AuthState, HasRoles, User}, model::OpencastId};
 
 use super::{
     err::ApiResult,
@@ -196,6 +196,16 @@ impl Query {
     /// Returns all known groups selectable in the ACL UI.
     async fn known_groups(context: &Context) -> ApiResult<Vec<KnownGroup>> {
         KnownGroup::load_all(context).await
+    }
+
+    /// Returns all known groups that a user is part of and which are
+    /// selectable in the ACL UI.
+    async fn known_groups_for_user(context: &Context) -> ApiResult<Vec<KnownGroup>> {
+        if context.auth.is_admin(&context.config.auth) {
+            KnownGroup::load_all(context).await
+        } else {
+            KnownGroup::load_for_user(context).await
+        }
     }
 
     /// Returns information for the admin dashboard.

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -809,6 +809,11 @@ type Query {
   searchKnownUsers(query: String!): KnownUsersSearchOutcome!
   "Returns all known groups selectable in the ACL UI."
   knownGroups: [KnownGroup!]!
+  """
+    Returns all known groups that a user is part of and which are
+    selectable in the ACL UI.
+  """
+  knownGroupsForUser: [KnownGroup!]!
   "Returns information for the admin dashboard."
   adminDashboardInfo: AdminInfo
 }

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -116,7 +116,7 @@ export const AclSelector: React.FC<AclSelectorProps> = ({
     itemType = "video",
 }) => {
     const { i18n } = useTranslation();
-    let knownGroups = [...knownRoles.knownGroups];
+    let knownGroups = [...knownRoles.knownGroupsForUser];
     [acl, inheritedAcl].forEach(list => insertBuiltinRoleInfo(list, knownGroups, i18n));
     if (disallowAnonymous) {
         knownGroups = knownGroups.filter(g => g.role !== COMMON_ROLES.ANONYMOUS);
@@ -166,7 +166,7 @@ type RoleKind = "group" | "user";
 
 export const knownRolesFragment = graphql`
     fragment AccessKnownRolesData on Query {
-        knownGroups { role label implies sortKey large }
+        knownGroupsForUser { role label implies sortKey large }
     }
 `;
 
@@ -973,7 +973,7 @@ const splitAcl = (initialAcl: Acl): [Acl, Acl] => {
 
 const insertBuiltinRoleInfo = (
     acl: Acl,
-    knownGroups: AccessKnownRolesData$data["knownGroups"][number][],
+    knownGroups: AccessKnownRolesData$data["knownGroupsForUser"][number][],
     i18n: i18n,
 ) => {
     const keyToTranslatedString = (key: ParseKeys): TranslatedLabel => ({
@@ -1036,7 +1036,7 @@ interface GroupDag {
     sort<T extends { role: string }>(groups: T[]): T[];
 }
 
-const buildDag = (groups: AccessKnownRolesData$data["knownGroups"]): GroupDag => {
+const buildDag = (groups: AccessKnownRolesData$data["knownGroupsForUser"]): GroupDag => {
     const vertices = new Map<string, Set<string>>();
     vertices.set(COMMON_ROLES.ANONYMOUS, new Set());
     vertices.set(COMMON_ROLES.USER, new Set([COMMON_ROLES.ANONYMOUS]));

--- a/util/known-groups.sql
+++ b/util/known-groups.sql
@@ -2,28 +2,28 @@
 -- ones taken from the realm tree, representing individual courses.
 
 insert into known_groups (role, label, implies, large)
-values 
-    ('ROLE_STUDENTS', hstore(array['en', 'Students', 'de', 'Studierende']), '{}', true),
-    ('ROLE_STAFF', hstore(array['en', 'Staff', 'de', 'Angestellte']), '{}', true),
-    ('ROLE_LECTURER', hstore(array['en', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'], true);
+values
+    ('ROLE_STUDENTS', hstore(array['default', 'Students', 'de', 'Studierende']), '{}', true),
+    ('ROLE_STAFF', hstore(array['default', 'Staff', 'de', 'Angestellte']), '{}', true),
+    ('ROLE_LECTURER', hstore(array['default', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'], true);
 
 insert into known_groups (role, label, implies, large)
-select 
+select
     'ROLE_COURSE_' || path_segment || '_' || kind,
-    hstore(array['en', 'de'], array[
+    hstore(array['default', 'de'], array[
         label_en || ' of „' || name || '“',
         label_de || ' von „' || name || '“'
     ]),
-    case 
+    case
         when kind = 'STUDENTS' then array[]::text[]
         when kind = 'ASSISTANTS' then array['ROLE_COURSE_' || path_segment || '_STUDENTS']
         when kind = 'INSTRUCTORS' then array['ROLE_COURSE_' || path_segment || '_ASSISTANTS']
     end,
     false
-from realms, 
-    (values 
-        ('STUDENTS', 'Studierende', 'Students'), 
-        ('ASSISTANTS', 'Assistierende', 'Assistants'), 
+from realms,
+    (values
+        ('STUDENTS', 'Studierende', 'Students'),
+        ('ASSISTANTS', 'Assistierende', 'Assistants'),
         ('INSTRUCTORS', 'Lehrende', 'Instructors')
     ) as tmp (kind, label_de, label_en)
 where full_path similar to '/lectures/[^/]+/2020/(autumn|spring)/%'


### PR DESCRIPTION
This will now only return those groups that a user is part of, except for admins, where it will still return all the groups.

Closes #1287 