### PR TITLE
Add pagination to video list blocks

### DIFF
--- a/frontend/src/routes/Playlist.tsx
+++ b/frontend/src/routes/Playlist.tsx
@@ -239,7 +239,7 @@ const fragment = graphql`
             description
             entries {
                 __typename
-                ...on AuthorizedEvent { id, ...VideoListEventData }
+                ...on AuthorizedEvent { ...VideoListEventData @arguments(includeSeries: true) }
                 ...on Missing { dummy }
                 ...on NotAllowed { dummy }
             }

--- a/frontend/src/routes/manage/Shared/Table.tsx
+++ b/frontend/src/routes/manage/Shared/Table.tsx
@@ -20,8 +20,6 @@ import { useTranslation } from "react-i18next";
 import {
     LuArrowDownNarrowWide,
     LuArrowUpWideNarrow,
-    LuChevronLeft,
-    LuChevronRight,
     LuCornerUpRight,
     LuX,
 } from "react-icons/lu";
@@ -29,8 +27,6 @@ import { IconType } from "react-icons";
 import { css } from "@emotion/react";
 import { LucideFunnel } from "lucide-react";
 
-import FirstPage from "../../../icons/first-page.svg";
-import LastPage from "../../../icons/last-page.svg";
 import { PrettyDate, prettyDate } from "../../../ui/time";
 import { ellipsisOverflowCss, focusStyle, IconWithTooltip } from "../../../ui";
 import CONFIG from "../../../config";
@@ -51,6 +47,11 @@ import { BREAKPOINT_MEDIUM, BREAKPOINT_SMALL } from "../../../GlobalStyle";
 import { FloatingBaseMenu } from "../../../ui/FloatingBaseMenu";
 import { MenuItem } from "../../../ui/Blocks/VideoList";
 import { LinkButton } from "../../../ui/LinkButton";
+import {
+    PaginationNav,
+    createPaginationControls,
+    paginationControlStyles,
+} from "../../../ui/PaginationNav";
 import { isRealUser, useUser } from "../../../User";
 import { Creators } from "../../../ui/Video";
 
@@ -1310,90 +1311,38 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
 
 const PageNavigation = <T, >({ connection, vars }: SharedManageProps<T>) => {
     const { t } = useTranslation();
-    const pageInfo = connection.pageInfo;
     const total = connection.totalCount;
     const page = vars.page;
+    const totalPages = Math.max(1, Math.ceil(total / LIMIT));
+    const controls = createPaginationControls({
+        currentPage: page,
+        totalPages,
+        navigateToPage: targetPage => ({
+            to: varsToLink({ ...vars, page: targetPage }),
+        }),
+    });
 
-    return (
-        <div css={{
-            display: "flex",
-            justifyContent: "flex-end",
-            alignItems: "center",
-            gap: 48,
-        }}>
-            <div>
-                {t("manage.table.page-showing-ids", {
-                    start: page * LIMIT - LIMIT + 1,
-                    end: Math.min(page * LIMIT, total),
-                    total,
-                })}
-            </div>
-            <div css={{ display: "flex", alignItems: "center" }}>
-                {/* First page */}
-                <PageLink
-                    vars={{ ...vars, page: 1 }}
-                    disabled={!pageInfo.hasPrevPage}
-                    label={t("manage.table.navigation.first")}
-                ><FirstPage /></PageLink>
-                {/* Previous page */}
-                <PageLink
-                    vars={{ ...vars, page: page - 1 }}
-                    disabled={!pageInfo.hasPrevPage}
-                    label={t("manage.table.navigation.previous")}
-                ><LuChevronLeft /></PageLink>
-                {/* Next page */}
-                <PageLink
-                    vars={{ ...vars, page: page + 1 }}
-                    disabled={!pageInfo.hasNextPage}
-                    label={t("manage.table.navigation.next")}
-                ><LuChevronRight /></PageLink>
-                {/* Last page */}
-                <PageLink
-                    vars={{ ...vars, page: Math.ceil(total / LIMIT) }}
-                    disabled={!pageInfo.hasNextPage}
-                    label={t("manage.table.navigation.last")}
-                ><LastPage /></PageLink>
-            </div>
-        </div>
-    );
+    return <PaginationNav
+        itemsSummary={t("manage.table.page-showing-ids", {
+            start: page * LIMIT - LIMIT + 1,
+            end: Math.min(page * LIMIT, total),
+            total,
+        })}
+        controls={controls}
+        renderControl={({ label, icon, disabled, target }) => <Link
+            css={paginationControlStyles}
+            to={target && "to" in target
+                ? target.to
+                : varsToLink(vars)
+            }
+            aria-label={t(label)}
+            aria-disabled={disabled}
+            tabIndex={disabled ? -1 : 0}
+        >
+            {icon}
+        </Link>}
+    />;
 };
-
-type PageLinkProps = {
-    vars: ItemVars;
-    disabled: boolean;
-    children: ReactNode;
-    label: string;
-};
-
-const PageLink: React.FC<PageLinkProps> = ({ children, vars, disabled, label }) => (
-    <Link
-        to={varsToLink(vars)}
-        tabIndex={disabled ? -1 : 0}
-        aria-hidden={disabled}
-        aria-label={label}
-        css={{
-            background: "none",
-            border: "none",
-            fontSize: 24,
-            padding: "4px 4px",
-            margin: "0 4px",
-            lineHeight: 0,
-            borderRadius: 4,
-            ...disabled
-                ? {
-                    color: COLORS.neutral25,
-                    pointerEvents: "none",
-                }
-                : {
-                    color: COLORS.neutral60,
-                    cursor: "pointer",
-                    ":hover, :focus": {
-                        color: COLORS.neutral90,
-                    },
-                },
-        }}
-    >{children}</Link>
-);
 
 
 

--- a/frontend/src/routes/manage/Shared/Table.tsx
+++ b/frontend/src/routes/manage/Shared/Table.tsx
@@ -47,11 +47,7 @@ import { BREAKPOINT_MEDIUM, BREAKPOINT_SMALL } from "../../../GlobalStyle";
 import { FloatingBaseMenu } from "../../../ui/FloatingBaseMenu";
 import { MenuItem } from "../../../ui/Blocks/VideoList";
 import { LinkButton } from "../../../ui/LinkButton";
-import {
-    PaginationNav,
-    createPaginationControls,
-    paginationControlStyles,
-} from "../../../ui/PaginationNav";
+import { PaginationNav, paginationControlStyles } from "../../../ui/PaginationNav";
 import { isRealUser, useUser } from "../../../User";
 import { Creators } from "../../../ui/Video";
 
@@ -1313,28 +1309,14 @@ const PageNavigation = <T, >({ connection, vars }: SharedManageProps<T>) => {
     const { t } = useTranslation();
     const total = connection.totalCount;
     const page = vars.page;
-    const totalPages = Math.max(1, Math.ceil(total / LIMIT));
-    const controls = createPaginationControls({
-        currentPage: page,
-        totalPages,
-        navigateToPage: targetPage => ({
-            to: varsToLink({ ...vars, page: targetPage }),
-        }),
-    });
 
     return <PaginationNav
-        itemsSummary={t("manage.table.page-showing-ids", {
-            start: page * LIMIT - LIMIT + 1,
-            end: Math.min(page * LIMIT, total),
-            total,
-        })}
-        controls={controls}
-        renderControl={({ label, icon, disabled, target }) => <Link
+        totalItems={total}
+        itemsPerPage={LIMIT}
+        currentPage={page}
+        renderControl={({ label, icon, disabled, targetPage }) => <Link
             css={paginationControlStyles}
-            to={target && "to" in target
-                ? target.to
-                : varsToLink(vars)
-            }
+            to={varsToLink({ ...vars, page: targetPage })}
             aria-label={t(label)}
             aria-disabled={disabled}
             tabIndex={disabled ? -1 : 0}

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -48,7 +48,7 @@ const playlistFragment = graphql`
             canWrite
             entries {
                 __typename
-                ... on AuthorizedEvent { id, ...VideoListEventData }
+                ... on AuthorizedEvent { ...VideoListEventData @arguments(includeSeries: true) }
                 ... on Missing { dummy }
                 ... on NotAllowed { dummy }
             }

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -52,7 +52,7 @@ const seriesFragment = graphql`
         canWrite
         entries {
             __typename
-            ...on AuthorizedEvent { id, ...VideoListEventData }
+            ...on AuthorizedEvent { ...VideoListEventData @arguments(includeSeries: false) }
             ...on NotAllowed { dummy }
         }
     }

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -53,14 +53,17 @@ import { LinkButton } from "../LinkButton";
 // This uses `@inline` because the fragment is used in different situations,
 // where using `useFragment` is very tricky (or maybe even impossible).
 export const videoListEventFragment = graphql`
