### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report something that is clearly broken or a problem
+title: ''
+labels: kind:bug
+assignees: ''
+type: Bug
+
+---
+
+**Tobira version**: [e.g. v3.14, check `/~tobira` if you are unsure]
+
+<!--
+Please describe the problem clearly and concisely. Provide all relevant information and explain how to see the bug for ourselves. We cannot fix bugs we cannot reproduce.
+
+If potentially relevant or helpful, please provide:
+- Screenshots/videos
+- What browser? (Firefox, Chrome, Safari, ...)
+- Information from the admin dashboard
+- Log output
+- PostgreSQL and/or MeiliSearch version
+- Server OS
+- Opencast version
+
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question
+    url: https://github.com/elan-ev/tobira/discussions
+    about: Create a "discussion", we gladly answer your questions there!

--- a/.github/ISSUE_TEMPLATE/feature-request-suggestion-idea.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-suggestion-idea.md
@@ -1,0 +1,15 @@
+---
+name: Feature request, suggestion or idea
+about: Request a new feature, suggest some changes or propose an idea
+title: ''
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+<!--
+
+Please describe the feature/suggestion in detail and with all relevant context. Provide screenshots, videos or sketches if it helps with the explanation. For user-facing requests, consider writing a "user story", an informal but detailed step by step description from the perspective of a hypothetical user.
+
+-->


### PR DESCRIPTION
This is a suggestion for issue templates for this repository. This was suggested by @dagraf recently. 

I'm not super happy with what I wrote, mostly because I wasn't sure what exactly we want to guard against. Mostly, issues made here were pretty decent. But maybe this still helps, especially because of the auto tagging as "Bug" or "Feature".

Feedback welcome. Click on the "Files changed" tab to see the markdown files. With this, creating a new issue shows the user three options: "Bug report", "Feature request, suggestion or idea" and "Blank issue". In theory in this order.
