### PR TITLE
Add video block show metadata option

### DIFF
--- a/backend/src/api/model/block/mod.rs
+++ b/backend/src/api/model/block/mod.rs
@@ -217,6 +217,7 @@ pub(crate) struct VideoBlock {
     pub(crate) event: Option<Id>,
     pub(crate) show_title: bool,
     pub(crate) show_link: bool,
+    pub(crate) show_metadata: bool,
 }
 
 impl_block!(VideoBlock);
@@ -237,6 +238,10 @@ impl VideoBlock {
 
     fn show_link(&self) -> bool {
         self.show_link
+    }
+
+    fn show_metadata(&self) -> bool {
+        self.show_metadata
     }
 
     fn id(&self) -> Id {
@@ -356,6 +361,7 @@ impl_from_db!(
                 event: row.video::<Option<Key>>().map(Id::event),
                 show_title: unwrap_type_dep(row.show_title(), "event", "show_title"),
                 show_link: unwrap_type_dep(row.show_link(), "event", "show_link"),
+                show_metadata: unwrap_type_dep(row.show_metadata(), "event", "show_metadata"),
             }.into(),
 
             BlockType::Playlist => PlaylistBlock {

--- a/backend/src/api/model/block/mutations.rs
+++ b/backend/src/api/model/block/mutations.rs
@@ -109,17 +109,17 @@ impl BlockValue {
         let (realm, index) = Self::prepare_realm_for_block(realm, index, context).await?;
         let event = block.event.key_for(Id::EVENT_KIND)
             .ok_or_else(|| invalid_input!("`block.event` does not refer to an event"))?;
-
         context.db
             .execute(
-                "insert into blocks (realm, index, type, video, show_title, show_link) \
-                    values ($1, $2, 'video', $3, $4, $5)",
+                "insert into blocks (realm, index, type, video, show_title, show_link,show_metadata) \
+                    values ($1, $2, 'video', $3, $4, $5, $6)",
                 &[
                     &realm.key,
                     &index,
                     &event,
                     &block.display_options.show_title,
                     &block.display_options.show_link,
+                    &block.display_options.show_metadata,
                 ],
             )
             .await?;
@@ -386,7 +386,8 @@ impl BlockValue {
             "update blocks set \
                 video = coalesce($2, video), \
                 show_title = coalesce($3, show_title), \
-                show_link = coalesce($4, show_link) \
+                show_link = coalesce($4, show_link), \
+                show_metadata = coalesce($5, show_metadata) \
                 where id = $1 \
                 and type = 'video' \
                 returning {selection}",
@@ -397,6 +398,7 @@ impl BlockValue {
                 &video_id,
                 &set.display_options.show_title,
                 &set.display_options.show_link,
+                &set.display_options.show_metadata,
             ])
             .await?
             .pipe(|row| Ok(Self::from_row_start(&row)))

--- a/backend/src/db/migrations/49-video-block-show-metadata-constraint.sql
+++ b/backend/src/db/migrations/49-video-block-show-metadata-constraint.sql
@@ -1,0 +1,13 @@
+-- Adds a single `show_metadata` field to blocks, used for video blocks to also show
+-- metadata below the video player.
+
+-- Ensure that all existing video blocks have a value for `show_metadata` (defaulting to false).
+update blocks set show_metadata = false where type = 'video' and show_metadata is null;
+
+alter table blocks
+    drop constraint video_block_has_fields,
+    add constraint video_block_has_fields check (type <> 'video' or (
+        show_title is not null and
+        show_link is not null and
+        show_metadata is not null
+    ));

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -113,7 +113,7 @@ type SyncConfig = {
     pollPeriod: number;
 };
 
-type MetadataLabel = "builtin:license" | "builtin:source" | TranslatedString;
+export type MetadataLabel = "builtin:license" | "builtin:source" | TranslatedString;
 
 export type TranslatedString = { default: string } & Record<"en" | "de", string | undefined>;
 

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -20,7 +20,6 @@ import {
     ProtoButton,
 } from "@opencast/appkit";
 import { VideoObject, WithContext } from "schema-dts";
-import { TFunction } from "i18next";
 
 import { fetchQuery, loadQuery } from "../relay";
 import { InitialLoading, RootLoader } from "../layout/Root";
@@ -97,6 +96,7 @@ import { isSpaceOnInteractiveElement } from "../ui/player/PlayerShortcuts";
 import { VideoListLayout } from "../ui/Blocks/__generated__/SeriesBlockData.graphql";
 import { LIST_ORDERS, Order } from "../ui/Blocks/VideoList";
 
+import { LICENSE_TRANSLATIONS, isValidLink } from "../ui/metadata";
 
 // ===========================================================================================
 // ===== Route definitions
@@ -1315,28 +1315,3 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({
         </dl>
     );
 });
-
-const LICENSE_TRANSLATIONS: Record<string, (t: TFunction) => string> = {
-    "ALLRIGHTS": (t: TFunction) => t("license.all-rights"),
-    "CC-BY": () => "CC BY",
-    "CC-BY-SA": () => "CC BY-SA",
-    "CC-BY-ND": () => "CC BY-ND",
-    "CC-BY-NC": () => "CC BY-NC",
-    "CC-BY-NC-SA": () => "CC BY-NC-SA",
-    "CC-BY-NC-ND": () => "CC BY-NC-ND",
-};
-
-const isValidLink = (s: string): boolean => {
-    const trimmed = s.trim();
-    if (!(trimmed.startsWith("http://") || trimmed.startsWith("https://"))) {
-        return false;
-    }
-
-    try {
-        new URL(trimmed);
-    } catch (_) {
-        return false;
-    }
-
-    return true;
-};

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -14,10 +14,9 @@ import {
     LuCode, LuDownload, LuInfo, LuLink, LuRss, LuSettings, LuLockOpen,
 } from "react-icons/lu";
 import {
-    match, unreachable, screenWidthAtMost, screenWidthAbove, useColorScheme,
+    unreachable, screenWidthAtMost, screenWidthAbove, useColorScheme,
     Floating, FloatingContainer, FloatingTrigger, WithTooltip, Card, Button,
     notNullish,
-    ProtoButton,
 } from "@opencast/appkit";
 import { VideoObject, WithContext } from "schema-dts";
 
@@ -36,7 +35,6 @@ import {
     isSynced,
     toIsoDuration,
     useForceRerender,
-    translatedConfig,
     secondsToTimeString,
     eventId,
     keyOfId,
@@ -96,7 +94,7 @@ import { isSpaceOnInteractiveElement } from "../ui/player/PlayerShortcuts";
 import { VideoListLayout } from "../ui/Blocks/__generated__/SeriesBlockData.graphql";
 import { LIST_ORDERS, Order } from "../ui/Blocks/VideoList";
 
-import { LICENSE_TRANSLATIONS, isValidLink } from "../ui/metadata";
+import { createAutoTimestampProcessor, getMetadataPairs } from "../ui/metadata";
 
 // ===========================================================================================
 // ===== Route definitions
@@ -898,31 +896,12 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
     const user = useUser();
     const { paella, playerIsLoaded } = usePlayerContext();
 
-    const autoTimestampProcessor = (text: string) => {
-        const timestampRegex = /((?<!\S)(?:\d?\d:)?\d?\d:\d{2}(?!\S))/g;
-        return <>{text.split(timestampRegex).map((part, index) => {
-            if (!part.match(timestampRegex)) {
-                return part;
-            }
-            const parts = part.split(":").map(Number);
-            const [hours, minutes, seconds] = parts.length === 2 ? [0, ...parts] : parts;
-            const timestamp = ((hours * 60) + minutes) * 60 + seconds;
-            if (timestamp * 1000 > event.syncedData.duration) {
-                return part;
-            }
-
-            return <ProtoButton
-                key={index}
-                onClick={() => paella.current?.player.videoContainer.setCurrentTime(timestamp)}
-                css={{
-                    color: COLORS.primary0,
-                    ":hover": {
-                        color: COLORS.primary1,
-                    },
-                }}
-            >{part}</ProtoButton>;
-        })}</>;
-    };
+    const autoTimestampProcessor = createAutoTimestampProcessor({
+        duration: event.syncedData.duration,
+        onTimestampClick: timestamp => {
+            paella.current?.player.videoContainer.setCurrentTime(timestamp);
+        },
+    });
 
     const shrinkOnMobile = {
         [screenWidthAtMost(BREAKPOINT_SMALL)]: {
@@ -1242,49 +1221,7 @@ const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({
         ]);
     }
 
-    if (event.metadata.dcterms.language) {
-        const languageNames = new Intl.DisplayNames(i18n.resolvedLanguage, { type: "language" });
-        const languages = event.metadata.dcterms.language.map(lng => languageNames.of(lng) ?? lng);
-
-        pairs.push([
-            t("general.language.language", { count: languages.length }),
-            languages.join(", "),
-        ]);
-    }
-
-    for (const [namespace, fields] of Object.entries(CONFIG.metadataLabels)) {
-        const metadataNs = event.metadata[namespace];
-        if (metadataNs === undefined) {
-            continue;
-        }
-
-        for (const [field, label] of Object.entries(fields)) {
-            if (field in metadataNs) {
-                const translatedLabel = typeof label === "object"
-                    ? translatedConfig(label, i18n)
-                    : match(label, {
-                        "builtin:license": () => t("video.license"),
-                        "builtin:source": () => t("video.source"),
-                    });
-
-                const values = metadataNs[field].map((value, i) => {
-                    const displayValue = (
-                        label === "builtin:license" && value in LICENSE_TRANSLATIONS
-                    ) ? LICENSE_TRANSLATIONS[value](t) : value;
-
-                    return <React.Fragment key={i}>
-                        {i > 0 && <br />}
-                        {isValidLink(displayValue)
-                            ? <Link to={displayValue}>{displayValue}</Link>
-                            : displayValue
-                        }
-                    </React.Fragment>;
-                });
-
-                pairs.push([translatedLabel, values]);
-            }
-        }
-    }
+    pairs.push(...getMetadataPairs(event, t, i18n, "line-break"));
 
     if (event.syncedData?.duration && !event.isLive) {
         pairs.push([

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1,5 +1,4 @@
 import React, {
-    ReactNode,
     useEffect,
     useRef,
     useState,
@@ -46,7 +45,7 @@ import {
 import { BREAKPOINT_SMALL, BREAKPOINT_MEDIUM } from "../GlobalStyle";
 import { LinkButton } from "../ui/LinkButton";
 import CONFIG from "../config";
-import { Link, useRouter } from "../router";
+import { useRouter } from "../router";
 import { isRealUser, useUser } from "../User";
 import { b64regex, checkRealmPath } from "./util";
 import { NotAuthorized } from "../ui/error";
@@ -68,13 +67,13 @@ import {
     PlaylistBlockPlaylistData$key,
 } from "../ui/Blocks/__generated__/PlaylistBlockPlaylistData.graphql";
 import { getEventTimeInfo } from "../util/video";
-import { formatDuration, TrackInfo } from "../ui/Video";
+import { TrackInfo } from "../ui/Video";
 import { ellipsisOverflowCss } from "../ui";
 import { realmBreadcrumbs } from "../util/realm";
 import { COLORS } from "../color";
 import { preciseDateTime, preferredLocaleForLang, PrettyDate } from "../ui/time";
 import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
-import { CollapsibleDescription } from "../ui/metadata";
+import { MetadataSection } from "../ui/metadata";
 import { DirectSeriesRoute, SeriesRoute } from "./Series";
 import { EmbedVideoRoute } from "./Embed";
 import { ManageVideoDetailsRoute } from "./manage/Video/VideoDetails";
@@ -93,8 +92,6 @@ import { usePlayerGroupContext } from "../ui/player/PlayerGroupContext";
 import { isSpaceOnInteractiveElement } from "../ui/player/PlayerShortcuts";
 import { VideoListLayout } from "../ui/Blocks/__generated__/SeriesBlockData.graphql";
 import { LIST_ORDERS, Order } from "../ui/Blocks/VideoList";
-
-import { createAutoTimestampProcessor, getMetadataPairs } from "../ui/metadata";
 
 // ===========================================================================================
 // ===== Route definitions
@@ -896,13 +893,6 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
     const user = useUser();
     const { paella, playerIsLoaded } = usePlayerContext();
 
-    const autoTimestampProcessor = createAutoTimestampProcessor({
-        duration: event.syncedData.duration,
-        onTimestampClick: timestamp => {
-            paella.current?.player.videoContainer.setCurrentTime(timestamp);
-        },
-    });
-
     const shrinkOnMobile = {
         [screenWidthAtMost(BREAKPOINT_SMALL)]: {
             padding: "5px 10px",
@@ -953,32 +943,23 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
                 />
             </section>
         </div>
-        <div css={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: 16,
-            "> div": {
-                backgroundColor: COLORS.neutral10,
-                borderRadius: 8,
-                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-                    overflowWrap: "anywhere",
-                },
-            },
-        }}>
-            <CollapsibleDescription
-                type="video"
-                description={event.description}
-                creators={event.creators}
-                bottomPadding={40}
-                textProcessor={autoTimestampProcessor}
-            />
-            <div css={{ flex: "1 200px", alignSelf: "flex-start", padding: "20px 22px" }}>
-                <MetadataTable {...{ event, realmPath }} />
-            </div>
-        </div>
+        <MetadataSection
+            event={event}
+            valueStyle="line-break"
+            seriesLink={getSeriesLink(event.series, realmPath)}
+        />
     </>;
 };
 
+export const getSeriesLink = (
+    series: { id: string; title: string } | null | undefined,
+    realmPath: string | null,
+): { title: string; url: string } | undefined => series ? {
+    title: series.title,
+    url: realmPath == null
+        ? DirectSeriesRoute.url({ seriesId: series.id })
+        : SeriesRoute.url({ seriesId: series.id, realmPath }),
+} : undefined;
 
 const DownloadButton: React.FC<{ event: SyncedEvent }> = ({ event }) => {
     const { t } = useTranslation();
@@ -1196,59 +1177,3 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
     );
 };
 
-type MetadataTableProps = {
-    event: Event;
-    realmPath: string | null;
-};
-
-const MetadataTable = React.forwardRef<HTMLDListElement, MetadataTableProps>(({
-    event, realmPath,
-}, ref) => {
-    const { t, i18n } = useTranslation();
-    const pairs: [string, ReactNode][] = [];
-
-    if (event.series) {
-        const seriesId = event.series.id;
-        const target = realmPath == null
-            ? DirectSeriesRoute.url({ seriesId })
-            : SeriesRoute.url({ seriesId, realmPath });
-        pairs.push([
-            t("video.part-of-series"),
-            // eslint-disable-next-line react/jsx-key
-            <Link to={target}>
-                {event.series.title}
-            </Link>,
-        ]);
-    }
-
-    pairs.push(...getMetadataPairs(event, t, i18n, "line-break"));
-
-    if (event.syncedData?.duration && !event.isLive) {
-        pairs.push([
-            t("video.duration"),
-            formatDuration(event.syncedData.duration),
-        ]);
-    }
-
-    return (
-        <dl ref={ref} css={{
-            display: "grid",
-            gridTemplateColumns: "max-content 1fr",
-            columnGap: 8,
-            rowGap: 6,
-            fontSize: 14,
-            lineHeight: 1.3,
-            "& > dt::after": {
-                content: "':'",
-            },
-            "& > dd": {
-                color: COLORS.neutral60,
-            },
-        }}>
-            {pairs.map(([label, value], i) => <React.Fragment key={i}>
-                <dt>{label}</dt>
-                <dd>{value}</dd>
-            </React.Fragment>)}
-        </dl>
-    );
-});

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -73,7 +73,7 @@ import { realmBreadcrumbs } from "../util/realm";
 import { COLORS } from "../color";
 import { preciseDateTime, preferredLocaleForLang, PrettyDate } from "../ui/time";
 import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
-import { MetadataSection } from "../ui/metadata";
+import { MetadataSection, MetadataSectionSeriesLink } from "../ui/metadata";
 import { DirectSeriesRoute, SeriesRoute } from "./Series";
 import { EmbedVideoRoute } from "./Embed";
 import { ManageVideoDetailsRoute } from "./manage/Video/VideoDetails";
@@ -954,7 +954,7 @@ const Metadata: React.FC<MetadataProps> = ({ event, realmPath }) => {
 export const getSeriesLink = (
     series: { id: string; title: string } | null | undefined,
     realmPath: string | null,
-): { title: string; url: string } | undefined => series ? {
+): MetadataSectionSeriesLink | undefined => series ? {
     title: series.title,
     url: realmPath == null
         ? DirectSeriesRoute.url({ seriesId: series.id })

--- a/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
+++ b/frontend/src/routes/manage/Realm/Content/AddButtons.tsx
@@ -124,6 +124,7 @@ const AddButtonsMenu: React.FC<Props & {floatingRef: RefObject<FloatingHandle>}>
         [LuFilm, "video", () => addBlock("Video", (_store, block) => {
             block.setValue(true, "showTitle");
             block.setValue(true, "showLink");
+            block.setValue(false, "showMetadata");
         })],
         [LuListVideo, "playlist", () => addBlock("Playlist", (_store, block) => {
             block.setValue("ORIGINAL", "order");

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Video.tsx
@@ -22,7 +22,8 @@ type VideoFormData = {
     displayOptions: {
         showTitle: boolean;
         showLink: boolean;
-    }
+        showMetadata: boolean;
+    };
 };
 
 type EditVideoBlockProps = {
@@ -34,7 +35,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
     const user = useUser();
 
 
-    const { event, showTitle, showLink } = useFragment(graphql`
+    const { event, showTitle, showLink, showMetadata } = useFragment(graphql`
         fragment VideoEditModeBlockData on VideoBlock {
             event {
                 __typename,
@@ -52,6 +53,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
             }
             showTitle
             showLink
+            showMetadata
         }
     `, blockRef);
 
@@ -91,6 +93,7 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
         displayOptions: {
             showTitle,
             showLink,
+            showMetadata,
         },
     };
 
@@ -128,6 +131,11 @@ export const EditVideoBlock: React.FC<EditVideoBlockProps> = ({ block: blockRef 
                 value: "showLink",
                 title: t("manage.block.options.show-link"),
                 defaultChecked: showLink,
+            },
+            {
+                value: "showMetadata",
+                title: t("manage.block.options.show-description"),
+                defaultChecked: showMetadata,
             },
         ]} />
     </EditModeForm>;

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -1286,6 +1286,7 @@ type VideoBlock implements Block {
   event: Event
   showTitle: Boolean!
   showLink: Boolean!
+  showMetadata: Boolean!
   id: ID!
   index: Int!
   realm: Realm!

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -161,65 +161,56 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
             <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
         </Link>}
 
-        {showMetadata && <div><div css={{
-            display: "flex",
-            alignItems: "center",
-            flexWrap: "wrap",
-            justifyContent: "space-between",
-            margin: "8px 0",
-            gap: 8,
-        }}>
-        </div>
-        <div css={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: 16,
-            "> div": {
-                backgroundColor: COLORS.neutral10,
-                borderRadius: 8,
-                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-                    overflowWrap: "anywhere",
+        {showMetadata && <div css={{ marginTop: 16 }}>
+            <div css={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 16,
+                "> div": {
+                    backgroundColor: COLORS.neutral10,
+                    borderRadius: 8,
+                    [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+                        overflowWrap: "anywhere",
+                    },
                 },
-            },
-        }}>
-            { event.description && <CollapsibleDescription
-                type="video"
-                description={event.description}
-                creators={event.creators}
-                bottomPadding={40}
-            />}
-            { pairs.length > 0 && <div css={{
-                flex: "1 200px",
-                alignSelf: "flex-start",
-                padding: "20px 22px",
             }}>
-                <dl css={{
-                    display: "grid",
-                    gridTemplateColumns: "max-content 1fr",
-                    columnGap: 8,
-                    rowGap: 6,
-                    fontSize: 14,
-                    lineHeight: 1.3,
-                    "& > dt::after": {
-                        content: "':'",
-                    },
-                    "& > dd": {
-                        color: COLORS.neutral60,
-                    },
-                    "& > li:not(:last-child)::after": {
-                        content: "'•'",
-                        padding: "0 6px",
-                        color: COLORS.neutral40,
-                    },
+                {event.description && <CollapsibleDescription
+                    type="video"
+                    description={event.description}
+                    creators={event.creators}
+                    bottomPadding={40}
+                />}
+                {pairs.length > 0 && <div css={{
+                    flex: "1 200px",
+                    alignSelf: "flex-start",
+                    padding: "20px 22px",
                 }}>
-                    {pairs.map(([label, value], i) => <React.Fragment key={i}>
-                        <dt>{label}</dt>
-                        <dd>{value}</dd>
-                    </React.Fragment>)}
-                </dl>
-            </div>}
-        </div>
-        </div>
-        }
+                    <dl css={{
+                        display: "grid",
+                        gridTemplateColumns: "max-content 1fr",
+                        columnGap: 8,
+                        rowGap: 6,
+                        fontSize: 14,
+                        lineHeight: 1.3,
+                        "& > dt::after": {
+                            content: "':'",
+                        },
+                        "& > dd": {
+                            color: COLORS.neutral60,
+                        },
+                        "& > li:not(:last-child)::after": {
+                            content: "'•'",
+                            padding: "0 6px",
+                            color: COLORS.neutral40,
+                        },
+                    }}>
+                        {pairs.map(([label, value], i) => <React.Fragment key={i}>
+                            <dt>{label}</dt>
+                            <dd>{value}</dd>
+                        </React.Fragment>)}
+                    </dl>
+                </div>}
+            </div>
+        </div>}
     </div>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -17,8 +17,9 @@ import { CollapsibleDescription, isValidLink, LICENSE_TRANSLATIONS } from "../..
 
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { ReactNode } from "react";
-import CONFIG from "../../config";
+import CONFIG, { MetadataLabel } from "../../config";
 import React from "react";
+import { TFunction } from "i18next";
 
 export type BlockEvent = VideoBlockData$data["event"];
 export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "AuthorizedEvent" }>;
@@ -27,6 +28,18 @@ type Props = {
     fragRef: VideoBlockData$key;
     basePath: string;
     edit?: boolean;
+};
+
+const translateValue = (
+    label: MetadataLabel, t: TFunction<"translation", undefined>, value: string,
+):ReactNode => {
+    const displayValue = (
+        label === "builtin:license" && value in LICENSE_TRANSLATIONS
+    ) ? LICENSE_TRANSLATIONS[value](t) : value;
+
+    return isValidLink(displayValue)
+        ? <Link to={displayValue}>{displayValue}</Link>
+        : displayValue;
 };
 
 export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
@@ -120,21 +133,9 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                             color: COLORS.neutral40,
                         },
                     }}>
-                        {values.map((v, i) => {
-                            const displayValue = (
-                                label === "builtin:license" && v in LICENSE_TRANSLATIONS
-                            ) ? LICENSE_TRANSLATIONS[v](t) : v;
-
-                            return <li key={i}>
-                                {isValidLink(displayValue)
-                                    ? <Link to={displayValue}>{displayValue}</Link>
-                                    : v
-                                }
-                            </li>;
-                        })
-                        }
+                        {values.map((v, i) => <li key={i}>{translateValue(label, t, v)}</li>)}
                     </ul>
-                    : values[0] ?? null;
+                    : translateValue(label, t, values[0]);
 
                 pairs.push([translatedLabel, node]);
             }

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -1,25 +1,29 @@
 import { graphql, useFragment } from "react-relay";
-import { Card, match, unreachable } from "@opencast/appkit";
+import { Card, unreachable } from "@opencast/appkit";
 
 import { InlinePlayer } from "../player";
 import { VideoBlockData$data, VideoBlockData$key } from "./__generated__/VideoBlockData.graphql";
 import { Title } from "..";
 import { useTranslation } from "react-i18next";
-import { isSynced, keyOfId, translatedConfig } from "../../util";
+import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
 import { LuCircleArrowRight } from "react-icons/lu";
-import { PlayerContextProvider } from "../player/PlayerContext";
+import { PlayerContextProvider, usePlayerContext } from "../player/PlayerContext";
 import { PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
 
 import { screenWidthAtMost } from "@opencast/appkit";
 import { COLORS } from "../../color";
-import { CollapsibleDescription, isValidLink, LICENSE_TRANSLATIONS } from "../../ui/metadata";
+import {
+    CollapsibleDescription,
+    createAutoTimestampProcessor,
+    getMetadataPairs,
+} from "../../ui/metadata";
 
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { ReactNode } from "react";
-import CONFIG, { MetadataLabel } from "../../config";
 import React from "react";
-import { TFunction } from "i18next";
+
+import { formatDuration } from "../Video";
 
 export type BlockEvent = VideoBlockData$data["event"];
 export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "AuthorizedEvent" }>;
@@ -28,18 +32,6 @@ type Props = {
     fragRef: VideoBlockData$key;
     basePath: string;
     edit?: boolean;
-};
-
-const translateValue = (
-    label: MetadataLabel, t: TFunction<"translation", undefined>, value: string,
-):ReactNode => {
-    const displayValue = (
-        label === "builtin:license" && value in LICENSE_TRANSLATIONS
-    ) ? LICENSE_TRANSLATIONS[value](t) : value;
-
-    return isValidLink(displayValue)
-        ? <Link to={displayValue}>{displayValue}</Link>
-        : displayValue;
 };
 
 export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
@@ -93,87 +85,25 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
         return unreachable();
     }
 
-    const pairs: [string, ReactNode][] = [];
+    const pairs: [string, ReactNode][] = getMetadataPairs(event, t, i18n, "inline-bullets");
 
-    if (event.metadata.dcterms.language) {
-        const languageNames = new Intl.DisplayNames(i18n.resolvedLanguage, { type: "language" });
-        const languages = event.metadata.dcterms.language.map(lng => languageNames.of(lng) ?? lng);
-
+    if (event.syncedData?.duration && !event.isLive) {
         pairs.push([
-            t("general.language.language", { count: languages.length }),
-            languages.join(", "),
+            t("video.duration"),
+            formatDuration(event.syncedData.duration),
         ]);
     }
 
-    for (const [namespace, fields] of Object.entries(CONFIG.metadataLabels)) {
-        const metadataNs = event.metadata[namespace];
-        if (metadataNs === undefined) {
-            continue;
-        }
+    const MetadataPanel: React.FC = () => {
+        const { paella } = usePlayerContext();
+        const autoTimestampProcessor = createAutoTimestampProcessor({
+            duration: event.syncedData?.duration,
+            onTimestampClick: timestamp => {
+                paella.current?.player.videoContainer.setCurrentTime(timestamp);
+            },
+        });
 
-        for (const [field, label] of Object.entries(fields)) {
-            if (field in metadataNs) {
-                const translatedLabel = typeof label === "object"
-                    ? translatedConfig(label, i18n)
-                    : match(label, {
-                        "builtin:license": () => t("video.license"),
-                        "builtin:source": () => t("video.source"),
-                    });
-                const values = metadataNs[field];
-                const node = values.length > 1
-                    ? <ul css={{
-                        listStyle: "none",
-                        display: "inline-flex",
-                        flexWrap: "wrap",
-                        margin: 0,
-                        padding: 0,
-                        "& > li:not(:last-child)::after": {
-                            content: "'•'",
-                            padding: "0 6px",
-                            color: COLORS.neutral40,
-                        },
-                    }}>
-                        {values.map((v, i) => <li key={i}>{translateValue(label, t, v)}</li>)}
-                    </ul>
-                    : translateValue(label, t, values[0]);
-
-                pairs.push([translatedLabel, node]);
-            }
-        }
-    }
-
-    return <div css={{ maxWidth: 800 }}>
-        {showTitle && <Title title={event.title} />}
-        <PlayerContextProvider>
-            <section aria-label={t("video.video-player")}>
-                {event.authorizedData && isSynced(event)
-                    ? <InlinePlayer
-                        event={{ ...event, authorizedData: event.authorizedData }}
-                        css={{ margin: "-4px auto 0" }}
-                    />
-                    : <PreviewPlaceholder {...{ event, refetch }} />
-                }
-            </section>
-        </PlayerContextProvider>
-
-        {showLink && <Link
-            to={`${basePath}/${keyOfId(event.id)}`}
-            css={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                marginTop: 8,
-                marginLeft: "auto",
-                width: "fit-content",
-                borderRadius: 4,
-                outlineOffset: 1,
-            }}
-        >
-            {t("video.details")}
-            <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
-        </Link>}
-
-        {showMetadata && <div css={{ marginTop: 16 }}>
+        return <div css={{ marginTop: 16 }}>
             <div css={{
                 display: "flex",
                 flexWrap: "wrap",
@@ -186,13 +116,14 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                     },
                 },
             }}>
-                {event.description && <CollapsibleDescription
+                <CollapsibleDescription
                     type="video"
                     description={event.description}
                     creators={event.creators}
                     bottomPadding={40}
-                />}
-                {pairs.length > 0 && <div css={{
+                    textProcessor={autoTimestampProcessor}
+                />
+                <div css={{
                     flex: "1 200px",
                     alignSelf: "flex-start",
                     padding: "20px 22px",
@@ -221,8 +152,42 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                             <dd>{value}</dd>
                         </React.Fragment>)}
                     </dl>
-                </div>}
+                </div>
             </div>
-        </div>}
-    </div>;
+        </div>;
+    };
+
+    return <PlayerContextProvider>
+        <div css={{ maxWidth: 800 }}>
+            {showTitle && <Title title={event.title} />}
+            <section aria-label={t("video.video-player")}>
+                {event.authorizedData && isSynced(event)
+                    ? <InlinePlayer
+                        event={{ ...event, authorizedData: event.authorizedData }}
+                        css={{ margin: "-4px auto 0" }}
+                    />
+                    : <PreviewPlaceholder {...{ event, refetch }} />
+                }
+            </section>
+
+            {showLink && <Link
+                to={`${basePath}/${keyOfId(event.id)}`}
+                css={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    marginTop: 8,
+                    marginLeft: "auto",
+                    width: "fit-content",
+                    borderRadius: 4,
+                    outlineOffset: 1,
+                }}
+            >
+                {t("video.details")}
+                <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
+            </Link>}
+
+            {showMetadata && <MetadataPanel />}
+        </div>
+    </PlayerContextProvider>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -1,16 +1,24 @@
 import { graphql, useFragment } from "react-relay";
-import { Card, unreachable } from "@opencast/appkit";
+import { Card, match, unreachable } from "@opencast/appkit";
 
 import { InlinePlayer } from "../player";
 import { VideoBlockData$data, VideoBlockData$key } from "./__generated__/VideoBlockData.graphql";
 import { Title } from "..";
 import { useTranslation } from "react-i18next";
-import { isSynced, keyOfId } from "../../util";
+import { isSynced, keyOfId, translatedConfig } from "../../util";
 import { Link } from "../../router";
 import { LuCircleArrowRight } from "react-icons/lu";
 import { PlayerContextProvider } from "../player/PlayerContext";
 import { PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
 
+import { screenWidthAtMost } from "@opencast/appkit";
+import { COLORS } from "../../color";
+import { CollapsibleDescription } from "../../ui/metadata";
+
+import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
+import { ReactNode } from "react";
+import CONFIG from "../../config";
+import React from "react";
 
 export type BlockEvent = VideoBlockData$data["event"];
 export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "AuthorizedEvent" }>;
@@ -22,8 +30,8 @@ type Props = {
 };
 
 export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
-    const { t } = useTranslation();
-    const { event: protoEvent, showTitle, showLink } = useFragment(graphql`
+    const { t, i18n } = useTranslation();
+    const { event: protoEvent, showTitle, showLink, showMetadata } = useFragment(graphql`
         fragment VideoBlockData on VideoBlock {
             event {
                 __typename
@@ -52,6 +60,7 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
             }
             showTitle
             showLink
+            showMetadata
         }
     `, fragRef);
     const [event, refetch] = useEventWithAuthData(protoEvent);
@@ -70,6 +79,56 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
     if (event.__typename !== "AuthorizedEvent") {
         return unreachable();
     }
+
+    const pairs: [string, ReactNode][] = [];
+
+    if (event.metadata.dcterms.language) {
+        const languageNames = new Intl.DisplayNames(i18n.resolvedLanguage, { type: "language" });
+        const languages = event.metadata.dcterms.language.map(lng => languageNames.of(lng) ?? lng);
+
+        pairs.push([
+            t("general.language.language", { count: languages.length }),
+            languages.join(", "),
+        ]);
+    }
+
+    for (const [namespace, fields] of Object.entries(CONFIG.metadataLabels)) {
+        const metadataNs = event.metadata[namespace];
+        if (metadataNs === undefined) {
+            continue;
+        }
+
+        for (const [field, label] of Object.entries(fields)) {
+            if (field in metadataNs) {
+                const translatedLabel = typeof label === "object"
+                    ? translatedConfig(label, i18n)
+                    : match(label, {
+                        "builtin:license": () => t("video.license"),
+                        "builtin:source": () => t("video.source"),
+                    });
+                const values = metadataNs[field];
+                const node = values.length > 1
+                    ? <ul css={{
+                        listStyle: "none",
+                        display: "inline-flex",
+                        flexWrap: "wrap",
+                        margin: 0,
+                        padding: 0,
+                        "& > li:not(:last-child)::after": {
+                            content: "'•'",
+                            padding: "0 6px",
+                            color: COLORS.neutral40,
+                        },
+                    }}>
+                        {values.map((v, i) => <li key={i}>{v}</li>)}
+                    </ul>
+                    : values[0] ?? null;
+
+                pairs.push([translatedLabel, node]);
+            }
+        }
+    }
+
 
     return <div css={{ maxWidth: 800 }}>
         {showTitle && <Title title={event.title} />}
@@ -101,5 +160,66 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
             {t("video.details")}
             <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
         </Link>}
+
+        {showMetadata && <div><div css={{
+            display: "flex",
+            alignItems: "center",
+            flexWrap: "wrap",
+            justifyContent: "space-between",
+            margin: "8px 0",
+            gap: 8,
+        }}>
+        </div>
+        <div css={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 16,
+            "> div": {
+                backgroundColor: COLORS.neutral10,
+                borderRadius: 8,
+                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+                    overflowWrap: "anywhere",
+                },
+            },
+        }}>
+            { event.description && <CollapsibleDescription
+                type="video"
+                description={event.description}
+                creators={event.creators}
+                bottomPadding={40}
+            />}
+            { pairs.length > 0 && <div css={{
+                flex: "1 200px",
+                alignSelf: "flex-start",
+                padding: "20px 22px",
+            }}>
+                <dl css={{
+                    display: "grid",
+                    gridTemplateColumns: "max-content 1fr",
+                    columnGap: 8,
+                    rowGap: 6,
+                    fontSize: 14,
+                    lineHeight: 1.3,
+                    "& > dt::after": {
+                        content: "':'",
+                    },
+                    "& > dd": {
+                        color: COLORS.neutral60,
+                    },
+                    "& > li:not(:last-child)::after": {
+                        content: "'•'",
+                        padding: "0 6px",
+                        color: COLORS.neutral40,
+                    },
+                }}>
+                    {pairs.map(([label, value], i) => <React.Fragment key={i}>
+                        <dt>{label}</dt>
+                        <dd>{value}</dd>
+                    </React.Fragment>)}
+                </dl>
+            </div>}
+        </div>
+        </div>
+        }
     </div>;
 };

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -13,7 +13,7 @@ import { PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
 
 import { screenWidthAtMost } from "@opencast/appkit";
 import { COLORS } from "../../color";
-import { CollapsibleDescription } from "../../ui/metadata";
+import { CollapsibleDescription, isValidLink, LICENSE_TRANSLATIONS } from "../../ui/metadata";
 
 import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
 import { ReactNode } from "react";
@@ -120,7 +120,19 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                             color: COLORS.neutral40,
                         },
                     }}>
-                        {values.map((v, i) => <li key={i}>{v}</li>)}
+                        {values.map((v, i) => {
+                            const displayValue = (
+                                label === "builtin:license" && v in LICENSE_TRANSLATIONS
+                            ) ? LICENSE_TRANSLATIONS[v](t) : v;
+
+                            return <li key={i}>
+                                {isValidLink(displayValue)
+                                    ? <Link to={displayValue}>{displayValue}</Link>
+                                    : v
+                                }
+                            </li>;
+                        })
+                        }
                     </ul>
                     : values[0] ?? null;
 
@@ -128,7 +140,6 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
             }
         }
     }
-
 
     return <div css={{ maxWidth: 800 }}>
         {showTitle && <Title title={event.title} />}

--- a/frontend/src/ui/Blocks/Video.tsx
+++ b/frontend/src/ui/Blocks/Video.tsx
@@ -8,22 +8,10 @@ import { useTranslation } from "react-i18next";
 import { isSynced, keyOfId } from "../../util";
 import { Link } from "../../router";
 import { LuCircleArrowRight } from "react-icons/lu";
-import { PlayerContextProvider, usePlayerContext } from "../player/PlayerContext";
-import { PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
-
-import { screenWidthAtMost } from "@opencast/appkit";
-import { COLORS } from "../../color";
-import {
-    CollapsibleDescription,
-    createAutoTimestampProcessor,
-    getMetadataPairs,
-} from "../../ui/metadata";
-
-import { BREAKPOINT_MEDIUM } from "../../GlobalStyle";
-import { ReactNode } from "react";
+import { PlayerContextProvider } from "../player/PlayerContext";
+import { getSeriesLink, PreviewPlaceholder, useEventWithAuthData } from "../../routes/Video";
+import { MetadataSection } from "../../ui/metadata";
 import React from "react";
-
-import { formatDuration } from "../Video";
 
 export type BlockEvent = VideoBlockData$data["event"];
 export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "AuthorizedEvent" }>;
@@ -31,11 +19,12 @@ export type AuthorizedBlockEvent = Extract<BlockEvent, { __typename: "Authorized
 type Props = {
     fragRef: VideoBlockData$key;
     basePath: string;
+    realmPath: string;
     edit?: boolean;
 };
 
-export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
-    const { t, i18n } = useTranslation();
+export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, realmPath, edit }) => {
+    const { t } = useTranslation();
     const { event: protoEvent, showTitle, showLink, showMetadata } = useFragment(graphql`
         fragment VideoBlockData on VideoBlock {
             event {
@@ -85,78 +74,6 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
         return unreachable();
     }
 
-    const pairs: [string, ReactNode][] = getMetadataPairs(event, t, i18n, "inline-bullets");
-
-    if (event.syncedData?.duration && !event.isLive) {
-        pairs.push([
-            t("video.duration"),
-            formatDuration(event.syncedData.duration),
-        ]);
-    }
-
-    const MetadataPanel: React.FC = () => {
-        const { paella } = usePlayerContext();
-        const autoTimestampProcessor = createAutoTimestampProcessor({
-            duration: event.syncedData?.duration,
-            onTimestampClick: timestamp => {
-                paella.current?.player.videoContainer.setCurrentTime(timestamp);
-            },
-        });
-
-        return <div css={{ marginTop: 16 }}>
-            <div css={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 16,
-                "> div": {
-                    backgroundColor: COLORS.neutral10,
-                    borderRadius: 8,
-                    [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
-                        overflowWrap: "anywhere",
-                    },
-                },
-            }}>
-                <CollapsibleDescription
-                    type="video"
-                    description={event.description}
-                    creators={event.creators}
-                    bottomPadding={40}
-                    textProcessor={autoTimestampProcessor}
-                />
-                <div css={{
-                    flex: "1 200px",
-                    alignSelf: "flex-start",
-                    padding: "20px 22px",
-                }}>
-                    <dl css={{
-                        display: "grid",
-                        gridTemplateColumns: "max-content 1fr",
-                        columnGap: 8,
-                        rowGap: 6,
-                        fontSize: 14,
-                        lineHeight: 1.3,
-                        "& > dt::after": {
-                            content: "':'",
-                        },
-                        "& > dd": {
-                            color: COLORS.neutral60,
-                        },
-                        "& > li:not(:last-child)::after": {
-                            content: "'•'",
-                            padding: "0 6px",
-                            color: COLORS.neutral40,
-                        },
-                    }}>
-                        {pairs.map(([label, value], i) => <React.Fragment key={i}>
-                            <dt>{label}</dt>
-                            <dd>{value}</dd>
-                        </React.Fragment>)}
-                    </dl>
-                </div>
-            </div>
-        </div>;
-    };
-
     return <PlayerContextProvider>
         <div css={{ maxWidth: 800 }}>
             {showTitle && <Title title={event.title} />}
@@ -187,7 +104,13 @@ export const VideoBlock: React.FC<Props> = ({ fragRef, basePath, edit }) => {
                 <LuCircleArrowRight size={18} css={{ marginTop: 1 }} />
             </Link>}
 
-            {showMetadata && <MetadataPanel />}
+            {showMetadata && <div css={{ marginTop: 16 }}>
+                <MetadataSection
+                    event={event}
+                    valueStyle="inline-bullets"
+                    seriesLink={getSeriesLink(event.series, realmPath)}
+                />
+            </div>}
         </div>
     </PlayerContextProvider>;
 };

--- a/frontend/src/ui/Blocks/index.tsx
+++ b/frontend/src/ui/Blocks/index.tsx
@@ -86,7 +86,11 @@ export const Block: React.FC<BlockProps> = ({ block: blockRef, realm, edit }) =>
                 realmPath={path}
                 editMode={edit}
             />,
-            "VideoBlock": () => <VideoBlock fragRef={block} {...{ basePath, edit }} />,
+            "VideoBlock": () => <VideoBlock
+                fragRef={block}
+                realmPath={path}
+                {...{ basePath, edit }}
+            />,
             "PlaylistBlock": () => <PlaylistBlockFromBlock
                 fragRef={block}
                 realmPath={path}

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -21,6 +21,7 @@ import { Inertable, OcEntity } from "../util";
 import { PrettyDate } from "./time";
 import { autoLink as makeAutoLink } from "./text";
 import { Link } from "../router";
+import { TFunction } from "i18next";
 
 
 export const TitleLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
@@ -420,4 +421,31 @@ export const SubmitButtonWithStatus: React.FC<SubmitButtonWithStatusProps> = ({
             }} />
         </span>
     </div>;
+};
+
+
+
+export const LICENSE_TRANSLATIONS: Record<string, (t: TFunction) => string> = {
+    "ALLRIGHTS": (t: TFunction) => t("license.all-rights"),
+    "CC-BY": () => "CC BY",
+    "CC-BY-SA": () => "CC BY-SA",
+    "CC-BY-ND": () => "CC BY-ND",
+    "CC-BY-NC": () => "CC BY-NC",
+    "CC-BY-NC-SA": () => "CC BY-NC-SA",
+    "CC-BY-NC-ND": () => "CC BY-NC-ND",
+};
+
+export const isValidLink = (s: string): boolean => {
+    const trimmed = s.trim();
+    if (!(trimmed.startsWith("http://") || trimmed.startsWith("https://"))) {
+        return false;
+    }
+
+    try {
+        new URL(trimmed);
+    } catch (_) {
+        return false;
+    }
+
+    return true;
 };

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -1,4 +1,5 @@
 import {
+    Fragment,
     PropsWithChildren,
     ReactNode,
     forwardRef,
@@ -22,6 +23,10 @@ import { PrettyDate } from "./time";
 import { autoLink as makeAutoLink } from "./text";
 import { Link } from "../router";
 import { TFunction } from "i18next";
+import { i18n as I18n } from "i18next";
+import { match } from "@opencast/appkit";
+import CONFIG, { MetadataLabel } from "../config";
+import { translatedConfig } from "../util";
 
 
 export const TitleLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
@@ -448,4 +453,131 @@ export const isValidLink = (s: string): boolean => {
     }
 
     return true;
+};
+
+export const createAutoTimestampProcessor = (args: {
+    duration?: number;
+    onTimestampClick: (timestamp: number) => void;
+}): ((text: string) => JSX.Element) => {
+    const { duration, onTimestampClick } = args;
+    const timestampRegex = /((?<!\S)(?:\d?\d:)?\d?\d:\d{2}(?!\S))/g;
+
+    return (text: string) => <>{text.split(timestampRegex).map((part, index) => {
+        if (!part.match(timestampRegex)) {
+            return part;
+        }
+
+        const parts = part.split(":").map(Number);
+        const [hours, minutes, seconds] = parts.length === 2 ? [0, ...parts] : parts;
+        const timestamp = ((hours * 60) + minutes) * 60 + seconds;
+        if (duration == null || timestamp * 1000 > duration) {
+            return part;
+        }
+
+        return <ProtoButton
+            key={index}
+            onClick={() => onTimestampClick(timestamp)}
+            css={{
+                color: COLORS.primary0,
+                ":hover": {
+                    color: COLORS.primary1,
+                },
+            }}
+        >{part}</ProtoButton>;
+    })}</>;
+};
+
+type MetadataPairsEvent = {
+    metadata: Record<string, Record<string, string[]>>;
+};
+
+export type MetadataValueStyle = "line-break" | "inline-bullets";
+
+const translateMetadataValue = (
+    label: MetadataLabel,
+    value: string,
+    t: TFunction,
+): ReactNode => {
+    const displayValue = (
+        label === "builtin:license" && value in LICENSE_TRANSLATIONS
+    ) ? LICENSE_TRANSLATIONS[value](t) : value;
+
+    return isValidLink(displayValue)
+        ? <Link to={displayValue}>{displayValue}</Link>
+        : displayValue;
+};
+
+const renderMetadataValues = (
+    values: string[],
+    label: MetadataLabel,
+    t: TFunction,
+    valueStyle: MetadataValueStyle,
+): ReactNode => {
+    if (valueStyle === "line-break") {
+        return values.map((value, i) => <Fragment key={i}>
+            {i > 0 && <br />}
+            {translateMetadataValue(label, value, t)}
+        </Fragment>);
+    }
+
+    return values.length > 1
+        ? <ul css={{
+            listStyle: "none",
+            display: "inline-flex",
+            flexWrap: "wrap",
+            margin: 0,
+            padding: 0,
+            "& > li:not(:last-child)::after": {
+                content: "'•'",
+                padding: "0 6px",
+                color: COLORS.neutral40,
+            },
+        }}>
+            {values.map((value, i) => <li key={i}>{translateMetadataValue(label, value, t)}</li>)}
+        </ul>
+        : translateMetadataValue(label, values[0], t);
+};
+
+export const getMetadataPairs = (
+    event: MetadataPairsEvent,
+    t: TFunction,
+    i18n: I18n,
+    valueStyle: MetadataValueStyle,
+): [string, ReactNode][] => {
+    const pairs: [string, ReactNode][] = [];
+
+    if (event.metadata.dcterms?.language) {
+        const languageNames = new Intl.DisplayNames(i18n.resolvedLanguage, { type: "language" });
+        const languages = event.metadata.dcterms.language.map(lng => languageNames.of(lng) ?? lng);
+
+        pairs.push([
+            t("general.language.language", { count: languages.length }),
+            languages.join(", "),
+        ]);
+    }
+
+    for (const [namespace, fields] of Object.entries(CONFIG.metadataLabels)) {
+        const metadataNs = event.metadata[namespace];
+        if (metadataNs === undefined) {
+            continue;
+        }
+
+        for (const [field, label] of Object.entries(fields)) {
+            if (field in metadataNs) {
+                const translatedLabel = typeof label === "object"
+                    ? translatedConfig(label, i18n)
+                    : match(label, {
+                        "builtin:license": () => t("video.license"),
+                        "builtin:source": () => t("video.source"),
+                    });
+
+                pairs.push([
+                    translatedLabel,
+                    renderMetadataValues(metadataNs[field], label, t, valueStyle),
+                ]);
+            }
+        }
+    }
+
+    return pairs;
 };

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -11,11 +11,13 @@ import {
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { LuCircleCheck, LuCalendar } from "react-icons/lu";
-import { boxError, Button, ProtoButton, Spinner, useColorScheme } from "@opencast/appkit";
+import {
+    boxError, Button, ProtoButton, Spinner, useColorScheme, screenWidthAtMost,
+} from "@opencast/appkit";
 
 import { ellipsisOverflowCss, focusStyle } from ".";
 import { COLORS } from "../color";
-import { Creators } from "./Video";
+import { Creators, formatDuration } from "./Video";
 import { Input, TextArea } from "./Input";
 import { Form } from "./Form";
 import { Inertable, OcEntity } from "../util";
@@ -27,6 +29,8 @@ import { i18n as I18n } from "i18next";
 import { match } from "@opencast/appkit";
 import CONFIG, { MetadataLabel } from "../config";
 import { translatedConfig } from "../util";
+import { BREAKPOINT_MEDIUM } from "../GlobalStyle";
+import { usePlayerContext } from "./player/PlayerContext";
 
 
 export const TitleLabel: React.FC<{ htmlFor: string }> = ({ htmlFor }) => {
@@ -581,3 +585,102 @@ export const getMetadataPairs = (
 
     return pairs;
 };
+
+export type EventWithMetadata = MetadataPairsEvent & {
+    description?: string | null;
+    creators: readonly string[];
+    isLive: boolean;
+    syncedData?: { duration: number } | null;
+};
+
+export type MetadataSectionSeriesLink = {
+    title: string;
+    url: string;
+};
+
+type MetadataSectionProps = {
+    event: EventWithMetadata;
+    valueStyle: MetadataValueStyle;
+    seriesLink?: MetadataSectionSeriesLink;
+};
+
+/**
+ * The description and metadata table of an event, shown side by side. Used on
+ * the video page as well as in the video block, so that both stay visually
+ * and behaviorally consistent.
+ */
+export const MetadataSection: React.FC<MetadataSectionProps> = ({
+    event, valueStyle, seriesLink,
+}) => {
+    const { t, i18n } = useTranslation();
+    const { paella } = usePlayerContext();
+
+    const autoTimestampProcessor = createAutoTimestampProcessor({
+        duration: event.syncedData?.duration,
+        onTimestampClick: timestamp => {
+            paella.current?.player.videoContainer.setCurrentTime(timestamp);
+        },
+    });
+
+    const pairs: [string, ReactNode][] = [];
+    if (seriesLink) {
+        pairs.push([
+            t("video.part-of-series"),
+            <Link key="series" to={seriesLink.url}>{seriesLink.title}</Link>,
+        ]);
+    }
+    pairs.push(...getMetadataPairs(event, t, i18n, valueStyle));
+    if (event.syncedData?.duration && !event.isLive) {
+        pairs.push([t("video.duration"), formatDuration(event.syncedData.duration)]);
+    }
+
+    return (
+        <div css={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 16,
+            "> div": {
+                backgroundColor: COLORS.neutral10,
+                borderRadius: 8,
+                [screenWidthAtMost(BREAKPOINT_MEDIUM)]: {
+                    overflowWrap: "anywhere",
+                },
+            },
+        }}>
+            <CollapsibleDescription
+                type="video"
+                description={event.description}
+                creators={event.creators}
+                bottomPadding={40}
+                textProcessor={autoTimestampProcessor}
+            />
+            <div css={{ flex: "1 200px", alignSelf: "flex-start", padding: "20px 22px" }}>
+                <MetadataList pairs={pairs} />
+            </div>
+        </div>
+    );
+};
+
+export const MetadataList = forwardRef<HTMLDListElement, { pairs: [string, ReactNode][] }>(
+    ({ pairs }, ref) => (
+        <dl ref={ref} css={{
+            display: "grid",
+            gridTemplateColumns: "max-content 1fr",
+            columnGap: 8,
+            rowGap: 6,
+            fontSize: 14,
+            lineHeight: 1.3,
+            "& > dt::after": {
+                content: "':'",
+            },
+            "& > dd": {
+                color: COLORS.neutral60,
+            },
+        }}>
+            {pairs.map(([label, value], i) => <Fragment key={i}>
+                <dt>{label}</dt>
+                <dd>{value}</dd>
+            </Fragment>)}
+        </dl>
+    ),
+);

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -522,24 +522,28 @@ const renderMetadataValues = (
             {i > 0 && <br />}
             {translateMetadataValue(label, value, t)}
         </Fragment>);
+    } else {
+        return values.length > 1
+            ? <ul css={{
+                listStyle: "none",
+                display: "inline-flex",
+                flexWrap: "wrap",
+                margin: 0,
+                padding: 0,
+                "& > li:not(:last-child)::after": {
+                    content: "'•'",
+                    padding: "0 6px",
+                    color: COLORS.neutral40,
+                },
+            }}>
+                {values.map((value, i) => (
+                    <li key={i}>{translateMetadataValue(label, value, t)}</li>
+                ))}
+            </ul>
+            : values.length === 1
+                ? translateMetadataValue(label, values[0], t)
+                : null;
     }
-
-    return values.length > 1
-        ? <ul css={{
-            listStyle: "none",
-            display: "inline-flex",
-            flexWrap: "wrap",
-            margin: 0,
-            padding: 0,
-            "& > li:not(:last-child)::after": {
-                content: "'•'",
-                padding: "0 6px",
-                color: COLORS.neutral40,
-            },
-        }}>
-            {values.map((value, i) => <li key={i}>{translateMetadataValue(label, value, t)}</li>)}
-        </ul>
-        : translateMetadataValue(label, values[0], t);
 };
 
 export const getMetadataPairs = (

--- a/frontend/tests/util/blocks.ts
+++ b/frontend/tests/util/blocks.ts
@@ -15,6 +15,7 @@ export type Block =
         query: string;
         showTitle?: boolean;
         showLink?: boolean;
+        showMetadata?: boolean;
     }
     | {
         type: "series";

--- a/frontend/tests/util/blocks.ts
+++ b/frontend/tests/util/blocks.ts
@@ -77,7 +77,11 @@ export const addBlock = async (page: Page, pos: number, block: Block) => {
             await titleCheckbox.setChecked(block.showTitle ?? true);
             const linkCheckbox = page.getByLabel("Show link to video page");
             await expect(linkCheckbox).toBeChecked();
-            await linkCheckbox.setChecked(block.showTitle ?? true);
+            await linkCheckbox.setChecked(block.showLink ?? true);
+
+            const metadataCheckbox = page.getByLabel("Show description and metadata");
+            await expect(metadataCheckbox).not.toBeChecked();
+            await metadataCheckbox.setChecked(block.showMetadata ?? false);
 
             await saveButton.click();
             break;


### PR DESCRIPTION
This PR introduces the option to display supplemental metadata for embedded videos within the video block.

<img width="2169" height="1041" alt="grafik" src="https://github.com/user-attachments/assets/ce4673ec-d7a2-49eb-9a71-f4a71f64a5d8" />

Without description:
<img width="2169" height="1041" alt="grafik" src="https://github.com/user-attachments/assets/c48de315-42b2-4cab-a2cc-574440b65d83" />
