### PR TITLE
Add configuration for republish workflow ID

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -665,7 +665,7 @@ impl AuthorizedEvent {
 
         if response.status() == StatusCode::NO_CONTENT {
             // 204: The access control list for the specified event is updated.
-            Self::start_workflow(&event.opencast_id, "republish-metadata", &context).await?;
+            Self::start_workflow(&event.opencast_id, &context.config.opencast.republish_workflow_id, &context).await?;
             let db_acl = convert_acl_input(acl);
 
             // Todo: also update custom and preview roles once frontend sends these
@@ -718,7 +718,7 @@ impl AuthorizedEvent {
 
         if response.status() == StatusCode::NO_CONTENT {
             // 204: The metadata of the given namespace has been updated.
-            Self::start_workflow(&event.opencast_id, "republish-metadata", &context).await?;
+            Self::start_workflow(&event.opencast_id, &context.config.opencast.republish_workflow_id, &context).await?;
 
             context.db.execute("\
                 update all_events \

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -553,7 +553,7 @@ impl Series {
 
                 if let Err(e) = AuthorizedEvent::start_workflow(
                     &event.opencast_id,
-                    "republish-metadata",
+                    &context.config.opencast.republish_workflow_id,
                     context,
                 ).await {
                     warn!(

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -113,7 +113,7 @@ pub(crate) struct GeneralConfig {
     pub users_searchable: bool,
 
     /// This allows users to edit the ACL of events and series they have write access for.
-    /// Doing so will update these in Opencast and start the `republish-metadata` workflow
+    /// Doing so will update these in Opencast and start the configured republish metadata workflow
     /// for events to propagate the changes to other publications as well (series however
     /// do not need the extra workflow for this to happen).
     /// Instead of waiting for the workflow, Tobira will immediately store the updated ACL in its

--- a/backend/src/config/opencast.rs
+++ b/backend/src/config/opencast.rs
@@ -61,6 +61,11 @@ pub(crate) struct OpencastConfig {
 
     /// Password of the user used to communicate with Opencast.
     password: SecretString,
+
+    /// ID of the workflow used to republish metadata.
+    #[config(default = "republish-metadata")]
+    pub(crate) republish_workflow_id: String,
+
 }
 
 impl OpencastConfig {

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -125,7 +125,7 @@
 #users_searchable = false
 
 # This allows users to edit the ACL of events and series they have write access for.
-# Doing so will update these in Opencast and start the `republish-metadata` workflow
+# Doing so will update these in Opencast and start the configured republish metadata workflow
 # for events to propagate the changes to other publications as well (series however
 # do not need the extra workflow for this to happen).
 # Instead of waiting for the workflow, Tobira will immediately store the updated ACL in its
@@ -527,6 +527,11 @@
 #
 # Required! This value must be specified.
 #password =
+
+# ID of the workflow used to republish metadata.
+#
+# Default value: "republish-metadata"
+#republish_workflow_id = "republish-metadata"
 
 
 [sync]


### PR DESCRIPTION
The hardcoded workflow ID for republishing metadata has been replaced with a configurable option. The default setting for this configuration is `republish-metadata`.