### PR TITLE
Increment search index version

### DIFF
--- a/backend/src/search/mod.rs
+++ b/backend/src/search/mod.rs
@@ -42,7 +42,7 @@ pub(crate) use self::{
 
 /// The version of search index schema. Increase whenever there is a change that
 /// requires an index rebuild.
-const VERSION: u32 = 7;
+const VERSION: u32 = 8;
 
 
 // ===== Configuration ============================================================================


### PR DESCRIPTION
https://github.com/elan-ev/tobira/pull/1573 was missing a search index increment, making a manual rebuild necessary when updating to Tobira v3.11.
We can't change that anymore, but with this commit, at least updates to 3.13 will automate that.