### PR TITLE
Allow line breaks in markdown via `\` (or `  `)

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -771,6 +771,7 @@ manage:
           monospace: Monospace
           link: Link
           quote: Zitat
+          line-break: Zeilenumbruch
           code-block: Codeblock
           external-image: Externes Bild
           hr: Trennlinie

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -733,6 +733,7 @@ manage:
           monospace: Monospace
           link: Link
           quote: Quote
+          line-break: Line break
           code-block: Code block
           external-image: External image
           hr: Separator

--- a/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
+++ b/frontend/src/routes/manage/Realm/Content/Edit/EditMode/Text.tsx
@@ -119,6 +119,10 @@ const FormattingGuide: React.FC = () => {
             "> To 🐝 or not to 🐝. ― Shakespeare",
         ],
         [
+            t("manage.block.text.formatting.line-break"),
+            "Lazy Dog\\\nQuick brown fox",
+        ],
+        [
             t("manage.block.text.formatting.hr"),
             "---",
         ],

--- a/frontend/src/ui/Blocks/Text.tsx
+++ b/frontend/src/ui/Blocks/Text.tsx
@@ -38,7 +38,7 @@ type Props = {
 // - headings (if we allow them, we need to map `#` to h2 or h3 so that they
 //   don't interfere with other headings on the page.)
 const ALLOWED_MARKDOWN_TAGS = [
-    "p", "blockquote", "pre", "ul", "ol", "li", "a", "em", "strong", "code", "hr", "img",
+    "p", "blockquote", "pre", "ul", "ol", "li", "a", "em", "strong", "code", "hr", "img", "br",
 ];
 
 const CODE_BACKGROUND_COLOR = COLORS.neutral10;


### PR DESCRIPTION
We did not white list them by accident. I honestly didn't even know about this syntax.

We preferred this explicit syntax over turning `\n` into breaks, as that would be a nasty breaking change. And the explicit syntax seems to be preferred anyway.

Still labelled as breaking change, as it technically is. But I doubt anyone is affected by it.