### PR TITLE
Add delete button for waiting events

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -596,64 +596,50 @@ impl AuthorizedEvent {
     pub(crate) async fn delete(id: Id, context: &Context) -> ApiResult<AuthorizedEvent> {
         let event = Self::load_for_mutation(id, context).await?;
 
-        let response = context
-            .oc_client
-            .delete(&event)
-            .await
-            .map_err(|e| {
-                error!("Failed to send delete request: {}", e);
-                err::opencast_unavailable!("Failed to communicate with Opencast")
-            })?;
+        // Events in "waiting" state are not yet fully synced, so we delete them directly
+        // from Tobira without requiring a successful OC response.
+        let is_pending = event.synced_data.is_none();
 
-        if response.status() == StatusCode::ACCEPTED {
-            // 202: The retraction of publications has started.
-            info!(event_id = %id, "Requested deletion of event");
+        match context.oc_client.delete(&event).await {
+            Ok(response) => {
+                if response.status() == StatusCode::ACCEPTED {
+                    // 202: The retraction of publications has started.
+                    info!(event_id = %id, "Requested deletion of event");
+                } else if is_pending {
+                    // For pending events, non-202 is not necessarily an error.
+                    // The event may have already been deleted prior to this request.
+                    warn!(
+                        event_id = %id,
+                        "Failed to delete event in OC, returned status: {}. \
+                        Event will still be deleted in Tobira.",
+                        response.status()
+                    );
+                } else {
+                    warn!(
+                        event_id = %id,
+                        "Failed to delete event, OC returned status: {}",
+                        response.status()
+                    );
+                    return Err(err::opencast_unavailable!("Opencast API error: {}", response.status()));
+                }
+            },
+            Err(e) => {
+                error!("Failed to send delete request: {}", e);
+                if !is_pending {
+                    return Err(err::opencast_unavailable!("Failed to communicate with Opencast"));
+                }
+            }
+        }
+
+        if is_pending {
+            context.db.execute("delete from all_events where id = $1", &[&event.key]).await?;
+        } else {
             context.db.execute("\
                 update all_events \
                 set tobira_deletion_timestamp = current_timestamp \
                 where id = $1 \
             ", &[&event.key]).await?;
-            Ok(event)
-        } else {
-            warn!(
-                event_id = %id,
-                "Failed to delete event, OC returned status: {}",
-                response.status()
-            );
-            Err(err::opencast_unavailable!("Opencast API error: {}", response.status()))
         }
-    }
-
-    pub(crate) async fn delete_pending(id: Id, context: &Context) -> ApiResult<AuthorizedEvent> {
-        // Todo: load from `all_events` instead.
-        let event = Self::load_for_mutation(id, context).await?;
-
-        match context
-            .oc_client
-            .delete(&event)
-            .await
-        {
-            Ok(response) => {
-                if response.status() == StatusCode::ACCEPTED {
-                    // 202: The event was still present in OC and retraction of publications has started.
-                    info!(event_id = %id, "Requested deletion of event");
-                } else {
-                    // Anything else is not necessarily an error. It is possible that the event has
-                    // already been deleted prior to this request.
-                    warn!(
-                        event_id = %id,
-                        "Failed to delete event in OC, returned status: {}.
-                        Event will still be deleted in Tobira.",
-                        response.status()
-                    );
-                }
-            },
-            Err(e) => {
-                error!("Failed to send delete request: {}", e);
-            }
-        }
-
-        context.db.execute("delete from all_events where id = $1", &[&event.key]).await?;
 
         Ok(event)
     }

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -74,15 +74,11 @@ impl Mutation {
     /// Note that "success" in this case only means the request was successfully sent
     /// and accepted, not that the deletion itself succeeded, which is instead checked
     /// in subsequent harvesting results.
+    ///
+    /// Special case: When a `waiting` event is deleted, this also sends a delete request to OC
+    /// but removes the event completely from our DB, regardless of that request's response.
     async fn delete_event(id: Id, context: &Context) -> ApiResult<AuthorizedEvent> {
         AuthorizedEvent::delete(id, context).await
-    }
-
-    /// Deletes events that are waiting for sync from our DB. It will also call the Opencast API
-    /// to request a deletion over there but ignores the outcome, as the event might have already
-    /// been deleted there.
-    async fn delete_pending_event(id: Id, context: &Context) -> ApiResult<AuthorizedEvent> {
-        AuthorizedEvent::delete_pending(id, context).await
     }
 
     /// Updates the acl of a given event by sending the changes to Opencast.
@@ -113,13 +109,6 @@ impl Mutation {
     /// Returns the preliminary deletion timestamp.
     async fn delete_series(id: Id, context: &Context) -> ApiResult<Series> {
         Series::delete(id, context).await
-    }
-
-    /// Can be used to delete series that are waiting for sync... if those existed. Right now this is useless.
-    /// The plan was to also use this to delete items whose deletion was already started once but failed.
-    /// However that requires loading the series from another table (`all_series`).
-    async fn delete_pending_series(id: Id, context: &Context) -> ApiResult<Series> {
-        Series::delete_pending(id, context).await
     }
 
     /// Updates the acl of a given series by sending the changes to Opencast.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -486,6 +486,7 @@ manage:
     details:
       delete: Video löschen
       confirm-delete: Video löschen?
+      delete-from-db: Dies weist Opencast an, das Video zu löschen, und entfernt es dann sofort aus diesem Videoportal.
       open-in-editor: Im Videoeditor öffnen
       referencing-pages-explanation: 'Dieses Video wird von den folgenden Seiten referenziert:'
       no-referencing-pages: Dieses Video wird von keiner Seite referenziert.
@@ -603,7 +604,7 @@ manage:
           Dieser Eintrag wurde {{time}} erstellt, wurde aber bisher nicht synchronisert.
           Dies ist möglicherweise fehlgeschlagen.
         pending: >
-          Dieser Eintrag wurde nocht nicht synchronisiert. Die Liste wird aktualisiert, sobald dies geschehen ist.
+          Dieser Eintrag wurde noch nicht synchronisiert. Die Liste wird aktualisiert, sobald dies geschehen ist.
           Möglicherweise müssen Sie diese Seite neu laden.
     deletion:
       failed: Löschen fehlgeschlagen.
@@ -613,16 +614,11 @@ manage:
       success: '„{{itemTitle}}“ wurde gelöscht.'
       tooltip:
         failed: >
-          Der Löschvorgang für diesen Eintrag wurde {{time}} angesetzt, ist aber bisher nicht erfolgt
+          Der Löschvorgang für diesen Eintrag wurde {{time}} angestoßen, ist aber bisher nicht erfolgt
           und daher möglicherweise fehlgeschlagen.
         pending: >
-          Der Löschvorgang dieses Eintrags in Opencast wurde angesetzt und es wird
+          Der Löschvorgang dieses Eintrags in Opencast wurde angestoßen und es wird
           nach dessen Erfolg hier entfernt.
-    delete-video-from-db: >
-      Dies setzt einen neuen Löschvorgang in Opencast an. Das Video wird unabhängig davon hier gelöscht.
-    delete-series-from-db: >
-      Dies setzt einen neuen Löschvorgang in Opencast an. Die Serie wird unabhängig davon hier gelöscht.
-
 
   realm:
     invalid-path: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -457,6 +457,8 @@ manage:
     details:
       delete: Delete video
       confirm-delete: Delete video?
+      delete-from-db: >
+        This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
       open-in-editor: Open in video editor
       referencing-pages-explanation: 'This video is referenced on the following pages:'
       no-referencing-pages: No pages reference this video.
@@ -583,10 +585,6 @@ manage:
           The deletion of this entry was requested {{time}} but still has not happened, so it might have failed.
         pending: >
           The deletion of this entry was requested in Opencast and it will be removed from this list upon success.
-    delete-video-from-db: >
-      This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
-    delete-series-from-db: >
-      This will trigger a new delete request in Opencast. The series will be removed here regardless of that request's success.
 
   realm:
     invalid-path: 'Error: invalid path to page. Was the page deleted or its path changed?'

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -464,6 +464,8 @@ manage:
     details:
       delete: Supprimer la vidéo
       confirm-delete: Supprimer la vidéo?
+      # delete-from-db: > # Todo
+      #   This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
       open-in-editor: Ouvrir dans l'éditeur vidéo
       referencing-pages-explanation: 'Cette vidéo est mentionnée dans les pages suivantes:'
       no-referencing-pages: Cette vidéo n'est mentionnée par aucun site.
@@ -598,10 +600,6 @@ manage:
         pending: >
           Cette entrée a été programmée pour être supprimée dans Opencast, ce
           qui sera fait après son succès.
-    # delete-video-from-db: >
-    #   This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
-    # delete-series-from-db: >
-    #   This will trigger a new delete request in Opencast. The series will be removed here regardless of that request's success.
 
   realm:
     invalid-path: >

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -506,6 +506,8 @@ manage:
     details:
       delete: Cancellare il video
       confirm-delete: Cancellare il video?
+      # delete-from-db: > # Todo.
+      #  This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
       open-in-editor: Aprire nell'editor video
       referencing-pages-explanation: 'Questo video è citato nelle pagine seguenti:'
       no-referencing-pages: Nessuna pagina fa riferimento a questo video.
@@ -635,10 +637,6 @@ manage:
         pending: >
           La cancellazione di questa voce è stata richiesta in Opencast e sarà
           rimossa da questo elenco in caso di successo.
-   # delete-video-from-db: > Todo.
-   #  This will trigger a new delete request in Opencast. The video will be removed here regardless of that request's success.
-   # delete-series-from-db: >
-   #  This will trigger a new delete request in Opencast. The series will be removed here regardless of that request's success.
 
   realm:
     invalid-path: >

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { LuCirclePlus } from "react-icons/lu";
-import { graphql, useMutation } from "react-relay";
+import { graphql } from "react-relay";
 import { match } from "@opencast/appkit";
 
 import i18n from "../../../i18n";
@@ -13,7 +13,6 @@ import {
     ColumnProps,
     createQueryParamsParser,
     DateColumn,
-    DeletePendingItemButton,
     ManageItems,
     TableRow,
 } from "../Shared/Table";
@@ -27,7 +26,6 @@ import { SeriesThumbnail } from "./Shared";
 import { CREATE_SERIES_PATH } from "./Create";
 import { LinkButton } from "../../../ui/LinkButton";
 import { isRealUser, useUser } from "../../../User";
-import { SeriesDeletePendingMutation } from "./__generated__/SeriesDeletePendingMutation.graphql";
 
 
 export const PATH = "/~manage/series" as const;
@@ -139,29 +137,14 @@ const seriesColumns: ColumnProps<SingleSeries>[] = [
 ];
 
 
-const deletePendingSeriesMutation = graphql`
-    mutation SeriesDeletePendingMutation($id: ID!) {
-        deletePendingSeries(id: $id) { id @deleteRecord }
-    }
-`;
-
-const DeletePendingSeriesButton: React.FC<{ item: SingleSeries }> = ({ item }) => {
-    const [commit] = useMutation<SeriesDeletePendingMutation>(deletePendingSeriesMutation);
-
-    return <DeletePendingItemButton {...{ item, commit }} itemKind={"series"} />;
-};
-
-
-
 const SeriesRow: React.FC<{ item: SingleSeries }> = ({ item }) => <TableRow
     itemType="series"
     item={item}
     thumbnail={state => <SeriesThumbnail series={item} seriesState={state} />}
     link={`${PATH}/${keyOfId(item.id)}`}
     customColumns={seriesColumns.map(col => <col.column key={col.key} item={item} />)}
-    deleteButton={<DeletePendingSeriesButton {...{ item }} />}
+    created={item.created ?? undefined}
 />;
-
 
 
 const parseSeriesColumn = (sortBy: string | null): SeriesSortColumn =>

--- a/frontend/src/routes/manage/Shared/Details.tsx
+++ b/frontend/src/routes/manage/Shared/Details.tsx
@@ -230,8 +230,8 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
                 setNotification({
                     kind: "info",
                     message: i18n => i18n.t(
-                        `manage.table.deletion.${
-                            kind === "playlist" ? "success" : "in-progress"
+                        `manage.table.deletion.${(kind === "playlist" || !isSynced(item))
+                            ? "success" : "in-progress"
                         }`, { itemTitle: item.title },
                     ),
                     scope: returnPath,
@@ -245,7 +245,7 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
         });
     };
 
-    return <Inertable isInert={!isSynced(item)}>
+    return <Inertable isInert={kind !== "video" && !isSynced(item)}>
         <Button kind="danger" onClick={() => currentRef(modalRef).open()}>
             <span css={{ whiteSpace: "normal", textWrap: "balance" }}>
                 {buttonText}
@@ -257,6 +257,9 @@ export const DeleteButton = <TMutation extends DeleteMutationParams>({
             onSubmit={onSubmit}
             ref={modalRef}
         >
+            {(!isSynced(item) && kind === "video") && <p>
+                {t("manage.video.details.delete-from-db")}
+            </p>}
             <p><Trans i18nKey="general.action.cannot-be-undone" /></p>
             {children}
         </ConfirmationModal>

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -113,13 +113,13 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
                     {t("manage.video.details.open-in-editor")}
                 </ExternalLink>
             )}
-            <DeleteButton
-                item={event}
-                kind="video"
-                returnPath="/~manage/videos"
-                commit={commit}
-            />
         </Inertable>
+        <DeleteButton
+            item={event}
+            kind="video"
+            returnPath="/~manage/videos"
+            commit={commit}
+        />
     </ButtonSection>;
 };
 

--- a/frontend/src/routes/manage/Video/index.tsx
+++ b/frontend/src/routes/manage/Video/index.tsx
@@ -1,4 +1,4 @@
-import { graphql, useMutation } from "react-relay";
+import { graphql } from "react-relay";
 import { useTranslation } from "react-i18next";
 import { match } from "@opencast/appkit";
 
@@ -18,7 +18,6 @@ import {
     ColumnProps,
     createQueryParamsParser,
     DateColumn,
-    DeletePendingItemButton,
     ManageItems,
     TableRow,
 } from "../Shared/Table";
@@ -26,7 +25,6 @@ import { ellipsisOverflowCss } from "../../../ui";
 import { Link } from "../../../router";
 import { DirectSeriesRoute } from "../../Series";
 import { COLORS } from "../../../color";
-import { VideoDeletePendingMutation } from "./__generated__/VideoDeletePendingMutation.graphql";
 
 
 const PATH = "/~manage/videos" as const;
@@ -159,26 +157,13 @@ const SeriesColumn: React.FC<SeriesColumnProps> = ({ title, seriesId }) => {
 };
 
 
-const deletePendingVideoMutation = graphql`
-    mutation VideoDeletePendingMutation($id: ID!) {
-        deletePendingEvent(id: $id) { id @deleteRecord }
-    }
-`;
-
-const DeletePendingVideoButton: React.FC<{ item: Event }> = ({ item }) => {
-    const [commit] = useMutation<VideoDeletePendingMutation>(deletePendingVideoMutation);
-
-    return <DeletePendingItemButton {...{ item, commit }} itemKind={"video"} />;
-};
-
-
 const EventRow: React.FC<{ item: Event }> = ({ item }) => <TableRow
     itemType="video"
     item={item}
     link={`${PATH}/${keyOfId(item.id)}`}
     thumbnail={state => <Thumbnail event={item} {...{ state }} />}
     customColumns={videoColumns.map(col => <col.column key={col.key} item={item} />)}
-    deleteButton={<DeletePendingVideoButton {...{ item }} />}
+    created={item.created}
 />;
 
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -547,14 +547,11 @@ type Mutation {
     Note that "success" in this case only means the request was successfully sent
     and accepted, not that the deletion itself succeeded, which is instead checked
     in subsequent harvesting results.
+
+    Special case: When a `waiting` event is deleted, this also sends a delete request to OC
+    but removes the event completely from our DB, regardless of that request's response.
   """
   deleteEvent(id: ID!): AuthorizedEvent!
-  """
-    Deletes events that are waiting for sync from our DB. It will also call the Opencast API
-    to request a deletion over there but ignores the outcome, as the event might have already
-    been deleted there.
-  """
-  deletePendingEvent(id: ID!): AuthorizedEvent!
   """
     Updates the acl of a given event by sending the changes to Opencast.
     The `acl` parameter can include `read` and `write` roles, as these are the
@@ -578,12 +575,6 @@ type Mutation {
     Returns the preliminary deletion timestamp.
   """
   deleteSeries(id: ID!): Series!
-  """
-    Can be used to delete series that are waiting for sync... if those existed. Right now this is useless.
-    The plan was to also use this to delete items whose deletion was already started once but failed.
-    However that requires loading the series from another table (`all_series`).
-  """
-  deletePendingSeries(id: ID!): Series!
   """
     Updates the acl of a given series by sending the changes to Opencast.
     The `acl` parameter can include `read` and `write` roles.


### PR DESCRIPTION
This will allow deleting events directly from our DB. The reasoning behind this is that processing in OC might fail, leaving an event in an indefinite limbo state. Previously they had to be manually removed from DB, now you can simply press a button.
This will send another delete request to Opencast but ignore the outcome, as the event might have already been removed over there.

Designwise, it's unfortunately not an improvement of the "my videos" table (we should really get back to https://github.com/elan-ev/tobira/pull/1515).

Also includes code to do the same for series... but we removed the "waiting" state for series recently, so that's a little pointless.

However, I am planning to also offer that delete button for items that are pending deletion but have been marked as "deletion probably failed", as they can get stuck in a similar limbo state. Hm that will probably be solved by sync though, so maybe not necessary.

Closes https://github.com/elan-ev/tobira/issues/1615