### PR TITLE
Pass block layout and order as query params

### DIFF
--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -93,6 +93,8 @@ import { QrCodeButton, ShareButton } from "../ui/ShareButton";
 import { SHORTCUTS, useShortcut } from "../ui/Shortcuts";
 import { usePlayerGroupContext } from "../ui/player/PlayerGroupContext";
 import { isSpaceOnInteractiveElement } from "../ui/player/PlayerShortcuts";
+import { VideoListLayout } from "../ui/Blocks/__generated__/SeriesBlockData.graphql";
+import { LIST_ORDERS, Order } from "../ui/Blocks/VideoList";
 
 
 // ===========================================================================================
@@ -108,7 +110,7 @@ export const VideoRoute = makeRoute({
         if (params === null) {
             return null;
         }
-        const { realmPath, videoId, listId } = params;
+        const { realmPath, videoId, listId, layout, order } = params;
         const id = eventId(videoId);
 
         const query = graphql`
@@ -158,6 +160,8 @@ export const VideoRoute = makeRoute({
                         realmRef={realm}
                         playlistRef={playlist ?? null}
                         realmPath={realmPath}
+                        layoutParam={layout}
+                        orderParam={order}
                     />;
                 }}
             />,
@@ -176,7 +180,7 @@ export const OpencastVideoRoute = makeRoute({
             return null;
         }
 
-        const { realmPath, videoId, listId } = params;
+        const { realmPath, videoId, listId, layout, order } = params;
         const id = videoId.substring(1);
 
         const query = graphql`
@@ -226,6 +230,8 @@ export const OpencastVideoRoute = makeRoute({
                         realmRef={realm}
                         playlistRef={playlist ?? null}
                         realmPath={realmPath}
+                        layoutParam={layout}
+                        orderParam={order}
                     />;
                 }}
             />,
@@ -336,19 +342,35 @@ export const DirectOpencastVideoRoute = makeRoute({
 
 const makeListId = (id: string | null) => id ? playlistId(id) : "";
 
+const VALID_LAYOUTS: VideoListLayout[] = ["GALLERY", "LIST", "SLIDER"];
+
 type VideoParams = {
     realmPath: string;
     videoId: string;
     listId: string;
+    layout?: VideoListLayout;
+    order?: Order;
 } | null;
 
-const getVideoDetailsFromUrl = (url: URL, idRegex: string): VideoParams => {
-    const params = checkRealmPath(url, "v", idRegex);
-    if (params === null) {
+const getVideoDetailsFromUrl = (url: URL, regEx: string): VideoParams => {
+    const params = checkRealmPath(url, "v", regEx);
+    if (!params) {
         return null;
     }
+    const { realmPath, id: videoId } = params;
     const listId = makeListId(url.searchParams.get("list"));
-    return { realmPath: params.realmPath, videoId: params.id, listId };
+    const layoutParam = url.searchParams.get("layout")?.toUpperCase();
+    const orderParam = url.searchParams.get("order")?.toUpperCase();
+
+    const isValidLayout = (v: string | undefined): v is VideoListLayout =>
+        v !== undefined && (VALID_LAYOUTS as string[]).includes(v);
+    const layout = isValidLayout(layoutParam) ? layoutParam : undefined;
+
+    const isValidOrder = (v: string | undefined): v is Order =>
+        v !== undefined && (LIST_ORDERS as readonly string[]).includes(v);
+    const order = isValidOrder(orderParam) ? orderParam : undefined;
+
+    return { realmPath, videoId, listId, layout, order };
 };
 
 interface DirectRouteQuery extends OperationType {
@@ -509,9 +531,13 @@ type Props = {
     realmRef: NonNullable<VideoPageRealmData$key>;
     playlistRef: PlaylistBlockPlaylistData$key | null;
     realmPath: string | null;
+    layoutParam?: VideoListLayout;
+    orderParam?: Order;
 };
 
-const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, realmPath }) => {
+const VideoPage: React.FC<Props> = ({
+    eventRef, realmRef, playlistRef, realmPath, layoutParam, orderParam,
+}) => {
     const { t } = useTranslation();
     const rerender = useForceRerender();
     const realm = useFragment(realmFragment, realmRef);
@@ -579,15 +605,15 @@ const VideoPage: React.FC<Props> = ({ eventRef, realmRef, playlistRef, realmPath
         {playlistRef
             ? <PlaylistBlockFromPlaylist
                 moreOfTitle
-                realmPath={realmPath}
                 fragRef={playlistRef}
                 activeEventId={event.id}
+                {...{ realmPath, layoutParam, orderParam }}
             />
             : event.series && <SeriesBlockFromSeries
-                realmPath={realmPath}
                 fragRef={event.series}
                 title={t("video.more-from-series", { series: event.series.title })}
                 activeEventId={event.id}
+                {...{ realmPath, layoutParam, orderParam }}
             />
         }
     </>;

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -13,7 +13,8 @@ import {
 } from "./__generated__/PlaylistBlockPlaylistData.graphql";
 import { ManagePlaylistDetailsRoute } from "../../routes/manage/Playlist/PlaylistDetails";
 import { keyOfId } from "../../util";
-import { VideoListBlock, VideoListBlockContainer } from "./VideoList";
+import { VideoListBlock, VideoListBlockContainer, Order } from "./VideoList";
+import { VideoListLayout } from "./__generated__/SeriesBlockData.graphql";
 import { DirectPlaylistRoute, PlaylistRoute } from "../../routes/Playlist";
 
 
@@ -21,6 +22,8 @@ type SharedProps = {
     realmPath: string | null;
     moreOfTitle?: boolean;
     editMode?: boolean;
+    layoutParam?: VideoListLayout;
+    orderParam?: Order;
 };
 
 const blockFragment = graphql`
@@ -114,8 +117,9 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
 
     return <VideoListBlock
         displayOptions={{
-            initialLayout: props.layout,
-            initialOrder: (props.order === "%future added value" ? undefined : props.order)
+            initialLayout: props.layoutParam ?? props.layout,
+            initialOrder: props.orderParam
+                ?? (props.order === "%future added value" ? undefined : props.order)
                 ?? "ORIGINAL",
             allowOriginalOrder: true,
         }}

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -11,7 +11,8 @@ import {
     SeriesBlockSeriesData$data,
     SeriesBlockSeriesData$key,
 } from "./__generated__/SeriesBlockSeriesData.graphql";
-import { VideoListBlock, VideoListBlockContainer } from "./VideoList";
+import { VideoListBlock, VideoListBlockContainer, Order } from "./VideoList";
+import { VideoListLayout } from "./__generated__/SeriesBlockData.graphql";
 import { ManageSeriesDetailsRoute } from "../../routes/manage/Series/SeriesDetails";
 import { DirectSeriesRoute, SeriesRoute } from "../../routes/Series";
 
@@ -23,6 +24,8 @@ import { DirectSeriesRoute, SeriesRoute } from "../../routes/Series";
 type SharedProps = {
     realmPath: string | null;
     editMode?: boolean;
+    layoutParam?: VideoListLayout;
+    orderParam?: Order;
 };
 
 const blockFragment = graphql`
@@ -113,8 +116,9 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
     const seriesKey = keyOfId(series.id);
     return <VideoListBlock
         displayOptions={{
-            initialLayout: props.layout,
-            initialOrder: (props.order === "%future added value" ? undefined : props.order)
+            initialLayout: props.layoutParam ?? props.layout,
+            initialOrder: props.orderParam
+                ?? (props.order === "%future added value" ? undefined : props.order)
                 ?? "NEW_TO_OLD",
             allowOriginalOrder: false,
         }}


### PR DESCRIPTION
When a videolink in a list block is visited, that block will now retain the selected layout and order for displaying that block on the video page.

Closes https://github.com/elan-ev/tobira/issues/1589