### PR TITLE
LTI 1.3 core (MVP): let an LMS launch Tobira

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1390,6 +1390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwtea"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80bd391477c696bb8a324e24b2176ed8efd21aabfbe9d4ec7b09c2b4da50d04"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +2933,7 @@ dependencies = [
  "hyperlocal",
  "iso8601",
  "juniper",
+ "jwtea",
  "meilisearch-sdk",
  "mime_guess",
  "nu-ansi-term",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -167,6 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2257,7 +2258,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2336,7 +2337,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3273,6 +3274,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,6 +44,7 @@ hyper-rustls = { version = "0.27.3", default-features = false, features = ["http
 hyper-util = { version = "0.1.3", features = ["client", "server", "http1", "http2", "server-graceful", "server-auto"] }
 iso8601 = "0.6.1"
 juniper = { version = "0.16.2", default-features = false, features = ["chrono", "schema-language", "anyhow", "backtrace"] }
+jwtea = "0.1.0"
 meilisearch-sdk = { path = "vendor/meilisearch-sdk" }
 mime_guess = { version = "2", default-features = false }
 nu-ansi-term = "0.50.1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,7 +19,7 @@ embed-in-debug = ["reinda/always-prod"]
 [dependencies]
 ahash = "0.8"
 anyhow = { version = "1.0.71", features = ["backtrace"] }
-aws-lc-rs = { version = "1.13.3", default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.13.3", default-features = false, features = ["aws-lc-sys", "ring-io"] }
 base64 = "0.22.1"
 bstr = "1.4.0"
 bunt = "0.2.7"

--- a/backend/src/auth/cache.rs
+++ b/backend/src/auth/cache.rs
@@ -12,6 +12,7 @@ use super::User;
 pub struct Caches {
     pub(crate) user: UserCache,
     pub(crate) callback: AuthCallbackCache,
+    pub(crate) lti_login: LtiNonceStore,
 }
 
 impl Caches {
@@ -19,6 +20,7 @@ impl Caches {
         Self {
             user: UserCache::new(),
             callback: AuthCallbackCache::new(),
+            lti_login: LtiNonceStore::new(),
         }
     }
 
@@ -69,12 +71,19 @@ impl Caches {
             } else {
                 None
             };
+            let next_lti_action = cleanup(
+                now,
+                &self.lti_login.0,
+                LTI_LOGIN_TTL,
+                |v| v.created,
+            ).await;
 
             // We will wait until the next entry in the hashmap gets stale, but
             // at least 30s to not do cleanup too often. In case there are no
             // entries currently, it will also retry in 30s. But we will wait
             // at most as long as we would do for an empty cache.
-            let next_action = [next_user_action, next_callback_action].into_iter()
+            let next_action = [next_user_action, next_callback_action, next_lti_action]
+                .into_iter()
                 .filter_map(|x| x)
                 .min();
             let wait_duration = std::cmp::min(
@@ -276,5 +285,81 @@ impl AuthCallbackCache {
                 user,
                 timestamp: Instant::now(),
             });
+    }
+}
+
+
+/// How long an issued LTI login `state`/`nonce` stays valid before it is
+/// cleaned up. LTI launches follow their login initiation within seconds, so
+/// this is deliberately short.
+const LTI_LOGIN_TTL: Duration = Duration::from_secs(60 * 5);
+
+/// What an LTI login initiation (`/~lti/login`) remembers so the subsequent
+/// launch (`/~lti/launch`) can verify it. Keyed by the OIDC `state` value.
+///
+/// A server-side store is used instead of a cookie because an LTI launch is a
+/// cross-site `form_post`: with `SameSite=Lax` a state cookie would not be sent
+/// back on that POST.
+// Fields are read by the LTI launch handler (follow-up MR).
+#[allow(dead_code)]
+pub(crate) struct LtiLoginState {
+    /// The `nonce` we issued; the launch's ID token must echo it exactly.
+    pub(crate) nonce: String,
+
+    /// Where to send the user after a successful launch (`target_link_uri`).
+    pub(crate) target_link_uri: String,
+
+    created: Instant,
+}
+
+/// Short-lived, one-time-use store of issued LTI login states, living in
+/// [`Caches`] so it shares the periodic cleanup task.
+pub(crate) struct LtiNonceStore(HashMap<String, LtiLoginState>);
+
+impl LtiNonceStore {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Remembers a `state -> {nonce, target_link_uri}` mapping. Called by the
+    /// login initiation.
+    pub(crate) async fn insert(&self, state: String, nonce: String, target_link_uri: String) {
+        let _ = self.0.insert_async(state, LtiLoginState {
+            nonce,
+            target_link_uri,
+            created: Instant::now(),
+        }).await;
+    }
+
+    /// Consumes the entry issued for `state`, returning it at most once
+    /// (one-time use → replay protection). Returns `None` if it was never
+    /// issued, already used, or has expired. Called by the launch handler.
+    #[allow(dead_code)] // Consumed by the LTI launch handler (follow-up MR).
+    pub(crate) async fn take(&self, state: &str) -> Option<LtiLoginState> {
+        self.0.remove_async(state).await
+            .map(|(_, v)| v)
+            .filter(|v| v.created.elapsed() <= LTI_LOGIN_TTL)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn lti_nonce_store_is_one_time_use() {
+        let store = LtiNonceStore::new();
+        store.insert("state-1".into(), "nonce-1".into(), "https://tobira/x".into()).await;
+
+        // Unknown state → None.
+        assert!(store.take("nope").await.is_none());
+
+        // Known state → the issued nonce.
+        let taken = store.take("state-1").await;
+        assert_eq!(taken.as_ref().map(|s| s.nonce.as_str()), Some("nonce-1"));
+
+        // Taking the same state again → None (one-time use, i.e. replay protection).
+        assert!(store.take("state-1").await.is_none());
     }
 }

--- a/backend/src/auth/cache.rs
+++ b/backend/src/auth/cache.rs
@@ -300,14 +300,17 @@ const LTI_LOGIN_TTL: Duration = Duration::from_secs(60 * 5);
 /// A server-side store is used instead of a cookie because an LTI launch is a
 /// cross-site `form_post`: with `SameSite=Lax` a state cookie would not be sent
 /// back on that POST.
-// Fields are read by the LTI launch handler (follow-up MR).
-#[allow(dead_code)]
 pub(crate) struct LtiLoginState {
     /// The `nonce` we issued; the launch's ID token must echo it exactly.
     pub(crate) nonce: String,
 
     /// Where to send the user after a successful launch (`target_link_uri`).
     pub(crate) target_link_uri: String,
+
+    /// The platform (issuer + client ID) this login was initiated for. The
+    /// launch must originate from the same platform.
+    pub(crate) issuer: String,
+    pub(crate) client_id: String,
 
     created: Instant,
 }
@@ -321,12 +324,21 @@ impl LtiNonceStore {
         Self(HashMap::new())
     }
 
-    /// Remembers a `state -> {nonce, target_link_uri}` mapping. Called by the
-    /// login initiation.
-    pub(crate) async fn insert(&self, state: String, nonce: String, target_link_uri: String) {
+    /// Remembers a `state -> {nonce, target_link_uri, platform}` mapping.
+    /// Called by the login initiation.
+    pub(crate) async fn insert(
+        &self,
+        state: String,
+        nonce: String,
+        target_link_uri: String,
+        issuer: String,
+        client_id: String,
+    ) {
         let _ = self.0.insert_async(state, LtiLoginState {
             nonce,
             target_link_uri,
+            issuer,
+            client_id,
             created: Instant::now(),
         }).await;
     }
@@ -334,7 +346,6 @@ impl LtiNonceStore {
     /// Consumes the entry issued for `state`, returning it at most once
     /// (one-time use → replay protection). Returns `None` if it was never
     /// issued, already used, or has expired. Called by the launch handler.
-    #[allow(dead_code)] // Consumed by the LTI launch handler (follow-up MR).
     pub(crate) async fn take(&self, state: &str) -> Option<LtiLoginState> {
         self.0.remove_async(state).await
             .map(|(_, v)| v)
@@ -350,7 +361,10 @@ mod tests {
     #[tokio::test]
     async fn lti_nonce_store_is_one_time_use() {
         let store = LtiNonceStore::new();
-        store.insert("state-1".into(), "nonce-1".into(), "https://tobira/x".into()).await;
+        store.insert(
+            "state-1".into(), "nonce-1".into(), "https://tobira/x".into(),
+            "https://lms.example.org".into(), "client-a".into(),
+        ).await;
 
         // Unknown state → None.
         assert!(store.take("nope").await.is_none());

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -69,6 +69,9 @@ pub(crate) struct AuthConfig {
 
     #[config(nested)]
     pub(crate) roles: RoleConfig,
+
+    #[config(nested)]
+    pub(crate) oidc: OidcConfig,
 }
 
 impl AuthConfig {
@@ -442,5 +445,38 @@ impl CallbackUri {
             CallbackUri::Tcp(uri) => uri,
             CallbackUri::Uds(uri) => uri,
         }
+    }
+}
+
+#[derive(Debug, Clone, confique::Config)]
+#[config(validate = Self::validate)]
+pub(crate) struct OidcConfig {
+    #[config(default = false)]
+    pub(crate) enabled: bool,
+
+    /// Base URL to the issuer/IdP, e.g. `https://foo.com/realms/bar`. Note
+    /// that these URLs basically never have a trailing `/`.
+    #[config(validate = HttpUrl::ensure_secure_no_fragment)]
+    pub(crate) issuer_url: Option<HttpUrl>,
+
+    /// The client identifier registered with the identity provider.
+    pub(crate) client_id: Option<String>,
+
+    /// The secret to authenticate against the identity provider.
+    pub(crate) client_secret: Option<SecretString>,
+}
+
+impl OidcConfig {
+    fn validate(&self) -> Result<()> {
+        if self.enabled {
+            anyhow::ensure!(self.issuer_url.is_some(),
+                "oidc.enabled = true, but 'issuer_url' is not set");
+            anyhow::ensure!(self.client_id.is_some(),
+                "oidc.enabled = true, but 'client_id' is not set");
+            anyhow::ensure!(self.client_secret.is_some(),
+                "oidc.enabled = true, but 'client_secret' is not set");
+        }
+
+        Ok(())
     }
 }

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -117,17 +117,26 @@ impl AuthConfig {
                 'auth.callback.relevant_cookies'. But it is set.");
         }
 
-        let session_sources_defined = false
+        // Session sources configured via the built-in `[auth.session]` handlers.
+        // These are mutually exclusive with a non-`tobira-session` auth source.
+        let session_handlers_defined = false
             || self.session.from_login_credentials != LoginCredentialsHandler::None
             || self.session.from_session_endpoint != SessionEndpointHandler::None;
+        // OIDC and LTI also create Tobira sessions (both call
+        // `create_session_with_cookies`), so enabling either is another valid
+        // way to create sessions when `auth.source = "tobira-session"`.
+        let can_create_sessions = session_handlers_defined
+            || self.oidc.enabled
+            || self.lti.enabled;
         if self.source == AuthSource::TobiraSession {
-            if !session_sources_defined {
+            if !can_create_sessions {
                 bail!("'auth.source' is 'tobira-session', but no way to create \
-                    sessions is configured: set 'auth.session.from_login_credentials' \
-                    or 'auth.session.from_session_endpoint'");
+                    sessions is configured: enable 'auth.oidc' or 'auth.lti', or set \
+                    'auth.session.from_login_credentials' or \
+                    'auth.session.from_session_endpoint'");
             }
         } else {
-            if session_sources_defined {
+            if session_handlers_defined {
                 bail!("'auth.source' is not 'tobira-session', but \
                     'auth.session.from_login_credentials' or \
                     'auth.session.from_session_endpoint' is set.");
@@ -608,5 +617,35 @@ mod tests {
         assert!(lti_config(false, vec![]).validate().is_ok());
         assert!(lti_config(true, vec![platform("https://moodle.example.org", "c")])
             .validate().is_ok());
+    }
+
+    /// A full `AuthConfig` with every field at its default value.
+    fn default_auth_config() -> AuthConfig {
+        use confique::{Config, Layer};
+        let layer = <<AuthConfig as Config>::Layer as Layer>::default_values();
+        AuthConfig::from_layer(layer).expect("default AuthConfig should be valid")
+    }
+
+    #[test]
+    fn tobira_session_needs_a_session_source() {
+        // `tobira-session` without any way to create sessions must be rejected.
+        let mut cfg = default_auth_config();
+        cfg.source = AuthSource::TobiraSession;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn oidc_and_lti_count_as_session_sources() {
+        // Enabling OIDC alone is a valid way to create sessions.
+        let mut cfg = default_auth_config();
+        cfg.source = AuthSource::TobiraSession;
+        cfg.oidc.enabled = true;
+        assert!(cfg.validate().is_ok());
+
+        // Enabling LTI alone is a valid way to create sessions.
+        let mut cfg = default_auth_config();
+        cfg.source = AuthSource::TobiraSession;
+        cfg.lti.enabled = true;
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -73,9 +73,6 @@ pub(crate) struct AuthConfig {
     #[config(nested)]
     pub(crate) oidc: OidcConfig,
 
-    // Read by the LTI launch handler (follow-up MR); wired in now so `[auth.lti]`
-    // parses and shows up in the generated config template.
-    #[allow(dead_code)]
     #[config(nested)]
     pub(crate) lti: LtiConfig,
 }
@@ -533,10 +530,15 @@ impl LtiConfig {
     /// uniquely identifies an LTI registration. Returns `None` if no such
     /// platform is configured. The LTI launch handler uses this to resolve the
     /// platform a launch originated from.
-    #[allow(dead_code)] // Consumed by the LTI launch handler (follow-up MR); covered by tests.
     pub(crate) fn find_platform(&self, issuer: &str, client_id: &str) -> Option<&LtiPlatform> {
         self.platforms.iter()
             .find(|p| p.issuer == issuer && p.client_id == client_id)
+    }
+
+    /// Looks up a platform by issuer alone — used when the login initiation does
+    /// not carry a `client_id`. Returns the first platform with that issuer.
+    pub(crate) fn find_platform_by_issuer(&self, issuer: &str) -> Option<&LtiPlatform> {
+        self.platforms.iter().find(|p| p.issuer == issuer)
     }
 }
 

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -521,6 +521,9 @@ pub(crate) struct LtiConfig {
     ///     deployment_id = "1"
     ///     auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
     ///     keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+    ///     # Moodle sends no `preferred_username`; take it from a custom parameter
+    ///     # (`username=$User.username`). See `username_source` for the caveat.
+    ///     username_source = "custom"
     #[config(default = [])]
     pub(crate) platforms: Vec<LtiPlatform>,
 }
@@ -587,6 +590,33 @@ pub(crate) struct LtiPlatform {
     /// The platform's JWKS URL, used to verify incoming launch tokens. LMS
     /// label: "Public keyset URL"; for Moodle this is `.../mod/lti/certs.php`.
     pub(crate) keyset_url: HttpUrl,
+
+    /// Which launch claim provides the Opencast username. Defaults to the
+    /// platform-asserted `preferred_username` (`"preferred-username"`).
+    ///
+    /// Set this to `"custom"` only for platforms that do not send a usable
+    /// `preferred_username` (e.g. Moodle), where the username has to be passed
+    /// via a `username` custom parameter (`username=$User.username`). Be aware
+    /// that custom parameters can be set per placement, often by instructors —
+    /// so `"custom"` trusts whoever configures the launch to assert the
+    /// identity. Only enable it for platforms where that is acceptable.
+    ///
+    /// `"sub"` uses the raw subject claim (rarely a valid Opencast username).
+    #[serde(default)]
+    pub(crate) username_source: LtiUsernameSource,
+}
+
+/// Which launch claim a platform's Opencast username is taken from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum LtiUsernameSource {
+    /// The `preferred_username` claim (safe default: platform-asserted).
+    #[default]
+    PreferredUsername,
+    /// The raw `sub` claim.
+    Sub,
+    /// The `username` custom parameter. See the caveat on `username_source`.
+    Custom,
 }
 
 
@@ -601,6 +631,7 @@ mod tests {
             deployment_id: "1".into(),
             auth_login_url: "https://lms.example.org/auth".parse().unwrap(),
             keyset_url: "https://lms.example.org/jwks".parse().unwrap(),
+            username_source: LtiUsernameSource::default(),
         }
     }
 

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -72,6 +72,12 @@ pub(crate) struct AuthConfig {
 
     #[config(nested)]
     pub(crate) oidc: OidcConfig,
+
+    // Read by the LTI launch handler (follow-up MR); wired in now so `[auth.lti]`
+    // parses and shows up in the generated config template.
+    #[allow(dead_code)]
+    #[config(nested)]
+    pub(crate) lti: LtiConfig,
 }
 
 impl AuthConfig {
@@ -478,5 +484,127 @@ impl OidcConfig {
         }
 
         Ok(())
+    }
+}
+
+
+/// LTI 1.3 configuration. Tobira can act as an LTI 1.3 tool that LMS platforms
+/// (e.g. Moodle, Canvas) launch. LTI runs *alongside* the normal login, not as a
+/// replacement for it. See `docs/docs/dev/rfc-lti-1.3.md`.
+#[derive(Debug, Clone, confique::Config)]
+#[config(validate = Self::validate)]
+pub(crate) struct LtiConfig {
+    /// If `true`, the LTI launch endpoints are enabled.
+    #[config(default = false)]
+    pub(crate) enabled: bool,
+
+    /// Registered LTI platforms, one table entry per platform/deployment:
+    ///
+    ///     [[auth.lti.platforms]]
+    ///     issuer = "https://moodle.example.org"
+    ///     client_id = "AbCd1234"
+    ///     deployment_id = "1"
+    ///     auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
+    ///     keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+    #[config(default = [])]
+    pub(crate) platforms: Vec<LtiPlatform>,
+}
+
+impl LtiConfig {
+    fn validate(&self) -> Result<()> {
+        if self.enabled {
+            anyhow::ensure!(
+                !self.platforms.is_empty(),
+                "auth.lti.enabled = true, but no '[[auth.lti.platforms]]' are configured",
+            );
+        }
+
+        // Platform URLs must be secure (https) and fragment-free, like all other
+        // externally-facing URLs in Tobira.
+        for platform in &self.platforms {
+            platform.auth_login_url.ensure_secure_no_fragment()?;
+            platform.keyset_url.ensure_secure_no_fragment()?;
+        }
+
+        Ok(())
+    }
+
+    /// Looks up a registered platform by the `(issuer, client_id)` pair, which
+    /// uniquely identifies an LTI registration. Returns `None` if no such
+    /// platform is configured. The LTI launch handler uses this to resolve the
+    /// platform a launch originated from.
+    #[allow(dead_code)] // Consumed by the LTI launch handler (follow-up MR); covered by tests.
+    pub(crate) fn find_platform(&self, issuer: &str, client_id: &str) -> Option<&LtiPlatform> {
+        self.platforms.iter()
+            .find(|p| p.issuer == issuer && p.client_id == client_id)
+    }
+}
+
+/// A single registered LTI platform (i.e. an LMS).
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+pub(crate) struct LtiPlatform {
+    /// The platform's issuer identifier; compared **verbatim** against the `iss`
+    /// claim of launches. LTI issuers are exact-match identifiers, not URLs we
+    /// dereference, so this is a plain string (no URL normalization).
+    pub(crate) issuer: String,
+
+    /// The client ID Tobira is registered under with this platform; matches the
+    /// `aud`/`azp` claim of launches.
+    pub(crate) client_id: String,
+
+    /// The deployment ID; matches the platform's `deployment_id` claim.
+    pub(crate) deployment_id: String,
+
+    /// The platform's OIDC authorization endpoint that the login initiation
+    /// redirects to.
+    pub(crate) auth_login_url: HttpUrl,
+
+    /// The platform's JWKS URL, used to verify incoming launch tokens.
+    pub(crate) keyset_url: HttpUrl,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform(issuer: &str, client_id: &str) -> LtiPlatform {
+        LtiPlatform {
+            issuer: issuer.into(),
+            client_id: client_id.into(),
+            deployment_id: "1".into(),
+            auth_login_url: "https://lms.example.org/auth".parse().unwrap(),
+            keyset_url: "https://lms.example.org/jwks".parse().unwrap(),
+        }
+    }
+
+    fn lti_config(enabled: bool, platforms: Vec<LtiPlatform>) -> LtiConfig {
+        LtiConfig { enabled, platforms }
+    }
+
+    #[test]
+    fn find_platform_matches_on_issuer_and_client_id() {
+        let cfg = lti_config(true, vec![
+            platform("https://moodle.example.org", "client-a"),
+            platform("https://canvas.example.org", "client-b"),
+        ]);
+
+        assert_eq!(
+            cfg.find_platform("https://canvas.example.org", "client-b")
+                .map(|p| p.client_id.as_str()),
+            Some("client-b"),
+        );
+        // Right issuer but wrong client ID must not match.
+        assert!(cfg.find_platform("https://moodle.example.org", "client-b").is_none());
+        // Unknown issuer must not match.
+        assert!(cfg.find_platform("https://unknown.example.org", "client-a").is_none());
+    }
+
+    #[test]
+    fn validate_requires_platforms_when_enabled() {
+        assert!(lti_config(true, vec![]).validate().is_err());
+        assert!(lti_config(false, vec![]).validate().is_ok());
+        assert!(lti_config(true, vec![platform("https://moodle.example.org", "c")])
+            .validate().is_ok());
     }
 }

--- a/backend/src/auth/config.rs
+++ b/backend/src/auth/config.rs
@@ -504,7 +504,16 @@ pub(crate) struct LtiConfig {
     #[config(default = false)]
     pub(crate) enabled: bool,
 
-    /// Registered LTI platforms, one table entry per platform/deployment:
+    /// Registered LTI platforms, one table entry per platform/deployment. All
+    /// values come from the tool registration in your LMS, which labels them
+    /// differently than the spec terms used here (Moodle labels shown; Canvas
+    /// calls `issuer` "Issuer"):
+    ///
+    ///     issuer         ->  "Platform ID"
+    ///     client_id      ->  "Client ID"
+    ///     deployment_id  ->  "Deployment ID"
+    ///     auth_login_url ->  "Authentication request URL"
+    ///     keyset_url     ->  "Public keyset URL"
     ///
     ///     [[auth.lti.platforms]]
     ///     issuer = "https://moodle.example.org"
@@ -557,20 +566,26 @@ pub(crate) struct LtiPlatform {
     /// The platform's issuer identifier; compared **verbatim** against the `iss`
     /// claim of launches. LTI issuers are exact-match identifiers, not URLs we
     /// dereference, so this is a plain string (no URL normalization).
+    ///
+    /// In the LMS this is the field labelled "Platform ID" (Moodle) or
+    /// "Issuer" (Canvas).
     pub(crate) issuer: String,
 
     /// The client ID Tobira is registered under with this platform; matches the
-    /// `aud`/`azp` claim of launches.
+    /// `aud`/`azp` claim of launches. LMS label: "Client ID".
     pub(crate) client_id: String,
 
     /// The deployment ID; matches the platform's `deployment_id` claim.
+    /// LMS label: "Deployment ID".
     pub(crate) deployment_id: String,
 
     /// The platform's OIDC authorization endpoint that the login initiation
-    /// redirects to.
+    /// redirects to. LMS label: "Authentication request URL" (Moodle) /
+    /// "OpenID Connect Authentication URL"; for Moodle this is `.../mod/lti/auth.php`.
     pub(crate) auth_login_url: HttpUrl,
 
-    /// The platform's JWKS URL, used to verify incoming launch tokens.
+    /// The platform's JWKS URL, used to verify incoming launch tokens. LMS
+    /// label: "Public keyset URL"; for Moodle this is `.../mod/lti/certs.php`.
     pub(crate) keyset_url: HttpUrl,
 }
 

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -3,11 +3,7 @@ use std::unreachable;
 use hyper::{body::Incoming, StatusCode, Request, http::HeaderValue};
 
 use crate::{
-    auth::config::LoginCredentialsHandler,
-    db,
-    http::{self, response::bad_request, Context, Response},
-    prelude::*,
-    util::{download_body, ByteBody},
+    auth::config::LoginCredentialsHandler, db, http::{self, Context, Response, response::bad_request}, prelude::*, sync::client::AuthMode, util::{ByteBody, download_body}
 };
 use super::{config::SessionEndpointHandler, AuthSource, SessionId, User};
 
@@ -151,7 +147,9 @@ pub(crate) async fn handle_post_login(req: Request<Incoming>, ctx: &Context) -> 
     // Check the login data.
     let user = match &ctx.config.auth.session.from_login_credentials {
         LoginCredentialsHandler::Opencast => {
-            match super::opencast::try_login(&userid, &password, ctx).await {
+            trace!("Checking Opencast login...");
+            let mode = AuthMode::User { username: &userid, password: &password };
+            match super::opencast::user_from_info_me(mode, ctx).await {
                 Err(e) => {
                     error!("Error occured while checking Opencast login data: {e:#}");
                     return http::response::internal_server_error();

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -258,21 +258,12 @@ async fn check_opencast_login(
 }
 
 /// Creates a session for the given user and persists it in the DB.
-async fn create_session(mut user: User, ctx: &Context) -> Result<Response, Response> {
-    user.add_default_roles();
-
-    // TODO: check if a user is already logged in? And remove that session then?
-
-    let db = db::get_conn_or_service_unavailable(&ctx.db_pool).await?;
-    let session_id = user.persist_new_session(&db).await.map_err(|e| {
-        error!("DB query failed when adding new user session: {}", e);
-        http::response::internal_server_error()
-    })?;
-    debug!("Persisted new session for '{}'", user.username);
+async fn create_session(user: User, ctx: &Context) -> Result<Response, Response> {
+    let cookie = super::create_session_with_cookies(user, ctx).await?;
 
     Response::builder()
         .status(StatusCode::NO_CONTENT)
-        .header("set-cookie", session_id.set_cookie(ctx.config.auth.session.duration).to_string())
+        .header("set-cookie", cookie.to_string())
         .body(ByteBody::empty())
         .unwrap()
         .pipe(Ok)

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -1,8 +1,6 @@
 use std::unreachable;
 
-use base64::Engine;
 use hyper::{body::Incoming, StatusCode, Request, http::HeaderValue};
-use serde::Deserialize;
 
 use crate::{
     auth::config::LoginCredentialsHandler,
@@ -153,7 +151,7 @@ pub(crate) async fn handle_post_login(req: Request<Incoming>, ctx: &Context) -> 
     // Check the login data.
     let user = match &ctx.config.auth.session.from_login_credentials {
         LoginCredentialsHandler::Opencast => {
-            match check_opencast_login(&userid, &password, ctx).await {
+            match super::opencast::try_login(&userid, &password, ctx).await {
                 Err(e) => {
                     error!("Error occured while checking Opencast login data: {e:#}");
                     return http::response::internal_server_error();
@@ -186,75 +184,6 @@ pub(crate) async fn handle_post_login(req: Request<Incoming>, ctx: &Context) -> 
             .unwrap(),
         Some(user) => create_session(user, ctx).await.unwrap_or_else(|e| e),
     }
-}
-
-async fn check_opencast_login(
-    userid: &str,
-    password: &str,
-    ctx: &Context,
-) -> Result<Option<User>> {
-    trace!("Checking Opencast login...");
-
-    // Send request. We use basic auth here: our configuration checks already
-    // assert that we use HTTPS or Opencast is running on the same machine
-    // (or the admin has explicitly opted out of this check).
-    let credentials = base64::engine::general_purpose::STANDARD
-        .encode(&format!("{userid}:{password}"));
-    let auth_header = format!("Basic {}", credentials);
-    let req = Request::builder()
-        .uri(ctx.config.opencast.sync_node().clone().with_path_and_query("/info/me.json"))
-        .header(hyper::header::AUTHORIZATION, auth_header)
-        .body(ByteBody::empty())
-        .unwrap();
-    let response = ctx.http_client.request(req).await?;
-
-
-    // We treat all non-OK response as invalid login data.
-    if response.status() != StatusCode::OK {
-        return Ok(None);
-    }
-
-
-    // Deserialize JSON body.
-    #[derive(Deserialize)]
-    struct InfoMeResponse {
-        roles: Vec<String>,
-        user: InfoMeUserResponse,
-        #[serde(rename = "userRole")]
-        user_role: String,
-    }
-
-    #[derive(Deserialize)]
-    struct InfoMeUserResponse {
-        name: String,
-        username: String,
-        email: Option<String>,
-    }
-
-    let body = download_body(response.into_body()).await?;
-    let mut info: InfoMeResponse = serde_json::from_slice(&body)
-        .context("Could not deserialize `/info/me.json` response")?;
-
-    // If all roles are `ROLE_ANONYMOUS`, then we assume the login was invalid.
-    if info.roles.iter().all(|role| role == super::ROLE_ANONYMOUS) {
-        return Ok(None);
-    }
-
-    // Make sure the roles list always contains the user role. This is very
-    // likely always the case, but better be sure.
-    if !info.roles.contains(&info.user_role) {
-        info.roles.push(info.user_role.clone());
-    }
-
-    // Otherwise the login was correct!
-    Ok(Some(User {
-        username: info.user.username,
-        display_name: info.user.name,
-        email: info.user.email,
-        roles: info.roles.into_iter().collect(),
-        user_role: info.user_role,
-        user_realm_handle: None,
-    }))
 }
 
 /// Creates a session for the given user and persists it in the DB.

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -290,13 +290,26 @@ async fn fetch_platform_jwks(
 /// Returns `target` if it points within our own Tobira instance, otherwise the
 /// Tobira base URL. Prevents the launch from being abused as an open redirect.
 fn safe_target(target: &str, ctx: &Context) -> String {
-    let base = ctx.config.general.tobira_url.to_string();
-    if target.starts_with(&base) {
-        target.to_owned()
-    } else {
+    resolve_target(target, &ctx.config.general.tobira_url.to_string())
+}
+
+/// Picks a safe in-Tobira redirect target for a launch, defaulting to `base`
+/// (the start page). Two things it guards against:
+///
+/// - **Open redirects:** a `target_link_uri` outside Tobira is discarded.
+/// - **Bouncing into our own endpoints:** platforms commonly use the tool URL
+///   as the default `target_link_uri`, which for us is `/~lti/launch` — a
+///   POST-only endpoint that a browser GET would 404 on. Any `/~lti/` target
+///   therefore falls back to the start page.
+fn resolve_target(target: &str, base: &str) -> String {
+    let Some(path) = target.strip_prefix(base) else {
         warn!("LTI launch: target_link_uri '{target}' is outside Tobira; using base URL");
-        base
+        return base.to_owned();
+    };
+    if path.starts_with("/~lti/") {
+        return base.to_owned();
     }
+    target.to_owned()
 }
 
 /// Builds the URL of a Tobira series page from an Opencast series ID, using
@@ -501,6 +514,22 @@ mod tests {
                 "preferred_username": "rrolf",
             }))),
             "rrolf",
+        );
+    }
+
+    #[test]
+    fn resolve_target_lands_on_start_page_for_lti_endpoints_and_open_redirects() {
+        let base = "https://tobira.example.org";
+
+        // Moodle's default `target_link_uri` is the tool URL (`/~lti/launch`),
+        // which must not be handed back to the browser.
+        assert_eq!(resolve_target("https://tobira.example.org/~lti/launch", base), base);
+        // Anything outside Tobira is refused (no open redirect).
+        assert_eq!(resolve_target("https://evil.example.org/phish", base), base);
+        // A real in-Tobira page is kept.
+        assert_eq!(
+            resolve_target("https://tobira.example.org/!s/:abc-123", base),
+            "https://tobira.example.org/!s/:abc-123",
         );
     }
 

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -8,8 +8,10 @@
 
 use std::{borrow::Cow, collections::BTreeMap};
 
+use aws_lc_rs::{digest, rsa::{KeyPair, KeySize}, signature::KeyPair as _};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use hyper::{Method, Request, StatusCode, Uri, body::Incoming, header};
+use once_cell::sync::Lazy;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
 
@@ -333,5 +335,92 @@ impl<H> jwtea::Validator<H, LtiClaims> for LtiLaunchValidator<'_> {
             return Err(jwtea::Error::ValidationError("'azp' does not match client ID".into()));
         }
         Ok(())
+    }
+}
+
+
+/// The tool's RSA key pair for LTI, plus its public JWKS document.
+///
+/// LTI tools sign the Deep Linking response and service `client_assertion`s
+/// with RSA (RS256); platforms fetch the tool's public key from `/~lti/jwks`
+/// and also require it during tool registration. `jwtea` only *verifies*, so
+/// the signing/keyset side uses `aws-lc-rs` directly.
+///
+/// For now the key is generated once per process. A configurable persistent key
+/// (PEM) is a later enhancement — platforms re-fetch the keyset, so a fresh key
+/// across restarts is still valid, it just invalidates in-flight signed
+/// messages (of which the MVP has none).
+struct LtiToolKey {
+    /// Kept for signing the Deep Linking response / NRPS `client_assertion`
+    /// (added with those features).
+    #[allow(dead_code)]
+    keypair: KeyPair,
+
+    /// The public JWKS document served at `/~lti/jwks`.
+    jwks: String,
+}
+
+impl LtiToolKey {
+    fn generate() -> Self {
+        let keypair = KeyPair::generate(KeySize::Rsa2048)
+            .expect("failed to generate LTI tool RSA key");
+        let public = keypair.public_key();
+
+        // JWK RSA components: base64url(big-endian modulus / exponent).
+        let n = BASE64_URL_SAFE_NO_PAD.encode(public.modulus().big_endian_without_leading_zero());
+        let e = BASE64_URL_SAFE_NO_PAD.encode(public.exponent().big_endian_without_leading_zero());
+        // A stable key id derived from the public key.
+        let kid = BASE64_URL_SAFE_NO_PAD.encode(
+            digest::digest(&digest::SHA256, public.as_ref()).as_ref(),
+        );
+
+        let jwks = serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": kid,
+                "n": n,
+                "e": e,
+            }],
+        }).to_string();
+
+        Self { keypair, jwks }
+    }
+}
+
+static LTI_TOOL_KEY: Lazy<LtiToolKey> = Lazy::new(LtiToolKey::generate);
+
+/// Handles `GET /~lti/jwks`: serves the tool's public keys (JWKS) so platforms
+/// can register Tobira and verify JWTs it signs (Deep Linking response, service
+/// grants). Only served when LTI is enabled.
+pub(crate) async fn handle_jwks(ctx: &Context) -> Response {
+    if !ctx.config.auth.lti.enabled {
+        return http::response::not_found();
+    }
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(ByteBody::new(LTI_TOOL_KEY.jwks.clone().into()))
+        .unwrap()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_jwks_has_one_rsa_signing_key() {
+        let key = LtiToolKey::generate();
+        let doc: serde_json::Value = serde_json::from_str(&key.jwks).unwrap();
+        let jwk = &doc["keys"][0];
+
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "RS256");
+        // 2048-bit modulus, base64url-encoded, is well over 300 chars.
+        assert!(jwk["n"].as_str().unwrap().len() > 300);
+        assert!(!jwk["e"].as_str().unwrap().is_empty());
+        assert!(!jwk["kid"].as_str().unwrap().is_empty());
     }
 }

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -199,13 +199,14 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
         return http::response::bad_request("LTI launch: deployment_id mismatch");
     }
 
+    debug!("LTI launch claims: {claims:#?}");
+
     // ----- Build the user and create a session ----------------------------------------------
-    // Roles come from Opencast, exactly like the OIDC login (#1706). The
-    // username is derived from the launch (`preferred_username`, else `sub`).
+    // Roles come from Opencast, exactly like the OIDC login (#1706).
     // NOTE: how the launch identity maps to an Opencast username is an open
     // design question (see docs/docs/dev/rfc-lti-1.3.md, OQ8) — this is the
     // provisional MVP mapping.
-    let username = claims.preferred_username.clone().unwrap_or_else(|| claims.sub.clone());
+    let username = resolve_username(&claims);
     let oc_user = match super::opencast::user_from_info_me(
         AuthMode::Sudo { as_user: &username },
         ctx,
@@ -252,6 +253,26 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
         .unwrap()
 }
 
+/// Determines the Opencast username from the launch claims.
+///
+/// Platforms differ in what identity they expose: Canvas sends
+/// `preferred_username`, while Moodle sends none of it — its `sub` is an opaque
+/// internal ID that Opencast does not know. Such platforms can supply the
+/// username explicitly via a `username` custom parameter (in Moodle:
+/// `username=$User.username`), which therefore takes precedence.
+fn resolve_username(claims: &LtiClaims) -> String {
+    let from_custom = claims.custom.as_ref()
+        .and_then(|custom| custom.get("username"))
+        .and_then(|username| username.as_str())
+        .filter(|username| !username.is_empty());
+
+    match (from_custom, &claims.preferred_username) {
+        (Some(username), _) => username.to_owned(),
+        (None, Some(username)) => username.clone(),
+        (None, None) => claims.sub.clone(),
+    }
+}
+
 /// Fetches and parses the platform's JWKS into verifying keys. Keys we do not
 /// understand are skipped.
 async fn fetch_platform_jwks(
@@ -286,7 +307,7 @@ fn series_landing(base: &str, opencast_series_id: &str) -> String {
 
 /// The subset of LTI 1.3 launch claims we read. Only the fields needed for the
 /// MVP (verification + identity) are modelled.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct LtiClaims {
     iss: String,
     aud: MaybeArray<String>,
@@ -309,7 +330,7 @@ struct LtiClaims {
 }
 
 /// A JSON value that may be a single item or an array of them (e.g. `aud`).
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum MaybeArray<T> {
     Single(T),
@@ -448,5 +469,51 @@ mod tests {
             series_landing("https://tobira.example.org", "abc-123"),
             "https://tobira.example.org/!s/:abc-123",
         );
+    }
+
+    /// Builds claims from the given user-identifying fields, filling in the
+    /// rest with values a launch would always carry.
+    fn claims_with(extra: serde_json::Value) -> LtiClaims {
+        let mut json = serde_json::json!({
+            "iss": "https://moodle.example.org",
+            "aud": "client-a",
+            "sub": "3",
+            "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "1",
+        });
+        let (serde_json::Value::Object(base), serde_json::Value::Object(extra))
+            = (&mut json, extra) else { panic!("expected JSON objects") };
+        base.extend(extra);
+
+        serde_json::from_value(json).expect("claims should deserialize")
+    }
+
+    #[test]
+    fn username_falls_back_to_sub_without_better_claims() {
+        // Moodle sends neither `preferred_username` nor a custom parameter, so
+        // we are left with the opaque `sub`.
+        assert_eq!(resolve_username(&claims_with(serde_json::json!({}))), "3");
+    }
+
+    #[test]
+    fn username_uses_preferred_username_when_present() {
+        assert_eq!(
+            resolve_username(&claims_with(serde_json::json!({
+                "preferred_username": "rrolf",
+            }))),
+            "rrolf",
+        );
+    }
+
+    #[test]
+    fn username_custom_parameter_wins_and_empty_is_ignored() {
+        let custom = |username| serde_json::json!({
+            "preferred_username": "from-claim",
+            "https://purl.imsglobal.org/spec/lti/claim/custom": { "username": username },
+        });
+
+        // An explicitly configured custom parameter takes precedence.
+        assert_eq!(resolve_username(&claims_with(custom("from-custom"))), "from-custom");
+        // An unsubstituted or blank value must not shadow the standard claim.
+        assert_eq!(resolve_username(&claims_with(custom(""))), "from-claim");
     }
 }

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -16,7 +16,7 @@ use secrecy::ExposeSecret;
 use serde::Deserialize;
 
 use crate::{
-    auth::{User, config::LtiPlatform},
+    auth::{User, config::{LtiPlatform, LtiUsernameSource}},
     http::{self, Context, Response},
     prelude::*,
     sync::client::AuthMode,
@@ -34,6 +34,9 @@ use crate::{
 /// authorization endpoint. The platform then POSTs the signed launch
 /// (`id_token`) back to `/~lti/launch` (handled in a follow-up).
 pub(crate) async fn handle_login(req: Request<Incoming>, ctx: &Context) -> Response {
+    if !ctx.config.auth.lti.enabled {
+        return http::response::not_found();
+    }
     let raw = match read_raw_params(req).await {
         Ok(raw) => raw,
         Err(response) => return response,
@@ -134,6 +137,10 @@ fn random_token() -> String {
 /// build a Tobira user and create a session, then redirect to the
 /// `target_link_uri`.
 pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Response {
+    if !ctx.config.auth.lti.enabled {
+        return http::response::not_found();
+    }
+
     // ----- Read the form_post body: `id_token` + `state` ------------------------------------
     let body = match download_body(req.into_body()).await {
         Ok(body) => body,
@@ -178,7 +185,11 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
         client_id: &platform.client_id,
     };
     let claims = match raw
-        .decode::<(), LtiClaims, _>(keys.as_slice(), &validator, |_header, payload| payload.extra_fields)
+        .decode::<(), LtiClaims, _>(
+            keys.as_slice(),
+            &validator,
+            |_header, payload| payload.extra_fields,
+        )
         .await
     {
         Ok(claims) => claims,
@@ -202,11 +213,16 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
     debug!("LTI launch claims: {claims:#?}");
 
     // ----- Build the user and create a session ----------------------------------------------
-    // Roles come from Opencast, exactly like the OIDC login (#1706).
-    // NOTE: how the launch identity maps to an Opencast username is an open
-    // design question (see docs/docs/dev/rfc-lti-1.3.md, OQ8) — this is the
-    // provisional MVP mapping.
-    let username = resolve_username(&claims);
+    // Roles come from Opencast, exactly like the OIDC login (#1706). The
+    // username comes from the claim the platform is configured to use; see the
+    // `username_source` config and RFC OQ8.
+    let Some(username) = resolve_username(&claims, platform.username_source) else {
+        warn!(
+            "LTI launch: no username in launch (username_source = {:?})",
+            platform.username_source,
+        );
+        return http::response::bad_request("LTI launch: no username provided by platform");
+    };
     let oc_user = match super::opencast::user_from_info_me(
         AuthMode::Sudo { as_user: &username },
         ctx,
@@ -245,31 +261,38 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
         Some(series) => series_landing(&ctx.config.general.tobira_url.to_string(), series),
         None => safe_target(&login.target_link_uri, ctx),
     };
+    // `target` is constrained to our own origin, but a `series` custom parameter
+    // could still carry characters that are invalid in a header; fall back to the
+    // base URL rather than panic when building the response.
+    let location = header::HeaderValue::from_str(&target).unwrap_or_else(|_| {
+        header::HeaderValue::from_str(&ctx.config.general.tobira_url.to_string())
+            .expect("tobira_url is a valid header value")
+    });
     Response::builder()
         .status(StatusCode::FOUND)
-        .header(header::LOCATION, target)
+        .header(header::LOCATION, location)
         .header(header::SET_COOKIE, cookie.to_string())
         .body(ByteBody::empty())
         .unwrap()
 }
 
-/// Determines the Opencast username from the launch claims.
+/// Determines the Opencast username from the launch claims, using the source
+/// the platform is configured with. Returns `None` if that claim is absent, so
+/// the caller can reject the launch instead of guessing an identity.
 ///
-/// Platforms differ in what identity they expose: Canvas sends
-/// `preferred_username`, while Moodle sends none of it — its `sub` is an opaque
-/// internal ID that Opencast does not know. Such platforms can supply the
-/// username explicitly via a `username` custom parameter (in Moodle:
-/// `username=$User.username`), which therefore takes precedence.
-fn resolve_username(claims: &LtiClaims) -> String {
-    let from_custom = claims.custom.as_ref()
-        .and_then(|custom| custom.get("username"))
-        .and_then(|username| username.as_str())
-        .filter(|username| !username.is_empty());
-
-    match (from_custom, &claims.preferred_username) {
-        (Some(username), _) => username.to_owned(),
-        (None, Some(username)) => username.clone(),
-        (None, None) => claims.sub.clone(),
+/// The source is an admin decision per platform: Canvas sends a trustworthy
+/// `preferred_username` (the safe default), while Moodle sends none and needs
+/// `Custom` (a `username` custom parameter). `Custom` trusts whoever configures
+/// the launch — see the `username_source` docs.
+fn resolve_username(claims: &LtiClaims, source: LtiUsernameSource) -> Option<String> {
+    match source {
+        LtiUsernameSource::PreferredUsername => claims.preferred_username.clone(),
+        LtiUsernameSource::Sub => Some(claims.sub.clone()),
+        LtiUsernameSource::Custom => claims.custom.as_ref()
+            .and_then(|custom| custom.get("username"))
+            .and_then(|username| username.as_str())
+            .filter(|username| !username.is_empty())
+            .map(str::to_owned),
     }
 }
 
@@ -281,6 +304,9 @@ async fn fetch_platform_jwks(
 ) -> Result<Vec<jwtea::VerifyingKey>> {
     let uri = platform.keyset_url.as_str().parse::<Uri>().context("invalid keyset URL")?;
     let response = ctx.http_client.get(uri).await?;
+    if !response.status().is_success() {
+        bail!("platform JWKS endpoint returned status {}", response.status());
+    }
     let body = download_body(response.into_body()).await?;
     let jwks: jwtea::Jwks = serde_json::from_slice(&body)
         .context("could not parse platform JWKS")?;
@@ -294,22 +320,26 @@ fn safe_target(target: &str, ctx: &Context) -> String {
 }
 
 /// Picks a safe in-Tobira redirect target for a launch, defaulting to `base`
-/// (the start page). Two things it guards against:
+/// (the start page). It guards against three things:
 ///
-/// - **Open redirects:** a `target_link_uri` outside Tobira is discarded.
-/// - **Bouncing into our own endpoints:** platforms commonly use the tool URL
-///   as the default `target_link_uri`, which for us is `/~lti/launch` — a
-///   POST-only endpoint that a browser GET would 404 on. Any `/~lti/` target
-///   therefore falls back to the start page.
+/// - **Open redirects:** the target must be `base` followed by a path starting
+///   with `/`. A bare string prefix is not enough — `https://<base>.evil.com/…`
+///   also starts with `base` — so the boundary `/` is what makes this safe.
+/// - **Bouncing into our own endpoints:** platforms commonly default
+///   `target_link_uri` to the tool URL, which for us is `/~lti/launch` — a
+///   POST-only endpoint that a browser GET would 404 on. `/~lti/` targets
+///   therefore fall back to the start page (this is the normal case).
+/// - **Header injection:** control characters are rejected, so the result is
+///   always a valid `Location` header value.
 fn resolve_target(target: &str, base: &str) -> String {
-    let Some(path) = target.strip_prefix(base) else {
-        warn!("LTI launch: target_link_uri '{target}' is outside Tobira; using base URL");
-        return base.to_owned();
-    };
-    if path.starts_with("/~lti/") {
-        return base.to_owned();
+    match target.strip_prefix(base).filter(|path| path.starts_with('/')) {
+        Some(path) if path.starts_with("/~lti/") => base.to_owned(),
+        Some(path) if !path.bytes().any(|b| b.is_ascii_control()) => target.to_owned(),
+        _ => {
+            warn!("LTI launch: unusable target_link_uri; falling back to the start page");
+            base.to_owned()
+        }
     }
-    target.to_owned()
 }
 
 /// Builds the URL of a Tobira series page from an Opencast series ID, using
@@ -501,19 +531,28 @@ mod tests {
     }
 
     #[test]
-    fn username_falls_back_to_sub_without_better_claims() {
-        // Moodle sends neither `preferred_username` nor a custom parameter, so
-        // we are left with the opaque `sub`.
-        assert_eq!(resolve_username(&claims_with(serde_json::json!({}))), "3");
+    fn username_default_source_uses_preferred_username() {
+        use LtiUsernameSource::PreferredUsername;
+        // Present → used.
+        assert_eq!(
+            resolve_username(
+                &claims_with(serde_json::json!({ "preferred_username": "rrolf" })),
+                PreferredUsername,
+            ),
+            Some("rrolf".to_owned()),
+        );
+        // Absent → None (the launch is rejected rather than guessing an identity).
+        assert_eq!(
+            resolve_username(&claims_with(serde_json::json!({})), PreferredUsername),
+            None,
+        );
     }
 
     #[test]
-    fn username_uses_preferred_username_when_present() {
+    fn username_sub_source_uses_subject() {
         assert_eq!(
-            resolve_username(&claims_with(serde_json::json!({
-                "preferred_username": "rrolf",
-            }))),
-            "rrolf",
+            resolve_username(&claims_with(serde_json::json!({})), LtiUsernameSource::Sub),
+            Some("3".to_owned()),
         );
     }
 
@@ -526,6 +565,11 @@ mod tests {
         assert_eq!(resolve_target("https://tobira.example.org/~lti/launch", base), base);
         // Anything outside Tobira is refused (no open redirect).
         assert_eq!(resolve_target("https://evil.example.org/phish", base), base);
+        // A host that merely *starts with* the base must not pass: without the
+        // path boundary this would be an open redirect.
+        assert_eq!(resolve_target("https://tobira.example.org.evil.com/phish", base), base);
+        // Control characters (header injection) are rejected.
+        assert_eq!(resolve_target("https://tobira.example.org/a\r\nb", base), base);
         // A real in-Tobira page is kept.
         assert_eq!(
             resolve_target("https://tobira.example.org/!s/:abc-123", base),
@@ -534,15 +578,21 @@ mod tests {
     }
 
     #[test]
-    fn username_custom_parameter_wins_and_empty_is_ignored() {
-        let custom = |username| serde_json::json!({
+    fn username_custom_source_reads_custom_parameter_only() {
+        use LtiUsernameSource::Custom;
+        let with_custom = |username| claims_with(serde_json::json!({
+            // A `preferred_username` must NOT be used when the source is Custom.
             "preferred_username": "from-claim",
             "https://purl.imsglobal.org/spec/lti/claim/custom": { "username": username },
-        });
+        }));
 
-        // An explicitly configured custom parameter takes precedence.
-        assert_eq!(resolve_username(&claims_with(custom("from-custom"))), "from-custom");
-        // An unsubstituted or blank value must not shadow the standard claim.
-        assert_eq!(resolve_username(&claims_with(custom(""))), "from-claim");
+        assert_eq!(
+            resolve_username(&with_custom("from-custom"), Custom),
+            Some("from-custom".to_owned()),
+        );
+        // A blank (e.g. unsubstituted) value yields None, not the standard claim.
+        assert_eq!(resolve_username(&with_custom(""), Custom), None);
+        // No custom parameter at all → None.
+        assert_eq!(resolve_username(&claims_with(serde_json::json!({})), Custom), None);
     }
 }

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -234,9 +234,16 @@ pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Resp
         Err(response) => return response,
     };
 
-    // Redirect to the launch target. Only allow targets within our own Tobira
-    // instance to avoid turning the launch into an open redirect.
-    let target = safe_target(&login.target_link_uri, ctx);
+    // Decide where to land: a Tobira series page if the placement carries a
+    // `series` custom parameter (an Opencast series ID), otherwise the
+    // platform's target_link_uri. Both are kept within Tobira (no open redirect).
+    let target = match claims.custom.as_ref()
+        .and_then(|custom| custom.get("series"))
+        .and_then(|series| series.as_str())
+    {
+        Some(series) => series_landing(&ctx.config.general.tobira_url.to_string(), series),
+        None => safe_target(&login.target_link_uri, ctx),
+    };
     Response::builder()
         .status(StatusCode::FOUND)
         .header(header::LOCATION, target)
@@ -271,6 +278,12 @@ fn safe_target(target: &str, ctx: &Context) -> String {
     }
 }
 
+/// Builds the URL of a Tobira series page from an Opencast series ID, using
+/// Tobira's direct series route (`/!s/:<opencast-id>`).
+fn series_landing(base: &str, opencast_series_id: &str) -> String {
+    format!("{base}/!s/:{opencast_series_id}")
+}
+
 /// The subset of LTI 1.3 launch claims we read. Only the fields needed for the
 /// MVP (verification + identity) are modelled.
 #[derive(Deserialize)]
@@ -288,6 +301,11 @@ struct LtiClaims {
 
     #[serde(rename = "https://purl.imsglobal.org/spec/lti/claim/deployment_id")]
     deployment_id: String,
+
+    /// Custom parameters configured for this placement in the platform. The MVP
+    /// reads `custom["series"]` (an Opencast series ID) to land on that series.
+    #[serde(rename = "https://purl.imsglobal.org/spec/lti/claim/custom")]
+    custom: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 /// A JSON value that may be a single item or an array of them (e.g. `aud`).
@@ -422,5 +440,13 @@ mod tests {
         assert!(jwk["n"].as_str().unwrap().len() > 300);
         assert!(!jwk["e"].as_str().unwrap().is_empty());
         assert!(!jwk["kid"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn series_landing_uses_direct_opencast_route() {
+        assert_eq!(
+            series_landing("https://tobira.example.org", "abc-123"),
+            "https://tobira.example.org/!s/:abc-123",
+        );
     }
 }

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -1,0 +1,115 @@
+//! LTI 1.3 launch flow. Tobira acts as an LTI *tool* that LMS *platforms*
+//! (Moodle, Canvas, …) launch. This runs alongside the normal login and reuses
+//! the session machinery — see `docs/docs/dev/rfc-lti-1.3.md`.
+//!
+//! This module currently implements the OIDC third-party-initiated login
+//! (`/~lti/login`). Verifying the actual launch (`/~lti/launch`) and creating a
+//! session follows in a separate change.
+
+use std::{borrow::Cow, collections::BTreeMap};
+
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use hyper::{Method, Request, StatusCode, body::Incoming, header};
+use secrecy::ExposeSecret;
+
+use crate::{
+    http::{self, Context, Response},
+    prelude::*,
+    util::{ByteBody, download_body, gen_random_bytes_crypto},
+};
+
+
+/// Handles `/~lti/login`: the OIDC third-party-initiated login that begins an
+/// LTI 1.3 launch.
+///
+/// The platform sends `iss`, `login_hint` and `target_link_uri` (and usually
+/// `client_id` / `lti_message_hint`), either as a GET query or a POST form. We
+/// resolve the platform, issue a `state` + `nonce` (remembering them so the
+/// launch can verify them), and redirect the browser to the platform's
+/// authorization endpoint. The platform then POSTs the signed launch
+/// (`id_token`) back to `/~lti/launch` (handled in a follow-up).
+pub(crate) async fn handle_login(req: Request<Incoming>, ctx: &Context) -> Response {
+    let raw = match read_raw_params(req).await {
+        Ok(raw) => raw,
+        Err(response) => return response,
+    };
+    let params: BTreeMap<Cow<str>, Cow<str>> = form_urlencoded::parse(&raw).collect();
+    let get = |key: &str| params.get(key).map(|s| s.trim()).filter(|s| !s.is_empty());
+
+    let (Some(iss), Some(login_hint), Some(target_link_uri))
+        = (get("iss"), get("login_hint"), get("target_link_uri"))
+    else {
+        return http::response::bad_request(
+            "LTI login: missing 'iss', 'login_hint' or 'target_link_uri'",
+        );
+    };
+
+    // Resolve the platform. `client_id` is optional in the initiation request:
+    // match on (iss, client_id) if it is present, otherwise on the issuer alone.
+    let lti = &ctx.config.auth.lti;
+    let platform = match get("client_id") {
+        Some(client_id) => lti.find_platform(iss, client_id),
+        None => lti.find_platform_by_issuer(iss),
+    };
+    let Some(platform) = platform else {
+        warn!("LTI login for unknown platform (iss = '{iss}')");
+        return http::response::bad_request("LTI login: unknown platform");
+    };
+
+    // Issue `state` + `nonce` and remember them for the launch to verify.
+    let state = random_token();
+    let nonce = random_token();
+    ctx.auth_caches.lti_login
+        .insert(state.clone(), nonce.clone(), target_link_uri.to_owned())
+        .await;
+
+    // Redirect to the platform's authorization endpoint. An LTI launch uses the
+    // implicit `id_token` flow with `form_post` response mode.
+    let redirect_uri = ctx.config.general.tobira_url.clone()
+        .with_path_and_query("/~lti/launch")
+        .to_string();
+    let mut auth_url = platform.auth_login_url.clone();
+    {
+        let mut query = auth_url.query_pairs_mut();
+        query.extend_pairs([
+            ("scope", "openid"),
+            ("response_type", "id_token"),
+            ("response_mode", "form_post"),
+            ("prompt", "none"),
+            ("client_id", platform.client_id.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
+            ("login_hint", login_hint),
+            ("state", state.as_str()),
+            ("nonce", nonce.as_str()),
+        ]);
+        if let Some(hint) = get("lti_message_hint") {
+            query.append_pair("lti_message_hint", hint);
+        }
+    }
+
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, auth_url.to_string())
+        .body(ByteBody::empty())
+        .unwrap()
+}
+
+/// Reads request parameters from the query string (GET) or the form-encoded
+/// body (POST) — LTI initiation may use either.
+async fn read_raw_params(req: Request<Incoming>) -> Result<Vec<u8>, Response> {
+    if *req.method() == Method::POST {
+        download_body(req.into_body()).await
+            .map(|body| body.to_vec())
+            .map_err(|e| {
+                error!("LTI login: failed to read request body: {e}");
+                http::response::bad_request("could not read request body")
+            })
+    } else {
+        Ok(req.uri().query().unwrap_or_default().as_bytes().to_vec())
+    }
+}
+
+/// A URL-safe, unguessable random token (128 bits), used for `state`/`nonce`.
+fn random_token() -> String {
+    BASE64_URL_SAFE_NO_PAD.encode(gen_random_bytes_crypto::<16>().expose_secret())
+}

--- a/backend/src/auth/lti.rs
+++ b/backend/src/auth/lti.rs
@@ -2,19 +2,22 @@
 //! (Moodle, Canvas, …) launch. This runs alongside the normal login and reuses
 //! the session machinery — see `docs/docs/dev/rfc-lti-1.3.md`.
 //!
-//! This module currently implements the OIDC third-party-initiated login
-//! (`/~lti/login`). Verifying the actual launch (`/~lti/launch`) and creating a
-//! session follows in a separate change.
+//! This module implements the OIDC third-party-initiated login (`/~lti/login`)
+//! and the launch (`/~lti/launch`): verifying the signed launch token against
+//! the platform's JWKS and creating a Tobira session.
 
 use std::{borrow::Cow, collections::BTreeMap};
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use hyper::{Method, Request, StatusCode, body::Incoming, header};
+use hyper::{Method, Request, StatusCode, Uri, body::Incoming, header};
 use secrecy::ExposeSecret;
+use serde::Deserialize;
 
 use crate::{
+    auth::{User, config::LtiPlatform},
     http::{self, Context, Response},
     prelude::*,
+    sync::client::AuthMode,
     util::{ByteBody, download_body, gen_random_bytes_crypto},
 };
 
@@ -60,7 +63,13 @@ pub(crate) async fn handle_login(req: Request<Incoming>, ctx: &Context) -> Respo
     let state = random_token();
     let nonce = random_token();
     ctx.auth_caches.lti_login
-        .insert(state.clone(), nonce.clone(), target_link_uri.to_owned())
+        .insert(
+            state.clone(),
+            nonce.clone(),
+            target_link_uri.to_owned(),
+            platform.issuer.clone(),
+            platform.client_id.clone(),
+        )
         .await;
 
     // Redirect to the platform's authorization endpoint. An LTI launch uses the
@@ -112,4 +121,217 @@ async fn read_raw_params(req: Request<Incoming>) -> Result<Vec<u8>, Response> {
 /// A URL-safe, unguessable random token (128 bits), used for `state`/`nonce`.
 fn random_token() -> String {
     BASE64_URL_SAFE_NO_PAD.encode(gen_random_bytes_crypto::<16>().expose_secret())
+}
+
+
+/// Handles `POST /~lti/launch`: the actual LTI 1.3 launch.
+///
+/// The platform `form_post`s the signed `id_token` (and the `state` we issued
+/// during login). We consume the matching login state (one-time use), verify
+/// the token against the platform's JWKS, check `nonce` + `deployment_id`,
+/// build a Tobira user and create a session, then redirect to the
+/// `target_link_uri`.
+pub(crate) async fn handle_launch(req: Request<Incoming>, ctx: &Context) -> Response {
+    // ----- Read the form_post body: `id_token` + `state` ------------------------------------
+    let body = match download_body(req.into_body()).await {
+        Ok(body) => body,
+        Err(e) => {
+            error!("LTI launch: failed to read request body: {e}");
+            return http::response::bad_request("could not read request body");
+        }
+    };
+    let params: BTreeMap<Cow<str>, Cow<str>> = form_urlencoded::parse(&body).collect();
+    let get = |key: &str| params.get(key).map(|s| s.trim()).filter(|s| !s.is_empty());
+
+    let (Some(id_token), Some(state)) = (get("id_token"), get("state")) else {
+        return http::response::bad_request("LTI launch: missing 'id_token' or 'state'");
+    };
+
+    // ----- Consume the login state (one-time use → replay/CSRF protection) ------------------
+    let Some(login) = ctx.auth_caches.lti_login.take(state).await else {
+        warn!("LTI launch with unknown, expired or already-used 'state'");
+        return http::response::bad_request("LTI launch: invalid or expired 'state'");
+    };
+    let Some(platform) = ctx.config.auth.lti.find_platform(&login.issuer, &login.client_id) else {
+        // The platform was reconfigured away between login and launch.
+        error!("LTI launch: platform for issued state no longer configured");
+        return http::response::internal_server_error();
+    };
+
+    // ----- Verify the launch token against the platform's JWKS ------------------------------
+    let keys = match fetch_platform_jwks(platform, ctx).await {
+        Ok(keys) => keys,
+        Err(e) => {
+            warn!("LTI launch: could not fetch platform JWKS: {e:?}");
+            return http::response::bad_request("LTI launch: could not fetch platform keys");
+        }
+    };
+    let raw = match jwtea::RawJwt::new(id_token.to_owned()) {
+        Ok(raw) => raw,
+        Err(_) => return http::response::bad_request("LTI launch: malformed 'id_token'"),
+    };
+    let validator = LtiLaunchValidator {
+        basic: jwtea::BasicValidator { allowed_clock_skew: 10 },
+        issuer: &platform.issuer,
+        client_id: &platform.client_id,
+    };
+    let claims = match raw
+        .decode::<(), LtiClaims, _>(keys.as_slice(), &validator, |_header, payload| payload.extra_fields)
+        .await
+    {
+        Ok(claims) => claims,
+        Err(e) => {
+            warn!("LTI launch: token verification failed: {e:?}");
+            return http::response::bad_request("LTI launch: token verification failed");
+        }
+    };
+
+    // ----- LTI-specific checks the signature verifier can't do ------------------------------
+    // `nonce` binds this launch to our login initiation (replay protection).
+    if claims.nonce.as_deref() != Some(login.nonce.as_str()) {
+        warn!("LTI launch: nonce mismatch");
+        return http::response::bad_request("LTI launch: nonce mismatch");
+    }
+    if claims.deployment_id != platform.deployment_id {
+        warn!("LTI launch: deployment_id mismatch");
+        return http::response::bad_request("LTI launch: deployment_id mismatch");
+    }
+
+    // ----- Build the user and create a session ----------------------------------------------
+    // Roles come from Opencast, exactly like the OIDC login (#1706). The
+    // username is derived from the launch (`preferred_username`, else `sub`).
+    // NOTE: how the launch identity maps to an Opencast username is an open
+    // design question (see docs/docs/dev/rfc-lti-1.3.md, OQ8) — this is the
+    // provisional MVP mapping.
+    let username = claims.preferred_username.clone().unwrap_or_else(|| claims.sub.clone());
+    let oc_user = match super::opencast::user_from_info_me(
+        AuthMode::Sudo { as_user: &username },
+        ctx,
+    ).await {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            warn!("LTI launch: user '{username}' is not known to Opencast");
+            return http::response::bad_request("LTI launch: user unknown to Opencast");
+        }
+        Err(e) => {
+            error!("LTI launch: failed to request Opencast user info: {e:#}");
+            return http::response::internal_server_error();
+        }
+    };
+    let user = User {
+        display_name: claims.name.clone().unwrap_or_else(|| username.clone()),
+        email: claims.email.clone(),
+        username,
+        user_role: oc_user.user_role,
+        roles: oc_user.roles,
+        user_realm_handle: None,
+    };
+
+    let cookie = match super::create_session_with_cookies(user, ctx).await {
+        Ok(cookie) => cookie,
+        Err(response) => return response,
+    };
+
+    // Redirect to the launch target. Only allow targets within our own Tobira
+    // instance to avoid turning the launch into an open redirect.
+    let target = safe_target(&login.target_link_uri, ctx);
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, target)
+        .header(header::SET_COOKIE, cookie.to_string())
+        .body(ByteBody::empty())
+        .unwrap()
+}
+
+/// Fetches and parses the platform's JWKS into verifying keys. Keys we do not
+/// understand are skipped.
+async fn fetch_platform_jwks(
+    platform: &LtiPlatform,
+    ctx: &Context,
+) -> Result<Vec<jwtea::VerifyingKey>> {
+    let uri = platform.keyset_url.as_str().parse::<Uri>().context("invalid keyset URL")?;
+    let response = ctx.http_client.get(uri).await?;
+    let body = download_body(response.into_body()).await?;
+    let jwks: jwtea::Jwks = serde_json::from_slice(&body)
+        .context("could not parse platform JWKS")?;
+    Ok(jwks.to_verifying_keys().filter_map(|res| res.ok()).collect())
+}
+
+/// Returns `target` if it points within our own Tobira instance, otherwise the
+/// Tobira base URL. Prevents the launch from being abused as an open redirect.
+fn safe_target(target: &str, ctx: &Context) -> String {
+    let base = ctx.config.general.tobira_url.to_string();
+    if target.starts_with(&base) {
+        target.to_owned()
+    } else {
+        warn!("LTI launch: target_link_uri '{target}' is outside Tobira; using base URL");
+        base
+    }
+}
+
+/// The subset of LTI 1.3 launch claims we read. Only the fields needed for the
+/// MVP (verification + identity) are modelled.
+#[derive(Deserialize)]
+struct LtiClaims {
+    iss: String,
+    aud: MaybeArray<String>,
+    azp: Option<String>,
+    sub: String,
+    nonce: Option<String>,
+
+    // User info (standard OIDC claims the platform may include).
+    name: Option<String>,
+    preferred_username: Option<String>,
+    email: Option<String>,
+
+    #[serde(rename = "https://purl.imsglobal.org/spec/lti/claim/deployment_id")]
+    deployment_id: String,
+}
+
+/// A JSON value that may be a single item or an array of them (e.g. `aud`).
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum MaybeArray<T> {
+    Single(T),
+    Array(Vec<T>),
+}
+
+impl<T> MaybeArray<T> {
+    fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Single(single) => std::slice::from_ref(single),
+            Self::Array(items) => items,
+        }
+    }
+}
+
+/// Verifies the LTI launch token's core claims. Runs *after* the signature has
+/// been checked, so the claims are trustworthy. Mirrors the OIDC
+/// `IdTokenValidator`, enforcing `iss`, `aud` and `azp` against the platform
+/// registration (plus `exp`/`nbf` via [`jwtea::BasicValidator`]).
+struct LtiLaunchValidator<'a> {
+    basic: jwtea::BasicValidator,
+    issuer: &'a str,
+    client_id: &'a str,
+}
+
+impl<H> jwtea::Validator<H, LtiClaims> for LtiLaunchValidator<'_> {
+    fn validate(
+        &self,
+        header: &jwtea::Header<H>,
+        payload: &jwtea::Payload<LtiClaims>,
+    ) -> Result<(), jwtea::Error> {
+        self.basic.validate(header, payload)?;
+        let claims = &payload.extra_fields;
+        if claims.iss != self.issuer {
+            return Err(jwtea::Error::ValidationError("'iss' does not match platform".into()));
+        }
+        if !claims.aud.as_slice().iter().any(|aud| aud == self.client_id) {
+            return Err(jwtea::Error::ValidationError("'aud' does not contain client ID".into()));
+        }
+        if claims.azp.as_deref().is_some_and(|azp| azp != self.client_id) {
+            return Err(jwtea::Error::ValidationError("'azp' does not match client ID".into()));
+        }
+        Ok(())
+    }
 }

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -24,6 +24,7 @@ mod cache;
 mod config;
 mod handlers;
 pub mod oidc;
+mod opencast;
 mod session_id;
 mod jwt;
 

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -11,11 +11,12 @@ use serde::Deserialize;
 use tokio_postgres::Error as PgError;
 
 use crate::{
+    Never,
     config::Config,
-    db::util::select,
-    http::{response, Context, Response},
+    db::{self, util::select},
+    http::{self, Context, Response, response},
     prelude::*,
-    util::{download_body, ByteBody}, Never,
+    util::{ByteBody, download_body},
 };
 
 
@@ -277,11 +278,7 @@ impl User {
         }
 
         if let Some(relevant_cookies) = &ctx.config.auth.callback.relevant_cookies {
-            headers.get_all(hyper::header::COOKIE)
-                .into_iter()
-                .filter_map(|value| value.to_str().ok()) // Ignore non-UTF8 cookies
-                .flat_map(|value| Cookie::split_parse(value))
-                .filter_map(|r| r.ok()) // Ignore unparsable cookies
+            all_cookies_of(headers)
                 .filter(|cookie| relevant_cookies.iter().any(|rc| cookie.name() == rc))
                 .for_each(|cookie| {
                     // Unwrap is fine: this value was a `HeaderValue` before.
@@ -587,4 +584,30 @@ pub(crate) fn callback_bad_gateway() -> Response {
         .status(StatusCode::BAD_GATEWAY)
         .body("Bad gateway: broken auth callback".into())
         .unwrap()
+}
+
+fn all_cookies_of(headers: &HeaderMap) -> impl Iterator<Item = Cookie<'_>> {
+    headers.get_all(hyper::header::COOKIE)
+        .into_iter()
+        .filter_map(|value| value.to_str().ok()) // Ignore non-UTF8 cookies
+        .flat_map(|value| Cookie::split_parse(value))
+        .filter_map(|r| r.ok()) // Ignore unparsable cookies
+}
+
+async fn create_session_with_cookies(
+    mut user: User,
+    ctx: &Context,
+) -> Result<Cookie<'static>, Response> {
+    user.add_default_roles();
+
+    // TODO: check if a user is already logged in? And remove that session then?
+
+    let db = db::get_conn_or_service_unavailable(&ctx.db_pool).await?;
+    let session_id = user.persist_new_session(&db).await.map_err(|e| {
+        error!("DB query failed when adding new user session: {}", e);
+        http::response::internal_server_error()
+    })?;
+    debug!("Persisted new session for '{}'", user.username);
+
+    Ok(session_id.set_cookie(ctx.config.auth.session.duration).into_owned())
 }

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -23,6 +23,7 @@ use crate::{
 mod cache;
 mod config;
 mod handlers;
+pub mod oidc;
 mod session_id;
 mod jwt;
 

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -23,6 +23,7 @@ use crate::{
 mod cache;
 mod config;
 mod handlers;
+pub mod lti;
 pub mod oidc;
 mod opencast;
 mod session_id;

--- a/backend/src/auth/oidc.rs
+++ b/backend/src/auth/oidc.rs
@@ -1,0 +1,417 @@
+// TODOs:
+// - Cache discovery info?
+// - Cache JWKS?
+
+use std::collections::BTreeMap;
+
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use cookie::Cookie;
+use hyper::{Method, Request, StatusCode, Uri, body::Incoming, header};
+use jwtea::{Jwks, RawJwt};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::{
+    auth::{User, all_cookies_of, config::OidcConfig},
+    http::{Context, Response},
+    prelude::*,
+    util::{ByteBody, FullBodyExt, HttpUrl, ResponseExt, download_body, gen_random_bytes_crypto},
+};
+
+
+const STATE_COOKIE: &str = "tobira-oidc-state";
+
+fn state_cookie_set(value: &str) -> Cookie<'_> {
+    Cookie::build((STATE_COOKIE, value))
+        .http_only(true)
+        .secure(true)
+        .path("/")
+        .same_site(cookie::SameSite::Lax)
+        .build()
+}
+
+fn state_cookie_unset() -> Cookie<'static> {
+    Cookie::build((STATE_COOKIE, ""))
+        .max_age(time::Duration::ZERO)
+        .secure(true)
+        .path("/")
+        .http_only(true)
+        .same_site(cookie::SameSite::Lax)
+        .build()
+}
+
+macro_rules! discover_info_or_redirect_to_error_page {
+    ($ctx:expr) => {
+        match DiscoveryInfo::fetch($ctx).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Failed to fetch OpenID configuration: {e:?}");
+                return redirect_to_error_page_custom("tobira:unreachable");
+            }
+        }
+    };
+}
+
+/// Handles GET requests to `/~oidc/login`.
+pub(crate) async fn handle_login(
+    _req: Request<Incoming>,
+    ctx: &Context,
+) -> Response {
+    let discover_info = discover_info_or_redirect_to_error_page!(ctx);
+
+    let state = BASE64_URL_SAFE_NO_PAD.encode(gen_random_bytes_crypto::<16>().expose_secret());
+    let target = discover_info.authorization_endpoint(&[
+        ("response_type", "code"),
+        ("client_id", ctx.config.auth.oidc.unwrap_client_id()),
+        ("redirect_uri", &callback_url(ctx).to_string()),
+        ("scope", "openid email"), // TODO
+        ("state", &state),
+    ]);
+
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, target.to_string())
+        .header(header::SET_COOKIE, state_cookie_set(&state).to_string())
+        .body(ByteBody::empty())
+        .unwrap()
+}
+
+/// Handles GET requests to `/~oidc/callback`.
+pub(crate) async fn handle_callback(
+    req: Request<Incoming>,
+    ctx: &Context,
+) -> Response {
+    // ----- Read and verify request ----------------------------------------------------------
+    let params = form_urlencoded::parse(req.uri().query().unwrap_or_default().as_bytes())
+        .collect::<BTreeMap<_, _>>();
+
+    // If the IdP reported an error, we log it and forward the user to a
+    // frontend route that shows a nice error message.
+    if let Some(error) = params.get("error") {
+        debug!(
+            %error,
+            error_description = ?params.get("error_description"),
+            error_uri = ?params.get("error_uri"),
+            "OIDC error in '/~oidc/callback'",
+        );
+
+        let target_params = query_params(params.iter().filter(|(key, _)| key.as_ref() != "state"));
+        return redirect_to_error_page(target_params);
+    }
+
+    // Make sure the `state` is the same as the one in the cookie. If any error
+    // occurs, we also redirect to the frontend error route.
+    let state_param = params.get("state")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty());
+    let state_cookie = all_cookies_of(req.headers())
+        .find(|c| c.name() == STATE_COOKIE)
+        .map(|c| c.value().to_owned());
+    match (state_param, state_cookie) {
+        (None, _) => {
+            debug!("OIDC error in '/~oidc/callback': state parameter not set");
+            return redirect_to_error_page_custom("tobira:state_missing");
+        }
+        (_, None) => {
+            debug!("OIDC error in '/~oidc/callback': state cookie not set");
+            return redirect_to_error_page_custom("tobira:state_missing");
+        }
+        (Some(param), Some(cookie)) if param != cookie => {
+            debug!("OIDC error in '/~oidc/callback': state mismatch between cookie and param");
+            return redirect_to_error_page_custom("tobira:state_mismatch");
+        }
+        (Some(_), Some(_)) => {} // All good
+    }
+
+    // Get code from request
+    let Some(code) = params.get("code").map(|s| s.trim()).filter(|s| !s.is_empty()) else {
+        debug!("OIDC error in '/~oidc/callback': code missing");
+        return redirect_to_error_page_custom("tobira:code_missing");
+    };
+
+
+
+    // ----- Talk to IdP directly ---------------------------------------------------------------
+    let discover_info = discover_info_or_redirect_to_error_page!(ctx);
+    let user = match fetch_token(code, &discover_info, ctx).await {
+        Ok(u) => u,
+        Err(e) => {
+            debug!("failed to do fetch OIDC token: {e:?}");
+            return redirect_to_error_page_custom("tobira:token_exchange_failed");
+        }
+    };
+
+    // All worked -> create user session
+    let cookie = match super::create_session_with_cookies(user, ctx).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, "/~session")
+        .header(header::SET_COOKIE, state_cookie_unset().to_string())
+        .header(header::SET_COOKIE, cookie.to_string())
+        .body(ByteBody::empty())
+        .unwrap()
+}
+
+/// Exchange the `code` for tokens.
+async fn fetch_token(code: &str, discover_info: &DiscoveryInfo, ctx: &Context) -> Result<User> {
+    let body = query_params([
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("client_id", ctx.config.auth.oidc.unwrap_client_id()),
+        ("client_secret", ctx.config.auth.oidc.unwrap_client_secret().expose_secret()),
+        ("redirect_uri", &callback_url(ctx).to_string()),
+    ]);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(discover_info.token_endpoint.as_str())
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(body.into())
+        .unwrap();
+
+    #[derive(Debug, serde::Deserialize)]
+    struct TokenEndpointResponse {
+        /// Required by OAuth 2.0 spec.
+        #[allow(dead_code)]
+        access_token: String,
+
+        /// Required by the OIDC spec (assuming we pass `openid` scope), always
+        /// a JWT.
+        id_token: RawJwt<String>,
+    }
+
+    // Make request to token endpoint
+    let response = ctx.http_client.request(req).await?;
+    let (_parts, body) = download_json::<TokenEndpointResponse>(response).await?;
+
+
+    // Download JWKS and then decode & verify ID token.
+    let keys = discover_info.fetch_jwks(ctx).await?;
+    let payload = body.id_token.decode::<(), IdTokenPayload, _>(
+        keys.as_slice(),
+        &IdTokenValidator::new(&ctx.config.auth.oidc),
+        |_header, payload| payload.extra_fields,
+    ).await?;
+
+
+    // TODO: whole bunch of TODOs!
+    let user = User {
+        display_name: payload.name.unwrap().into(),
+        email: payload.email.map(Into::into),
+        username: payload.preferred_username.unwrap().into(),
+        user_role: "TODO".into(),
+        roles: Default::default(),
+        user_realm_handle: None,
+    };
+
+    Ok(user)
+}
+
+/// See OIDC spec section 2.
+/// https://openid.net/specs/openid-connect-core-1_0-final.html#IDToken
+#[derive(Debug, serde::Deserialize)]
+struct IdTokenPayload {
+    iss: String,
+    sub: String,
+    aud: MaybeArray<String>,
+    azp: Option<String>,
+
+    // User info
+    name: Option<String>,
+    preferred_username: Option<String>,
+    email: Option<String>,
+
+    #[serde(flatten)]
+    rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum MaybeArray<T> {
+    Single(T),
+    Array(Vec<T>),
+}
+
+impl<T> MaybeArray<T> {
+    fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Single(single) => std::slice::from_ref(single),
+            Self::Array(items) => items,
+        }
+    }
+}
+
+struct IdTokenValidator<'a> {
+    basic: jwtea::BasicValidator,
+    client_id: &'a str,
+    issuer_url: &'a HttpUrl,
+}
+
+impl<'a> IdTokenValidator<'a> {
+    fn new(config: &'a OidcConfig) -> Self {
+        Self {
+            basic: jwtea::BasicValidator { allowed_clock_skew: 10 },
+            client_id: config.unwrap_client_id(),
+            issuer_url: config.unwrap_issuer_url(),
+        }
+    }
+}
+
+impl<H> jwtea::Validator<H, IdTokenPayload> for IdTokenValidator<'_> {
+    fn validate(
+        &self,
+        header: &jwtea::Header<H>,
+        payload: &jwtea::Payload<IdTokenPayload>,
+    ) -> Result<(), jwtea::Error> {
+        self.basic.validate(header, payload)?;
+        if !payload.extra_fields.aud.as_slice().iter().any(|aud| aud == self.client_id) {
+            return Err(jwtea::Error::ValidationError("'aud' does not match client ID".into()));
+        }
+        if payload.extra_fields.azp.as_ref().is_some_and(|azp| azp != self.client_id) {
+            return Err(jwtea::Error::ValidationError("'azp' does not match client ID".into()));
+        }
+        if payload.extra_fields.iss != self.issuer_url.as_str() {
+            return Err(jwtea::Error::ValidationError("'iss' does not match issuer URL".into()));
+        }
+        Ok(())
+    }
+}
+
+
+/// Builds a query string.
+fn query_params(iter: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>) -> String {
+    let mut params = form_urlencoded::Serializer::new(String::new());
+    params.extend_pairs(iter);
+    params.finish()
+}
+
+/// Redirects the user to `/~oidc/error`, which is a frontend route, showing
+/// an error message to the user, depending on the parameters.
+fn redirect_to_error_page(params: String) -> Response {
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, format!("/~oidc/error?{params}"))
+        .header(header::SET_COOKIE, state_cookie_unset().to_string())
+        .body(ByteBody::empty())
+        .unwrap()
+}
+
+/// Like `redirect_to_error_page`, but only setting the `error` parameter to the
+/// given string. Used for our own error cases (not part of the OIDC standard).
+fn redirect_to_error_page_custom(error_code: &str) -> Response {
+    redirect_to_error_page(query_params([("error", error_code)]))
+}
+
+impl OidcConfig {
+    fn unwrap_client_id(&self) -> &str {
+        self.client_id.as_deref().expect("oidc.client_id not set")
+    }
+    fn unwrap_client_secret(&self) -> &SecretString {
+        self.client_secret.as_ref().expect("oidc.client_secret not set")
+    }
+    fn unwrap_issuer_url(&self) -> &HttpUrl {
+        self.issuer_url.as_ref().expect("oidc.issuer_url not set")
+    }
+}
+
+/// Returns our own callback URL.
+fn callback_url(ctx: &Context) -> Uri {
+    ctx.config.general.tobira_url.clone()
+        .with_path_and_query("/~oidc/callback")
+}
+
+
+/// Info returned by `/.well-known/openid-configuration`.
+///
+/// See https://openid.net/specs/openid-connect-discovery-1_0.html
+/// I assume that all URLs are always absolute (contain scheme and authority),
+/// though I couldn't find any part of the spec saying this.
+#[derive(Deserialize)]
+struct DiscoveryInfo {
+    /// > REQUIRED. URL of the OP's OAuth 2.0 Authorization Endpoint. This URL
+    /// > MUST use the https scheme and MAY contain port, path, and query
+    /// > parameter components.
+    authorization_endpoint: HttpUrl,
+
+    /// > URL of the OP's OAuth 2.0 Token Endpoint. This is REQUIRED unless only
+    /// > the Implicit Flow is used. This URL MUST use the https scheme and MAY
+    /// > contain port, path, and query parameter components.
+    ///
+    /// Since we require the authorization code flow, we can also require this.
+    token_endpoint: HttpUrl,
+
+    /// > REQUIRED. URL of the OP's JWK Set document, which MUST use the https
+    /// > scheme.
+    jwks_uri: HttpUrl,
+}
+
+impl DiscoveryInfo {
+    async fn fetch(ctx: &Context) -> Result<Self> {
+        // According to the specification, simply concatting to the issuer URL
+        // is fine, with no regard for trailing slashes.
+        // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
+        let issuer = ctx.config.auth.oidc.unwrap_issuer_url();
+        let url = format!("{issuer}/.well-known/openid-configuration");
+
+        trace!(%url, "fetching OIDC discovery info");
+        let response = ctx.http_client.get(url.parse()?).await?;
+        let (_parts, out) = download_json(response).await
+            .context("failed to fetch OpenID configuration (discover)")?;
+
+        // We do not verify the things demanded by the spec (e.g. https, no
+        // query) since we need to trust the IdP anyway.
+        Ok(out)
+    }
+
+    /// Authorization endpoint with the given extra query parameters.
+    fn authorization_endpoint(&self, params: &[(&str, &str)]) -> HttpUrl {
+        let mut out = self.authorization_endpoint.clone();
+        out.query_pairs_mut().extend_pairs(params);
+        out
+    }
+
+    async fn fetch_jwks(&self, ctx: &Context) -> Result<Vec<jwtea::VerifyingKey>> {
+        let uri = self.jwks_uri.as_str().parse::<Uri>().context("invalid JWKS url")?;
+        let response = ctx.http_client.get(uri).await?;
+        let (_, jwks) = download_json::<Jwks>(response).await?;
+
+        // We ignore keys that we do not understand or that are buggy.
+        let keys = jwks.to_verifying_keys().filter_map(|res| res.ok()).collect::<Vec<_>>();
+        Ok(keys)
+    }
+}
+
+/// Downloads and deserializes a JSON body from the `response`.
+async fn download_json<T: for<'a> Deserialize<'a>>(
+    response: hyper::Response<Incoming>,
+) -> Result<(hyper::http::response::Parts, T)> {
+    if response.headers().get(header::CONTENT_TYPE).is_none_or(|h| h != "application/json") {
+        bail!("response Content-Type is not 'application/json'");
+    }
+
+    let (parts, body) = response.into_parts();
+    let body = download_body(body).await?;
+
+    let log_body = || {
+        if tracing::event_enabled!(tracing::Level::TRACE) {
+            match serde_json::from_slice::<serde_json::Value>(&body) {
+                Ok(json) => trace!("Body: {json:#?}"),
+                Err(_) => trace!("Body: {:?}", String::from_utf8_lossy(&body)),
+            }
+        }
+    };
+
+    if !parts.status.is_success() {
+        log_body();
+        bail!("non 2xx status returned: {}", parts.status);
+    }
+
+    let body = serde_json::from_slice::<T>(&body)
+        .context("failed to deserialize JSON")
+        .inspect_err(|_| log_body())?;
+
+    Ok((parts, body))
+}

--- a/backend/src/auth/oidc.rs
+++ b/backend/src/auth/oidc.rs
@@ -12,10 +12,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
 use crate::{
-    auth::{User, all_cookies_of, config::OidcConfig},
-    http::{Context, Response},
-    prelude::*,
-    util::{ByteBody, FullBodyExt, HttpUrl, ResponseExt, download_body, gen_random_bytes_crypto},
+    auth::{User, all_cookies_of, config::OidcConfig}, http::{Context, Response}, prelude::*, sync::client::AuthMode, util::{ByteBody, FullBodyExt, HttpUrl, ResponseExt, download_body, gen_random_bytes_crypto}
 };
 
 
@@ -133,12 +130,43 @@ pub(crate) async fn handle_callback(
 
     // ----- Talk to IdP directly ---------------------------------------------------------------
     let discover_info = discover_info_or_redirect_to_error_page!(ctx);
-    let user = match fetch_token(code, &discover_info, ctx).await {
+    let id_token = match fetch_token(code, &discover_info, ctx).await {
         Ok(u) => u,
         Err(e) => {
             debug!("failed to do fetch OIDC token: {e:?}");
             return redirect_to_error_page_custom("tobira:token_exchange_failed");
         }
+    };
+    debug!("ID token: {id_token:#?}");
+
+    let Some(preferred_username) = id_token.preferred_username else {
+        return redirect_to_error_page_custom("tobira:preferred_username_missing");
+    };
+
+    // Request user info from Opencast. TODO: this will be configurable.
+    let oc_user = {
+        let auth_mode = AuthMode::Sudo { as_user: &preferred_username };
+        match super::opencast::user_from_info_me(auth_mode, ctx).await {
+            Ok(Some(u)) => u,
+            Ok(None) => {
+                return redirect_to_error_page_custom("tobira:user_not_in_oc");
+            }
+            Err(e) => {
+                warn!("failed to request OC user: {e}");
+                return redirect_to_error_page_custom("tobira:oc_request_failed");
+            }
+        }
+    };
+    debug!("OC user: {oc_user:#?}");
+
+    // TODO: add configurable mapping!
+    let user = User {
+        display_name: id_token.name.unwrap().into(),
+        email: id_token.email.map(Into::into),
+        username: preferred_username,
+        user_role: oc_user.user_role,
+        roles: oc_user.roles,
+        user_realm_handle: None,
     };
 
     // All worked -> create user session
@@ -157,7 +185,11 @@ pub(crate) async fn handle_callback(
 }
 
 /// Exchange the `code` for tokens.
-async fn fetch_token(code: &str, discover_info: &DiscoveryInfo, ctx: &Context) -> Result<User> {
+async fn fetch_token(
+    code: &str,
+    discover_info: &DiscoveryInfo,
+    ctx: &Context,
+) -> Result<IdTokenPayload> {
     let body = query_params([
         ("grant_type", "authorization_code"),
         ("code", code),
@@ -196,18 +228,7 @@ async fn fetch_token(code: &str, discover_info: &DiscoveryInfo, ctx: &Context) -
         |_header, payload| payload.extra_fields,
     ).await?;
 
-
-    // TODO: whole bunch of TODOs!
-    let user = User {
-        display_name: payload.name.unwrap().into(),
-        email: payload.email.map(Into::into),
-        username: payload.preferred_username.unwrap().into(),
-        user_role: "TODO".into(),
-        roles: Default::default(),
-        user_realm_handle: None,
-    };
-
-    Ok(user)
+    Ok(payload)
 }
 
 /// See OIDC spec section 2.
@@ -215,6 +236,7 @@ async fn fetch_token(code: &str, discover_info: &DiscoveryInfo, ctx: &Context) -
 #[derive(Debug, serde::Deserialize)]
 struct IdTokenPayload {
     iss: String,
+    #[allow(dead_code)] // TODO
     sub: String,
     aud: MaybeArray<String>,
     azp: Option<String>,
@@ -224,6 +246,7 @@ struct IdTokenPayload {
     preferred_username: Option<String>,
     email: Option<String>,
 
+    #[allow(dead_code)] // TODO
     #[serde(flatten)]
     rest: serde_json::Map<String, serde_json::Value>,
 }

--- a/backend/src/auth/opencast.rs
+++ b/backend/src/auth/opencast.rs
@@ -1,70 +1,17 @@
-use base64::Engine;
-use hyper::{StatusCode, Request};
-use serde::Deserialize;
 
 use crate::{
-    http::Context,
-    prelude::*,
-    util::{download_body, ByteBody},
+    http::Context, prelude::*, sync::client::AuthMode
 };
 use super::User;
 
 
-
-/// Requests `/info/me.json` with the given credentials via HTTP Basic auth.
-///
-///
-pub(super) async fn try_login(
-    userid: &str,
-    password: &str,
+/// Requests `/info/me.json` and converts the information into a `User`.
+pub(super) async fn user_from_info_me(
+    mode: AuthMode<'_>,
     ctx: &Context,
 ) -> Result<Option<User>> {
-    trace!("Checking Opencast login...");
-
-    // Send request. We use basic auth here: our configuration checks already
-    // assert that we use HTTPS or Opencast is running on the same machine
-    // (or the admin has explicitly opted out of this check).
-    let credentials = base64::engine::general_purpose::STANDARD
-        .encode(&format!("{userid}:{password}"));
-    let auth_header = format!("Basic {}", credentials);
-    let req = Request::builder()
-        .uri(ctx.config.opencast.sync_node().clone().with_path_and_query("/info/me.json"))
-        .header(hyper::header::AUTHORIZATION, auth_header)
-        .body(ByteBody::empty())
-        .unwrap();
-    let response = ctx.http_client.request(req).await?;
-
-
-    // We treat all non-OK response as invalid login data.
-    if response.status() != StatusCode::OK {
-        return Ok(None);
-    }
-
-
-    // Deserialize JSON body.
-    #[derive(Deserialize)]
-    struct InfoMeResponse {
-        roles: Vec<String>,
-        user: InfoMeUserResponse,
-        #[serde(rename = "userRole")]
-        user_role: String,
-    }
-
-    #[derive(Deserialize)]
-    struct InfoMeUserResponse {
-        name: String,
-        username: String,
-        email: Option<String>,
-    }
-
-    let body = download_body(response.into_body()).await?;
-    let mut info: InfoMeResponse = serde_json::from_slice(&body)
-        .context("Could not deserialize `/info/me.json` response")?;
-
-    // If all roles are `ROLE_ANONYMOUS`, then we assume the login was invalid.
-    if info.roles.iter().all(|role| role == super::ROLE_ANONYMOUS) {
-        return Ok(None);
-    }
+    let info = ctx.oc_client.info_me(mode).await?;
+    let Some(mut info) = info else { return Ok(None); };
 
     // Make sure the roles list always contains the user role. This is very
     // likely always the case, but better be sure.

--- a/backend/src/auth/opencast.rs
+++ b/backend/src/auth/opencast.rs
@@ -1,0 +1,84 @@
+use base64::Engine;
+use hyper::{StatusCode, Request};
+use serde::Deserialize;
+
+use crate::{
+    http::Context,
+    prelude::*,
+    util::{download_body, ByteBody},
+};
+use super::User;
+
+
+
+/// Requests `/info/me.json` with the given credentials via HTTP Basic auth.
+///
+///
+pub(super) async fn try_login(
+    userid: &str,
+    password: &str,
+    ctx: &Context,
+) -> Result<Option<User>> {
+    trace!("Checking Opencast login...");
+
+    // Send request. We use basic auth here: our configuration checks already
+    // assert that we use HTTPS or Opencast is running on the same machine
+    // (or the admin has explicitly opted out of this check).
+    let credentials = base64::engine::general_purpose::STANDARD
+        .encode(&format!("{userid}:{password}"));
+    let auth_header = format!("Basic {}", credentials);
+    let req = Request::builder()
+        .uri(ctx.config.opencast.sync_node().clone().with_path_and_query("/info/me.json"))
+        .header(hyper::header::AUTHORIZATION, auth_header)
+        .body(ByteBody::empty())
+        .unwrap();
+    let response = ctx.http_client.request(req).await?;
+
+
+    // We treat all non-OK response as invalid login data.
+    if response.status() != StatusCode::OK {
+        return Ok(None);
+    }
+
+
+    // Deserialize JSON body.
+    #[derive(Deserialize)]
+    struct InfoMeResponse {
+        roles: Vec<String>,
+        user: InfoMeUserResponse,
+        #[serde(rename = "userRole")]
+        user_role: String,
+    }
+
+    #[derive(Deserialize)]
+    struct InfoMeUserResponse {
+        name: String,
+        username: String,
+        email: Option<String>,
+    }
+
+    let body = download_body(response.into_body()).await?;
+    let mut info: InfoMeResponse = serde_json::from_slice(&body)
+        .context("Could not deserialize `/info/me.json` response")?;
+
+    // If all roles are `ROLE_ANONYMOUS`, then we assume the login was invalid.
+    if info.roles.iter().all(|role| role == super::ROLE_ANONYMOUS) {
+        return Ok(None);
+    }
+
+    // Make sure the roles list always contains the user role. This is very
+    // likely always the case, but better be sure.
+    if !info.roles.contains(&info.user_role) {
+        info.roles.push(info.user_role.clone());
+    }
+
+    // Otherwise the login was correct!
+    Ok(Some(User {
+        username: info.user.username,
+        display_name: info.user.name,
+        email: info.user.email,
+        roles: info.roles.into_iter().collect(),
+        user_role: info.user_role,
+        user_realm_handle: None,
+    }))
+}

--- a/backend/src/auth/session_id.rs
+++ b/backend/src/auth/session_id.rs
@@ -57,6 +57,7 @@ impl SessionId {
     /// ID in the client's cookie jar.
     pub(crate) fn set_cookie(&self, session_duration: Duration) -> Cookie<'_> {
         Cookie::build((SESSION_COOKIE, base64encode(self.0.expose_secret())))
+            .path("/")
 
             // Only send via HTTPS as it contains sensitive information.
             .secure(true)
@@ -88,6 +89,7 @@ impl SessionId {
     /// from the client's cookie jar.
     pub(crate) fn unset_cookie() -> Cookie<'static> {
         Cookie::build((SESSION_COOKIE, ""))
+            .path("/")
             .max_age(time::Duration::ZERO)
             .secure(true)
             .http_only(true)

--- a/backend/src/config/opencast.rs
+++ b/backend/src/config/opencast.rs
@@ -1,10 +1,9 @@
 
-use base64::Engine as _;
 use secrecy::{ExposeSecret as _, SecretString};
 
 use crate::{
     prelude::*,
-    util::{HttpHost, HttpUrl},
+    util::{self, HttpHost, HttpUrl},
 };
 
 
@@ -110,10 +109,7 @@ impl OpencastConfig {
     }
 
     pub(crate) fn basic_auth_header(&self) -> SecretString {
-        let credentials = format!("{}:{}", self.user, self.password.expose_secret());
-        let encoded_credentials = base64::engine::general_purpose::STANDARD.encode(credentials);
-        let auth_header = format!("Basic {}", encoded_credentials);
-        SecretString::new(auth_header.into())
+        util::basic_auth_header(&self.user, self.password.expose_secret())
     }
 
     pub(crate) fn trusted_hosts(&self) -> Vec<HttpHost> {

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -141,6 +141,15 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
                 .unwrap()
         },
 
+        "/~oidc/login" => {
+            register_req!(HttpReqCategory::Other);
+            auth::oidc::handle_login(req, &ctx).await
+        }
+        "/~oidc/callback" => {
+            register_req!(HttpReqCategory::Other);
+            auth::oidc::handle_callback(req, &ctx).await
+        }
+
         // Currently we just reply with our `index.html` to everything else.
         // That's of course not optimal because for many paths, our frontend
         // will show 404. It would be nice to reply 404 from the server

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -64,6 +64,10 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
             register_req!(HttpReqCategory::Logout);
             auth::handle_delete_session(req, &ctx).await
         },
+        "/~lti/login" if method == Method::POST => {
+            register_req!(HttpReqCategory::Other);
+            auth::lti::handle_login(req, &ctx).await
+        },
 
         // From this point on, we only support GET and HEAD requests. All others
         // will result in 404.
@@ -148,6 +152,13 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
         "/~oidc/callback" => {
             register_req!(HttpReqCategory::Other);
             auth::oidc::handle_callback(req, &ctx).await
+        }
+
+        // LTI 1.3 third-party-initiated login. May arrive as GET or POST; the
+        // POST variant is matched in the POST section above.
+        "/~lti/login" => {
+            register_req!(HttpReqCategory::Other);
+            auth::lti::handle_login(req, &ctx).await
         }
 
         // Currently we just reply with our `index.html` to everything else.

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -164,6 +164,10 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
             register_req!(HttpReqCategory::Other);
             auth::lti::handle_login(req, &ctx).await
         }
+        "/~lti/jwks" => {
+            register_req!(HttpReqCategory::Other);
+            auth::lti::handle_jwks(&ctx).await
+        }
 
         // Currently we just reply with our `index.html` to everything else.
         // That's of course not optimal because for many paths, our frontend

--- a/backend/src/http/handlers.rs
+++ b/backend/src/http/handlers.rs
@@ -68,6 +68,10 @@ pub(super) async fn handle(req: Request<Incoming>, ctx: Arc<Context>) -> Respons
             register_req!(HttpReqCategory::Other);
             auth::lti::handle_login(req, &ctx).await
         },
+        "/~lti/launch" if method == Method::POST => {
+            register_req!(HttpReqCategory::Other);
+            auth::lti::handle_launch(req, &ctx).await
+        },
 
         // From this point on, we only support GET and HEAD requests. All others
         // will result in 404.

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -4,9 +4,7 @@ use bytes::Bytes;
 use chrono::{DateTime, TimeZone, Utc};
 use form_urlencoded::Serializer;
 use hyper::{
-    Response, Request, StatusCode,
-    body::Incoming,
-    http::{self, request, uri::Uri},
+    Request, Response, StatusCode, body::Incoming, header, http::{self, request, uri::Uri}
 };
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::{connect::HttpConnector, Client};
@@ -21,7 +19,7 @@ use crate::{
     model::{AclItem, OpencastId},
     prelude::*,
     sync::harvest::HarvestResponse,
-    util::{download_body, HttpHost},
+    util::{self, HttpHost, download_body},
 };
 
 use super::VersionResponse;
@@ -142,6 +140,37 @@ impl OcClient {
 
         let (out, _) = self.deserialize_response(response, &uri).await?;
         Ok(out)
+    }
+
+    /// Requests `/info/me.json`. Returns `Ok(None)` if the user login is
+    /// incorrect or the user does not exist.
+    pub async fn info_me(&self, mode: AuthMode<'_>) -> Result<Option<InfoMeResponse>> {
+        let uri = self.sync_node.clone().with_path_and_query("/info/me.json");
+        let req = self.set_auth_headers(mode, Request::get(uri));
+        let req = req.body(RequestBody::empty()).unwrap();
+        let response = self.http_client.request(req).await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            if status == StatusCode::FORBIDDEN {
+                // Either login data is incorrect or user is not known.
+                return Ok(None);
+            } else {
+                bail!("non-2xx status code returned by '/info/me.json': {status}");
+            }
+        }
+
+        let body = download_body(response.into_body()).await?;
+        let info: InfoMeResponse = serde_json::from_slice(&body)
+            .context("could not deserialize `/info/me.json` response")?;
+
+        // If all roles are `ROLE_ANONYMOUS`, then we assume the login was
+        // invalid or user is not known.
+        if info.roles.iter().all(|role| role == crate::auth::ROLE_ANONYMOUS) {
+            return Ok(None);
+        }
+
+        Ok(Some(info))
     }
 
     pub async fn delete<T: OpencastItem>(&self, endpoint: &T) -> Result<Response<Incoming>> {
@@ -370,6 +399,22 @@ impl OcClient {
         (builder, uri)
     }
 
+    fn set_auth_headers(&self, mode: AuthMode<'_>, req: request::Builder) -> request::Builder {
+        match mode {
+            AuthMode::Admin => {
+                req.header(header::AUTHORIZATION, self.auth_header.expose_secret())
+            }
+            AuthMode::Sudo { as_user } => {
+                req.header(header::AUTHORIZATION, self.auth_header.expose_secret())
+                    .header("X-RUN-AS-USER", as_user)
+            }
+            AuthMode::User { username, password } => {
+                let auth_header = util::basic_auth_header(username, password);
+                req.header(header::AUTHORIZATION, auth_header.expose_secret())
+            }
+        }
+    }
+
     fn build_form_request(&self, path_and_query: &str, method: http::Method, params: &[(&str, &str)]) -> (Request<RequestBody>, Uri) {
         let mut serializer = Serializer::new(String::new());
         for (key, value) in params {
@@ -421,6 +466,40 @@ impl OcClient {
 pub struct ExternalApiVersions {
     pub default: String,
     pub versions: Vec<String>,
+}
+
+#[derive(Deserialize)]
+pub struct InfoMeResponse {
+    pub roles: Vec<String>,
+    pub user: InfoMeUserResponse,
+    #[serde(rename = "userRole")]
+    pub user_role: String,
+}
+
+#[derive(Deserialize)]
+pub struct InfoMeUserResponse {
+    pub name: String,
+    pub username: String,
+    pub email: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+pub enum AuthMode<'a> {
+    /// Use the configured admin credentials.
+    #[allow(dead_code)]
+    Admin,
+
+    /// Use the configured admin credentials, but use `X-RUN-AS-USER` to pretend
+    /// to be a different user.
+    Sudo {
+        as_user: &'a str,
+    },
+
+    /// Use the specified credentials.
+    User {
+        username: &'a str,
+        password: &'a str,
+    },
 }
 
 /// ACL structure used in Opencast (different from the structure used in Tobira)

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -1,10 +1,11 @@
+use base64::Engine as _;
 use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{connect::HttpConnector, Client};
 use hyperlocal::UnixConnector;
 use rand::{RngCore, CryptoRng};
-use secrecy::SecretBox;
+use secrecy::{SecretBox, SecretString};
 
 use crate::{http::Response, prelude::*};
 
@@ -147,4 +148,10 @@ where
         .context("failed to download HTTP body")?
         .to_bytes()
         .pipe(Ok)
+}
+
+pub fn basic_auth_header(user: &str, password: &str) -> SecretString {
+    let credentials = format!("{user}:{password}");
+    let encoded_credentials = base64::engine::general_purpose::STANDARD.encode(credentials);
+    SecretString::new(format!("Basic {encoded_credentials}").into())
 }

--- a/backend/src/util/url.rs
+++ b/backend/src/util/url.rs
@@ -30,6 +30,10 @@ impl HttpUrl {
         self
     }
 
+    pub fn query_pairs_mut(&mut self) -> form_urlencoded::Serializer<'_, url::UrlQuery<'_>> {
+        self.0.query_pairs_mut()
+    }
+
     /// Returns `true` if this URL has a non-empty, non `/` path.
     pub fn has_real_path(&self) -> bool {
         !self.path().is_empty() && self.path() != "/"

--- a/docs/docs/dev/rfc-lti-1.3.md
+++ b/docs/docs/dev/rfc-lti-1.3.md
@@ -1,0 +1,514 @@
+---
+sidebar_position: 100
+---
+
+# RFC: LTI 1.3 / LTI Advantage integration
+
+| | |
+|---|---|
+| **Status** | Draft / for discussion. **LTI 1.3 Core is implemented** (see below); Deep Linking, NRPS and Dynamic Registration are not. |
+| **Author** | rrolf@uni-osnabrück.de |
+| **Scope** | Backend (`backend/src/auth`), frontend (selection UI), docs |
+| **Target** | LTI 1.3 Core + Deep Linking 2.0 + NRPS 2.0 (LTI Advantage) |
+
+> **Implementation status.** The Core launch (`/~lti/login`, `/~lti/launch`, `/~lti/jwks`)
+> is built and verified end-to-end against Moodle; operator documentation lives in
+> [`docs/setup/auth/user/lti.md`](../setup/auth/user/lti). Where the implementation settled
+> an open question differently than sketched here, the code and that document are
+> authoritative — notably **OQ8 (identity mapping)**, which is resolved by the per-platform
+> `username_source` config option. Later phases (§7) remain proposals.
+
+This document proposes adding LTI 1.3 support to Tobira so it can be embedded as a
+standalone LTI **tool** in LMS **platforms** such as Moodle and Canvas. The primary
+driver is **Deep Linking**: letting teachers pick individual videos, series or
+playlists from Tobira's UI and embed links to them inside a course. Tobira keeps
+handling all Opencast authentication itself; the LMS only delegates identity.
+
+> **Why a video portal as an LTI tool?** Tobira already has the more usable UIs for
+> browsing recordings, series and playlists than the Opencast LTI module. Exposing it
+> over LTI lets institutions surface those UIs directly inside their LMS.
+
+
+## 0. Basis: PR #1706 (OIDC support)
+
+**This work builds directly on [PR #1706 — "Add OpenID Connect support (MVP)"](https://github.com/elan-ev/tobira/pull/1706)**
+by the maintainer, not on a green field. #1706 adds OIDC login (authorization-*code*
+flow) and, in doing so, already builds most of the auth foundation LTI needs. LTI 1.3 is
+"OIDC with a specific launch shape", so the overlap is large.
+
+**Reused from #1706 (do not reimplement):**
+
+| Piece (in #1706) | LTI use |
+|---|---|
+| `jwtea` crate (`Jwks`, `RawJwt::decode`, `Validator` trait) | verify platform launch JWTs against the platform JWKS (see §4.1) |
+| `IdTokenValidator` (`aud`/`azp`/`iss`/clock-skew) | LTI launch validator = same pattern + `nonce` + `deployment_id` |
+| `create_session_with_cookies(user, ctx)` (`auth/mod.rs`) | the session entry point — build a `User`, call this (see §3) |
+| `tobira-oidc-state` state cookie | LTI `state` binding / login-CSRF protection (§6) |
+| `DiscoveryInfo` (OIDC discovery + JWKS fetch) | platform key retrieval |
+| `auth/opencast.rs` (fetch roles from Opencast) | one option for role resolution (see caveat below) |
+
+**LTI-specific delta to add on top:**
+
+- **Third-party-initiated login** (platform-initiated, carrying `iss`/`login_hint`/
+  `target_link_uri`) — vs. #1706's user-initiated `/~oidc/login`.
+- **`response_type=id_token` + `response_mode=form_post`**: the platform POSTs the
+  `id_token` straight to the launch endpoint — there is **no `code` exchange** like
+  #1706's backchannel `fetch_token`.
+- LTI `nonce` (required) + `deployment_id`; LTI claims (`message_type`, roles,
+  `resource_link`, `deep_linking_settings`); Deep Linking response; later NRPS.
+- Manual per-platform registration (`client_id`/`deployment_id`/`keyset_url`), since LTI
+  platforms are typically registered by hand rather than via pure OIDC discovery.
+
+**Status / coordination:** #1706 is an in-progress MVP, **not yet merged**, and currently
+conflicts with `main`. Its own central open question — *how to map ID-token claims to a
+Tobira user* (config string vs. Rhai/Lua/JS/WASM; currently hardcoded, `TODO`) — is the
+**same** problem as this RFC's §5.6 (role mapping) and OQ8 (identity mapping). It must be
+solved *once*, upstream, with the maintainer. ⚠️ Note also that the MVP tech sheet (#1697)
+explicitly *rejected* "ask Opencast for roles", whereas #1706 does exactly that
+(`auth/opencast.rs`) — reconcile before building.
+
+## 1. Goals and non-goals
+
+**Goals**
+
+- Tobira acts as an LTI 1.3 tool that can be launched from any conformant platform.
+- **Deep Linking 2.0**: teachers select content in Tobira; Tobira returns
+  `ltiResourceLink` content items to the LMS.
+- **Resource link launch**: a previously embedded link launches the learner straight
+  into the relevant Tobira page (event / series / realm).
+- **Names and Role Provisioning (NRPS) 2.0**: use the course roster to grant access to
+  series and playlists (and individual events) for *course groups* — e.g. "all members
+  of course X may view this series", "instructors of course X may edit it". (Per-role
+  *page/realm visibility* is not supported by Tobira today — see §5.8 — so it is out of
+  scope for the first iteration.)
+- Reuse Tobira's existing session, user and role model — LTI runs **alongside** normal
+  login (sharing the session machinery), not as a replacement for it (see §3).
+
+**Non-goals (for the first iteration)**
+
+- Assignment and Grade Services (AGS) — Tobira is not a graded activity.
+- Proctoring, Submission Review, Caliper, Course Groups.
+- LTI 1.1 / LTI 1.0 backwards compatibility (legacy, not worth the security cost).
+
+**Possible later additions**
+
+- Dynamic Registration — automated tool registration instead of manual key exchange.
+
+
+## 2. The LTI 1.3 spec landscape
+
+There is no "LTI 1.3a". The relevant specs are **LTI 1.3 Core** plus the **LTI
+Advantage** service bundle:
+
+| Component | Spec | In scope? | Notes |
+|---|---|---|---|
+| OIDC third-party-initiated login | Core | yes | mandatory handshake |
+| Signed launch message (JWT/JWS, RS256) | Core | yes | security-critical verification |
+| Tool JWKS + key rotation | Core | yes | needed for DL response & service grants |
+| **Deep Linking 2.0** | Advantage | **yes** | the main feature |
+| **Names & Role Provisioning (NRPS) 2.0** | Advantage | **yes** | course roster → group-based access |
+| Assignment & Grade Services (AGS) 2.0 | Advantage | no | grading — not applicable |
+| Dynamic Registration | optional | later | nice-to-have |
+| PNS / Proctoring / Submission Review / Course Groups | optional | no | out of scope |
+
+
+## 3. How LTI maps onto Tobira's auth architecture
+
+> **Design note.** LTI must **not** be framed as a replacement "auth source", and
+> `auth.source` is no longer current Tobira terminology. LTI is configured and runs **in
+> addition to** the main user login, sharing much of its code. So: LTI reuses the
+> session/user machinery below, but runs **alongside** normal login — a user must still be
+> able to log in directly, not only via LTI.
+
+Tobira's authentication is deliberately pluggable. The current sources
+(`AuthSource` in [`backend/src/auth/config.rs`], dispatched in
+[`backend/src/auth/mod.rs`]) are:
+
+- `None`
+- `TobiraSession` — DB-backed sessions (`user_sessions` table, `tobira-session` cookie)
+- `TrustAuthHeaders` — a trusted reverse proxy sets `x-tobira-username`, … headers
+- `Callback` — an external service validates the request and returns user info
+
+A user is modelled as `struct User { username, display_name, email, roles, user_role,
+user_realm_handle }` (`backend/src/auth/mod.rs`). **An LTI launch produces exactly this
+shape of data** (`sub`, `name`, `email`, the `roles` claim). So the proposal is:
+
+> **Treat a verified LTI launch as another way to create a session, reusing the session
+> machinery — but running alongside normal login, not instead of it.** After a verified
+> launch, Tobira builds a `User` and calls `create_session_with_cookies()` (added by
+> [#1706](https://github.com/elan-ev/tobira/pull/1706)) — the same path `/~oidc/callback`
+> already uses. This does **not** require disabling other login methods; LTI is additive.
+
+Everything downstream (realms, ACLs, GraphQL, the `HasRoles` trait) then works
+unchanged, because the user is an ordinary authenticated Tobira user.
+
+**Reused building blocks** (all already present):
+
+| Need | Existing code |
+|---|---|
+| Create session + set cookie | `User::persist_new_session()` / `create_session()` (`auth/mod.rs`, `auth/handlers.rs`) |
+| User model & roles | `struct User`, `HasRoles` trait (`auth/mod.rs`) |
+| Route registration | central `match path` in `handle()` (`http/handlers.rs`) |
+| JWT signing + JWKS serving | `JwtContext`, `/.well-known/jwks.json` (`auth/jwt.rs`, `http/handlers.rs`) |
+| HTTP client for platform JWKS | `ctx.http_client` (hyper) and `reqwest` |
+
+
+## 4. Key technical decisions (need core-team input)
+
+### 4.1 Tobira's JWT module is sign-only and EC/Ed25519-only
+
+`backend/src/auth/jwt.rs` uses `aws-lc-rs` purely to **sign** JWTs with ES256 / ES384 /
+Ed25519, and serves the corresponding JWKS at `/.well-known/jwks.json`. LTI needs two
+things this module does **not** currently provide:
+
+1. **Verification of incoming launch JWTs** — RS256, signature checked against the
+   platform's JWKS (fetched and cached). Not present today.
+2. **A tool key pair** to sign the Deep Linking response JWT and the OAuth2
+   `client_assertion` used for service calls (NRPS/AGS). Platforms such as Moodle and
+   Canvas in practice expect **RSA (RS256)** from tools; Tobira's existing EC keys are
+   generally not accepted as tool keys.
+
+**Consequence:** the LTI module needs its own **RSA key pair** and its own JWKS endpoint
+(`/~lti/jwks`), separate from the Opencast-facing `/.well-known/jwks.json`.
+
+**Decision: use `jwtea` — already chosen by the maintainer in [PR #1706](https://github.com/elan-ev/tobira/pull/1706).**
+
+This supersedes the earlier `jsonwebtoken`-vs-`aws-lc-rs` deliberation: PR #1706 (OIDC
+support) already introduced the **`jwtea`** crate and uses it to download JWKS and verify
+incoming ID-token JWTs. Since LTI builds on that same OIDC foundation (see §0), it must
+use the same library for consistency. `jwtea` provides exactly the verification pattern
+LTI needs:
+
+- `Jwks` — download and hold the platform's public keys.
+- `RawJwt::decode(keys, validator, …)` — decode + verify a JWT against the JWKS.
+- A `jwtea::Validator` trait — #1706's `IdTokenValidator` already enforces `aud`, `azp`,
+  `iss`, and clock skew (`BasicValidator { allowed_clock_skew }`). **The LTI launch
+  validator is the same pattern plus two checks: `nonce` (replay-protected) and
+  `deployment_id`.**
+
+**Single crypto backend (aws-lc-rs), but note the split.** `jwtea` is built **on
+`aws-lc-rs`**, not `ring`, so an earlier "two crypto stacks" worry is void. However —
+**`jwtea` is verification-only**: it parses JWKS and verifies incoming JWTs, but has no
+signing API and cannot build a JWK. The **tool side** (signing the Deep Linking response
+and the NRPS `client_assertion`, and serving `/~lti/jwks`) is therefore done with
+`aws-lc-rs`'s RSA directly (`rsa::KeyPair::generate`/`from_pkcs8`, `sign`, and — with the
+`ring-io` feature enabled — `public_key().modulus()`/`.exponent()` to build the JWK).
+So: **verify = `jwtea`, sign / serve keyset = `aws-lc-rs`.** The tool needs its own RSA
+key pair + `/~lti/jwks` endpoint, separate from the Opencast-facing EC keys in
+`auth/jwt.rs`.
+
+### 4.2 The session cookie is hard-coded to `SameSite=Lax`
+
+`SessionId::set_cookie()` in `backend/src/auth/session_id.rs` sets `SameSite=Lax`. In the
+standard LTI scenario Tobira renders **inside the LMS iframe** (cross-site), where a
+`Lax` cookie is **not sent** — so the session silently fails.
+
+Required: make the cookie `SameSite=None; Secure` for the embedded case. Even then,
+browsers increasingly block third-party cookies, so we should plan for at least one of:
+
+- **Storage Access API** to request cookie access from within the iframe, or
+- **CHIPS** partitioned cookies (`Partitioned` attribute), or
+- launching Tobira in a **new top-level window/tab** instead of an iframe (LTI permits
+  this; sidesteps third-party cookies but is a worse UX for embeds).
+
+This is the classic LTI-in-iframe pain point and should be settled in the design phase.
+
+**Open decision:** make `SameSite` configurable per deployment, or auto-relax it only on
+the LTI routes? A blanket `SameSite=None` weakens CSRF posture for non-LTI deployments,
+so it should be opt-in.
+
+
+## 5. Proposed design
+
+### 5.1 Endpoints
+
+All under the existing `/~` internal-route convention, registered in the central
+`match path` in `http/handlers.rs`:
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/~lti/login` | GET/POST | OIDC third-party-initiated login (issues `state` + `nonce`, redirects to platform `auth_login_url`) |
+| `/~lti/launch` | POST | Receives the `id_token`, verifies it, builds a `User`, creates a session, then routes to content or the Deep Linking UI |
+| `/~lti/jwks` | GET | Tool public keys (RSA) for the platform to verify our signed JWTs |
+| `/~lti/deep-link-return` | POST | Builds and auto-POSTs the `DeepLinkingResponse` JWT to the platform's return URL |
+
+### 5.2 Module layout
+
+*Illustrative, not prescriptive* — this many files is likely unnecessary, and the file
+layout need not be settled here. The point is the responsibilities, not the file count.
+Mirrors the existing `auth/` structure:
+
+```
+backend/src/auth/lti/
+  mod.rs        – route dispatch, platform registry lookup
+  config.rs     – [auth.lti] config + per-platform entries
+  oidc.rs       – /~lti/login: state+nonce generation, redirect
+  launch.rs     – /~lti/launch: fetch+verify id_token, claims → User → session
+  jwks.rs       – tool RSA key pair, /~lti/jwks, client_assertion signing
+  deeplink.rs   – detect DeepLinkingRequest, build+POST the response JWT
+  claims.rs     – LTI claim types (serde), role mapping
+  nonce.rs      – nonce/state store with TTL (replay protection)
+  nrps.rs       – NRPS client (client_credentials grant), roster sync, role augmentation
+```
+
+### 5.3 Configuration sketch
+
+```toml
+[auth]
+source = "tobira-session"
+
+[auth.lti]
+# Tool key for signing DL responses & service grants (RSA, PEM/PKCS8).
+tool_private_key = "/etc/tobira/lti-tool-key.pem"
+# Relax the session cookie so it survives the LMS iframe.
+cookie_same_site_none = true
+# NRPS: fetch course rosters for group-based access.
+nrps_enabled = true
+# Background roster refresh interval; omit to sync only on launch.
+nrps_sync_interval = "6h"
+# How long to retain roster PII after the last sync.
+nrps_retention = "30d"
+
+# One entry per registered platform/deployment.
+[[auth.lti.platforms]]
+issuer = "https://moodle.example.org"
+client_id = "AbCd1234"
+deployment_id = "1"
+auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
+auth_token_url = "https://moodle.example.org/mod/lti/token.php"
+keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+```
+
+### 5.4 Launch flow
+
+```
+LMS (Moodle/Canvas)              Tobira backend                         Browser
+  │ 1. OIDC login init ─────────▶ /~lti/login
+  │                               └─ store state+nonce, redirect ──────▶
+  │ ◀── 2. authorize (login_hint) ─┘
+  │ 3. POST id_token (JWT) ──────▶ /~lti/launch
+  │                               ├─ look up platform by (iss, client_id)
+  │                               ├─ fetch+cache platform JWKS by `kid`
+  │                               ├─ verify sig (RS256) + iss/aud/azp/exp/nonce/deployment_id
+  │                               ├─ map claims → User, persist_new_session()
+  │                               ├─ Set-Cookie: tobira-session (SameSite=None)
+  │                               └─ branch on message_type ───────────▶ content page OR DL selection UI
+```
+
+`message_type = LtiResourceLinkRequest` → resolve `target_link_uri` / a custom claim to a
+realm or event ID and redirect. `message_type = LtiDeepLinkingRequest` → render the
+selection UI.
+
+### 5.5 Deep Linking flow
+
+1. A Deep Linking launch is detected; the `deep_linking_settings` claim
+   (`deep_link_return_url`, accepted types, multiple, …) is stored against the session.
+2. The frontend reuses the existing browse components (series / playlists / events) in a
+   **selection mode**.
+3. On confirm, `/~lti/deep-link-return` builds a `DeepLinkingResponse` JWT whose
+   `https://purl.imsglobal.org/spec/lti-dl/claim/content_items` array contains
+   `ltiResourceLink` items (`url`, `title`, optional `iframe` dimensions, custom params
+   encoding the Tobira target), signs it with the **tool key**, and auto-submits a form
+   POST to `deep_link_return_url`.
+
+### 5.6 Role mapping
+
+Map the LTI `roles` claim to Tobira/Opencast `ROLE_*` values, e.g.
+`http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor` → an instructor/moderator
+role; `…#Learner` → `ROLE_USER`. The exact mapping should be configurable per platform.
+Without NRPS, access control derives solely from these launch claims.
+
+### 5.7 NRPS and group-based access
+
+Goal: grant access to realms (pages), series and playlists to *course groups* — e.g.
+"all members of course X may view this series", "instructors of course X may edit it".
+
+**Core mechanism — context-derived roles registered as known groups.** Tobira ACLs are
+role-based: a user may access a resource if it holds a matching `ROLE_*`
+(`HasRoles::overlaps_roles`). Tobira already has a group model purpose-built for this —
+see §5.8. We mint a deterministic role per LTI context (course) and register it as a
+**known group** so it gets a friendly, localised label in the ACL UI:
+
+- `ROLE_LTI_<hash(issuer + context_id)>` — every member of the course
+- `ROLE_LTI_<hash(...)>_INSTRUCTOR` — role-scoped within the course (optional)
+
+When a teacher embeds or deep-links content from a course, the selection UI offers to
+set the resource ACL to that course's group role. Members then match the ACL and gain
+access. The basic mechanism works from launch claims alone — but only for the launching
+user, and only after they have launched from that context.
+
+> **Caveat — `implies` is not transitive at runtime.** The `known_groups.implies` field
+> is *display-only* metadata for the ACL UI; it is **not** expanded into a user's roles
+> during access checks (`overlaps_roles` is a plain set intersection). So an instructor
+> role must not rely on `implies` to also grant member access — the launch / role
+> augmentation must add **every** applicable context role to the session explicitly.
+
+**Where NRPS comes in.** NRPS lets the tool fetch the **full roster of the context**, so
+group access works for *every* member — including those who have not launched yet, and
+on direct navigation to Tobira (not only via the course launch):
+
+- A launch carrying the NRPS claim
+  (`…/spec/lti-nrps/claim/namesroleservice` → `context_memberships_url`) tells Tobira
+  where to fetch the roster.
+- Auth is an **OAuth2 `client_credentials` grant** with a signed `client_assertion` JWT
+  (signed with the **tool RSA key** from §4.1) and scope
+  `…/spec/lti-nrps/scope/contextmembership.readonly`. → This makes the tool key from
+  §4.1 *required*, reinforcing that decision.
+- The response lists members with `user_id` (matching the launch `sub`), their `roles`,
+  a `status` (Active/Inactive/Deleted), and — subject to the platform's privacy
+  settings — name and email.
+
+**Storage & role augmentation.**
+
+- `lti_context(issuer, context_id, label, title, group_role)` — registered contexts.
+- `lti_membership(issuer, context_id, lti_user_id, roles, status, synced_at)` — roster.
+- On session creation / role resolution, Tobira augments the user's roles with the
+  `group_role` of every context in which they are an *active* member (joined on the LTI
+  user id ↔ Tobira username). This is what makes group access apply beyond the original
+  launch.
+
+**Identity mapping.** The join key is the Tobira `username`, which must be derived
+deterministically from the launch (recommended: from `(issuer, client_id, sub)` or a
+configured claim) and must match what NRPS returns as `user_id`.
+
+**Sync timing.** Membership can be refreshed (a) lazily on each launch from a context,
+(b) on a scheduled background job (cf. `db_maintenance()` in `auth/mod.rs`), or (c) both.
+Eager sync gives accurate membership at the cost of periodic service calls and stored
+PII (see §6).
+
+### 5.8 Tobira's existing permission model (and how groups fit)
+
+Investigation of the backend confirms the mechanism above maps cleanly onto what Tobira
+already has:
+
+**ACL columns per resource type**
+
+| Resource | Columns | Notes |
+|---|---|---|
+| Events | `read_roles`, `write_roles`, `preview_roles` | synced from Opencast |
+| Series | `read_roles`, `write_roles` | synced from Opencast |
+| Playlists | `read_roles`, `write_roles` | `db/migrations/35-playlists.sql` |
+| Realms (pages) | `moderator_roles`, `admin_roles` + `flattened_*` | `db/migrations/30-realm-permissions.sql` |
+
+**Enforcement** is a direct set intersection: `context.auth.overlaps_roles(read_roles)`
+(see `model/event/mod.rs`), short-circuited by `is_admin`. There is no role hierarchy at
+enforcement time — a user gains access iff a role string it actually holds appears in the
+resource's role list.
+
+**Realm (page) permissions are edit-only — there is no per-role page visibility.**
+Confirmed in `api/model/realm/mod.rs`: realms have exactly two permission levels, both
+gating *editing*:
+
+- `moderator_roles` → `can_current_user_moderate()` (add subpages, edit content and
+  non-critical settings)
+- `admin_roles` → `is_current_user_page_admin()` (full control: edit ACL, change path,
+  delete)
+
+Both flow down the realm tree automatically via the `flattened_*` columns maintained by
+triggers (`db/migrations/30-realm-permissions.sql`). **There is no `read_roles` /
+visibility column on realms** — a page is always viewable; what is actually protected is
+the *content* embedded in it (series / videos / playlists), each via its own
+`read_roles`.
+
+⚠️ **Consequence for group access:** "release a *page* to a course group" in the sense of
+restricting who can *see* the page is **not expressible today** and would require a new
+feature (a realm `read_roles` column with flattened inheritance, enforcement on the realm
+read path, and GraphQL/UI support). Group-based access to **series, playlists and
+events** works out of the box via their `read_roles`. Recommendation for the first
+iteration: scope group access to series/playlists/events; treat per-role page visibility
+as a separate, optional enhancement to propose to the core team.
+
+**Group model — `known_groups`.** The table
+`known_groups(role pk, label hstore, implies text[], large bool, sort_key)`
+(`db/migrations/24-known-groups.sql`) is purpose-built for exactly this use case — its
+own migration comment uses `ROLE_COURSE_123_LEARNER` as the example. It provides:
+
+- `label` — localised (`{ "default": …, "de": … }`), shown in the ACL selector and on
+  ACL entries (`RoleInfo` in `api/model/acl.rs`), so LTI course groups can display as
+  e.g. *"Course: Machine Learning (SS26)"* instead of an opaque role.
+- `implies` — **display-only** (see caveat in §5.7), not enforced.
+- `large` — drives a UI warning when granting write access to big groups; a whole-course
+  membership role should likely be flagged `large`.
+
+**Gap to close:** `known_groups` is currently populated **only via the CLI**
+(`tobira known-groups upsert <file.json>`, `cmd/known_groups.rs`) — there is no runtime
+API. LTI course groups appear and change dynamically, so the LTI module must be able to
+**upsert known groups at runtime** (refactor the CLI's insert logic into a shared
+function). Access still works via raw role strings without this, but the ACL UI would
+show no labels and admins could not discover course groups — so it is needed for a usable
+feature.
+
+
+## 6. Security considerations
+
+- **JWT verification is the critical path.** Enforce `iss`, `aud`/`azp`, `exp`/`iat`
+  (with bounded clock skew), and `deployment_id`. Reject unexpected `alg`.
+- **Nonce replay protection.** Persist issued nonces with a TTL and reject reuse.
+- **State binding.** Bind the OIDC `state` to the browser (cookie) to prevent
+  login-CSRF on the launch endpoint.
+- **JWKS caching with rotation.** Honour `kid`; refetch on unknown `kid`; cap cache TTL.
+- **Cookie scope.** `SameSite=None` must be opt-in and only paired with `Secure`.
+- **Privacy / GDPR (DSGVO).** NRPS returns personal data (names, emails) for *all*
+  course members, not just the launching user. Store only what is needed, honour the
+  `status` field (drop Deleted/Inactive members), make roster sync and PII retention
+  configurable (`nrps_retention`), and document this for the institution's
+  data-protection review. Platforms may also redact PII depending on their privacy
+  settings, so the tool must work with partial member data.
+- **Service token handling.** Cache the NRPS `client_credentials` access token until
+  expiry; never log it. The `client_assertion` JWT must be short-lived and audience-
+  scoped to the platform token endpoint.
+- **Test against the 1EdTech reference implementation** and real Moodle/Canvas
+  instances — unit tests alone do not cover the protocol's failure modes.
+
+
+## 7. Implementation plan (phased)
+
+- **Phase 0 — Spike.** Stand up the dev stack (`x.sh`) + a local Moodle (Docker). One
+  endpoint that fetches a real launch JWT, verifies it against the platform JWKS, and
+  logs the claims. Resolves the RSA question (§4.1) immediately.
+- **Phase 1 — LTI as an auth source (Core).** `/~lti/login`, `/~lti/launch`,
+  `/~lti/jwks`; platform config; claims → `User` → session; configurable `SameSite`;
+  nonce/state validation.
+- **Phase 2 — Resource link launch → content.** Resolve target to realm/event; role
+  mapping.
+- **Phase 3 — Deep Linking 2.0.** Selection UI (reuse browse components) + signed
+  `DeepLinkingResponse`.
+- **Phase 4 — NRPS & group-based access.** `client_credentials` grant + tool key,
+  roster fetch/sync (`lti_context` / `lti_membership` tables), context-derived group
+  roles registered in `known_groups` (requires factoring `cmd/known_groups.rs`'s upsert
+  into a runtime-callable function — see §5.8), role augmentation on session creation,
+  ACL UI to grant a course group. Depends on the tool RSA key from Phase 1/§4.1.
+- **Phase 5 — Hardening & conformance.** Full claim validation, JWKS rotation, PII
+  retention enforcement, 1EdTech reference + Moodle/Canvas testing.
+- **Phase 6 (optional) — Dynamic Registration.**
+
+
+## 8. Open questions for the core team
+
+1. ~~RSA via `aws-lc-rs` vs. adding `jsonwebtoken`?~~ *(resolved by [PR #1706](https://github.com/elan-ev/tobira/pull/1706):
+   use **`jwtea`**, the JWT crate the OIDC work already introduced — see §0 and §4.1.)*
+   Remaining sub-point: confirm `jwtea` can *sign* RS256 for the tool side (DL response /
+   `client_assertion`); if not, use `aws-lc-rs` RSA for signing only.
+2. How to expose the `SameSite=None` relaxation safely? (§4.2)
+3. ~~Multi-tenant: one tool key for all platforms, or per-tenant keys?~~ *(resolved:
+   Tobira has no multi-tenancy — one completely separate Tobira runs per tenant. So: one
+   tool key per Tobira instance; no per-tenant key handling needed.)*
+4. ~~Should LTI be a compile-time feature flag or always built in?~~ *(resolved: **always
+   built in.** Tobira uses no compile-time feature flags, and adding one here would bring
+   a lot of mostly unnecessary complexity.)*
+5. Is `auth.source = "tobira-session"` the intended host mode, or should LTI be its own
+   `AuthSource` variant?
+6. **Group modelling** *(resolved — see §5.8)*: use synthetic per-context roles
+   registered in `known_groups`; group access targets series/playlists/events via
+   `read_roles`. Confirmed findings:
+   - (b) **Resolved:** realms have no per-role visibility — `moderator_roles` /
+     `admin_roles` gate editing only. Restricting who can *see* a page would be a new
+     feature; out of scope for iteration 1.
+   - (a) **Open (core team):** is a runtime `known_groups` upsert API acceptable, or
+     should group registration stay CLI/batch-only?
+   - (c) **Open (design):** how are role-scoped grants (instructor vs. member) surfaced
+     in the ACL selector?
+7. **NRPS sync strategy & PII retention:** lazy (on launch) vs. scheduled background
+   sync, and how long roster PII may be retained (DSGVO).
+8. **Identity mapping:** how is the Tobira `username` derived from the launch so it
+   reliably matches the NRPS `user_id` across platforms?

--- a/docs/docs/setup/auth/user/index.md
+++ b/docs/docs/setup/auth/user/index.md
@@ -35,6 +35,8 @@ You can chose between three options here, configured as `auth.source`:
 - [**`"trust-auth-headers"`**](./user/trust-auth-headers): Tobira just checks a few fixed headers of the incoming request, which directly specify how the request is authenticated.
   This assumes some auth logic in front of Tobira, i.e. in your reverse proxy.
 
+Additionally, when using `"tobira-session"`, sessions can be created from an **[LTI 1.3 launch](./user/lti)** by an LMS (Moodle, Canvas, …), on top of the options above.
+
 What to chose? `"tobira-session"` is likely the fastest (in terms of processing time) and easiest to set up, but comes with limitations:
 Tobira only gets new data about a user at login, and it's impossible to implement SSO with this.
 If you can't use the built-in session management, use `"callback:..."`, which gives you full flexibility.

--- a/docs/docs/setup/auth/user/lti.md
+++ b/docs/docs/setup/auth/user/lti.md
@@ -187,7 +187,12 @@ Common failures and their log lines:
 ## Known limitations
 
 - **New window only** — iframe embedding needs `SameSite=None` / Storage Access work.
-- **Tool key is process-ephemeral** — regenerated on restart. Fine for launches (the LMS
-  refetches `/~lti/jwks`); a configurable persistent key is a later addition.
+- **Tool key is process-ephemeral** — regenerated on every start, and each Tobira process
+  serves its own key, so behind a load balancer `/~lti/jwks` answers with a different key
+  set depending on which process replies. That is harmless for launches, because nothing
+  currently signs with this key — Tobira only *verifies* the platform's tokens, and the
+  keyset is served purely so the LMS registration form can be completed. A configurable
+  persistent key becomes necessary once Tobira signs anything itself (Deep Linking
+  responses, NRPS service calls).
 - **No Deep Linking, NRPS or Dynamic Registration yet** — platforms must be registered
   manually, and landing is via the `series` custom parameter or `target_link_uri`.

--- a/docs/docs/setup/auth/user/lti.md
+++ b/docs/docs/setup/auth/user/lti.md
@@ -1,0 +1,185 @@
+---
+sidebar_position: 4
+---
+
+# LTI 1.3
+
+Tobira can act as an **LTI 1.3 tool** that Learning Management Systems ("platforms" in
+LTI terms, e.g. Moodle or Canvas) launch. A user who clicks a Tobira activity in the LMS
+is logged into Tobira and lands on a Tobira page — without a separate login.
+
+LTI runs **alongside** the normal login: it is an additional way to create sessions, not a
+replacement for `auth.source`. It therefore requires Tobira's built-in session management:
+
+```toml
+[auth]
+source = "tobira-session"
+```
+
+:::note
+This is the MVP of LTI support. It implements LTI 1.3 Core (launch + login). Deep Linking,
+Names & Role Provisioning (NRPS), and Dynamic Registration are **not** included yet. See
+[Known limitations](#known-limitations).
+:::
+
+
+## How it works
+
+A launch is a standard LTI 1.3 / OpenID Connect flow across three Tobira endpoints:
+
+1. The LMS sends the browser to **`/~lti/login`** (OIDC third-party login initiation).
+   Tobira looks up the platform, issues a one-time `state` + `nonce`, and redirects back
+   to the platform's authorization endpoint.
+2. The platform posts a signed launch token (`id_token`, a JWT) to **`/~lti/launch`**.
+   Tobira verifies the signature against the platform's public keys, checks `iss`, `aud`,
+   `nonce` and `deployment_id`, and then resolves the user (see
+   [Users and roles](#users-and-roles)).
+3. Tobira creates a normal `tobira-session` cookie and redirects the browser to the
+   target page.
+
+**`/~lti/jwks`** serves Tobira's own public key set (the LMS uses it to verify tokens that
+Tobira signs; only relevant for future service calls).
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/~lti/login` | GET/POST | OIDC third-party login initiation |
+| `/~lti/launch` | POST | Receives and verifies the signed launch |
+| `/~lti/jwks` | GET | Tobira's public JWK set |
+
+
+## Prerequisites
+
+- **`auth.source = "tobira-session"`** — LTI creates Tobira sessions.
+- **HTTPS** — LTI 1.3 mandates it, and Tobira's session cookie is `Secure`.
+- **Launch in a new window/tab, not an iframe.** Tobira's session cookie is `SameSite=Lax`,
+  which is not sent inside a cross-site iframe. In the LMS, set the launch container to
+  "New window". Embedding in an iframe is not supported yet.
+- **The launching user must exist in Opencast.** Just like the normal login, Tobira asks
+  Opencast for the user's roles; see below.
+
+
+## Users and roles {#users-and-roles}
+
+Tobira does not manage roles itself. After verifying the launch, it asks Opencast for the
+user (via `/info/me.json`, impersonating the user with the `[sync]` admin credentials),
+exactly like a normal login. **The user must exist in Opencast**, otherwise the launch is
+rejected (`user … is not known to Opencast`).
+
+The username Tobira uses to look the user up is taken from the launch, in this order:
+
+1. the `username` **custom parameter**, if set (see below),
+2. the `preferred_username` claim,
+3. the `sub` claim (fallback).
+
+This matters because platforms differ:
+
+- **Canvas** sends `preferred_username`, so it works out of the box.
+- **Moodle** sends neither a login name via `preferred_username` nor a usable `sub` (its
+  `sub` is an opaque internal ID). You **must** supply the username via a custom parameter
+  (see [Moodle setup](#moodle)).
+
+The resulting username must match a user Opencast knows.
+
+
+## Configuration
+
+Enable LTI and register each platform/deployment under `[auth.lti]`:
+
+```toml
+[auth.lti]
+enabled = true
+
+[[auth.lti.platforms]]
+issuer = "https://moodle.example.org"
+client_id = "AbCd1234"
+deployment_id = "1"
+auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
+keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+```
+
+All values come from the tool registration in the LMS, which labels them differently than
+the LTI spec terms used here:
+
+| Config field | Moodle label | Canvas label |
+| --- | --- | --- |
+| `issuer` | Platform ID | Issuer |
+| `client_id` | Client ID | Client ID |
+| `deployment_id` | Deployment ID | Deployment ID |
+| `auth_login_url` | Authentication request URL | OIDC Auth endpoint |
+| `keyset_url` | Public keyset URL | Public JWKS URL |
+
+`issuer` is compared **verbatim** against the launch's `iss` claim — copy it exactly (no
+trailing slash, correct scheme and host).
+
+
+## Landing page
+
+By default the launch lands on the platform's `target_link_uri`. Most platforms default
+that to the tool URL (Tobira's `/~lti/launch`), which is not a page — in that case Tobira
+falls back to its **start page** (the user is logged in). Targets outside Tobira are
+ignored (no open redirect).
+
+To land directly on a specific series, set a `series` **custom parameter** to an Opencast
+series ID (its `identifier`, a UUID; find it under `…/api/series/series.json` on your
+Opencast). Tobira then opens that series' page.
+
+
+## Moodle setup {#moodle}
+
+*Site administration → Plugins → Activity modules → External tool → Manage tools →
+configure a tool manually*, LTI version **LTI 1.3**:
+
+- **Tool URL:** `https://tobira.example.org/~lti/launch`
+- **Redirection URI(s):** `https://tobira.example.org/~lti/launch`
+  — a **separate, required field**. Moodle validates the launch's `redirect_uri` against
+  this list only and does **not** fall back to the Tool URL. If it is empty (or the host
+  differs), the launch fails at `mod/lti/auth.php` with a generic **"Invalid request"**.
+- **Initiate login URL:** `https://tobira.example.org/~lti/login`
+- **Public key type:** *Keyset URL* → `https://tobira.example.org/~lti/jwks`
+- **Custom parameters:**
+  ```
+  username=$User.username
+  ```
+  Required — Moodle sends no usable username otherwise (see
+  [Users and roles](#users-and-roles)). Moodle substitutes `$User.username` at launch time.
+  There is no Privacy setting that shares the login name; the substitution variable is the
+  supported way. Add `series=<opencast-series-id>` on a separate line to land on a series.
+- **Default launch container:** **New window** (not an iframe).
+
+Every URL must use the **exact** public host of your Tobira — a wrong subdomain fails
+silently (the launch never reaches Tobira, and nothing is logged).
+
+Moodle then shows the platform `issuer`, `client_id` and `deployment_id` — copy them into
+`[[auth.lti.platforms]]` and restart Tobira. Finally, make sure the launching Moodle user
+exists in Opencast under the same username.
+
+
+## Debugging
+
+Set the LTI module to debug logging to see the resolved username and the full set of
+launch claims:
+
+```toml
+[log]
+filters."tobira::auth::lti" = "debug"
+```
+
+Common failures and their log lines:
+
+| Symptom | Cause |
+| --- | --- |
+| Nothing logged on launch | The launch never reached Tobira — wrong host/URL in the LMS tool config. |
+| `mod/lti/auth.php` "Invalid request" (Moodle) | `redirect_uri` not registered — fill in Moodle's *Redirection URI(s)*. |
+| `LTI login for unknown platform (iss = …)` | The launch's `iss` is not in any `[[auth.lti.platforms]]` entry. |
+| `LTI launch with unknown, expired or already-used 'state'` / `nonce mismatch` | A stale or replayed launch (e.g. reloading the result page). Start a fresh launch. |
+| `LTI launch: deployment_id mismatch` | `deployment_id` in the config does not match the platform. |
+| `user '…' is not known to Opencast` | The resolved username does not exist in Opencast, or no username was provided (see [Users and roles](#users-and-roles)). |
+
+
+## Known limitations
+
+- **New window only** — iframe embedding needs `SameSite=None` / Storage Access work.
+- **Tool key is process-ephemeral** — regenerated on restart. Fine for launches (the LMS
+  refetches `/~lti/jwks`); a configurable persistent key is a later addition.
+- **No Deep Linking, NRPS or Dynamic Registration yet** — platforms must be registered
+  manually, and landing is via the `series` custom parameter or `target_link_uri`.

--- a/docs/docs/setup/auth/user/lti.md
+++ b/docs/docs/setup/auth/user/lti.md
@@ -65,20 +65,26 @@ user (via `/info/me.json`, impersonating the user with the `[sync]` admin creden
 exactly like a normal login. **The user must exist in Opencast**, otherwise the launch is
 rejected (`user … is not known to Opencast`).
 
-The username Tobira uses to look the user up is taken from the launch, in this order:
+Which launch claim provides that username is an **admin decision per platform**, set with
+`username_source` on the platform entry:
 
-1. the `username` **custom parameter**, if set (see below),
-2. the `preferred_username` claim,
-3. the `sub` claim (fallback).
+| `username_source` | Uses | When |
+| --- | --- | --- |
+| `"preferred-username"` (default) | the `preferred_username` claim | Platforms that assert it, e.g. **Canvas** — works out of the box. |
+| `"custom"` | the `username` **custom parameter** | Platforms that send no usable `preferred_username`, e.g. **Moodle** (see [Moodle setup](#moodle)). |
+| `"sub"` | the raw `sub` claim | Rarely useful — `sub` is usually an opaque platform ID. |
 
-This matters because platforms differ:
+If the configured claim is absent, the launch is **rejected** rather than falling back to
+a guessed identity. The resulting username must match a user Opencast knows.
 
-- **Canvas** sends `preferred_username`, so it works out of the box.
-- **Moodle** sends neither a login name via `preferred_username` nor a usable `sub` (its
-  `sub` is an opaque internal ID). You **must** supply the username via a custom parameter
-  (see [Moodle setup](#moodle)).
-
-The resulting username must match a user Opencast knows.
+:::warning
+`username_source = "custom"` trusts the `username` custom parameter to assert the user's
+identity. In most LMS, custom parameters can be set **per placement, by instructors** — so
+only enable `"custom"` for platforms where you accept that whoever configures a launch can
+choose the asserted username. Where possible, pin the custom parameter at the tool level
+(admin) to the substitution value `$User.username`. The default `"preferred-username"`
+does not have this concern, because that claim is asserted by the platform.
+:::
 
 
 ## Configuration
@@ -95,10 +101,12 @@ client_id = "AbCd1234"
 deployment_id = "1"
 auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
 keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+username_source = "custom"   # Moodle only; see "Users and roles". Omit for Canvas etc.
 ```
 
-All values come from the tool registration in the LMS, which labels them differently than
-the LTI spec terms used here:
+The first five values come from the tool registration in the LMS, which labels them
+differently than the LTI spec terms used here (`username_source` is Tobira-only, see
+[Users and roles](#users-and-roles)):
 
 | Config field | Moodle label | Canvas label |
 | --- | --- | --- |
@@ -140,10 +148,10 @@ configure a tool manually*, LTI version **LTI 1.3**:
   ```
   username=$User.username
   ```
-  Required — Moodle sends no usable username otherwise (see
-  [Users and roles](#users-and-roles)). Moodle substitutes `$User.username` at launch time.
-  There is no Privacy setting that shares the login name; the substitution variable is the
-  supported way. Add `series=<opencast-series-id>` on a separate line to land on a series.
+  Required together with `username_source = "custom"` on the platform (see
+  [Users and roles](#users-and-roles)) — Moodle sends no usable username otherwise. Moodle
+  substitutes `$User.username` at launch time; there is no Privacy setting that shares the
+  login name. Add `series=<opencast-series-id>` on a separate line to land on a series.
 - **Default launch container:** **New window** (not an iframe).
 
 Every URL must use the **exact** public host of your Tobira — a wrong subdomain fails

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -439,6 +439,21 @@
 #tenant_admin =
 
 
+[auth.oidc]
+# Default value: false
+#enabled = false
+
+# Base URL to the issuer/IdP, e.g. `https://foo.com/realms/bar`. Note
+# that these URLs basically never have a trailing `/`.
+#issuer_url =
+
+# The client identifier registered with the identity provider.
+#client_id =
+
+# The secret to authenticate against the identity provider.
+#client_secret =
+
+
 [log]
 # Specifies what log messages to emit, based on the module path and log level.
 #

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -477,6 +477,9 @@
 #     deployment_id = "1"
 #     auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
 #     keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+#     # Moodle sends no `preferred_username`; take it from a custom parameter
+#     # (`username=$User.username`). See `username_source` for the caveat.
+#     username_source = "custom"
 #
 # Default value: []
 #platforms = []

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -460,7 +460,16 @@
 # Default value: false
 #enabled = false
 
-# Registered LTI platforms, one table entry per platform/deployment:
+# Registered LTI platforms, one table entry per platform/deployment. All
+# values come from the tool registration in your LMS, which labels them
+# differently than the spec terms used here (Moodle labels shown; Canvas
+# calls `issuer` "Issuer"):
+#
+#     issuer         ->  "Platform ID"
+#     client_id      ->  "Client ID"
+#     deployment_id  ->  "Deployment ID"
+#     auth_login_url ->  "Authentication request URL"
+#     keyset_url     ->  "Public keyset URL"
 #
 #     [[auth.lti.platforms]]
 #     issuer = "https://moodle.example.org"

--- a/docs/docs/setup/config.toml
+++ b/docs/docs/setup/config.toml
@@ -454,6 +454,25 @@
 #client_secret =
 
 
+[auth.lti]
+# If `true`, the LTI launch endpoints are enabled.
+#
+# Default value: false
+#enabled = false
+
+# Registered LTI platforms, one table entry per platform/deployment:
+#
+#     [[auth.lti.platforms]]
+#     issuer = "https://moodle.example.org"
+#     client_id = "AbCd1234"
+#     deployment_id = "1"
+#     auth_login_url = "https://moodle.example.org/mod/lti/auth.php"
+#     keyset_url = "https://moodle.example.org/mod/lti/certs.php"
+#
+# Default value: []
+#platforms = []
+
+
 [log]
 # Specifies what log messages to emit, based on the module path and log level.
 #

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -66,6 +66,19 @@ errors:
   unknown: Unknown error.
   detailed-error-info: Detailed error information for developers
   embedded: An error occurred in the embedded application.
+  oidc-error:
+    title: Login failed (OIDC)
+    # TODO: can we add more useful details to this?
+    access-denied: >
+      <strong>Login failed</strong>: external authentication was denied.
+    internal-error: >
+      <strong>Login failed</strong>: an internal OIDC error occured.  This is
+      very likely not your fault. You can try again later or contact a system
+      administrator.
+    temporarily-unavailable: >
+      <strong>Login failed</strong>: the authentication service is temporarily
+      unavailable. Try again later.
+
 
 not-found:
   page-not-found: Page not found

--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -5,10 +5,9 @@ import { APIError, NotJson, ServerError } from ".";
 import { Root } from "../layout/Root";
 import { useRouter } from "../router";
 import { Card } from "@opencast/appkit";
-import { ErrorDisplay, NetworkError } from "../util/err";
+import { ErrorDetails, ErrorDisplay, NetworkError } from "../util/err";
 import { RouterControl } from "../rauta";
 import { UserProvider, Props as UserProviderProps } from "../User";
-import { COLORS } from "../color";
 
 
 type Props = {
@@ -110,28 +109,10 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                             <div css={{ display: "flex", justifyContent: "center" }}>
                                 <Card kind="error"><ErrorDisplay error={error} /></Card>
                             </div>
-                            <details css={{
-                                border: `1px solid ${COLORS.neutral40}`,
-                                borderRadius: 4,
-                                padding: "6px 8px",
-                                marginTop: "min(150px, 12vh)",
-                                marginBottom: 16,
-                            }}>
-                                <summary css={{ cursor: "pointer" }}>
-                                    {t("errors.detailed-error-info")}
-                                </summary>
-                                <pre css={{
-                                    backgroundColor: COLORS.neutral10,
-                                    borderRadius: 4,
-                                    padding: "12px 16px",
-                                    fontSize: 14,
-                                    marginTop: 10,
-                                }}>
-                                    <code css={{ whiteSpace: "pre-wrap" }}>
-                                        {errorMsg}
-                                    </code>
-                                </pre>
-                            </details>
+                            <ErrorDetails
+                                summary={t("errors.detailed-error-info")}
+                                body={errorMsg}
+                            />
                         </div>
                     )}</Translation>
                 </Root>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -45,6 +45,7 @@ import { ManagePlaylistAccessRoute } from "./routes/manage/Playlist/PlaylistAcce
 import { CreatePlaylistRoute } from "./routes/manage/Playlist/Create";
 import { AdminDashboardUserRealmsRoute } from "./routes/manage/admin/UserRealm";
 import { AdminDashboardUserSessionsRoute } from "./routes/manage/admin/UserSessions";
+import { OidcErrorRoute } from "./routes/OidcError";
 
 
 
@@ -63,6 +64,7 @@ const {
         InvalidUrlRoute,
         AboutRoute,
         LoginRoute,
+        OidcErrorRoute,
         RealmRoute,
         SearchRoute,
         OpencastVideoRoute,

--- a/frontend/src/routes/OidcError.tsx
+++ b/frontend/src/routes/OidcError.tsx
@@ -1,0 +1,82 @@
+import { Trans, useTranslation } from "react-i18next";
+import { graphql } from "react-relay";
+
+import { RootLoader } from "../layout/Root";
+import { loadQuery } from "../relay";
+import { makeRoute } from "../rauta";
+import { OidcErrorQuery } from "./__generated__/OidcErrorQuery.graphql";
+import { RealmNav } from "../layout/Navigation";
+import { Card } from "@opencast/appkit";
+import { useTitle } from "../util";
+import { ErrorDetails } from "../util/err";
+
+
+const PATH = "/~oidc/error";
+
+export const OidcErrorRoute = makeRoute({
+    url: PATH,
+    match: url => {
+        if (url.pathname !== PATH) {
+            return null;
+        }
+
+        const queryRef = loadQuery<OidcErrorQuery>(query, {});
+        return {
+            render: () => <RootLoader
+                {...{ query, queryRef }}
+                nav={data => <RealmNav fragRef={data.rootRealm} />}
+                render={() => <Page url={url} />}
+            />,
+            dispose: () => queryRef.dispose(),
+        };
+    },
+});
+
+const query = graphql`
+    query OidcErrorQuery {
+        ... UserData
+        rootRealm { ... NavigationData }
+    }
+`;
+
+type Props = {
+    url: URL;
+};
+
+const Page: React.FC<Props> = ({ url }) => {
+    const { t } = useTranslation();
+
+    useTitle(t("errors.oidc-error.title"));
+
+    // Figure out what's wrong
+    let message = null;
+    let errorDetails = null;
+
+    const errorCode = url.searchParams.get("error");
+    if (errorCode === "access_denied") {
+        // "The resource owner or authorization server denied the request."
+        message = <Trans i18nKey="errors.oidc-error.access-denied" />;
+    } else if (errorCode === "temporarily_unavailable" || errorCode === "tobira:unreachable") {
+        message = <Trans i18nKey="errors.oidc-error.temporarily-unavailable" />;
+    } else {
+        // TODO: maybe specifically handle `tobira:state_mismatch`
+
+        message = <Trans i18nKey="errors.oidc-error.internal-error" />;
+        errorDetails = "";
+        for (const [key, value] of url.searchParams) {
+            errorDetails += `${key} = ${value}\n`;
+        }
+    }
+
+    return (
+        <div css={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <Card kind="error" iconPos="top" css={{ maxWidth: 700 }}>
+                {message}
+            </Card>
+            {errorDetails && <ErrorDetails
+                summary={t("errors.detailed-error-info")}
+                body={errorDetails}
+            />}
+        </div>
+    );
+};

--- a/frontend/src/util/err.tsx
+++ b/frontend/src/util/err.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { match } from "@opencast/appkit";
 
 import { APIError, NotJson, ServerError } from "../relay";
+import { COLORS } from "../color";
 
 
 /** A network error while fetching the response. */
@@ -279,3 +280,33 @@ export class GlobalErrorBoundary
         }
     }
 }
+
+export type ErrorDetailsProps = {
+    summary: string;
+    body: string;
+};
+
+export const ErrorDetails: React.FC<ErrorDetailsProps> = ({ summary, body }) => (
+    <details css={{
+        border: `1px solid ${COLORS.neutral40}`,
+        borderRadius: 4,
+        padding: "6px 8px",
+        marginTop: "min(150px, 12vh)",
+        marginBottom: 16,
+    }}>
+        <summary css={{ cursor: "pointer" }}>
+            {summary}
+        </summary>
+        <pre css={{
+            backgroundColor: COLORS.neutral10,
+            borderRadius: 4,
+            padding: "12px 16px",
+            fontSize: 14,
+            marginTop: 10,
+        }}>
+            <code css={{ whiteSpace: "pre-wrap" }}>
+                {body}
+            </code>
+        </pre>
+    </details>
+);

--- a/util/dev-config/config.toml
+++ b/util/dev-config/config.toml
@@ -27,6 +27,7 @@ source = "tobira-session"
 session.from_login_credentials = "login-callback:http://localhost:3091"
 trusted_external_key = "tobira"
 pre_auth_external_links = true
+login_link = "/~oidc/login"
 
 [auth.roles]
 editor = "ROLE_USER"
@@ -34,6 +35,12 @@ editor = "ROLE_USER"
 [auth.jwt]
 signing_algorithm = "ES256"
 secret_key = "jwt-key.pem"
+
+[auth.oidc]
+enabled = true
+issuer_url = "http://localhost:8070/realms/main"
+client_id = "tobira-test"
+client_secret = "Z6ol4bSwWlUq6QHuHdSt3HWTS4rKphUy"
 
 [opencast]
 host = "http://localhost:8081"


### PR DESCRIPTION
Adds LTI 1.3 Core so an LMS (Moodle, Canvas, …) can launch Tobira as a tool: a user who
clicks a Tobira activity in the LMS ends up logged into Tobira (a normal `tobira-session`)
on a Tobira page. It runs alongside the existing login, not as a replacement.

Core-only MVP, per the RFC added here (`docs/docs/dev/rfc-lti-1.3.md`). Deep Linking, NRPS
and Dynamic Registration are intentionally left for later.

## ⚠️ Please read first: this branch contains #1706

This is branched off **#1706 (OIDC MVP)**, not `main`, because LTI reuses its `jwtea`
JWT/JWKS verification, `create_session_with_cookies`, and `auth/opencast.rs`. Consequences:

- Of the 18 commits here, **6 are from #1706** (`961a6a8e`…`8a258330`) — that's
  @LukasKalbertodt's work, not ours. We are not resubmitting it; it is only carried along
  because our commits sit on top.
- **This is therefore not mergeable as-is.** #1706 is still open and currently conflicts
  with `main`.
- **To review only the LTI part**, use this diff (12 commits, 11 files):
  https://github.com/rrolf/tobira/pull/1

We didn't want to sit on the work while #1706 is pending, hence opening this now — but
we're happy to rebase, split, or reshape it however suits you. **The main thing we need
from you is how you'd like to sequence this with #1706.** If #1706 is going to be reworked
substantially, tell us and we'll adapt rather than have you review something built on a
moving base.

## What it does

Three endpoints, a standard LTI 1.3 / OIDC launch:

- `GET/POST /~lti/login` — login initiation: resolve the platform, issue a one-time
  `state`+`nonce`, redirect to the platform.
- `POST /~lti/launch` — verify the signed launch token (signature against the platform
  JWKS first, then `iss`/`aud`/`azp`/`exp`/`nonce`/`deployment_id`), resolve the user,
  create the session.
- `GET /~lti/jwks` — Tobira's own public keys.

Roles come from Opencast (`/info/me.json` with `X-RUN-AS-USER`), exactly like the OIDC
login — so the launching user has to exist in Opencast.

Operator documentation: `docs/setup/auth/user/lti.md`.

## Decisions worth knowing

- **Session reuse.** LTI just creates a `tobira-session`; requires
  `auth.source = "tobira-session"`. Config validation now accepts an enabled `auth.oidc`
  or `auth.lti` as a valid session source (before, it insisted on an `[auth.session]`
  handler, which made an LTI/OIDC-only setup impossible).
- **Roles from Opencast**, following #1706. Note this contradicts the older MVP tech sheet
  (#1697), which had rejected that approach — we went with #1706 for consistency. Happy to
  revisit.
- **Manual platform config** in `[[auth.lti.platforms]]`. No DB-backed registration; that
  belongs with Dynamic Registration, which is deferred.
- **Username source is per-platform config** (`username_source`): default
  `preferred-username`; `custom` reads a `username=$User.username` custom parameter, which
  Moodle needs since it sends nothing usable otherwise. `custom` is a deliberate opt-in
  because custom parameters are often instructor-settable, so the default stays the
  platform-asserted claim. (This is RFC OQ8, and the same "map claims to a Tobira user"
  question #1706 has open — a config string rather than a scripting language.)
- **New window, not iframe.** The session cookie is `SameSite=Lax`; iframe support needs
  `SameSite=None` / Storage Access and is deferred.
- **Tool key is process-ephemeral** — fine for launch verification (the LMS refetches the
  keyset); a persistent key is only needed once we add service calls (NRPS/AGS).

## Not in this PR

Deep Linking, NRPS, AGS, Dynamic Registration, iframe embedding, persistent tool key.

## Testing

Unit tests for platform lookup, config validation, the one-time nonce store, username
resolution, redirect/open-redirect safety, and the tool JWKS; backend suite green.

Verified end-to-end against a real Moodle 5.1 + Keycloak setup (Rocky Linux 10,
Caddy/HTTPS): the LTI launch logs the user in and lands on the start page, or on a series
page when a `series` custom parameter is set. The last commit is a round of hardening from
a pre-submission review (an open redirect in the landing logic, `enabled = false` not
actually disabling the endpoints, and the `username_source` change above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
