### PR TITLE
Remove admin dummy entries from ACL tables

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -359,10 +359,8 @@ acl:
     users: Personen hinzufügen
     create: '{{item}} erstellen'
   groups:
-    admins: Administration
     everyone: Alle
     logged-in-users: Eingeloggte Nutzende
-    global-page-admins: "Globale Seiten\u00ADadministration"
   table:
     group: Gruppe
     user: Person

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -352,10 +352,8 @@ acl:
     users: Add users
     create: 'Create {{item}}'
   groups:
-    admins: Administrators
     everyone: Everyone
     logged-in-users: Logged in users
-    global-page-admins: Global page admins
   table:
     group: Group
     user: User

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -368,10 +368,8 @@ acl:
     users: Ajouter des personnes
     create: créer {{item}}
   groups:
-    admins: Administration
     everyone: Tous
     logged-in-users: Utilisateurs connectés
-    global-page-admins: Administration globale de la page
   table:
     group: Groupe
     user: Utilisateur

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -369,10 +369,8 @@ acl:
     users: Aggiungi persone
     create: Crea {{item}}
   groups:
-    admins: Amministratori
     everyone: Tutti
     logged-in-users: Utenti connessi
-    global-page-admins: Amministratori globali di pagine
   table:
     group: Gruppo
     user: Persona

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -199,9 +199,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
     const isDark = useColorScheme().scheme === "dark";
     const user = useUser();
     const { t, i18n } = useTranslation();
-    const {
-        change, knownGroups, groupDag, permissionLevels, ownerDisplayName, itemType,
-    } = useAclContext();
+    const { change, knownGroups, groupDag, permissionLevels, ownerDisplayName } = useAclContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
     const userIsOwner = isRealUser(user) && user.displayName === ownerDisplayName;
     const [error, setError] = useState<ReactNode>(null);
@@ -268,21 +266,8 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             large: false, // Don't show any warning on inherited entries as they can't be changed.
         }));
 
-    const userIsAdmin = isRealUser(user) && user.roles.includes(COMMON_ROLES.ADMIN);
-    const showAdminEntry = kind === "group"
-        && !entries.some(e => e.role === COMMON_ROLES.ADMIN)
-        && userIsAdmin;
-
-    const userIsGlobalPageAdmin = isRealUser(user)
-        && user.roles.includes(COMMON_ROLES.TOBIRA_GLOBAL_PAGE_ADMIN);
-    const showGlobalPageAdminEntry = kind === "group"
-        && itemType === "realm"
-        && !entries.some(e => e.role === COMMON_ROLES.TOBIRA_GLOBAL_PAGE_ADMIN)
-        && userIsGlobalPageAdmin;
-
     const showUserEntry = (kind === "user" && ownerDisplayName);
-    const noEntries = entries.length === 0
-        && !(showAdminEntry || showUserEntry || showGlobalPageAdminEntry);
+    const noEntries = entries.length === 0 && !showUserEntry;
 
     const remove = (item: Entry) => change(prev => prev.delete(item.role));
 
@@ -407,21 +392,8 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                 }
 
                 {/*
-                    The ACLs usually don't explicitly include admins, but showing that
-                    entry makes sense if the user is admin. Same for the global page admin.
-                */}
-                {showAdminEntry && <TableRow
-                    labelCol={<>{t("acl.groups.admins")}</>}
-                    actionCol={<UnchangeableAllActions />}
-                />}
-                {showGlobalPageAdminEntry && <TableRow
-                    labelCol={<>{t("acl.groups.global-page-admins")}</>}
-                    actionCol={<UnchangeableAllActions />}
-                />}
-
-                {/*
-                    Similarly to the above, the ACL for user realms does not explicitly
-                    include that realm's owning user, but it should still be shown in the UI.
+                    ACL for user realms do not explicitly include that realm's owning user,
+                    but it should still be shown in the UI.
                 */}
                 {showUserEntry && <TableRow
                     labelCol={!userIsOwner ? <>{ownerDisplayName}</> : <>


### PR DESCRIPTION
Admins will usually understand that they have write access, even though it's not explicitly stated. The fact that they can see and edit the ACL should be a strong enough hint anyway.

Closes https://github.com/elan-ev/tobira/issues/1633