### PR TITLE
Add graphql queries for Opencast user provider lookup

### DIFF
--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -65,7 +65,10 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     // First: load labels for roles from the DB. For that we use the `users`
-    // and `known_groups` table.
+    // and `known_groups` table. The join on `users` is case-insensitive
+    // because the casing of usernames (and thus user roles) can change in
+    // Opencast, so an ACL role might not exactly match `users.user_role`.
+    // Failure to find a matching user just means no friendly label; the role still works.
     let (selection, mapping) = select!(
         role: "roles.role",
         actions,
@@ -86,10 +89,11 @@ where
             from raw_roles
             group by role
         )
-        select {selection}
+        select distinct on (roles.role) {selection}
         from roles
-        left join users on users.user_role = role
-        left join known_groups on known_groups.role = roles.role\
+        left join users on lower(users.user_role) = lower(roles.role)
+        left join known_groups on known_groups.role = roles.role
+        order by roles.role, users.username\
     ");
 
     context.db.query_mapped(&sql, params, |row| {

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -2,7 +2,7 @@ use meilisearch_sdk::search::{Selectors, MatchingStrategies};
 
 use crate::{
     api::{err::ApiResult, Context},
-    model::KnownUser,
+    model::{KnownUser, OpencastKnownUser},
     db::util::select,
     prelude::*,
 };
@@ -84,4 +84,84 @@ pub(crate) async fn search_known_users(
     }
 
     Ok(KnownUsersSearchOutcome::Results(SearchResults { items, total_hits, duration: elapsed_time() }))
+}
+
+/// Looks up a single known user by exact username.
+pub(crate) async fn lookup_known_user(
+    username: String,
+    context: &Context,
+) -> ApiResult<Option<OpencastKnownUser>> {
+    if !context.auth.is_admin(&context.config.auth) {
+        return Err(context.not_logged_in_error());
+    }
+
+    let (selection, mapping) = select!(username, display_name, email, user_role);
+    let query = format!("select {selection} from users where lower(username) = $1 limit 1");
+    let users = context.db.query_mapped(&query, dbargs![&username.to_lowercase()], |row| {
+        OpencastKnownUser {
+            username: mapping.username.of(&row),
+            display_name: mapping.display_name.of(&row),
+            email: mapping.email.of(&row),
+            user_role: mapping.user_role.of(&row),
+        }
+    }).await?;
+
+    Ok(users.into_iter().next())
+}
+
+/// Searches for known users by partial match on username, display name, email, or user role.
+///
+/// Passing `None` (or an empty string) for `query` returns all users, paginated by `limit`
+/// and `offset`. Results are ordered by `username` for stable pagination.
+pub(crate) async fn find_known_users_for_opencast(
+    query: Option<String>,
+    limit: i32,
+    offset: i32,
+    context: &Context,
+) -> ApiResult<Vec<OpencastKnownUser>> {
+    if !context.auth.is_admin(&context.config.auth) {
+        return Err(context.not_logged_in_error());
+    }
+
+    let limit = (limit as i64).clamp(1, 1000);
+    let offset = (offset as i64).max(0);
+
+    // An empty/missing query means "no filter": return all users.
+    let filter = query.as_deref().filter(|q| !q.is_empty());
+
+    let (selection, mapping) = select!(username, display_name, email, user_role);
+    let map_row = |row| OpencastKnownUser {
+        username: mapping.username.of(&row),
+        display_name: mapping.display_name.of(&row),
+        email: mapping.email.of(&row),
+        user_role: mapping.user_role.of(&row),
+    };
+
+    match filter {
+        Some(q) => {
+            let escaped = q.to_lowercase()
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
+            let like_pattern = format!("%{}%", escaped);
+            let sql = format!("select {selection} from users \
+                where lower(username) like $1 \
+                    or lower(display_name) like $1 \
+                    or lower(email) like $1 \
+                    or lower(user_role) like $1 \
+                order by lower(username), username \
+                limit $2 offset $3"
+            );
+            context.db.query_mapped(&sql, dbargs![&like_pattern, &limit, &offset], map_row)
+                .await.map_err(Into::into)
+        }
+        None => {
+            let sql = format!("select {selection} from users \
+                order by lower(username), username \
+                limit $1 offset $2"
+            );
+            context.db.query_mapped(&sql, dbargs![&limit, &offset], map_row)
+                .await.map_err(Into::into)
+        }
+    }
 }

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -3,7 +3,7 @@ use juniper::graphql_object;
 
 use crate::{
     auth::{AuthState, User},
-    model::{OpencastId, KnownGroup},
+    model::{OpencastId, KnownGroup, OpencastKnownUser},
 };
 
 use super::{
@@ -199,6 +199,32 @@ impl Query {
     /// Returns all known groups selectable in the ACL UI.
     async fn known_groups(context: &Context) -> ApiResult<Vec<KnownGroup>> {
         KnownGroup::load_all(context).await.map_err(Into::into)
+    }
+
+    /// Looks up a single known user by exact username.
+    /// Returns username, display name, email, and user role.
+    async fn known_user_by_username(
+        username: String,
+        context: &Context,
+    ) -> ApiResult<Option<OpencastKnownUser>> {
+        known_roles::lookup_known_user(username, context).await
+    }
+
+    /// Searches for known users by partial match on username, display name,
+    /// email, or user role. Returns username, display name, email, and user
+    /// role.
+    ///
+    /// `query` may be `null` or an empty string, in which case all users are
+    /// returned (paginated). `limit` is clamped to `[1, 1000]`. `offset` is
+    /// clamped to be non-negative. Results are ordered by username so that
+    /// pagination via `limit`/`offset` is stable.
+    async fn find_known_users(
+        query: Option<String>,
+        limit: i32,
+        offset: i32,
+        context: &Context,
+    ) -> ApiResult<Vec<OpencastKnownUser>> {
+        known_roles::find_known_users_for_opencast(query, limit, offset, context).await
     }
 
     /// Returns information for the admin dashboard.

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -51,3 +51,13 @@ pub(crate) struct KnownUser {
     pub display_name: String,
     pub user_role: String,
 }
+
+/// User information exposed to Opencast.
+/// Unlike `KnownUser`, this includes username and email.
+#[derive(juniper::GraphQLObject)]
+pub(crate) struct OpencastKnownUser {
+    pub username: String,
+    pub display_name: String,
+    pub email: Option<String>,
+    pub user_role: String,
+}

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use self::{
     },
     extra_metadata::ExtraMetadata,
     key::Key,
-    known_roles::{KnownGroup, KnownUser},
+    known_roles::{KnownGroup, KnownUser, OpencastKnownUser},
     misc::ByteSpan,
     series::SeriesState,
     translated_string::{LangKey, TranslatedString},

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -717,6 +717,17 @@ type NotAllowed {
   dummy: Boolean
 }
 
+"""
+  User information exposed to Opencast.
+  Unlike `KnownUser`, this includes username and email.
+"""
+type OpencastKnownUser {
+  username: String!
+  displayName: String!
+  email: String
+  userRole: String!
+}
+
 type PageInfo {
   hasNextPage: Boolean!
   hasPrevPage: Boolean!
@@ -836,6 +847,22 @@ type Query {
   searchKnownUsers(query: String!): KnownUsersSearchOutcome!
   "Returns all known groups selectable in the ACL UI."
   knownGroups: [KnownGroup!]!
+  """
+    Looks up a single known user by exact username.
+    Returns username, display name, email, and user role.
+  """
+  knownUserByUsername(username: String!): OpencastKnownUser
+  """
+    Searches for known users by partial match on username, display name,
+    email, or user role. Returns username, display name, email, and user
+    role.
+
+    `query` may be `null` or an empty string, in which case all users are
+    returned (paginated). `limit` is clamped to `[1, 1000]`. `offset` is
+    clamped to be non-negative. Results are ordered by username so that
+    pagination via `limit`/`offset` is stable.
+  """
+  findKnownUsers(query: String, limit: Int!, offset: Int!): [OpencastKnownUser!]!
   "Returns information for the admin dashboard."
   adminDashboardInfo: AdminInfo
 }


### PR DESCRIPTION
This adds `knownUserByUsername` and `findKnownUsers` queries that expose username, display name, email, and user role for external application(s). They can be used in the admin UI to display and add user roles that are only known in Tobira to ACLs in Opencast.

Also added is a case-insensitive role label resolution since Opencast changes username casing of roles. This avoids situations where OC queries a role like `ROLE_ROLO_TONY` from Tobira and transforms it to `ROLE_rolo_tony` when writing it to an ACL, which in turn would end up in Tobira as `rolo tony (unknown)`.

Closes https://github.com/elan-ev/tobira/issues/1700 (when combined with https://github.com/opencast/opencast/pull/7629 in Opencast) 