### PR TITLE
Hide RSS sharing for private lists

### DIFF
--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -351,6 +351,7 @@ impl AuthorizedEvent {
                     write_roles: None,
                     num_videos: LazyLoad::NotLoaded,
                     thumbnail_stack: LazyLoad::NotLoaded,
+                    has_public_videos: LazyLoad::NotLoaded,
                     tobira_deletion_timestamp: None,
                 }))
             } else {

--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         Node,
         NodeValue,
     },
-    auth::AuthContext,
+    auth::{AuthContext, ROLE_ANONYMOUS},
     db::util::{impl_from_db, select},
     model::{Key, OpencastId, SearchThumbnailInfo, ThumbnailInfo, ThumbnailStack},
     prelude::*,
@@ -56,6 +56,7 @@ pub(crate) struct AuthorizedPlaylist {
     updated: DateTime<Utc>,
     num_entries: LazyLoad<u32>,
     thumbnail_stack: LazyLoad<ThumbnailStack>,
+    has_public_videos: LazyLoad<bool>,
 
     pub(crate) read_roles: Vec<String>,
     write_roles: Vec<String>,
@@ -81,6 +82,7 @@ impl_from_db!(
             updated: row.updated(),
             num_entries: LazyLoad::NotLoaded,
             thumbnail_stack: LazyLoad::NotLoaded,
+            has_public_videos: LazyLoad::NotLoaded,
         }
     },
 );
@@ -92,14 +94,23 @@ impl Playlist {
             return Ok(None);
         };
 
-        let selection = AuthorizedPlaylist::select();
+        let (selection, mapping) = select!(
+            playlist: AuthorizedPlaylist,
+            has_public_videos: "exists(\
+                select from events \
+                where opencast_id = any(event_entry_ids(playlists.entries)) \
+                and 'ROLE_ANONYMOUS' = any(events.read_roles)\
+            )",
+        );
         let col = id.column();
         let query = format!("select {selection} from playlists where {col} = $1");
         context.db
             .query_opt(&query, &[&id_arg])
             .await?
             .map(|row| {
-                let playlist = AuthorizedPlaylist::from_row_start(&row);
+                let mut playlist = AuthorizedPlaylist::from_row(&row, mapping.playlist);
+                playlist.has_public_videos =
+                    LazyLoad::Loaded(mapping.has_public_videos.of::<bool>(&row));
                 Self::check_auth(playlist, &context.auth)
             })
             .pipe(Ok)
@@ -150,6 +161,11 @@ impl Playlist {
                     from unnest(playlists.entries) as playlist_entry \
                 ) \
             )",
+            has_public_videos: "exists(\
+                select from events \
+                where opencast_id = any(event_entry_ids(playlists.entries)) \
+                and 'ROLE_ANONYMOUS' = any(events.read_roles)\
+            )",
         );
         load_writable_for_user(context, order, filter, offset, limit, parts, selection, |row| {
             let mut out = AuthorizedPlaylist::from_row(row, mapping.playlist);
@@ -160,6 +176,7 @@ impl Playlist {
                     .filter_map(|info| ThumbnailInfo::from_search(info, &context))
                     .collect(),
             });
+            out.has_public_videos = LazyLoad::Loaded(mapping.has_public_videos.of::<bool>(row));
             out
         }).await
     }
@@ -238,6 +255,20 @@ impl AuthorizedPlaylist {
 
     async fn acl(&self, context: &Context) -> ApiResult<Acl> {
         acl::load_for(context, &acl::query_for("playlists"), dbargs![&self.key]).await
+    }
+
+    /// Returns whether at least one video in this playlist is public, i.e. accessible to
+    /// anonymous users.
+    /// Note: this is lazily loaded and only available in certain contexts (`load` and
+    /// `load_writable_for_user`).
+    fn has_public_videos(&self) -> bool {
+        self.has_public_videos.unwrap()
+    }
+
+    /// Returns whether this playlist's RSS feed is public (i.e. the playlist itself is
+    /// accessible to anonymous users, and it contains at least one public video).
+    fn has_public_rss_feed(&self) -> bool {
+        self.has_public_videos() && self.read_roles.iter().any(|role| role == ROLE_ANONYMOUS)
     }
 
     /// Returns `true` if the realm has a playlist block with this playlist.

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -70,6 +70,7 @@ pub(crate) struct Series {
     pub(crate) write_roles: Option<Vec<String>>,
     pub(crate) num_videos: LazyLoad<u32>,
     pub(crate) thumbnail_stack: LazyLoad<ThumbnailStack>,
+    pub(crate) has_public_videos: LazyLoad<bool>,
     pub(crate) tobira_deletion_timestamp: Option<DateTime<Utc>>,
 }
 
@@ -103,6 +104,7 @@ impl_from_db!(
             description: row.description(),
             num_videos: LazyLoad::NotLoaded,
             thumbnail_stack: LazyLoad::NotLoaded,
+            has_public_videos: LazyLoad::NotLoaded,
         }
     },
 );
