### PR TITLE
Remove `X-Frame-Options deny` header from test deployment

### DIFF
--- a/.deployment/templates/nginx-host.conf
+++ b/.deployment/templates/nginx-host.conf
@@ -17,7 +17,6 @@ server {
 
       proxy_pass http://unix:///opt/tobira/{{ id }}/socket/tobira.sock;
 
-      add_header X-Frame-Options deny always;
       add_header X-Content-Type-Options nosniff always;
       add_header Referrer-Policy no-referrer-when-downgrade always;
       add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains' always;


### PR DESCRIPTION
I added this in https://github.com/elan-ev/tobira/pull/439 but it seems like there is no big reason behind it. A scanner recommended it because it can prevent attacks like clickjacking but for this test deployment it's not important.