### PR TITLE
Support basic markdown in footer

### DIFF
--- a/.deployment/templates/config.toml
+++ b/.deployment/templates/config.toml
@@ -3,6 +3,18 @@ site_title.default = "Tobira Test Deployment"
 tobira_url = "https://{% if id != 'main' %}{{id}}.{% endif %}tobira.opencast.org"
 users_searchable = true
 
+footer_markdown.default = """
+Asbestos-free since 2023
+
+Found a bug? Report it [here](https://github.com/elan-ev/tobira/issues). *Thanks!*
+"""
+
+footer_markdown.de = """
+Asbest-frei seit zwanzig-zwanzig-drei
+
+Einen Bug gefunden? Melde ihn [hier](https://github.com/elan-ev/tobira/issues). *Danke!*
+"""
+
 [general.metadata]
 dcterms.source = "builtin:source"
 dcterms.license = "builtin:license"

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -50,6 +50,7 @@ pub(crate) struct GeneralConfig {
     /// be specified with only the shown string. To add custom ones, you need
     /// to define a label and a link. The link is either the same for every language
     /// or can be specified for each language in the same manner as the label.
+    /// To leave this empty and only use the markdown footer below, set this to `[]`.
     /// Example:
     ///
     /// ```
@@ -59,11 +60,16 @@ pub(crate) struct GeneralConfig {
     ///     "about",
     /// ]
     /// ```
+    ///
+    /// Example (empty):
+    ///
+    /// ```
+    /// footer_links = []
+    /// ```
     #[config(default = ["about", "graphiql"])]
     pub footer_links: Vec<FooterLink>,
 
-    /// Optional markdown footer content. If set, this markdown is rendered
-    /// instead of the inline footer links.
+    /// Optional markdown footer content. Will be rendered below the footer links or on its own.
     ///
     /// Example:
     ///

--- a/backend/src/config/general.rs
+++ b/backend/src/config/general.rs
@@ -62,6 +62,36 @@ pub(crate) struct GeneralConfig {
     #[config(default = ["about", "graphiql"])]
     pub footer_links: Vec<FooterLink>,
 
+    /// Optional markdown footer content. If set, this markdown is rendered
+    /// instead of the inline footer links.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// footer_markdown.default = """
+    /// Tobira is the university video portal for recorded lectures,
+    /// seminars, and academic events.
+    ///
+    /// This footer supports markdown, so you can add links and formatting:
+    ///
+    /// - [Support](https://example.edu/support)
+    /// - [Contact](mailto:help@example.edu)
+    /// - **Important:** Only authorized users may access this portal.
+    /// """
+    /// ```
+    ///
+    /// Example with translated markdown:
+    ///
+    /// ```
+    /// footer_markdown.default = """
+    /// Tobira is the university video portal.
+    /// """
+    /// footer_markdown.de = """
+    /// Tobira ist das universitäre Portal für Videoaufzeichnungen.
+    /// """
+    /// ```
+    pub footer_markdown: Option<TranslatedString>,
+
     /// Additional metadata that is shown below a video. Example:
     ///
     ///     [general.metadata]

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -345,6 +345,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         "lockAclToSeries": config.general.lock_acl_to_series,
         "allowSeriesEventRemoval": config.general.allow_series_event_removal,
         "footerLinks": config.general.footer_links,
+        "footerMarkdown": config.general.footer_markdown,
         "metadataLabels": config.general.metadata,
         "paellaPluginConfig": config.player.paella_plugin_config,
         "paellaSettingsIcon": PAELLA_SETTINGS_ICON,

--- a/backend/src/http/assets.rs
+++ b/backend/src/http/assets.rs
@@ -345,6 +345,7 @@ fn frontend_config(config: &Config) -> serde_json::Value {
         "usersSearchable": config.general.users_searchable,
         "lockAclToSeries": config.general.lock_acl_to_series,
         "footerLinks": config.general.footer_links,
+        "footerMarkdown": config.general.footer_markdown,
         "metadataLabels": config.general.metadata,
         "paellaPluginConfig": config.player.paella_plugin_config,
         "paellaSettingsIcon": PAELLA_SETTINGS_ICON,

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -64,6 +64,7 @@
 # be specified with only the shown string. To add custom ones, you need
 # to define a label and a link. The link is either the same for every language
 # or can be specified for each language in the same manner as the label.
+# To leave this empty and only use the markdown footer below, set this to `[]`.
 # Example:
 #
 # ```
@@ -74,11 +75,16 @@
 # ]
 # ```
 #
+# Example (empty):
+#
+# ```
+# footer_links = []
+# ```
+#
 # Default value: ["about", "graphiql"]
 #footer_links = ["about", "graphiql"]
 
-# Optional markdown footer content. If set, this markdown is rendered
-# instead of the inline footer links.
+# Optional markdown footer content. Will be rendered below the footer links or on its own.
 #
 # Example:
 #

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -77,6 +77,36 @@
 # Default value: ["about", "graphiql"]
 #footer_links = ["about", "graphiql"]
 
+# Optional markdown footer content. If set, this markdown is rendered
+# instead of the inline footer links.
+#
+# Example:
+#
+# ```
+# footer_markdown.default = """
+# Tobira is the university video portal for recorded lectures,
+# seminars, and academic events.
+#
+# This footer supports markdown, so you can add links and formatting:
+#
+# - [Support](https://example.edu/support)
+# - [Contact](mailto:help@example.edu)
+# - **Important:** Only authorized users may access this portal.
+# """
+# ```
+#
+# Example with translated markdown:
+#
+# ```
+# footer_markdown.default = """
+# Tobira is the university video portal.
+# """
+# footer_markdown.de = """
+# Tobira ist das universitäre Portal für Videoaufzeichnungen.
+# """
+# ```
+#footer_markdown =
+
 # Additional metadata that is shown below a video. Example:
 #
 #     [general.metadata]

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -37,6 +37,7 @@ type Config = {
     },
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
+    footerMarkdown: TranslatedString | null;
     metadataLabels: Record<string, Record<string, MetadataLabel>>;
     paellaSettingsIcon: string;
     paellaThemeJson: string;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -38,6 +38,7 @@ type Config = {
     };
     opencast: OpencastConfig;
     footerLinks: FooterLink[];
+    footerMarkdown: TranslatedString | null;
     metadataLabels: Record<string, Record<string, MetadataLabel>>;
     paellaSettingsIcon: string;
     paellaThemeJson: string;

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -1,13 +1,19 @@
 import { useTranslation } from "react-i18next";
+
 import CONFIG from "../config";
 import { Link } from "../router";
 import { translatedConfig } from "../util";
 import { COLORS } from "../color";
+import { RenderMarkdown } from "../ui/Blocks/Text";
 import { AboutRoute } from "../routes/About";
 
 
 export const Footer: React.FC = () => {
     const { t, i18n } = useTranslation();
+
+    const markdownText = CONFIG.footerMarkdown
+        ? translatedConfig(CONFIG.footerMarkdown, i18n)
+        : null;
 
     return (
         <footer css={{
@@ -16,47 +22,66 @@ export const Footer: React.FC = () => {
             fontSize: 14,
             textAlign: "center",
         }}>
-            <ul css={{
-                listStyle: "none",
-                margin: 0,
-                padding: 0,
-                display: "flex",
-                justifyContent: "center",
-                flexWrap: "wrap",
-                "& > li": {
-                    "&:not(:first-child):before": {
-                        content: "\"•\"",
-                        color: COLORS.neutral60,
-                        margin: "0 12px",
+            {markdownText ? (
+                <div css={{
+                    margin: "0 auto",
+                    maxWidth: 800,
+                    color: COLORS.neutral80,
+                    textAlign: "center",
+                    p: {
+                        margin: "4px 0",
                     },
-                    a: {
-                        borderRadius: 4,
-                        outlineOffset: 1,
+                    ul: {
+                        listStyleType: "none",
+                        margin: "0 auto",
+                        padding: 0,
                     },
-                },
-            }}>
-                {CONFIG.footerLinks.map((entry, i) => {
-                    if (entry === "about") {
-                        return <li key={i}>
-                            <Link to={AboutRoute.url}>{t("about-tobira.title")}</Link>
-                        </li>;
-                    } else if (entry === "graphiql") {
-                        return <li key={i}>
-                            <Link to="/~graphiql" htmlLink>Graph<em>i</em>QL</Link>
-                        </li>;
-                    } else {
-                        return <li key={i}>
-                            <Link to={
-                                typeof entry.link === "string"
-                                    ? entry.link
-                                    : translatedConfig(entry.link, i18n)
-                            }>
-                                {translatedConfig(entry.label, i18n)}
-                            </Link>
-                        </li>;
-                    }
-                })}
-            </ul>
+                }}>
+                    <RenderMarkdown>{markdownText}</RenderMarkdown>
+                </div>
+            ) : (
+                <ul css={{
+                    listStyle: "none",
+                    margin: 0,
+                    padding: 0,
+                    display: "flex",
+                    justifyContent: "center",
+                    flexWrap: "wrap",
+                    "& > li": {
+                        "&:not(:first-child):before": {
+                            content: "\"•\"",
+                            color: COLORS.neutral60,
+                            margin: "0 12px",
+                        },
+                        a: {
+                            borderRadius: 4,
+                            outlineOffset: 1,
+                        },
+                    },
+                }}>
+                    {CONFIG.footerLinks.map((entry, i) => {
+                        if (entry === "about") {
+                            return <li key={i}>
+                                <Link to={AboutRoute.url}>{t("about-tobira.title")}</Link>
+                            </li>;
+                        } else if (entry === "graphiql") {
+                            return <li key={i}>
+                                <Link to="/~graphiql" htmlLink>Graph<em>i</em>QL</Link>
+                            </li>;
+                        } else {
+                            return <li key={i}>
+                                <Link to={
+                                    typeof entry.link === "string"
+                                        ? entry.link
+                                        : translatedConfig(entry.link, i18n)
+                                }>
+                                    {translatedConfig(entry.label, i18n)}
+                                </Link>
+                            </li>;
+                        }
+                    })}
+                </ul>
+            )}
         </footer>
     );
 };

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -22,65 +22,65 @@ export const Footer: React.FC = () => {
             fontSize: 14,
             textAlign: "center",
         }}>
-            {markdownText ? (
+            <ul css={{
+                listStyle: "none",
+                margin: 0,
+                padding: 0,
+                display: "flex",
+                justifyContent: "center",
+                flexWrap: "wrap",
+                "& > li": {
+                    "&:not(:first-child):before": {
+                        content: "\"•\"",
+                        color: COLORS.neutral60,
+                        margin: "0 12px",
+                    },
+                    a: {
+                        borderRadius: 4,
+                        outlineOffset: 1,
+                    },
+                },
+            }}>
+                {CONFIG.footerLinks.map((entry, i) => {
+                    if (entry === "about") {
+                        return <li key={i}>
+                            <Link to={AboutRoute.url}>{t("about-tobira.title")}</Link>
+                        </li>;
+                    } else if (entry === "graphiql") {
+                        return <li key={i}>
+                            <Link to="/~graphiql" htmlLink>Graph<em>i</em>QL</Link>
+                        </li>;
+                    } else {
+                        return <li key={i}>
+                            <Link to={
+                                typeof entry.link === "string"
+                                    ? entry.link
+                                    : translatedConfig(entry.link, i18n)
+                            }>
+                                {translatedConfig(entry.label, i18n)}
+                            </Link>
+                        </li>;
+                    }
+                })}
+            </ul>
+            {markdownText && (
                 <div css={{
                     margin: "0 auto",
+                    marginTop: CONFIG.footerLinks.length > 0 ? 10 : 0,
                     maxWidth: 800,
                     color: COLORS.neutral80,
                     textAlign: "center",
                     p: {
-                        margin: "4px 0",
+                        margin: 0,
                     },
                     ul: {
                         listStyleType: "none",
                         margin: "0 auto",
-                        padding: 0,
+                        padding: 2,
                     },
                 }}>
                     <RenderMarkdown>{markdownText}</RenderMarkdown>
                 </div>
-            ) : (
-                <ul css={{
-                    listStyle: "none",
-                    margin: 0,
-                    padding: 0,
-                    display: "flex",
-                    justifyContent: "center",
-                    flexWrap: "wrap",
-                    "& > li": {
-                        "&:not(:first-child):before": {
-                            content: "\"•\"",
-                            color: COLORS.neutral60,
-                            margin: "0 12px",
-                        },
-                        a: {
-                            borderRadius: 4,
-                            outlineOffset: 1,
-                        },
-                    },
-                }}>
-                    {CONFIG.footerLinks.map((entry, i) => {
-                        if (entry === "about") {
-                            return <li key={i}>
-                                <Link to={AboutRoute.url}>{t("about-tobira.title")}</Link>
-                            </li>;
-                        } else if (entry === "graphiql") {
-                            return <li key={i}>
-                                <Link to="/~graphiql" htmlLink>Graph<em>i</em>QL</Link>
-                            </li>;
-                        } else {
-                            return <li key={i}>
-                                <Link to={
-                                    typeof entry.link === "string"
-                                        ? entry.link
-                                        : translatedConfig(entry.link, i18n)
-                                }>
-                                    {translatedConfig(entry.label, i18n)}
-                                </Link>
-                            </li>;
-                        }
-                    })}
-                </ul>
             )}
         </footer>
     );

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -15,9 +15,9 @@ export const Footer: React.FC = () => {
         ? translatedConfig(CONFIG.footerMarkdown, i18n)
         : null;
 
-    return (
+    return <>
+        <div css={{ margin: 0, height: 2, backgroundColor: COLORS.neutral15 }} />
         <footer css={{
-            backgroundColor: COLORS.neutral10,
             padding: 16,
             fontSize: 14,
             textAlign: "center",
@@ -83,5 +83,5 @@ export const Footer: React.FC = () => {
                 </div>
             )}
         </footer>
-    );
+    </>;
 };

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -16,7 +16,7 @@ export const Footer: React.FC = () => {
         : null;
 
     return <>
-        <div css={{ margin: 0, height: 2, backgroundColor: COLORS.neutral15 }} />
+        <div css={{ margin: 0, height: 1, backgroundColor: COLORS.neutral15 }} />
         <footer css={{
             padding: 16,
             fontSize: 14,

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -19,7 +19,6 @@ export const Footer: React.FC = () => {
         <footer css={{
             padding: 16,
             fontSize: 14,
-            textAlign: "center",
             borderTop: `1px solid ${COLORS.neutral15}`,
         }}>
             {CONFIG.footerLinks.length > 0 && (
@@ -71,15 +70,10 @@ export const Footer: React.FC = () => {
                     marginTop: CONFIG.footerLinks.length > 0 ? 10 : 0,
                     maxWidth: 800,
                     color: COLORS.neutral80,
-                    textAlign: "center",
-                    p: {
-                        margin: 0,
-                    },
-                    ul: {
-                        listStyleType: "none",
-                        margin: "0 auto",
-                        padding: 2,
-                    },
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    alignItems: "center",
                 }}>
                     <RenderMarkdown>{markdownText}</RenderMarkdown>
                 </div>

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -22,24 +22,7 @@ export const Footer: React.FC = () => {
             fontSize: 14,
             textAlign: "center",
         }}>
-            {markdownText ? (
-                <div css={{
-                    margin: "0 auto",
-                    maxWidth: 800,
-                    color: COLORS.neutral80,
-                    textAlign: "center",
-                    p: {
-                        margin: "4px 0",
-                    },
-                    ul: {
-                        listStyleType: "none",
-                        margin: "0 auto",
-                        padding: 0,
-                    },
-                }}>
-                    <RenderMarkdown>{markdownText}</RenderMarkdown>
-                </div>
-            ) : (
+            {CONFIG.footerLinks.length > 0 && (
                 <ul css={{
                     listStyle: "none",
                     margin: 0,
@@ -81,6 +64,25 @@ export const Footer: React.FC = () => {
                         }
                     })}
                 </ul>
+            )}
+            {markdownText && (
+                <div css={{
+                    margin: "0 auto",
+                    marginTop: CONFIG.footerLinks.length > 0 ? 10 : 0,
+                    maxWidth: 800,
+                    color: COLORS.neutral80,
+                    textAlign: "center",
+                    p: {
+                        margin: 0,
+                    },
+                    ul: {
+                        listStyleType: "none",
+                        margin: "0 auto",
+                        padding: 2,
+                    },
+                }}>
+                    <RenderMarkdown>{markdownText}</RenderMarkdown>
+                </div>
             )}
         </footer>
     );

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -16,11 +16,11 @@ export const Footer: React.FC = () => {
         : null;
 
     return <>
-        <div css={{ margin: 0, height: 2, backgroundColor: COLORS.neutral15 }} />
         <footer css={{
             padding: 16,
             fontSize: 14,
             textAlign: "center",
+            borderTop: `1px solid ${COLORS.neutral15}`,
         }}>
             {CONFIG.footerLinks.length > 0 && (
                 <ul css={{

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -15,9 +15,9 @@ export const Footer: React.FC = () => {
         ? translatedConfig(CONFIG.footerMarkdown, i18n)
         : null;
 
-    return (
+    return <>
+        <div css={{ margin: 0, height: 2, backgroundColor: COLORS.neutral15 }} />
         <footer css={{
-            backgroundColor: COLORS.neutral10,
             padding: 16,
             fontSize: 14,
             textAlign: "center",
@@ -85,5 +85,5 @@ export const Footer: React.FC = () => {
                 </div>
             )}
         </footer>
-    );
+    </>;
 };


### PR DESCRIPTION
This keeps the previous footer config ~~, rebranding it as `footer_links.~~ which is rendered inline, divided by a bullet point. So just like before.

Added is `footer_markdown`, which will be shown below the `footer_links` if both are configured or on its own if `footer_links` in set to `[]`. This new config allows basic markdown, using the same component we use to render the text block markdown. So people can relatively freely configure their footer using links, lists and other markdown like formatting.

Note that this does not support a column like layout yet but will always be a single centered block.

Closes #1556