### PR TITLE
Fix duplicated base URL in series and playlist share links

### DIFF
--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -475,16 +475,14 @@ export const VideoListShareButton: React.FC<VideoListShareButtonProps> = ({
 }) => {
     const { t } = useTranslation();
 
-    const directLinkUrl = document.location.origin + shareUrl;
     const rssLinkUrl = document.location.origin + rssUrl;
-
     const tabs = {
         "main": {
             label: t("share.link"),
             Icon: LuLink,
             render: () => <>
-                <CopyableInput label={t("share.copy-link")} value={directLinkUrl} />
-                <QrCodeButton label={t("share.link")} target={directLinkUrl} />
+                <CopyableInput label={t("share.copy-link")} value={shareUrl} />
+                <QrCodeButton label={t("share.link")} target={shareUrl} />
             </>,
         },
         "rss": {


### PR DESCRIPTION
The base URL was inadvertently added in two different places, leading to duplication.

Fixes #1759 