### PR TITLE
Fix `mount` and `remove` Admin UI endpoints

### DIFF
--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -359,11 +359,11 @@ impl Mutation {
 
     /// Adds a series block to an empty realm and makes that realm derive its name from said series.
     async fn add_series_mount_point(
-        series_oc_id: OpencastId,
+        series_oc_id: String,
         target_path: String,
         context: &Context,
     ) -> ApiResult<Realm> {
-        Series::add_mount_point(series_oc_id, target_path, context).await
+        Series::add_mount_point(OpencastId(series_oc_id), target_path, context).await
     }
 
     /// Removes the series block of given series from the given realm.
@@ -373,11 +373,11 @@ impl Mutation {
     /// Errors if the given realm does not have exactly one series block referring to the
     /// specified series.
     async fn remove_series_mount_point(
-        series_oc_id: OpencastId,
+        series_oc_id: String,
         path: String,
         context: &Context,
     ) -> ApiResult<RemoveMountedSeriesOutcome> {
-        Series::remove_mount_point(series_oc_id, path, context).await
+        Series::remove_mount_point(OpencastId(series_oc_id), path, context).await
     }
 
     /// Atomically mount a series into an (empty) realm.

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -675,7 +675,7 @@ type Mutation {
   "Stores series information in Tobira's DB, so it can be mounted without having to be harvested first."
   announceSeries(series: NewSeries!): Series!
   "Adds a series block to an empty realm and makes that realm derive its name from said series."
-  addSeriesMountPoint(seriesOcId: OpencastId!, targetPath: String!): Realm!
+  addSeriesMountPoint(seriesOcId: String!, targetPath: String!): Realm!
   """
     Removes the series block of given series from the given realm.
     If the realm has sub-realms and used to derive its name from the block,
@@ -684,7 +684,7 @@ type Mutation {
     Errors if the given realm does not have exactly one series block referring to the
     specified series.
   """
-  removeSeriesMountPoint(seriesOcId: OpencastId!, path: String!): RemoveMountedSeriesOutcome!
+  removeSeriesMountPoint(seriesOcId: String!, path: String!): RemoveMountedSeriesOutcome!
   """
     Atomically mount a series into an (empty) realm.
     Creates all the necessary realms on the path to the target


### PR DESCRIPTION
Unfortunately I missed these two when testing API changes.
Mounting still works when _creating_ a series using the Admin UI, but not when changing the path afterwards.