### PR TITLE
Fix misleading warning when editing ACL as tenant admin

### DIFF
--- a/backend/src/api/model/user.rs
+++ b/backend/src/api/model/user.rs
@@ -94,6 +94,12 @@ impl User {
         HasRoles::is_tobira_admin(self, &context.config.auth)
     }
 
+    /// `True` if the user is a global Opencast administrator and can do
+    /// anything.
+    fn is_admin(&self, context: &Context) -> bool {
+        HasRoles::is_admin(self, &context.config.auth)
+    }
+
     /// Returns all events that somehow "belong" to the user, i.e. that appear
     /// on the "my videos" page. This also returns events that have been marked
     /// as deleted (meaning their deletion in Opencast has been requested but they

--- a/frontend/src/User.tsx
+++ b/frontend/src/User.tsx
@@ -28,6 +28,7 @@ export type User = {
     canCreateSeries: boolean;
     canCreatePlaylists: boolean;
     isTobiraAdmin: boolean;
+    isAdmin: boolean;
     canFindUnlisted: boolean;
     roles: readonly string[];
     userRole: string;
@@ -68,6 +69,7 @@ export const userDataFragment = graphql`
             canCreateSeries
             canCreatePlaylists
             isTobiraAdmin
+            isAdmin
             canFindUnlisted
             roles
             userRole

--- a/frontend/src/relay/boundary.tsx
+++ b/frontend/src/relay/boundary.tsx
@@ -76,6 +76,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                 && "canCreateSeries" in user && typeof user.canCreateSeries === "boolean"
                 && "canCreatePlaylists" in user && typeof user.canCreatePlaylists === "boolean"
                 && "isTobiraAdmin" in user && typeof user.isTobiraAdmin === "boolean"
+                && "isAdmin" in user && typeof user.isAdmin === "boolean"
                 && "canFindUnlisted" in user && typeof user.canFindUnlisted === "boolean"
                 && "roles" in user && isStringArray(user.roles)
                 && "userRole" in user && typeof user.userRole === "string"
@@ -94,6 +95,7 @@ class GraphQLErrorBoundaryImpl extends React.Component<Props, State> {
                     canCreateSeries: user.canCreateSeries,
                     canCreatePlaylists: user.canCreatePlaylists,
                     isTobiraAdmin: user.isTobiraAdmin,
+                    isAdmin: user.isAdmin,
                     canFindUnlisted: user.canFindUnlisted,
                     roles: user.roles,
                     userRole: user.userRole,

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -1268,6 +1268,11 @@ type User {
   """
   isTobiraAdmin: Boolean!
   """
+    `True` if the user is a global Opencast administrator and can do
+    anything.
+  """
+  isAdmin: Boolean!
+  """
     Returns all events that somehow "belong" to the user, i.e. that appear
     on the "my videos" page. This also returns events that have been marked
     as deleted (meaning their deletion in Opencast has been requested but they

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -827,9 +827,8 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
     const resetModalRef = useRef<ModalHandle>(null);
 
     const containsUser = (acl: Acl) => isRealUser(user) && (
-        userIsOwner || user.roles.some(r => r === COMMON_ROLES.ADMIN
-            || acl.get(r)?.actions.has(kind)
-            || inheritedAcl?.get(r)?.actions.has(kind))
+        userIsOwner || user.isAdmin || user.roles.some(r =>
+            acl.get(r)?.actions.has(kind) || inheritedAcl?.get(r)?.actions.has(kind))
     );
 
     const selectionIsInitial = selections.size === initialAcl.size


### PR DESCRIPTION
When editing ACL as tenant admin that isn't explicitly listed, you'd get a false warning that the own access would be removed (regardless of what was changed). This would not actually remove that access, but it didn't use the right check for that warning.
This fix replaces the hardcoded frontend value with the `isTobiraAdmin` check from backend which already includes configured tenant roles as well.

Fixes https://github.com/elan-ev/tobira/issues/1729