@@ -113,13 +115,23 @@ impl Series {
             return Ok(None);
         };
 
-        let selection = Self::select();
+        let (selection, mapping) = select!(
+            series: Series,
+            has_public_videos: "exists(\
+                select from events \
+                where events.series = series.id and 'ROLE_ANONYMOUS' = any(events.read_roles)\
+            )",
+        );
         let col = id.column();
         let query = format!("select {selection} from series where {col} = $1");
         context.db
             .query_opt(&query, &[&id_arg])
             .await?
-            .map(|row| Self::from_row_start(&row))
+            .map(|row| {
+                let mut series = Series::from_row(&row, mapping.series);
+                series.has_public_videos = LazyLoad::Loaded(mapping.has_public_videos.of::<bool>(&row));
+                series
+            })
             .pipe(Ok)
     }
 
@@ -380,6 +392,10 @@ impl Series {
                 select search_thumbnail_info_for_event(events.*) \
                 from events \
                 where events.series = series.id)",
+            has_public_videos: "exists(\
+                select from events \
+                where events.series = series.id and 'ROLE_ANONYMOUS' = any(events.read_roles)\
+            )",
         );
         load_writable_for_user(context, order, filter, offset, limit, parts, selection, |row| {
             let mut out = Self::from_row(row, mapping.series);
@@ -390,6 +406,7 @@ impl Series {
                     .filter_map(|info| ThumbnailInfo::from_search(info, &context))
                     .collect(),
             });
+            out.has_public_videos = LazyLoad::Loaded(mapping.has_public_videos.of::<bool>(row));
             out
         }).await
     }
@@ -754,6 +771,15 @@ impl Series {
 
     async fn acl(&self, context: &Context) -> ApiResult<Acl> {
         acl::load_for(context, &acl::query_for("series"), dbargs![&self.key]).await
+    }
+
+    /// Returns whether at least one video in this series is public, i.e. accessible to
+    /// anonymous users. This is what determines whether the RSS feed of this series has any
+    /// content.
+    /// Note: this is lazily loaded and only available in certain contexts (`load` and
+    /// `load_writable_for_user`).
+    fn has_public_videos(&self) -> bool {
+        self.has_public_videos.unwrap()
     }
 
     /// Whether the current user has write access to this series.

--- a/backend/src/rss.rs
+++ b/backend/src/rss.rs
@@ -111,7 +111,8 @@ pub(crate) async fn generate_playlist_feed(
     let query = format!("select {selection} from events \
         where opencast_id = any(event_entry_ids((\
             select entries from playlists where id = $1 and read_roles && $2\
-        )))",
+        ))) \
+        and read_roles && $2",
     );
     let events = db.query_raw(&query, dbargs![&playlist_id, &auth.roles_vec()])
         .await

