### PR TITLE
Fix a "fix" that was meant to *fix* a duplicated URL but broke another one

### DIFF
--- a/frontend/src/routes/manage/Playlist/index.tsx
+++ b/frontend/src/routes/manage/Playlist/index.tsx
@@ -124,7 +124,7 @@ const PlaylistItem: React.FC<{ item: SinglePlaylist }> = ({ item }) => <ListItem
     renderShareButton={url => <VideoListShareButton
         kind="playlist"
         shareUrl={url}
-        rssUrl={`/~rss/series/${keyOfId(item.id)}`}
+        rssUrl={`/~rss/playlist/${keyOfId(item.id)}`}
         hideLabel
     />}
 />;

--- a/frontend/src/routes/manage/Playlist/index.tsx
+++ b/frontend/src/routes/manage/Playlist/index.tsx
@@ -120,7 +120,7 @@ const PlaylistItem: React.FC<{ item: SinglePlaylist }> = ({ item }) => <ListItem
         creators: [item.creator],
     }}
     specificMetadata={[<EntryCount key="count" count={item.numEntries} />]}
-    directUrl={new URL(DirectPlaylistRoute.url({ playlistId: item.id }), document.baseURI).href}
+    directUrl={DirectPlaylistRoute.url({ playlistId: item.id })}
     renderShareButton={url => <VideoListShareButton
         kind="playlist"
         shareUrl={url}

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -117,7 +117,7 @@ const SeriesItem: React.FC<{ item: SingleSeries }> = ({ item }) => <ListItem
         creators: [...item.creators],
     }}
     specificMetadata={[<EntryCount key="count" count={item.numVideos} />]}
-    directUrl={new URL(DirectSeriesRoute.url({ seriesId: item.id }), document.baseURI).href}
+    directUrl={DirectSeriesRoute.url({ seriesId: item.id })}
     renderShareButton={url => <VideoListShareButton
         kind="series"
         shareUrl={url}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -475,14 +475,16 @@ export const VideoListShareButton: React.FC<VideoListShareButtonProps> = ({
 }) => {
     const { t } = useTranslation();
 
+    const directLinkUrl = document.location.origin + shareUrl;
     const rssLinkUrl = document.location.origin + rssUrl;
+
     const tabs = {
         "main": {
             label: t("share.link"),
             Icon: LuLink,
             render: () => <>
-                <CopyableInput label={t("share.copy-link")} value={shareUrl} />
-                <QrCodeButton label={t("share.link")} target={shareUrl} />
+                <CopyableInput label={t("share.copy-link")} value={directLinkUrl} />
+                <QrCodeButton label={t("share.link")} target={directLinkUrl} />
             </>,
         },
         "rss": {


### PR DESCRIPTION
There were places that passed the URL prefixed with the current path. That was done both at the call site and in the component definition, leading to the duplicated path. Removing it in the component meant that other call sites, that only pass the stripped URL, were missing the path.

So the proper fix is to remove the extra path addition at the other call sites.

To verify that this is now working correctly, look at the share buttons in series and playlist:
- (a) overviews (i.e. "My series", "My playlists")
- (b) details (i.e. "Series details", "Playlist details")
- (c) individual playlist and series blocks

Fixes #1763 