### PR TITLE
Improve uploader UX when there is no writable series

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -304,6 +304,9 @@ search:
 
 upload:
   title: Video hochladen
+  no-writable-series-blocked: >
+    Für den Upload ist eine Serie erforderlich, aber Sie haben auf keine Serie Schreibzugriff und können auch keine erstellen.
+  create-series-first: Sie müssen zunächst eine Serie erstellen, in welche das hochgeladene Video eingebunden werden kann.
   drop-to-upload: Videodatei zum Hochladen per Drag-and-drop hinzufügen
   not-authorized: Sie haben nicht die Berechtigung, Videos hochzuladen.
   specified-series-not-found: Angegebene Serie nicht gefunden.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -301,6 +301,9 @@ search:
 
 upload:
   title: Upload video
+  no-writable-series-blocked: >
+    Uploading requires a series, but you do not have write access to any series and cannot create one either.
+  create-series-first: You need to create a series first in order to upload.
   drop-to-upload: Drag and drop video file to upload
   not-authorized: You do not have the permission to upload videos.
   specified-series-not-found: Specified series not found.

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -307,6 +307,10 @@ search:
 
 upload:
   title: Importer une vidéo
+  no-writable-series-blocked: > #verify
+    L’importation nécessite une série. Vous n’avez accès en écriture à aucune série et vous ne pouvez pas en créer.
+  create-series-first: > #verify
+    L’importation nécessite une série. Veuillez en créer une ci-dessous pour continuer.
   drop-to-upload: Ajouter un fichier vidéo à importer par Drag-and-Drop
   not-authorized: Vous n’avez pas l’autorisation d’importer des vidéos.
   specified-series-not-found: La série spécifiée n'a pas été trouvée.

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -306,6 +306,10 @@ search:
 
 upload:
   title: Caricare video
+  no-writable-series-blocked: > #verify
+    Il caricamento richiede una serie. Non hai accesso in scrittura a nessuna serie e non puoi crearne una.
+  create-series-first: > #verify
+    Il caricamento richiede una serie. Creane una qui sotto per continuare.
   drop-to-upload: Trascina e rilascia il file video da caricare
   not-authorized: Non hai l'autorizzazione a caricare video.
   specified-series-not-found: Serie specificata non trovata.

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -48,7 +48,10 @@ import {
     NewEvent,
     UploadCreatePlaceholderMutation,
 } from "./__generated__/UploadCreatePlaceholderMutation.graphql";
+import { UploadCreateSeriesMutation } from "./__generated__/UploadCreateSeriesMutation.graphql";
 import { ManageVideosRoute } from "./manage/Video";
+import { CreateVideoList } from "./manage/Shared/Create";
+import { CreateSeriesPageProps } from "./manage/Series/Create";
 
 
 export const PATH = "/~manage/upload" as const;
