### PR TITLE
Add part of series and playlists sections to video details

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 use super::{
-    playlist::VideoListEntry,
+    playlist::{AuthorizedPlaylist, Playlist, VideoListEntry},
     shared::{
         define_sort_column_and_order,
         load_writable_for_user,
@@ -366,6 +366,21 @@ impl AuthorizedEvent {
         }
     }
 
+    async fn referencing_playlists(&self, context: &Context) -> ApiResult<Vec<Playlist>> {
+        let selection = AuthorizedPlaylist::select();
+        let query = format!("select {selection} from playlists where array[$1] <@ event_entry_ids(entries)");
+        let playlists = context.db.query_mapped(&query, &[&self.opencast_id], |row| {
+            let playlist = AuthorizedPlaylist::from_row_start(&row);
+            if context.auth.overlaps_roles(&playlist.read_roles) {
+                Playlist::Playlist(playlist)
+            } else {
+                Playlist::NotAllowed(NotAllowed)
+            }
+        }).await?;
+
+        Ok(playlists.into_iter().collect())
+    }
+
     /// Returns a list of realms where this event is referenced (via some kind of block).
     async fn host_realms(&self, context: &Context) -> ApiResult<Vec<Realm>> {
         let selection = Realm::select();
@@ -383,7 +398,6 @@ impl AuthorizedEvent {
             |row| Realm::from_row_start(&row)
         ).await?.pipe(Ok)
     }
-
 
     /// Whether this event is password protected.
     async fn has_password(&self) -> bool {

--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -56,7 +56,7 @@ pub(crate) struct AuthorizedPlaylist {
     num_entries: LazyLoad<u32>,
     thumbnail_stack: LazyLoad<ThumbnailStack>,
 
-    read_roles: Vec<String>,
+    pub(crate) read_roles: Vec<String>,
     write_roles: Vec<String>,
 }
 

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -139,6 +139,8 @@ video:
   duration: Abspielzeit
   details: Videodetails
   part-of-series: Teil der Serie
+  part-of-playlists: Teil der Playlists
+  private-playlist: Private Playlist
   more-from-series: Mehr von „{{series}}“
   more-from-playlist: Mehr von „{{playlist}}”
   deleted-block: Das hier referenzierte Video wurde gelöscht.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -137,6 +137,8 @@ video:
   duration: Duration
   details: Video details
   part-of-series: Part of series
+  part-of-playlists: Part of playlists
+  private-playlist: Private playlist
   more-from-series: More from “{{series}}”
   more-from-playlist: More from “{{playlist}}”
   deleted-block: The video referenced here was deleted.

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -142,6 +142,8 @@ video:
   duration: Durée de lecture
   details: Détails de la vidéo
   part-of-series: Partie de la série
+  part-of-playlists: Partie des playlist # verify
+  private-playlist: Playlist privée # verify
   more-from-series: Plus de « {{series}} »
   more-from-playlist: Plus de « {{playlist}} »
   deleted-block: La vidéo mentionnée ici a été supprimée.

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -138,6 +138,8 @@ video:
   duration: Durata
   details: Dettagli video
   part-of-series: Parte della serie
+  part-of-playlists: Parte delle playlist # verify
+  private-playlist: Playlist privata # verify
   more-from-series: Altro da "{{series}}“
   more-from-playlist: Altro da "{{playlist}}”
   deleted-block: Il video a cui si fa riferimento è stato cancellato.

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -114,6 +114,14 @@ const query = graphql`
                     opencastId
                     ...SeriesBlockSeriesData
                 }
+                referencingPlaylists {
+                    __typename
+                    ... on AuthorizedPlaylist {
+                        id
+                        title
+                    }
+                    ... on NotAllowed { dummy }
+                }
                 hostRealms { id isMainRoot name path }
             }
         }

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -10,6 +10,7 @@ import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
 import { Inertable, isSynced, translatedConfig } from "../../../util";
 import { DirectVideoRoute, VideoRoute, VideoShareButton } from "../../Video";
+import { DirectSeriesRoute } from "../../Series";
 import { ManageVideosRoute } from ".";
 import CONFIG from "../../../config";
 import {
@@ -43,6 +44,7 @@ export const ManageVideoDetailsRoute = makeManageVideoRoute(
             }} />,
             <VideoButtonSection key="button-section" event={authEvent} />,
             <VideoMetadataSection key="metadata" event={event} />,
+            <VideoSeriesSection key="series" event={event} />,
             <div key="host-realms" css={{ marginBottom: 32 }}>
                 <HostRealms kind="video" hostRealms={authEvent.hostRealms} itemLink={realmPath => (
                     <Link to={VideoRoute.url({ realmPath: realmPath, videoID: authEvent.id })}>
@@ -121,6 +123,24 @@ const VideoButtonSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
             commit={commit}
         />
     </ButtonSection>;
+};
+
+const VideoSeriesSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => {
+    const { t } = useTranslation();
+    if (!event.series) {
+        return null;
+    }
+
+    return <div css={{ marginBottom: 32 }}>
+        <h2 css={{ fontSize: 20, marginBottom: 16 }}>
+            {t("video.part-of-series")}
+        </h2>
+        <span css={{ marginLeft: 40 }}>
+            <Link to={DirectSeriesRoute.url({ seriesId: event.series.id })}>
+                {event.series.title}
+            </Link>
+        </span>
+    </div>;
 };
 
 const VideoMetadataSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => {

--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -10,6 +10,7 @@ import { AuthorizedEvent, makeManageVideoRoute } from "./Shared";
 import { ExternalLink } from "../../../relay/auth";
 import { Inertable, isSynced, translatedConfig } from "../../../util";
 import { DirectVideoRoute, VideoRoute, VideoShareButton } from "../../Video";
+import { DirectPlaylistRoute } from "../../Playlist";
 import { DirectSeriesRoute } from "../../Series";
 import { ManageVideosRoute } from ".";
 import CONFIG from "../../../config";
@@ -45,6 +46,7 @@ export const ManageVideoDetailsRoute = makeManageVideoRoute(
             <VideoButtonSection key="button-section" event={authEvent} />,
             <VideoMetadataSection key="metadata" event={event} />,
             <VideoSeriesSection key="series" event={event} />,
+            <VideoPlaylistSection key="playlists" event={event} />,
             <div key="host-realms" css={{ marginBottom: 32 }}>
                 <HostRealms kind="video" hostRealms={authEvent.hostRealms} itemLink={realmPath => (
                     <Link to={VideoRoute.url({ realmPath: realmPath, videoID: authEvent.id })}>
@@ -140,6 +142,35 @@ const VideoSeriesSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
                 {event.series.title}
             </Link>
         </span>
+    </div>;
+};
+
+const VideoPlaylistSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => {
+    const { t } = useTranslation();
+    if (!event.referencingPlaylists || event.referencingPlaylists.length === 0) {
+        return null;
+    }
+
+    return <div css={{ marginBottom: 32 }}>
+        <h2 css={{ fontSize: 20 }}>
+            {t("video.part-of-playlists")}
+        </h2>
+        <ul>
+            {event.referencingPlaylists.map((playlist, index) => (
+                <li key={playlist.__typename === "AuthorizedPlaylist"
+                    ? playlist.id
+                    : `private-${index}`
+                }>
+                    {playlist.__typename === "AuthorizedPlaylist" ? (
+                        <Link to={DirectPlaylistRoute.url({ playlistId: playlist.id })}>
+                            {playlist.title}
+                        </Link>
+                    ) : (
+                        <span>{t("video.private-playlist")}</span>
+                    )}
+                </li>
+            ))}
+        </ul>
     </div>;
 };
 

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -415,6 +415,7 @@ type AuthorizedEvent implements Node {
   "Whether the event has active workflows."
   workflowStatus: WorkflowStatus!
   series: Series
+  referencingPlaylists: [Playlist!]!
   "Returns a list of realms where this event is referenced (via some kind of block)."
   hostRealms: [Realm!]!
   "Whether this event is password protected."


### PR DESCRIPTION
The links reference the respective direct link of the series and playlists. It would be possible to make those contextual (i.e. pointing at the mounting point of a series or playlist (I don't think playlists have mounting points though, not sure right now)). In any case that would only make sense if there is a singular mounting point.
Using the direct link seems fine to me at any rate.

This is more of an interim solution anyway as it is planned to overhaul these details pages at some point (see https://github.com/elan-ev/tobira/issues/1392). So this also doesn't include the editing of the series field, which is a larger task and should be done in a separate PR.

Closes https://github.com/elan-ev/tobira/issues/1591