### PR TITLE
Add video count to videolist-blocks

### DIFF
--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -45,9 +45,9 @@ const seriesFragment = graphql`
         id
         title
         created
+        creators
         description
         state
-        metadata
         canWrite
         entries {
             __typename
@@ -103,17 +103,6 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
             </div>
         </VideoListBlockContainer>;
     }
-    const creators = (() => {
-        const raw = series.metadata?.dcterms?.creator;
-
-        if (raw && Array.isArray(raw) && raw.length > 0 && typeof raw[0] === "string") {
-            return raw;
-        } else if (raw && typeof raw === "string") {
-            return [raw];
-        } else {
-            return undefined;
-        }
-    })();
 
     const seriesKey = keyOfId(series.id);
     return <VideoListBlock
@@ -130,7 +119,7 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
             title: props.title ?? (props.showTitle ? series.title : undefined),
             description: (props.showMetadata && series.description) || undefined,
             timestamp: props.showMetadata ? series.created ?? undefined : undefined,
-            creators: props.showMetadata ? creators : undefined,
+            creators: props.showMetadata ? [...series.creators] : undefined,
             canWrite: series.canWrite,
         }}
         activeEventId={props.activeEventId}

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -35,7 +35,10 @@ import {
     BaseThumbnailReplacement, Thumbnail, ThumbnailOverlayContainer,
 } from "../Thumbnail";
 import { PrettyDate } from "../time";
-import { CollapsibleDescription, DateAndCreators, SmallDescription } from "../metadata";
+import {
+    BadgeItem, BadgeList, CollapsibleDescription, CreatorsBadge, DateAndCreators, DateBadge,
+    SmallDescription,
+} from "../metadata";
 import { darkModeBoxShadow, ellipsisOverflowCss, focusStyle } from "..";
 import { COLORS } from "../../color";
 import { FloatingBaseMenu } from "../FloatingBaseMenu";
@@ -211,31 +214,21 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
         </div>}
     </>;
 
-    let metadataUI = undefined;
-    const hasTimestampOrCreators = metadata.timestamp || ((metadata.creators ?? []).length > 0);
-    if (metadata.description || hasTimestampOrCreators) {
-        metadataUI = <>
-            {hasTimestampOrCreators && <DateAndCreators
-                timestamp={metadata.timestamp}
-                isLive={false}
-                creators={metadata.creators}
-                css={{
-                    margin: "0px 12px",
-                    gap: 16,
-                    "> *": {
-                        padding: "4px 6px",
-                        borderRadius: 4,
-                        background: COLORS.neutral15,
-                    },
-                }}
-            />}
-            {metadata.description && <CollapsibleDescription
-                type="series"
-                bottomPadding={32}
-                description={metadata.description}
-            />}
-        </>;
-    }
+    const metadataUI = <>
+        <BadgeList css={{ margin: "0px 12px" }}>
+            {metadata.timestamp && <BadgeItem>
+                <DateBadge date={new Date(metadata.timestamp)} isLive={false} />
+            </BadgeItem>}
+            {metadata.creators && metadata.creators.length > 0 && <BadgeItem>
+                <CreatorsBadge creators={metadata.creators} />
+            </BadgeItem>}
+        </BadgeList>
+        {metadata.description && <CollapsibleDescription
+            type="series"
+            bottomPadding={32}
+            description={metadata.description}
+        />}
+    </>;
 
     return <LayoutOrderContext.Provider value={layoutOrderContext}>
         <VideoListBlockContainer

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -19,6 +19,7 @@ import { IconType } from "react-icons";
 import {
     LuColumns2, LuList, LuChevronLeft, LuChevronRight, LuPlay, LuLayoutGrid, LuCircleAlert, LuInfo,
     LuRss, LuLink, LuSettings,
+    LuFilm,
 } from "react-icons/lu";
 import { graphql, readInlineData } from "react-relay";
 
@@ -219,6 +220,10 @@ export const VideoListBlock: React.FC<VideoListBlockProps> = ({
             {metadata.timestamp && <BadgeItem>
                 <DateBadge date={new Date(metadata.timestamp)} isLive={false} />
             </BadgeItem>}
+            <BadgeItem>
+                <LuFilm />
+                {t("manage.video-list.no-of-videos", { count: items.length })}
+            </BadgeItem>
             {metadata.creators && metadata.creators.length > 0 && <BadgeItem>
                 <CreatorsBadge creators={metadata.creators} />
             </BadgeItem>}

--- a/frontend/src/ui/metadata.tsx
+++ b/frontend/src/ui/metadata.tsx
@@ -19,7 +19,7 @@ import { Creators } from "./Video";
 import { Input, TextArea } from "./Input";
 import { Form } from "./Form";
 import { Inertable, OcEntity } from "../util";
-import { PrettyDate } from "./time";
+import { PrettyDate, PrettyDateProps } from "./time";
 import { autoLink as makeAutoLink } from "./text";
 import { Link } from "../router";
 
@@ -62,33 +62,66 @@ export type DateAndCreatorsProps = {
 export const DateAndCreators: React.FC<DateAndCreatorsProps> = ({
     timestamp, isLive, creators, className,
 }) => (
+    <BadgeList {...{ className }}>
+        {timestamp && <DateBadge date={new Date(timestamp)} isLive={isLive} />}
+        {creators && <CreatorsBadge creators={creators} />}
+    </BadgeList>
+);
+
+
+export const DateBadge: React.FC<PrettyDateProps> = props => <>
+    <LuCalendar css={{ fontSize: 15, color: COLORS.neutral60 }} />
+    <PrettyDate {...props} />
+</>;
+
+export type CreatorsBadgeProps = {
+    creators: (string | JSX.Element)[];
+};
+
+export const CreatorsBadge: React.FC<CreatorsBadgeProps> = ({ creators }) => (
+    <Creators creators={creators} css={{
+        minWidth: 0,
+        fontSize: 12,
+        svg: {
+            fontSize: 15,
+        },
+        ul: {
+            display: "inline-block",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+        },
+        li: {
+            display: "inline",
+        },
+    }} />
+);
+
+export type BadgeListProps = React.PropsWithChildren<{
+    className?: string,
+}>;
+
+export const BadgeList: React.FC<BadgeListProps> = ({ children, className }) => (
     <div {...{ className }} css={{
         display: "inline-flex",
         color: COLORS.neutral80,
         fontSize: 12,
-        gap: 24,
+        gap: 16,
         whiteSpace: "nowrap",
+    }}>{children}</div>
+);
+
+export const BadgeItem: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <div css={{
+        padding: "4px 6px",
+        borderRadius: 4,
+        background: COLORS.neutral15,
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        svg: { fontSize: 15, color: COLORS.neutral60 },
     }}>
-        {timestamp && <div css={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <LuCalendar css={{ fontSize: 15, color: COLORS.neutral60 }} />
-            <PrettyDate date={new Date(timestamp)} isLive={isLive} />
-        </div>}
-        <Creators creators={creators ?? null} css={{
-            minWidth: 0,
-            fontSize: 12,
-            svg: {
-                fontSize: 15,
-            },
-            ul: {
-                display: "inline-block",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-            },
-            li: {
-                display: "inline",
-            },
-        }} />
+        {children}
     </div>
 );
 

--- a/frontend/src/ui/time.tsx
+++ b/frontend/src/ui/time.tsx
@@ -74,7 +74,7 @@ export const prettyDate = (
     return [out, kind];
 };
 
-type PrettyDateProps = {
+export type PrettyDateProps = {
     date: Date;
     isLive?: boolean;
     prefixKind?: "start" | "end";


### PR DESCRIPTION
Fixes #1731

This metadata line was the obvious and visually likely best place to add that information. However, if the block author hides metadata, the user also won't see the video count, which is slightly annoying. In the future, we are planning to allow users to always toggle showing the metadata (just like the layout can be changed now as well).