--- a/frontend/src/routes/manage/Playlist/PlaylistDetails.tsx
+++ b/frontend/src/routes/manage/Playlist/PlaylistDetails.tsx
@@ -115,7 +115,7 @@ const PlaylistButtonSection: React.FC<{ playlist: AuthorizedPlaylist }> = ({ pla
     const shareInfo = {
         kind: "playlist" as const,
         shareUrl: `/!p/${playlistKey}`,
-        rssUrl: `/~rss/playlist/${playlistKey}`,
+        rssUrl: playlist.hasPublicRssFeed ? `/~rss/playlist/${playlistKey}` : undefined,
     };
 
     return <div css={{ display: "flex", gap: 12, marginBottom: 16 }}>

--- a/frontend/src/routes/manage/Playlist/Shared.tsx
+++ b/frontend/src/routes/manage/Playlist/Shared.tsx
@@ -89,6 +89,7 @@ const query = graphql`
                 canWrite
                 readRoles
                 writeRoles
+                hasPublicRssFeed
                 acl { role actions info { label implies large } }
                 updated
                 thumbnailStack { thumbnails { url live audioOnly state }}

--- a/frontend/src/routes/manage/Playlist/index.tsx
+++ b/frontend/src/routes/manage/Playlist/index.tsx
@@ -88,6 +88,7 @@ const query = graphql`
                     numEntries
                     readRoles
                     writeRoles
+                    hasPublicRssFeed
                     thumbnailStack { thumbnails { url live audioOnly state }}
                     hostRealms { id }
                 }
@@ -124,7 +125,7 @@ const PlaylistItem: React.FC<{ item: SinglePlaylist }> = ({ item }) => <ListItem
     renderShareButton={url => <VideoListShareButton
         kind="playlist"
         shareUrl={url}
-        rssUrl={`/~rss/playlist/${keyOfId(item.id)}`}
+        rssUrl={item.hasPublicRssFeed ? `/~rss/playlist/${keyOfId(item.id)}` : undefined}
         hideLabel
     />}
 />;

--- a/frontend/src/routes/manage/Series/SeriesDetails.tsx
+++ b/frontend/src/routes/manage/Series/SeriesDetails.tsx
@@ -107,7 +107,7 @@ const SeriesButtonSection: React.FC<{ series: Series }> = ({ series }) => {
     const shareInfo = {
         kind: "series" as const,
         shareUrl: `/!s/${seriesKey}`,
-        rssUrl: `/~rss/series/${seriesKey}`,
+        rssUrl: series.hasPublicVideos ? `/~rss/series/${seriesKey}` : undefined,
     };
 
     const disableDelete = CONFIG.behavior.disallowEventsWithoutSeries && series.entries.length > 0;

--- a/frontend/src/routes/manage/Series/Shared.tsx
+++ b/frontend/src/routes/manage/Series/Shared.tsx
@@ -89,6 +89,7 @@ const query = graphql`
             canWrite
             description
             state
+            hasPublicVideos
             tobiraDeletionTimestamp
             thumbnailStack { thumbnails { url live audioOnly state }}
             entries {

--- a/frontend/src/routes/manage/Series/index.tsx
+++ b/frontend/src/routes/manage/Series/index.tsx
@@ -86,6 +86,7 @@ const query = graphql`
                     description
                     state
                     numVideos
+                    hasPublicVideos
                     creators
                     thumbnailStack { thumbnails { url live audioOnly state }}
                 }
@@ -121,7 +122,7 @@ const SeriesItem: React.FC<{ item: SingleSeries }> = ({ item }) => <ListItem
     renderShareButton={url => <VideoListShareButton
         kind="series"
         shareUrl={url}
-        rssUrl={`/~rss/series/${keyOfId(item.id)}`}
+        rssUrl={item.hasPublicVideos ? `/~rss/series/${keyOfId(item.id)}` : undefined}
         hideLabel
     />}
 />;

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -479,6 +479,18 @@ type AuthorizedPlaylist implements Node {
   thumbnailStack: ThumbnailStack!
   acl: [AclItemWithInfo!]!
   """
+    Returns whether at least one video in this playlist is public, i.e. accessible to
+    anonymous users.
+    Note: this is lazily loaded and only available in certain contexts (`load` and
+    `load_writable_for_user`).
+  """
+  hasPublicVideos: Boolean!
+  """
+    Returns whether this playlist's RSS feed is public (i.e. the playlist itself is
+    accessible to anonymous users, and it contains at least one public video).
+  """
+  hasPublicRssFeed: Boolean!
+  """
     Returns `true` if the realm has a playlist block with this playlist.
     Otherwise, `false` is returned.
   """
@@ -1123,6 +1135,14 @@ type Series implements Node {
   """
   thumbnailStack: ThumbnailStack!
   acl: [AclItemWithInfo!]!
+  """
+    Returns whether at least one video in this series is public, i.e. accessible to
+    anonymous users. This is what determines whether the RSS feed of this series has any
+    content.
+    Note: this is lazily loaded and only available in certain contexts (`load` and
+    `load_writable_for_user`).
+  """
+  hasPublicVideos: Boolean!
   "Whether the current user has write access to this series."
   canWrite: Boolean!
   tobiraDeletionTimestamp: DateTime

--- a/frontend/src/ui/Blocks/Playlist.tsx
+++ b/frontend/src/ui/Blocks/Playlist.tsx
@@ -45,6 +45,7 @@ const playlistFragment = graphql`
             description
             creator
             canWrite
+            hasPublicRssFeed
             entries {
                 __typename
                 ... on AuthorizedEvent { ...VideoListEventData @arguments(includeSeries: true) }
@@ -139,7 +140,7 @@ export const PlaylistBlock: React.FC<Props> = ({ playlist, ...props }) => {
             shareUrl: props.realmPath == null
                 ? DirectPlaylistRoute.url({ playlistId: playlist.id })
                 : PlaylistRoute.url({ realmPath: props.realmPath, playlistId: playlist.id }),
-            rssUrl: `/~rss/playlist/${playlistKey}`,
+            rssUrl: playlist.hasPublicRssFeed ? `/~rss/playlist/${playlistKey}` : undefined,
         }}
         linkToManagePage={ManagePlaylistDetailsRoute.url({ id: playlist.id })}
     />;

--- a/frontend/src/ui/Blocks/Series.tsx
+++ b/frontend/src/ui/Blocks/Series.tsx
@@ -49,6 +49,7 @@ const seriesFragment = graphql`
         description
         state
         canWrite
+        hasPublicVideos
         entries {
             __typename
             ...on AuthorizedEvent { ...VideoListEventData @arguments(includeSeries: false) }
@@ -131,7 +132,7 @@ const SeriesBlock: React.FC<Props> = ({ series, ...props }) => {
             shareUrl: props.realmPath == null
                 ? DirectSeriesRoute.url({ seriesId: series.id })
                 : SeriesRoute.url({ realmPath: props.realmPath, seriesId: series.id }),
-            rssUrl: `/~rss/series/${seriesKey}`,
+            rssUrl: series.hasPublicVideos ? `/~rss/series/${seriesKey}` : undefined,
         }}
         linkToManagePage={ManageSeriesDetailsRoute.url({ id: series.id })}
     />;

--- a/frontend/src/ui/Blocks/VideoList.tsx
+++ b/frontend/src/ui/Blocks/VideoList.tsx
@@ -479,7 +479,7 @@ const buttonStyle = {
 
 type VideoListShareButtonProps = {
     shareUrl: string;
-    rssUrl: string;
+    rssUrl?: string;
     kind: ListKind;
     className?: string;
     hideLabel?: boolean;
@@ -491,7 +491,6 @@ export const VideoListShareButton: React.FC<VideoListShareButtonProps> = ({
     const { t } = useTranslation();
 
     const directLinkUrl = document.location.origin + shareUrl;
-    const rssLinkUrl = document.location.origin + rssUrl;
 
     const tabs = {
         "main": {
@@ -502,13 +501,18 @@ export const VideoListShareButton: React.FC<VideoListShareButtonProps> = ({
                 <QrCodeButton label={t("share.link")} target={directLinkUrl} />
             </>,
         },
-        "rss": {
-            label: t("share.rss"),
-            Icon: LuRss,
-            render: () => <>
-                <CopyableInput label={t("share.copy-rss")} value={rssLinkUrl} />
-                <QrCodeButton label={t("share.rss")} target={rssLinkUrl} />
-            </>,
+        ...rssUrl != null && {
+            "rss": {
+                label: t("share.rss"),
+                Icon: LuRss,
+                render: () => {
+                    const rssLinkUrl = document.location.origin + rssUrl;
+                    return <>
+                        <CopyableInput label={t("share.copy-rss")} value={rssLinkUrl} />
+                        <QrCodeButton label={t("share.rss")} target={rssLinkUrl} />
+                    </>;
+                },
+            },
         },
     };
     return <ShareButton height={180} {...{ tabs, className, hideLabel, kind }} css={buttonStyle} />;


### PR DESCRIPTION
This will hide the RSS tab of the share menu for series and playlists that contain no entries where `ROLE_ANOYMOUS` has read access.

See commit messages for technical-ish details.

Closes #1622 