### PR TITLE
Add some margin below the last realm edit add button

### DIFF
--- a/frontend/src/routes/manage/Realm/Content/index.tsx
+++ b/frontend/src/routes/manage/Realm/Content/index.tsx
@@ -160,6 +160,7 @@ const ManageContent: React.FC<Props> = ({ data }) => {
                 padding: 0,
                 // To position the loading overlay
                 position: "relative",
+                marginBottom: 100,
             }}>
                 {blocks.filter(block => block != null).map((block, index) => (
                     <React.Fragment key={block.id}>


### PR DESCRIPTION
Select menus at the bottom of a screen could open "out of bounds" and cause subtle to not-so-subtle layout shifts.
This commit just adds some margin below to prevent that.
Closes https://github.com/elan-ev/tobira/issues/1336