### PR TITLE
Improve video date detail view

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -158,6 +158,7 @@ video:
   upcoming: Anstehend
   ended: Beendet
   ended-at: Beendet {{datetime}}
+  ending: Endet
   license: Lizenz
   source: Quelle
   stream-ended: Dieser Stream ist beendet.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -156,6 +156,7 @@ video:
   upcoming: Upcoming
   ended: Ended
   ended-at: Ended {{datetime}}
+  ending: Ending
   license: License
   source: Source
   stream-ended: This stream has ended.

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1216,7 +1216,7 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
             color: COLORS.neutral60,
             fontSize: 14,
         }}>
-            <WithTooltip distance={0} tooltip={tooltip}>
+            <WithTooltip tooltip={tooltip}>
                 <div>
                     <PrettyDate
                         {...prettyDateProps}

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -75,7 +75,7 @@ import { formatDuration, TrackInfo } from "../ui/Video";
 import { ellipsisOverflowCss } from "../ui";
 import { realmBreadcrumbs } from "../util/realm";
 import { COLORS } from "../color";
-import { preciseDateTime, preferredLocaleForLang, PrettyDate } from "../ui/time";
+import { PrettyDate, semiPreciseDateTime } from "../ui/time";
 import { PlayerContextProvider, usePlayerContext } from "../ui/player/PlayerContext";
 import { CollapsibleDescription } from "../ui/metadata";
 import { DirectSeriesRoute, SeriesRoute } from "./Series";
@@ -1185,11 +1185,10 @@ type VideoDateProps = {
 };
 
 const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
 
     const { created, updated, startTime, endTime, hasEnded, hasStarted } = getEventTimeInfo(event);
 
-    const locale = preferredLocaleForLang(i18n.language);
     const prettyDateProps = event.isLive && hasEnded
         ? { date: endTime, prefixKind: "end" as const }
         : { date: startTime ?? created };
@@ -1226,7 +1225,7 @@ const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
         <tbody>
             {fields.map(({ label, date }, i) => <tr key={i}>
                 <td css={{ fontStyle: "italic", textAlign: "right" }}>{label}</td>
-                <td css={{ paddingLeft: 12 }}>{preciseDateTime(date, locale)}</td>
+                <td css={{ paddingLeft: 12 }}>{semiPreciseDateTime(date)}</td>
             </tr>)}
         </tbody>
     </table>;

--- a/frontend/src/routes/Video.tsx
+++ b/frontend/src/routes/Video.tsx
@@ -1187,22 +1187,44 @@ type VideoDateProps = {
 const VideoDate: React.FC<VideoDateProps> = ({ event }) => {
     const { t, i18n } = useTranslation();
 
-    const { created, updated, startTime, endTime, hasEnded } = getEventTimeInfo(event);
+    const { created, updated, startTime, endTime, hasEnded, hasStarted } = getEventTimeInfo(event);
 
     const locale = preferredLocaleForLang(i18n.language);
     const prettyDateProps = event.isLive && hasEnded
         ? { date: endTime, prefixKind: "end" as const }
         : { date: startTime ?? created };
-    const fields: [string, Date | null][] = [
-        [t("video.started"), startTime],
-        [t("video.ended"), endTime],
-        [t("video.created"), created],
-        [t("manage.table.updated"), updated],
+
+    // Decide what dates to show in the detail view. This is a bit of a mess
+    // because the dates supplied by Opencast are really weird.
+    const differs = (a: Date, b: Date) => Math.abs(a.getTime() - b.getTime()) > 1000 * 30;
+    const fields: { label: string, date: Date }[] = [
+        { label: t("manage.table.updated"), date: updated },
     ];
+    if (startTime && !differs(startTime, created)) {
+        fields.push({
+            label: hasStarted ? `${t("video.created")}/${t("video.started")}` : t("video.starts"),
+            date: created,
+        });
+    } else {
+        fields.push({ label: t("video.created"), date: created });
+        if (startTime) {
+            fields.push({
+                label: hasStarted ? t("video.started") : t("video.starts"),
+                date: startTime,
+            });
+        }
+    }
+    if (endTime && differs(endTime, startTime ?? created)) {
+        fields.push({
+            label: hasEnded ? t("video.ended") : t("video.ending"),
+            date: endTime,
+        });
+    }
+    fields.sort((a, b) => a.date.getTime() - b.date.getTime());
 
     const tooltip = <table css={{}}>
         <tbody>
-            {fields.map(([label, date], i) => date && <tr key={i}>
+            {fields.map(({ label, date }, i) => <tr key={i}>
                 <td css={{ fontStyle: "italic", textAlign: "right" }}>{label}</td>
                 <td css={{ paddingLeft: 12 }}>{preciseDateTime(date, locale)}</td>
             </tr>)}

--- a/frontend/src/ui/time.tsx
+++ b/frontend/src/ui/time.tsx
@@ -157,6 +157,17 @@ export const preciseDateTime = (date: Date, locale: string): string => {
     return `${year}-${month}-${day} ${hour}:${minute}:${second} (${weekday})`;
 };
 
+export const semiPreciseDateTime = (date: Date): string => {
+    const pad2 = (n: number) => String(n).padStart(2, "0");
+    const year = date.getFullYear();
+    const month = pad2(date.getMonth() + 1);
+    const day = pad2(date.getDate());
+    const hour = pad2(date.getHours());
+    const minute = pad2(date.getMinutes());
+
+    return `${year}-${month}-${day} ${hour}:${minute}`;
+};
+
 /**
  * Returns the browser-preferred locale (potentially with region) for the given
  * language.


### PR DESCRIPTION
Closes #1576

- The seconds and workday is removed from the detailed view. 
- The logic of what dates to show with what labels has improved quite a bit. Now, the same date shouldn't be shown twice. If the endTime equals startTime/created it is not shown. If created and startTime are the same, they are shown in one line. 
- When start or end time is in the future, we now use the correct label (e.g. "starts" vs "started")

This is still not perfect! But I think this is the best we can do with the weird dates Opencast gives to us. For example, the `created` date for upcoming live event equals the (future) startTime. Which is weird. Also, the startTime and endTime are seemingly always set to something even if it's a normal upload (i.e. not a scheduled thing). So I think we should really go to the Opencast side and improve, what you would call the _data model_...