-    fragment VideoListEventData on AuthorizedEvent @inline {
+    fragment VideoListEventData on AuthorizedEvent @inline
+    @argumentDefinitions(
+        includeSeries: { type: "Boolean!", defaultValue: false }
+    ) {
         id
         title
         created
         creators
         isLive
         description
-        series { title id }
+        series @include(if: $includeSeries) { title id }
         syncedData {
             thumbnail
             duration

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -3,7 +3,6 @@ import React, {
     ReactNode,
     createContext,
     useContext,
-    useEffect,
     useId,
     useRef,
     useState,
@@ -85,6 +84,7 @@ type ListKind = "series" | "playlist";
 
 const VIDEO_GRID_BREAKPOINT = 600;
 const DEFAULT_ITEMS_PER_PAGE = 36;
+const SLIDER_BATCH_SIZE = 36;
 
 type VideoListItem = Event | "missing" | "unauthorized";
 
@@ -778,7 +778,6 @@ const Items: React.FC<ItemsProps> = ({
     const shownItems = items.slice(startIndex, startIndex + itemsPerPage);
 
     if (layoutState === "SLIDER") {
-        // Todo: pagination for slider view.
         return <SliderView {...{ listId, basePath, items }} />;
     }
 
@@ -968,32 +967,47 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items, listId }) => {
     const { t } = useTranslation();
     const ref = useRef<HTMLDivElement>(null);
     const scrollDistance = 240;
+    const [loadedCount, setLoadedCount] = useState(() => Math.min(items.length, SLIDER_BATCH_SIZE));
 
-    const [rightVisible, setRightVisible] = useState(false);
+    const [rightVisible, setRightVisible] = useState(items.length > SLIDER_BATCH_SIZE);
     const [leftVisible, setLeftVisible] = useState(false);
 
     /**
      * This hides the left and/or right scroll buttons if the slider is scrolled almost all
      * the way to the left or right respectively, or when there is nothing to scroll to.
+     *
+     * We also load the next batch here so native scrolling keeps working as the track grows.
      */
-    const setVisibilities = () => {
-        if (ref.current) {
-            const totalSliderWidth = ref.current.scrollWidth;
-            const scrollPositionLeft = ref.current.scrollLeft;
-            const scrollPositionRight = ref.current.scrollLeft + ref.current.offsetWidth;
-            setRightVisible(scrollPositionRight < (totalSliderWidth - 16));
-            setLeftVisible(scrollPositionLeft > 16);
+    const updateSliderState = () => {
+        if (!ref.current) {
+            return;
         }
+
+        const totalSliderWidth = ref.current.scrollWidth;
+        const scrollPositionLeft = ref.current.scrollLeft;
+        const scrollPositionRight = ref.current.scrollLeft + ref.current.offsetWidth;
+        const hasMoreItems = loadedCount < items.length;
+
+        // 1200px is the width of roughly four thumbnails (+ margins).
+        // So will load in more items when the scroll state is at a point where about
+        // four items are still off screen on the right.
+        if (hasMoreItems && scrollPositionRight >= (totalSliderWidth - 1200)) {
+            setLoadedCount(currentLoadedCount => Math.min(
+                items.length,
+                currentLoadedCount + SLIDER_BATCH_SIZE,
+            ));
+        }
+
+        setRightVisible(hasMoreItems || scrollPositionRight < (totalSliderWidth - 16));
+        setLeftVisible(scrollPositionLeft > 16);
     };
 
     const scroll = (distance: number) => {
         if (ref.current) {
             ref.current.scrollLeft += distance;
-            setVisibilities();
+            updateSliderState();
         }
     };
-
-    useEffect(setVisibilities, []);
 
     const buttonCss = {
         zIndex: 5,
@@ -1016,7 +1030,7 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items, listId }) => {
     } as const;
 
     return <div css={{ position: "relative" }}>
-        <div tabIndex={-1} onScroll={() => setVisibilities()} ref={ref} css={{
+        <div tabIndex={-1} onScroll={updateSliderState} ref={ref} css={{
             display: "flex",
             marginRight: 5,
             overflow: "auto",
@@ -1026,7 +1040,7 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items, listId }) => {
                 scrollMargin: 6,
             },
         }}>
-            {items.map(({ item, active }, idx) => (
+            {items.slice(0, loadedCount).map(({ item, active }, idx) => (
                 <Item
                     key={idx}
                     {...{ item, active, basePath, listId }}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -760,6 +760,11 @@ type ItemsProps = ViewProps & {
     itemsPerPage: number;
 };
 
+const itemKey = (item: VideoListItem, index: number): string =>
+    item === "missing" || item === "unauthorized"
+        ? `${item}-${index}`
+        : item.id;
+
 const Items: React.FC<ItemsProps> = ({
     basePath,
     items,
@@ -894,7 +899,7 @@ const GalleryView: React.FC<ViewProps> = ({ basePath, items, listId }) => (
     }}>
         {items.map(({ item, active }, idx) => (
             <Item
-                key={idx}
+                key={itemKey(item, idx)}
                 {...{ item, active, basePath, listId }}
                 css={{
                     width: "100%",
@@ -924,7 +929,7 @@ const ListView: React.FC<ViewProps> = ({ basePath, items, showSeries, listId }) 
     }}>
         {items.map(({ item, active }, idx) => (
             <Item
-                key={idx}
+                key={itemKey(item, idx)}
                 {...{ item, active, basePath, showSeries, listId }}
                 showDescription
                 dateAndCreatorOneLine
@@ -1027,7 +1032,7 @@ const SliderView: React.FC<ViewProps> = ({ basePath, items, listId }) => {
         }}>
             {items.slice(0, loadedCount).map(({ item, active }, idx) => (
                 <Item
-                    key={idx}
+                    key={itemKey(item, idx)}
                     {...{ item, active, basePath, listId }}
                     css={{
                         scrollSnapAlign: "start",

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -45,7 +45,7 @@ import { LoginLink } from "../../routes/util";
 import { QrCodeButton, ShareButton } from "../ShareButton";
 import { CopyableInput } from "../Input";
 import { LinkButton } from "../LinkButton";
-import { PaginationNav, createPaginationControls, paginationControlStyles } from "../PaginationNav";
+import { PaginationNav, paginationControlStyles } from "../PaginationNav";
 
 
 
@@ -794,33 +794,18 @@ const Items: React.FC<ItemsProps> = ({
         return content;
     }
 
-    const start = items.length === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
-    const end = Math.min(currentPage * itemsPerPage, items.length);
-    const controls = createPaginationControls({
-        currentPage,
-        totalPages,
-        navigateToPage: targetPage => ({
-            onClick: () => setPage(Math.max(1, Math.min(totalPages, targetPage))),
-        }),
-    });
-
     return <>
         {content}
         <div css={{ marginTop: 16 }}>
             <PaginationNav
-                itemsSummary={t("manage.table.page-showing-ids", {
-                    start, end, total: items.length,
-                })}
-                controls={controls}
-                renderControl={({ label, icon, disabled, target }) => <ProtoButton
+                totalItems={items.length}
+                {...{ itemsPerPage, currentPage }}
+                renderControl={({ label, icon, disabled, targetPage }) => <ProtoButton
                     css={paginationControlStyles}
                     aria-label={t(label)}
                     aria-disabled={disabled}
                     disabled={disabled}
-                    onClick={target && "onClick" in target
-                        ? target.onClick
-                        : undefined
-                    }
+                    onClick={() => setPage(Math.max(1, Math.min(totalPages, targetPage)))}
                 >
                     {icon}
                 </ProtoButton>}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -46,6 +46,7 @@ import { LoginLink } from "../../routes/util";
 import { QrCodeButton, ShareButton } from "../ShareButton";
 import { CopyableInput } from "../Input";
 import { LinkButton } from "../LinkButton";
+import { PaginationNav, createPaginationControls, paginationControlStyles } from "../PaginationNav";
 
 
 
@@ -83,6 +84,7 @@ type ListKind = "series" | "playlist";
 
 
 const VIDEO_GRID_BREAKPOINT = 600;
+const DEFAULT_ITEMS_PER_PAGE = 36;
 
 type VideoListItem = Event | "missing" | "unauthorized";
 
@@ -136,6 +138,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
     const { initialOrder, allowOriginalOrder, initialLayout = "GALLERY" } = displayOptions;
     const [eventOrder, setEventOrder] = useState<Order>(initialOrder);
     const [layoutState, setLayoutState] = useState<VideoListLayout>(initialLayout);
+    const itemsPerPage = DEFAULT_ITEMS_PER_PAGE;
     const layoutOrderContext: LayoutOrderContext = {
         allowOriginalOrder,
         eventOrder,
@@ -164,7 +167,7 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
         <Items
             basePath={basePath}
             showSeries={shareInfo.kind === "playlist"}
-            {...{ listId }}
+            {...{ listId, itemsPerPage }}
             items={events.map(item => ({
                 item,
                 active: item !== "missing"
@@ -753,14 +756,78 @@ type ViewProps = {
     }[];
 };
 
-const Items: React.FC<ViewProps> = ({ basePath, items, showSeries = false, listId }) => {
+type ItemsProps = ViewProps & {
+    itemsPerPage: number;
+};
+
+const Items: React.FC<ItemsProps> = ({
+    basePath,
+    items,
+    showSeries = false,
+    listId,
+    itemsPerPage,
+}) => {
+    const { t } = useTranslation();
     const { layoutState } = useLayoutOrderContext();
-    return match(layoutState, {
-        SLIDER: () => <SliderView {...{ listId, basePath, items }} />,
-        GALLERY: () => <GalleryView {...{ listId, basePath, items }} />,
-        LIST: () => <ListView {...{ listId, basePath, items, showSeries }} />,
-        "%future added value": () => unreachable(),
+
+    const [page, setPage] = useState(1);
+    const totalPages = Math.max(1, Math.ceil(items.length / itemsPerPage));
+    const currentPage = Math.min(page, totalPages);
+
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const shownItems = items.slice(startIndex, startIndex + itemsPerPage);
+
+    if (layoutState === "SLIDER") {
+        // Todo: pagination for slider view.
+        return <SliderView {...{ listId, basePath, items }} />;
+    }
+
+    if (layoutState === "%future added value") {
+        return unreachable();
+    }
+
+    const content = match(layoutState, {
+        GALLERY: () => <GalleryView {...{ listId, basePath, items: shownItems }} />,
+        LIST: () => <ListView {...{ listId, basePath, items: shownItems, showSeries }} />,
     });
+
+    if (totalPages <= 1) {
+        return content;
+    }
+
+    const start = items.length === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
+    const end = Math.min(currentPage * itemsPerPage, items.length);
+    const controls = createPaginationControls({
+        currentPage,
+        totalPages,
+        navigateToPage: targetPage => ({
+            onClick: () => setPage(Math.max(1, Math.min(totalPages, targetPage))),
+        }),
+    });
+
+    return <>
+        {content}
+        <div css={{ marginTop: 16 }}>
+            <PaginationNav
+                itemsSummary={t("manage.table.page-showing-ids", {
+                    start, end, total: items.length,
+                })}
+                controls={controls}
+                renderControl={({ label, icon, disabled, target }) => <ProtoButton
+                    css={paginationControlStyles}
+                    aria-label={t(label)}
+                    aria-disabled={disabled}
+                    disabled={disabled}
+                    onClick={target && "onClick" in target
+                        ? target.onClick
+                        : undefined
+                    }
+                >
+                    {icon}
+                </ProtoButton>}
+            />
+        </div>
+    </>;
 };
 
 const ITEM_MIN_SIZE = 250;

--- a/frontend/src/ui/PaginationNav.tsx
+++ b/frontend/src/ui/PaginationNav.tsx
@@ -10,105 +10,92 @@ import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";
 
 
-type PaginationControlTarget = { to: string } | { onClick: () => void };
-
 type PaginationControl = {
     key: "first" | "previous" | "next" | "last";
     label: ParseKeys;
     icon: ReactNode;
     disabled: boolean;
-    target?: PaginationControlTarget;
+    targetPage: number;
 };
 
 type PaginationNavProps = {
-    itemsSummary: ReactNode;
-    controls: PaginationControl[];
+    totalItems: number;
+    itemsPerPage: number;
+    currentPage: number;
     renderControl: (control: PaginationControl) => ReactNode;
 };
 
 export const PaginationNav: React.FC<PaginationNavProps> = ({
-    itemsSummary,
-    controls,
+    totalItems,
+    itemsPerPage,
+    currentPage,
     renderControl,
 }) => {
     const { t } = useTranslation();
-
-    return <nav aria-label={t("general.page")} css={{
-        display: "flex",
-        justifyContent: "flex-end",
-        alignItems: "center",
-        gap: 48,
-        flexWrap: "wrap",
-    }}>
-        <span css={{
-            color: COLORS.neutral70,
-            display: "inline-flex",
-            alignItems: "center",
-        }}>
-            {itemsSummary}
-        </span>
-
-        <div css={{ display: "flex", alignItems: "center" }}>
-            {controls.map(control => (
-                <Fragment key={control.key}>
-                    {renderControl(control)}
-                </Fragment>
-            ))}
-        </div>
-    </nav>;
-};
-
-
-type CreatePaginationControlsOptions = {
-    currentPage: number;
-    totalPages: number;
-    navigateToPage: (page: number) => PaginationControlTarget;
-};
-
-/**
- * Returns the props for arrow nav elements as an array.
- * These are used in conjunction with the `renderControl`
- * function prop of `PaginationNav` and passed to a
- * custom nav control "wrapper" like a button or link.
- */
-export const createPaginationControls = ({
-    currentPage,
-    totalPages,
-    navigateToPage,
-}: CreatePaginationControlsOptions): PaginationControl[] => {
+    const totalPages = Math.max(1, Math.ceil(totalItems / itemsPerPage));
+    const start = totalItems === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
+    const end = Math.min(currentPage * itemsPerPage, totalItems);
     const hasPrevPage = currentPage > 1;
     const hasNextPage = currentPage < totalPages;
 
-    return [
+    const controls: PaginationControl[] = [
         {
             key: "first",
             label: "manage.table.navigation.first",
             icon: <FirstPage />,
             disabled: !hasPrevPage,
-            target: hasPrevPage ? navigateToPage(1) : undefined,
+            targetPage: hasPrevPage ? 1 : currentPage,
         },
         {
             key: "previous",
             label: "manage.table.navigation.previous",
             icon: <LuChevronLeft />,
             disabled: !hasPrevPage,
-            target: hasPrevPage ? navigateToPage(currentPage - 1) : undefined,
+            targetPage: hasPrevPage ? currentPage - 1 : currentPage,
         },
         {
             key: "next",
             label: "manage.table.navigation.next",
             icon: <LuChevronRight />,
             disabled: !hasNextPage,
-            target: hasNextPage ? navigateToPage(currentPage + 1) : undefined,
+            targetPage: hasNextPage ? currentPage + 1 : currentPage,
         },
         {
             key: "last",
             label: "manage.table.navigation.last",
             icon: <LastPage />,
             disabled: !hasNextPage,
-            target: hasNextPage ? navigateToPage(totalPages) : undefined,
+            targetPage: hasNextPage ? totalPages : currentPage,
         },
     ];
+
+    return (
+        <nav aria-label={t("general.page")} css={{
+            display: "flex",
+            justifyContent: "flex-end",
+            alignItems: "center",
+            gap: 48,
+            flexWrap: "wrap",
+        }}>
+            <span css={{
+                color: COLORS.neutral70,
+                display: "inline-flex",
+                alignItems: "center",
+            }}>
+                {t("manage.table.page-showing-ids", {
+                    start,
+                    end,
+                    total: totalItems,
+                })}
+            </span>
+
+            <div css={{ display: "flex", alignItems: "center" }}>
+                {controls.map(control => (
+                    <Fragment key={control.key}>{renderControl(control)}</Fragment>
+                ))}
+            </div>
+        </nav>
+    );
 };
 
 

--- a/frontend/src/ui/PaginationNav.tsx
+++ b/frontend/src/ui/PaginationNav.tsx
@@ -1,0 +1,135 @@
+import { Fragment, ReactNode } from "react";
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
+import { ParseKeys } from "i18next";
+
+import { COLORS } from "../color";
+import { focusStyle } from ".";
+import FirstPage from "../icons/first-page.svg";
+import LastPage from "../icons/last-page.svg";
+import { useTranslation } from "react-i18next";
+import { css } from "@emotion/react";
+
+
+type PaginationControlTarget = { to: string } | { onClick: () => void };
+
+type PaginationControl = {
+    key: "first" | "previous" | "next" | "last";
+    label: ParseKeys;
+    icon: ReactNode;
+    disabled: boolean;
+    target?: PaginationControlTarget;
+};
+
+type PaginationNavProps = {
+    itemsSummary: ReactNode;
+    controls: PaginationControl[];
+    renderControl: (control: PaginationControl) => ReactNode;
+};
+
+export const PaginationNav: React.FC<PaginationNavProps> = ({
+    itemsSummary,
+    controls,
+    renderControl,
+}) => {
+    const { t } = useTranslation();
+
+    return <nav aria-label={t("general.page")} css={{
+        display: "flex",
+        justifyContent: "flex-end",
+        alignItems: "center",
+        gap: 48,
+        flexWrap: "wrap",
+    }}>
+        <span css={{
+            color: COLORS.neutral70,
+            display: "inline-flex",
+            alignItems: "center",
+        }}>
+            {itemsSummary}
+        </span>
+
+        <div css={{ display: "flex", alignItems: "center" }}>
+            {controls.map(control => (
+                <Fragment key={control.key}>
+                    {renderControl(control)}
+                </Fragment>
+            ))}
+        </div>
+    </nav>;
+};
+
+
+type CreatePaginationControlsOptions = {
+    currentPage: number;
+    totalPages: number;
+    navigateToPage: (page: number) => PaginationControlTarget;
+};
+
+/**
+ * Returns the props for arrow nav elements as an array.
+ * These are used in conjunction with the `renderControl`
+ * function prop of `PaginationNav` and passed to a
+ * custom nav control "wrapper" like a button or link.
+ */
+export const createPaginationControls = ({
+    currentPage,
+    totalPages,
+    navigateToPage,
+}: CreatePaginationControlsOptions): PaginationControl[] => {
+    const hasPrevPage = currentPage > 1;
+    const hasNextPage = currentPage < totalPages;
+
+    return [
+        {
+            key: "first",
+            label: "manage.table.navigation.first",
+            icon: <FirstPage />,
+            disabled: !hasPrevPage,
+            target: hasPrevPage ? navigateToPage(1) : undefined,
+        },
+        {
+            key: "previous",
+            label: "manage.table.navigation.previous",
+            icon: <LuChevronLeft />,
+            disabled: !hasPrevPage,
+            target: hasPrevPage ? navigateToPage(currentPage - 1) : undefined,
+        },
+        {
+            key: "next",
+            label: "manage.table.navigation.next",
+            icon: <LuChevronRight />,
+            disabled: !hasNextPage,
+            target: hasNextPage ? navigateToPage(currentPage + 1) : undefined,
+        },
+        {
+            key: "last",
+            label: "manage.table.navigation.last",
+            icon: <LastPage />,
+            disabled: !hasNextPage,
+            target: hasNextPage ? navigateToPage(totalPages) : undefined,
+        },
+    ];
+};
+
+
+export const paginationControlStyles = css({
+    background: "none",
+    border: "none",
+    fontSize: 24,
+    padding: 4,
+    margin: "0 4px",
+    lineHeight: 0,
+    borderRadius: 4,
+    "&[aria-disabled='true']": {
+        color: COLORS.neutral25,
+        pointerEvents: "none",
+    },
+    "&:not([aria-disabled='true'])": {
+        color: COLORS.neutral60,
+        cursor: "pointer",
+        ":hover, :focus": {
+            color: COLORS.neutral90,
+        },
+        ...focusStyle({ inset: true }),
+    },
+});


### PR DESCRIPTION
Larger series and playlist blocks now load in only 36 items per default and have pagination controls at the bottom of gallery and list views.
The slider view uses a different approach where also a batch of 36 items is loaded at the beginning but scrolling to the right eventually loads in more items.

This alone improves performance by quite a bit. I tested and measured this locally with series containing 1200 items. Before this patch, the load-in LCP time was reported at around 5 seconds. Now it is at below 1s.

There is still some potential for improvement, especially looking at thumbnail load in, but that could also be done separately for #1641.

This closes #1562 