### PR TITLE
Remove thin grey line in iframe previews

### DIFF
--- a/frontend/src/ui/player/Paella.tsx
+++ b/frontend/src/ui/player/Paella.tsx
@@ -282,6 +282,17 @@ const PaellaPlayer: React.FC<PaellaPlayerProps> = ({ event }) => {
                     containerName: "video-canvas",
                     containerType: "inline-size",
                 },
+                "& .preview-container": {
+                    backgroundColor: "#000 !important",
+                    "div, div img": {
+                        height: "inherit",
+                    },
+                    "div img": {
+                        display: "block",
+                        margin: "0 auto",
+                        width: "unset !important",
+                    },
+                },
                 "@container video-canvas (width < 400px)": {
                     "& .button-area": {
                         padding: "2px !important",

--- a/frontend/src/ui/player/index.tsx
+++ b/frontend/src/ui/player/index.tsx
@@ -156,17 +156,6 @@ export const InlinePlayer: React.FC<PlayerProps> = ({ className, event, ...playe
             "div.video-canvas": {
                 backgroundColor: "#000",
             },
-            "div.preview-container": {
-                backgroundColor: "#000 !important",
-                "div, div img": {
-                    height: "inherit",
-                },
-                "div img": {
-                    display: "block",
-                    margin: "0 auto",
-                    width: "unset !important",
-                },
-            },
             display: "flex",
             flexDirection: "column",
             // We want to be able to see the full header, the video title and some metadata.


### PR DESCRIPTION
Embedded iframes show a thin grey line at the bottom of their preview thumbnail. We already have some custom css overrides to fix that in our inline player, but that wasn't used for the embeds.
So this moves the overrides to a place where they will be used for all player instances, including iframes. Again, this only affects the preview container and shouldn't break anything.