### PR TITLE
Fix event/series on root page in search result having "missing name"

### DIFF
--- a/frontend/src/routes/Search.tsx
+++ b/frontend/src/routes/Search.tsx
@@ -536,7 +536,7 @@ const SearchEvent: React.FC<EventItem> = ({
                 flexDirection: "column",
                 height: "100%",
             }}>
-                {hostRealms.length === 1 && (
+                {hostRealms.length === 1 && hostRealms[0].ancestorNames.length > 0 && (
                     <SearchBreadcrumbs parts={[
                         ...hostRealms[0].ancestorNames,
                         hostRealms[0].name,
@@ -834,7 +834,7 @@ const SearchSeries: React.FC<SeriesItem> = ({
             flexDirection: "column",
             minWidth: 0,
         }}>
-            {hostRealms.length === 1 && (
+            {hostRealms.length === 1 && hostRealms[0].ancestorNames.length > 0 && (
                 <SearchBreadcrumbs parts={[
                     ...hostRealms[0].ancestorNames,
                     // Oftentimes realms are named after the series. In that


### PR DESCRIPTION
Problem:

<img width="1820" height="658" alt="image" src="https://github.com/user-attachments/assets/9be05c69-52be-4e50-a9a5-20f89bb9932e" />
