### PR TITLE
Limit title blocks and markdown-code-blocks to 800px in width as well

### DIFF
--- a/frontend/src/ui/Blocks/Text.tsx
+++ b/frontend/src/ui/Blocks/Text.tsx
@@ -6,6 +6,7 @@ import type { Options } from "react-markdown";
 import { TextBlockData$key } from "./__generated__/TextBlockData.graphql";
 import { COLORS } from "../../color";
 import { Link } from "../../router";
+import { TEXT_MAX_WIDTH } from ".";
 
 
 const fragment = graphql`
@@ -41,15 +42,12 @@ const CODE_BACKGROUND_COLOR = COLORS.neutral10;
 // We override some components emitted by the Markdown parser to add CSS.
 const MARKDOWN_COMPONENTS: Options["components"] = {
     p: ({ node, ...props }) => <p
-        css={{
-            margin: "16px 0",
-            maxWidth: 800,
-        }}
+        css={{ margin: "16px 0" }}
         {...props}
     />,
     a: ({ node, href, ...props }) => <Link to={href ?? ""} {...props} />,
-    ul: ({ node, ...props }) => <ul css={{ maxWidth: 800, paddingLeft: 32 }} {...props} />,
-    ol: ({ node, ...props }) => <ol css={{ maxWidth: 800, paddingLeft: 32 }} {...props} />,
+    ul: ({ node, ...props }) => <ul css={{ paddingLeft: 32 }} {...props} />,
+    ol: ({ node, ...props }) => <ol css={{ paddingLeft: 32 }} {...props} />,
     blockquote: ({ node, ...props }) => <blockquote
         css={{
             borderLeft: `4px solid ${COLORS.neutral25}`,
@@ -73,6 +71,7 @@ const MARKDOWN_COMPONENTS: Options["components"] = {
             padding: "8px",
             overflowX: "auto",
             maxWidth: "100%",
+            fontSize: 14,
         }}
         {...props}
     />,
@@ -87,7 +86,7 @@ const MARKDOWN_COMPONENTS: Options["components"] = {
 
 export const TextBlock: React.FC<Props> = ({ content }) => (
     <div css={{
-        maxWidth: 1200,
+        maxWidth: TEXT_MAX_WIDTH,
         "& > *:first-child": { marginTop: 0 },
         "& > *:last-child": { marginBottom: 0 },
         color: COLORS.neutral80,

--- a/frontend/src/ui/Blocks/Title.tsx
+++ b/frontend/src/ui/Blocks/Title.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from "react-relay";
 
 import { Title } from "..";
 import { TitleBlockData$key } from "./__generated__/TitleBlockData.graphql";
+import { TEXT_MAX_WIDTH } from ".";
 
 
 const fragment = graphql`
@@ -20,5 +21,5 @@ export const TitleBlock: React.FC<Props> = ({ fragRef }) => {
     // Normally, there is a gap between any two blocks.
     // We don't want that for titles, though.
     // They are supposed to be closer to whatever they are titling.
-    return <Title title={content} css={{ marginBottom: -16 }} />;
+    return <Title title={content} css={{ marginBottom: -16, maxWidth: TEXT_MAX_WIDTH }} />;
 };

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -16,6 +16,8 @@ import { PlaylistBlockFromBlock } from "./Playlist";
 import { COLORS } from "../../color";
 
 
+export const TEXT_MAX_WIDTH = 800;
+
 type BlocksProps = {
     realm: BlocksData$key & RealmQuery$data["realm"];
 };


### PR DESCRIPTION
Everything else in a text block was already limited by 800px. For text it makes sense to increase readability. Long lines make it easier to lose the line when jumping to the next one. Images were put into <p> tags as well by our markdown renderer, also resulting in that max width. It also make it look a bit nicer when everything is aligned like that.

Only two things were behaving differently: code blocks inside text blocks stretched to the text block outer max size of 1200px. Title blocks even stretched to the <main> max size of I dunno very large.

This commit makes everything max-width: 800px to make everything align nicely. For code blocks, the font size was decreased to 14px to make more fit into one line (it was barely 80 chars before). But at some point, we should probably ship a monofont with Tobira.

I mainly noticed this due to https://opencast.lmu.de/faq

---

**Before**

<img width="1762" height="1580" alt="image" src="https://github.com/user-attachments/assets/754fd094-a7ca-4f13-aec8-046748df5ddd" />

**With this PR**

<img width="1762" height="1580" alt="image" src="https://github.com/user-attachments/assets/556480e5-24a1-4cab-88ef-e3c41cb305ba" />
