### PR TITLE
Add correct license labels

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -459,6 +459,10 @@ shortcuts:
     shift: Shift
     tab: Tab
 
+license:
+  all-rights: Alle Rechte vorbehalten
+
+
 manage:
   admin-dashboard: Admin dashboard
   dashboard:

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -432,6 +432,9 @@ shortcuts:
     shift: Shift
     tab: Tab
 
+license:
+  all-rights: All rights reserved
+
 
 manage:
   admin-dashboard: Admin dashboard

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -439,6 +439,10 @@ player:
     title: Options
     label: Afficher les options
 
+license:
+  all-rights: Tous droits réservés # verify
+
+
 manage:
   dashboard:
     title: Dashboard

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -480,6 +480,10 @@ shortcuts:
     shift: Shift
     tab: Tab
 
+license:
+  all-rights: Tutti i diritti riservati # verify
+
+
 manage:
   admin-dashboard: Admin dashboard
   dashboard:

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -19,6 +19,7 @@ import {
     notNullish,
 } from "@opencast/appkit";
 import { VideoObject, WithContext } from "schema-dts";
+import { TFunction } from "i18next";
 
 import { fetchQuery, loadQuery } from "../relay";
 import { InitialLoading, RootLoader } from "../layout/Root";
@@ -1224,10 +1225,19 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({
                         "builtin:source": () => t("video.source"),
                     });
 
-                const values = metadataNs[field].map((value, i) => <React.Fragment key={i}>
-                    {i > 0 && <br />}
-                    {isValidLink(value) ? <Link to={value}>{value}</Link> : value}
-                </React.Fragment>);
+                const values = metadataNs[field].map((value, i) => {
+                    const displayValue = (
+                        label === "builtin:license" && value in LICENSE_TRANSLATIONS
+                    ) ? LICENSE_TRANSLATIONS[value](t) : value;
+
+                    return <React.Fragment key={i}>
+                        {i > 0 && <br />}
+                        {isValidLink(displayValue)
+                            ? <Link to={displayValue}>{displayValue}</Link>
+                            : displayValue
+                        }
+                    </React.Fragment>;
+                });
 
                 pairs.push([translatedLabel, values]);
             }
@@ -1263,6 +1273,16 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({
         </dl>
     );
 });
+
+const LICENSE_TRANSLATIONS: Record<string, (t: TFunction) => string> = {
+    "ALLRIGHTS": (t: TFunction) => t("license.all-rights"),
+    "CC-BY": () => "CC BY",
+    "CC-BY-SA": () => "CC BY-SA",
+    "CC-BY-ND": () => "CC BY-ND",
+    "CC-BY-NC": () => "CC BY-NC",
+    "CC-BY-NC-SA": () => "CC BY-NC-SA",
+    "CC-BY-NC-ND": () => "CC BY-NC-ND",
+};
 
 const isValidLink = (s: string): boolean => {
     const trimmed = s.trim();


### PR DESCRIPTION
The dcterms:license fields in our database get their entries from Opencast as an unbroken string (for instance with dashes in place of spaces).
We used to just display that value, i.e. "CC-BY", which should be shown "CC BY" instead, or "ALLRIGHTS", which should display a translated string like "All rights reserved".

So this commit adds a small record that maps these values to their correct representation (at least the same ones that are used in the Admin UI).

If the field should hold any other value that is not present in that map, it still just gets displayed without transformation.