### PR TITLE
Improve upload success message and cancel button label

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -304,7 +304,6 @@ upload:
   missing-series-write-permission: >
     Sie haben nicht die Berechtigung, in die angegebene Serie hochzuladen.
   select-files: Datei auswählen
-  reselect: Datei erneut auswählen
   upload-another: Weiteres Video hochladen
   too-many-files: >
     Sie haben zu viele Dateien ausgewählt. Zurzeit werden nur einzelne Dateien unterstützt.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -300,7 +300,6 @@ upload:
   specified-series-not-found: Specified series not found.
   missing-series-write-permission: You do not have the permission to upload into this series.
   select-files: Select file
-  reselect: Reselect file
   upload-another: Upload another video
   too-many-files: You selected too many files. Currently, only a single file is supported.
   not-a-file: You dropped something that's not a file.

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -306,7 +306,6 @@ upload:
   specified-series-not-found: La série spécifiée n'a pas été trouvée.
   missing-series-write-permission: Vous n’avez pas l’autorisation d’importer dans la série indiquée.
   select-files: Sélectionner un fichier
-  reselect: Re-sélectionner le fichier
   too-many-files: >
     Vous avez sélectionné trop de fichiers. Actuellement, seul un fichier unique
     est supporté.

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -305,7 +305,6 @@ upload:
   specified-series-not-found: Serie specificata non trovata.
   missing-series-write-permission: Non hai l'autorizzazione a caricare in questa serie.
   select-files: Seleziona file
-  reselect: Seleziona di nuovo il file
   too-many-files: >
     Sono stati selezionati troppi file. Attualmente è supportato solo un singolo
     file.

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -665,7 +665,7 @@ const UploadState: React.FC<UploadStateProps> = ({ state, seriesId }) => {
             <LinkButton kind="call-to-action" to={UploadRoute.url({
                 seriesId: seriesId ? keyOfId(seriesId) : null,
             })}>
-                {t("upload.reselect")}
+                {t("upload.select-files")}
             </LinkButton>
         </div>;
     } else if (state.state === "error") {


### PR DESCRIPTION
Namely the "you may close this page now" part.
That was deemed unnecessary (I agree). Instead it now links to the "my videos" page.

Also removes the "re" part of the "reselect file" button after cancelling an upload. 

Closes https://github.com/elan-ev/tobira/issues/1094
Closes https://github.com/elan-ev/tobira/issues/1378
Closes https://github.com/elan-ev/tobira/issues/1379