@@ -80,6 +83,11 @@ const query = graphql`
     query UploadQuery($seriesId: ID!) {
         ... UserData
         ... AccessKnownRolesData
+        writableSeries: searchAllSeries(query: "", writableOnly: true) {
+            ... on SeriesSearchResults {
+                items { id }
+            }
+        }
         series: seriesById(id: $seriesId) {
             id
             opencastId
@@ -114,11 +122,33 @@ const Upload: React.FC<Props> = ({ uploadQueryData, seriesUrlParamSet }) => {
     const { t } = useTranslation();
     const knownRoles = useFragment<AccessKnownRolesData$key>(knownRolesFragment, uploadQueryData);
     const preselectedSeries = uploadQueryData.series;
+    const user = useUser();
 
     if (preselectedSeries && !preselectedSeries.canWrite) {
         return <Card kind="error">
             {t("upload.missing-series-write-permission")}
         </Card>;
+    }
+
+    const breadcrumbs = <Breadcrumbs
+        path={[{ label: t("user.manage"), link: ManageRoute.url }]}
+        tail={t("upload.title")}
+    />;
+
+    const userCanUpload = isRealUser(user) && user.canUpload;
+    const noWritableSeries = CONFIG.upload.requireSeries
+        && (uploadQueryData.writableSeries.items?.length ?? 0) === 0
+        && !preselectedSeries;
+
+    if (noWritableSeries && userCanUpload) {
+        return <>
+            {breadcrumbs}
+            <PageTitle title={t("upload.title")} />
+            {user.canCreateSeries
+                ? <SeriesCreationStep knownRolesRef={uploadQueryData} />
+                : <Card kind="error">{t("upload.no-writable-series-blocked")}</Card>
+            }
+        </>;
     }
 
     return (
@@ -127,10 +157,7 @@ const Upload: React.FC<Props> = ({ uploadQueryData, seriesUrlParamSet }) => {
             display: "flex",
             flexDirection: "column",
         }}>
-            <Breadcrumbs
-                path={[{ label: t("user.manage"), link: ManageRoute.url }]}
-                tail={t("upload.title")}
-            />
+            {breadcrumbs}
             <PageTitle title={t("upload.title")} />
             {seriesUrlParamSet && preselectedSeries == null && (
                 <Card kind="error" css={{ marginBottom: 16 }}>
@@ -168,6 +195,12 @@ const CancelButton: React.FC<CancelButtonProps> = ({ abortController }) => {
 const createPlaceholderMutation = graphql`
     mutation UploadCreatePlaceholderMutation($event: NewEvent!) {
         createPlaceholderEvent(event: $event) { id }
+    }
+`;
+
+const createSeriesMutation = graphql`
+    mutation UploadCreateSeriesMutation($metadata: BasicMetadata!, $acl: [AclItem!]!) {
+        createSeries(metadata: $metadata, acl: $acl) { id }
     }
 `;
 
@@ -345,6 +378,26 @@ const UploadMain: React.FC<UploadMainProps> = ({ knownRoles, preselectedSeries }
             </div>
         );
     }
+};
+
+const SeriesCreationStep: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) => {
+    const { t } = useTranslation();
+    const [commit, inFlight] = useMutation<UploadCreateSeriesMutation>(createSeriesMutation);
+
+    return <div css={{ maxWidth: 900 }}>
+        <Card kind="info" css={{ marginBottom: 20 }}>
+            {t("upload.create-series-first")}
+        </Card>
+        <CreateVideoList
+            {...{ commit, inFlight, knownRolesRef }}
+            canUserCreateList={user => user.canCreateSeries}
+            kind="series"
+            returnPath={response => UploadRoute.url({
+                seriesId: keyOfId(response.createSeries.id),
+            })}
+            showTitle={false}
+        />
+    </div>;
 };
 
 type ProgressHistory = {

--- a/frontend/src/routes/manage/Series/Create.tsx
+++ b/frontend/src/routes/manage/Series/Create.tsx
@@ -48,7 +48,7 @@ const createSeriesMutation = graphql`
     }
 `;
 
-type CreateSeriesPageProps = {
+export type CreateSeriesPageProps = {
     knownRolesRef: AccessKnownRolesData$key;
 };
 

--- a/frontend/src/routes/manage/Shared/Create.tsx
+++ b/frontend/src/routes/manage/Shared/Create.tsx
@@ -1,22 +1,23 @@
 import { useTranslation } from "react-i18next";
+import { useId, useState, PropsWithChildren } from "react";
+import { useFragment, UseMutationConfig } from "react-relay";
+import { Controller, useForm } from "react-hook-form";
+import { Disposable, MutationParameters } from "relay-runtime";
+import { boxError } from "@opencast/appkit";
+
 import { AccessKnownRolesData$key } from "../../../ui/__generated__/AccessKnownRolesData.graphql";
 import { Acl, AclSelector, knownRolesFragment } from "../../../ui/Access";
 import { useRouter } from "../../../router";
-import { useId, useState, PropsWithChildren } from "react";
-import { useFragment, UseMutationConfig } from "react-relay";
 import { useNotification } from "../../../ui/NotificationContext";
 import { isRealUser, User, useUser } from "../../../User";
-import { Controller, useForm } from "react-hook-form";
 import { defaultAclMap } from "../../../util/roles";
 import { NotAuthorized } from "../../../ui/error";
-import { Disposable, MutationParameters } from "relay-runtime";
 import { displayCommitError } from "../Realm/util";
 import { aclMapToArray } from "../../util";
 import { PageTitle } from "../../../layout/header/ui";
 import { Form } from "../../../ui/Form";
 import { InputContainer, SubmitButtonWithStatus, TitleLabel } from "../../../ui/metadata";
 import { Input, TextArea } from "../../../ui/Input";
-import { boxError } from "@opencast/appkit";
 import { READ_WRITE_ACTIONS } from "../../../util/permissionLevels";
 
 
@@ -33,6 +34,7 @@ export type CreateVideoListProps<TMutation extends MutationParameters> = PropsWi
     inFlight: boolean;
     returnPath: (response: TMutation["response"]) => string;
     kind: "series" | "playlist";
+    showTitle?: boolean;
     buildVariables?: (args: {
         username: string;
     }) => Omit<TMutation["variables"], "metadata" | "acl">;
@@ -45,6 +47,7 @@ export const CreateVideoList = <TMutation extends MutationParameters>({
     inFlight,
     returnPath,
     kind,
+    showTitle = true,
     buildVariables,
     children,
 }: CreateVideoListProps<TMutation>) => {
@@ -98,7 +101,7 @@ export const CreateVideoList = <TMutation extends MutationParameters>({
     const onSubmit = handleSubmit(data => create(data));
 
     return <>
-        <PageTitle title={t(`manage.${kind}.table.create`)} />
+        {showTitle && <PageTitle title={t(`manage.${kind}.table.create`)} />}
         <Form
             noValidate
             onSubmit={e => e.preventDefault()}


### PR DESCRIPTION
There are two scenarios:
- (1) a user has no writable series but is allowed to create some
- (2) a user has no writable series and is not allowed to create any

In the first case, we add an in between step that requires a user to create a series before they can upload. For this, the user is automatically directed to a "create series" screen. When they do create a series there, they are then directed to the regular uploader, with their newly created series already selected.

In the second case we simply state the requirements and regrettably inform the user that they cannot upload.

Closes #1409