### PR TITLE
Fix timezone in user session 'created' field

### DIFF
--- a/backend/src/api/model/admin.rs
+++ b/backend/src/api/model/admin.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, future};
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use juniper::{GraphQLObject, graphql_object};
 use meilisearch_sdk::documents::DocumentsQuery;
 
@@ -76,7 +76,7 @@ impl AdminInfo {
             out.entry(username).or_default().push(UserSessionInfo {
                 display_name: mapping.display_name.of(&row),
                 roles: mapping.roles.of(&row),
-                created: mapping.created.of::<NaiveDateTime>(&row).and_utc(),
+                created: mapping.created.of::<DateTime<Utc>>(&row),
                 email: mapping.email.of(&row),
                 user_role: mapping.user_role.of(&row),
                 user_realm_handle: mapping.user_realm_handle.of(&row),

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -380,4 +380,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     45: "custom-user-realm-path",
     46: "known-groups-sort-key",
     47: "search-thumbnail-info-with-state",
+    48: "user-session-timestamp-fix",
 ];

--- a/backend/src/db/migrations/48-user-session-timestamp-fix.sql
+++ b/backend/src/db/migrations/48-user-session-timestamp-fix.sql
@@ -1,0 +1,13 @@
+-- Migration 09 added this table and a comment says that 'created' is always
+-- in UTC. It is always filled via 'now()' though, which returns a timestamp
+-- of the local time zone. Luckily, this was consistently wrong everywhere, so
+-- all calculations were still correct as long as the DB server would not change
+-- its TZ.
+--
+-- To fix this, we convert the type to 'timestamptz'. Storing the time zone does
+-- not cost any additional memory and the minimal extra work required by it is
+-- well worth the benefit of not having TZ problems. The automatic conversion
+-- from timestamp to timestamptz is to assume that the former has the local
+-- timezone, which is exactly what we want here.
+alter table user_sessions
+    alter column created type timestamptz;


### PR DESCRIPTION
We thought we stored it in always UTC; but it was always stored in the DB's local timezone. All calculation were performed in that TZ, so it was fine, except if the timezone of the DB changed. With the new admin dashboard, this bug became visible, so we might as well fix it here.