### PR TITLE
Display series link as list item

### DIFF
--- a/frontend/src/routes/manage/Video/VideoDetails.tsx
+++ b/frontend/src/routes/manage/Video/VideoDetails.tsx
@@ -137,7 +137,11 @@ const VideoSeriesSection: React.FC<{ event: AuthorizedEvent }> = ({ event }) => 
         <h2 css={{ fontSize: 20, marginBottom: 16 }}>
             {t("video.part-of-series")}
         </h2>
-        <span css={{ marginLeft: 40 }}>
+        <span css={{
+            display: "list-item",
+            listStyleType: "disc",
+            marginLeft: 40,
+        }}>
             <Link to={DirectSeriesRoute.url({ seriesId: event.series.id })}>
                 {event.series.title}
             </Link>


### PR DESCRIPTION
Following the discussion in #1591, this adds back the bullet point for the single "part of series" entry.