### PR TITLE
Add option to filter out groups in ACL selector

### DIFF
--- a/.deployment/files/known-groups.json
+++ b/.deployment/files/known-groups.json
@@ -1,6 +1,40 @@
 {
-    "ROLE_STUDENT": { "label": { "default": "Students", "de": "Studierende", "it": "Studenti", "fr": "Étudiants" }, "implies": [], "large": true },
-    "ROLE_STAFF": { "label": { "default": "Staff", "de": "Angestellte", "it": "Personale", "fr": "Personnel" }, "implies": [], "large": true },
-    "ROLE_INSTRUCTOR": { "label": { "default": "Lecturers", "de": "Vortragende", "it": "Docenti", "fr": "Conférenciers" }, "implies": ["ROLE_STAFF"], "large": true },
-    "ROLE_TOBIRA_MODERATOR": { "label": { "default": "Moderators", "de": "Moderierende", "it": "Moderatori", "fr": "Modérateurs" }, "implies": ["ROLE_STAFF"], "large": false }
+    "ROLE_STUDENT": {
+        "label": { "default": "Students", "de": "Studierende", "it": "Studenti", "fr": "Étudiants" },
+        "implies": [],
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+    },
+    "ROLE_STAFF": {
+        "label": { "default": "Staff", "de": "Angestellte", "it": "Personale", "fr": "Personnel" },
+        "implies": [],
+        "warnForAction": ["write"],
+        "assignableBy": { "write": ["ROLE_STAFF"] }
+    },
+    "ROLE_INSTRUCTOR": {
+        "label": { "default": "Lecturers", "de": "Vortragende", "it": "Docenti", "fr": "Conférenciers" },
+        "implies": ["ROLE_STAFF"],
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"], "write": ["ROLE_STAFF"] }
+    },
+    "ROLE_TOBIRA_MODERATOR": {
+        "label": { "default": "Moderators", "de": "Moderierende", "it": "Moderatori", "fr": "Modérateurs" },
+        "implies": ["ROLE_STAFF"],
+        "warnForAction": [],
+        "assignableBy": {}
+    },
+    "ROLE_ANONYMOUS": {
+        "implies": [],
+        "label": { "default": "Everyone", "de": "Alle" },
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
+        "sortKey": "_a"
+    },
+    "ROLE_USER": {
+        "implies": [],
+        "label": { "default": "Logged in users", "de": "Eingeloggte Nutzende" },
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
+        "sortKey": "_b"
+    }
 }

--- a/.deployment/files/known-groups.json
+++ b/.deployment/files/known-groups.json
@@ -11,7 +11,7 @@
     "ROLE_INSTRUCTOR": {
         "label": { "default": "Lecturers", "de": "Vortragende", "it": "Docenti", "fr": "Conférenciers" },
         "implies": ["ROLE_STAFF"],
-        "assignableBy": { "read": ["ROLE_USER"], "write": ["ROLE_STAFF"] }
+        "assignableBy": { "read": ["ROLE_USER"], "write": ["ROLE_STAFF"], "tobira:realm:moderate": ["ROLE_INSTRUCTOR"] }
     },
     "ROLE_TOBIRA_MODERATOR": {
         "label": { "default": "Moderators", "de": "Moderierende", "it": "Moderatori", "fr": "Modérateurs" },

--- a/.deployment/files/known-groups.json
+++ b/.deployment/files/known-groups.json
@@ -1,25 +1,22 @@
 {
     "ROLE_STUDENT": {
         "label": { "default": "Students", "de": "Studierende", "it": "Studenti", "fr": "Étudiants" },
-        "implies": [],
-        "warnForAction": ["write"]
+        "implies": []
     },
     "ROLE_STAFF": {
         "label": { "default": "Staff", "de": "Angestellte", "it": "Personale", "fr": "Personnel" },
         "implies": [],
-        "warnForAction": ["write"],
         "assignableBy": { "write": ["ROLE_STAFF"] }
     },
     "ROLE_INSTRUCTOR": {
         "label": { "default": "Lecturers", "de": "Vortragende", "it": "Docenti", "fr": "Conférenciers" },
         "implies": ["ROLE_STAFF"],
-        "warnForAction": ["write"],
         "assignableBy": { "read": ["ROLE_USER"], "write": ["ROLE_STAFF"] }
     },
     "ROLE_TOBIRA_MODERATOR": {
         "label": { "default": "Moderators", "de": "Moderierende", "it": "Moderatori", "fr": "Modérateurs" },
         "implies": ["ROLE_STAFF"],
-        "warnForAction": [],
+        "safeActions": ["read", "write"],
         "assignableBy": {}
     }
 }

--- a/.deployment/files/known-groups.json
+++ b/.deployment/files/known-groups.json
@@ -2,8 +2,7 @@
     "ROLE_STUDENT": {
         "label": { "default": "Students", "de": "Studierende", "it": "Studenti", "fr": "Étudiants" },
         "implies": [],
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+        "warnForAction": ["write"]
     },
     "ROLE_STAFF": {
         "label": { "default": "Staff", "de": "Angestellte", "it": "Personale", "fr": "Personnel" },
@@ -15,26 +14,12 @@
         "label": { "default": "Lecturers", "de": "Vortragende", "it": "Docenti", "fr": "Conférenciers" },
         "implies": ["ROLE_STAFF"],
         "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"], "write": ["ROLE_STAFF"] }
+        "assignableBy": { "read": ["ROLE_USER"], "write": ["ROLE_STAFF"] }
     },
     "ROLE_TOBIRA_MODERATOR": {
         "label": { "default": "Moderators", "de": "Moderierende", "it": "Moderatori", "fr": "Modérateurs" },
         "implies": ["ROLE_STAFF"],
         "warnForAction": [],
         "assignableBy": {}
-    },
-    "ROLE_ANONYMOUS": {
-        "implies": [],
-        "label": { "default": "Everyone", "de": "Alle" },
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
-        "sortKey": "_a"
-    },
-    "ROLE_USER": {
-        "implies": [],
-        "label": { "default": "Logged in users", "de": "Eingeloggte Nutzende" },
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
-        "sortKey": "_b"
     }
 }

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -41,9 +41,10 @@ pub(crate) struct RoleInfo {
     /// also has these other roles.
     pub implies: Option<Vec<String>>,
 
-    /// Is `true` if this role represents a large group. Used to warn users
-    /// accidentally giving write access to large groups.
-    pub large: bool,
+    /// List of actions that should trigger a warning when assigning this
+    /// role, e.g. because it represents an unusually large or broad group.
+    /// Always empty for roles that are not a known group.
+    pub warn_for_action: Vec<String>,
 }
 
 pub(crate) fn query_for(table: &str) -> String {
@@ -70,7 +71,7 @@ where
         role: "roles.role",
         actions,
         implies,
-        large: "coalesce(known_groups.large, false)",
+        warn_for_action: "coalesce(known_groups.warn_for_action, '{}')",
         label: "coalesce(
             known_groups.label,
             case when users.display_name is null
@@ -99,7 +100,7 @@ where
             info: mapping.label.of::<Option<_>>(&row).map(|label| RoleInfo {
                 label,
                 implies: mapping.implies.of(&row),
-                large: mapping.large.of(&row),
+                warn_for_action: mapping.warn_for_action.of(&row),
             }),
         }
     }).await.map_err(Into::into)

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -1,7 +1,12 @@
 use juniper::GraphQLObject;
 use postgres_types::BorrowToSql;
 
-use crate::{api::{err::ApiResult, Context}, model::TranslatedString, db::util::select};
+use crate::{
+    HasRoles,
+    api::{err::ApiResult, Context},
+    db::{types::ActionRoleMap, util::select},
+    model::{actions_assignable_by, TranslatedString},
+};
 
 
 
@@ -45,6 +50,11 @@ pub(crate) struct RoleInfo {
     /// role, e.g. because it represents an unusually large or broad group.
     /// Always empty for roles that are not a known group.
     pub warn_for_action: Vec<String>,
+
+    /// Actions the current user is allowed to assign this role for.
+    /// `null` if the role is not a known group (like free-text roles added in the ACL selector).
+    /// In that case the assignment is unrestricted.
+    pub assignable_actions: Option<Vec<String>>,
 }
 
 pub(crate) fn query_for(table: &str) -> String {
@@ -67,11 +77,16 @@ where
 {
     // First: load labels for roles from the DB. For that we use the `users`
     // and `known_groups` table.
+    // `assignable_by` is deliberately *not* coalesced, because
+    // `NULL` is how we tell "not a known group" (unrestricted
+    // assignment) apart from "known group with an empty `assignable_by`".
+    // That is only relevant for admins though.
     let (selection, mapping) = select!(
         role: "roles.role",
         actions,
         implies,
         warn_for_action: "coalesce(known_groups.warn_for_action, '{}')",
+        assignable_by: "known_groups.assignable_by",
         label: "coalesce(
             known_groups.label,
             case when users.display_name is null
@@ -93,7 +108,13 @@ where
         left join known_groups on known_groups.role = roles.role\
     ");
 
+    let is_admin = context.auth.is_admin(&context.config.auth);
+    let user_roles = context.auth.roles();
+
     context.db.query_mapped(&sql, params, |row| {
+        let assignable_actions = mapping.assignable_by.of::<Option<ActionRoleMap>>(&row)
+            .map(|assignable_by| actions_assignable_by(&assignable_by, user_roles, is_admin));
+
         AclItemWithInfo {
             role: mapping.role.of(&row),
             actions: mapping.actions.of(&row),
@@ -101,6 +122,7 @@ where
                 label,
                 implies: mapping.implies.of(&row),
                 warn_for_action: mapping.warn_for_action.of(&row),
+                assignable_actions,
             }),
         }
     }).await.map_err(Into::into)

--- a/backend/src/api/model/acl.rs
+++ b/backend/src/api/model/acl.rs
@@ -46,10 +46,11 @@ pub(crate) struct RoleInfo {
     /// also has these other roles.
     pub implies: Option<Vec<String>>,
 
-    /// List of actions that should trigger a warning when assigning this
-    /// role, e.g. because it represents an unusually large or broad group.
+    /// List of actions that are considered harmless to assign to this group.
+    /// All other actions will show a warning, as assigning it is considered
+    /// questionable, e.g. because the group is very large.
     /// Always empty for roles that are not a known group.
-    pub warn_for_action: Vec<String>,
+    pub safe_actions: Vec<String>,
 
     /// Actions the current user is allowed to assign this role for.
     /// `null` if the role is not a known group (like free-text roles added in the ACL selector).
@@ -85,7 +86,7 @@ where
         role: "roles.role",
         actions,
         implies,
-        warn_for_action: "coalesce(known_groups.warn_for_action, '{}')",
+        safe_actions: "coalesce(known_groups.safe_actions, '{}')",
         assignable_by: "known_groups.assignable_by",
         label: "coalesce(
             known_groups.label,
@@ -121,7 +122,7 @@ where
             info: mapping.label.of::<Option<_>>(&row).map(|label| RoleInfo {
                 label,
                 implies: mapping.implies.of(&row),
-                warn_for_action: mapping.warn_for_action.of(&row),
+                safe_actions: mapping.safe_actions.of(&row),
                 assignable_actions,
             }),
         }

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -18,7 +18,7 @@ use crate::{
             acl::{self, Acl},
             realm::Realm,
             series::Series,
-            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input},
+            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input, ensure_acl_assignment_allowed},
         },
         util::{OcItemId, LazyLoad},
     },
@@ -587,6 +587,7 @@ impl AuthorizedEvent {
             ) returning id \
         ");
 
+        ensure_acl_assignment_allowed(context, &event.acl, None).await?;
         let acl = convert_acl_input(&event.acl);
 
         context.db.execute(&query, &[
@@ -666,6 +667,9 @@ impl AuthorizedEvent {
     pub(crate) async fn update_acl(id: Id, acl: Vec<AclItem>, context: &Context) -> ApiResult<AuthorizedEvent> {
         let event = Self::load_for_mutation(id, context).await?;
         event.require_idle(context).await?;
+
+        let previous = Some((event.read_roles.as_slice(), event.write_roles.as_slice()));
+        ensure_acl_assignment_allowed(context, &acl, previous).await?;
 
         info!(
             event_id = %id,

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -18,7 +18,7 @@ use crate::{
             acl::{self, Acl},
             realm::Realm,
             series::Series,
-            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input, ensure_acl_assignment_allowed},
+            shared::{AclForDb, SearchFilter, SortDirection, ToSqlColumn, ensure_acl_assignment_allowed},
         },
         util::{OcItemId, LazyLoad},
     },
@@ -59,8 +59,7 @@ pub(crate) struct AuthorizedEvent {
     pub(crate) creators: Vec<String>,
 
     pub(crate) metadata: ExtraMetadata,
-    pub(crate) read_roles: Vec<String>,
-    pub(crate) write_roles: Vec<String>,
+    pub(crate) acl: AclForDb,
     pub(crate) preview_roles: Vec<String>,
     pub(crate) credentials: Option<Credentials>,
 
@@ -124,8 +123,10 @@ impl_from_db!(
             created: row.created(),
             creators: row.creators(),
             metadata: row.metadata(),
-            read_roles: row.read_roles::<Vec<String>>(),
-            write_roles: row.write_roles::<Vec<String>>(),
+            acl: AclForDb {
+                read_roles: row.read_roles::<Vec<String>>(),
+                write_roles: row.write_roles::<Vec<String>>(),
+            },
             preview_roles: row.preview_roles::<Vec<String>>(),
             credentials: row.credentials(),
             tobira_deletion_timestamp: row.tobira_deletion_timestamp(),
@@ -252,11 +253,11 @@ impl AuthorizedEvent {
     }
     /// This doesn't contain `ROLE_ADMIN` as that is included implicitly.
     fn read_roles(&self) -> &[String] {
-        &self.read_roles
+        &self.acl.read_roles
     }
     /// This doesn't contain `ROLE_ADMIN` as that is included implicitly.
     fn write_roles(&self) -> &[String] {
-        &self.write_roles
+        &self.acl.write_roles
     }
     /// This doesn't contain `ROLE_ADMIN` as that is included implicitly.
     fn preview_roles(&self) -> &[String] {
@@ -287,7 +288,7 @@ impl AuthorizedEvent {
                 && password.map_or(false, |p| sha1_matches(&p, &credentials.password))
         });
 
-        if context.auth.overlaps_roles(&self.read_roles) || credentials_match {
+        if context.auth.overlaps_roles(&self.acl.read_roles) || credentials_match {
             self.authorized_data.as_ref()
         } else {
             None
@@ -296,7 +297,7 @@ impl AuthorizedEvent {
 
     /// Whether the current user has write access to this event.
     fn can_write(&self, context: &Context) -> bool {
-        context.auth.overlaps_roles(&self.write_roles)
+        context.auth.overlaps_roles(&self.acl.write_roles)
     }
 
     fn tobira_deletion_timestamp(&self) -> &Option<DateTime<Utc>> {
@@ -305,7 +306,7 @@ impl AuthorizedEvent {
 
     /// Whether the event has active workflows.
     async fn workflow_status(&self, context: &Context) -> ApiResult<WorkflowStatus> {
-        if !context.auth.overlaps_roles(&self.write_roles) {
+        if !context.auth.overlaps_roles(&self.acl.write_roles) {
             return Err(err::not_authorized!(
                 key = "event.workflow.not-allowed",
                 "you are not allowed to inquire about this event's workflow activity",
@@ -347,8 +348,7 @@ impl AuthorizedEvent {
                     created: None,
                     updated: None,
                     metadata: None,
-                    read_roles: None,
-                    write_roles: None,
+                    acl: AclForDb::empty(),
                     is_bookmark: LazyLoad::NotLoaded,
                     num_videos: LazyLoad::NotLoaded,
                     thumbnail_stack: LazyLoad::NotLoaded,
@@ -422,7 +422,7 @@ impl AuthorizedEvent {
     fn jwt_for_read(&self, context: &Context) -> Option<String> {
         // TODO: think about how to make it work for password-protected videos,
         // i.e. whether to use preview roles.
-        if !context.auth.overlaps_roles(&self.read_roles) {
+        if !context.auth.overlaps_roles(&self.acl.read_roles) {
             return None;
         }
 
@@ -434,7 +434,7 @@ impl AuthorizedEvent {
     fn jwt_for_download(&self, context: &Context) -> Option<String> {
         // TODO: think about how to make it work for password-protected videos,
         // i.e. whether to use preview roles.
-        if !context.auth.overlaps_roles(&self.read_roles) {
+        if !context.auth.overlaps_roles(&self.acl.read_roles) {
             return None;
         }
 
@@ -528,7 +528,7 @@ impl Event {
 impl AuthorizedEvent {
     fn can_be_previewed(&self, context: &AuthContext) -> bool {
         context.overlaps_roles(&self.preview_roles)
-            || context.overlaps_roles(&self.read_roles)
+            || context.overlaps_roles(&self.acl.read_roles)
     }
 
     fn series_key(&self) -> Option<Key> {
@@ -544,7 +544,7 @@ impl AuthorizedEvent {
             .ok_or_else(|| err::invalid_input!(key = "event.not-found", "event not found"))?
             .into_result()?;
 
-        if !context.auth.overlaps_roles(&event.write_roles) {
+        if !context.auth.overlaps_roles(&event.acl.write_roles) {
             return Err(err::not_authorized!(key = "event.not-allowed", "event action not allowed"));
         }
 
@@ -588,7 +588,7 @@ impl AuthorizedEvent {
         ");
 
         ensure_acl_assignment_allowed(context, &event.acl, None).await?;
-        let acl = convert_acl_input(&event.acl);
+        let acl = AclForDb::from_items(&event.acl);
 
         context.db.execute(&query, &[
             &event.opencast_id,
@@ -667,9 +667,7 @@ impl AuthorizedEvent {
     pub(crate) async fn update_acl(id: Id, acl: Vec<AclItem>, context: &Context) -> ApiResult<AuthorizedEvent> {
         let event = Self::load_for_mutation(id, context).await?;
         event.require_idle(context).await?;
-
-        let previous = Some((event.read_roles.as_slice(), event.write_roles.as_slice()));
-        ensure_acl_assignment_allowed(context, &acl, previous).await?;
+        ensure_acl_assignment_allowed(context, &acl, Some(&event.acl)).await?;
 
         info!(
             event_id = %id,
@@ -689,7 +687,7 @@ impl AuthorizedEvent {
         if response.status() == StatusCode::NO_CONTENT {
             // 204: The access control list for the specified event is updated.
             Self::start_workflow(&event.opencast_id, &context.config.opencast.republish_workflow_id, &context).await?;
-            let db_acl = convert_acl_input(&acl);
+            let db_acl = AclForDb::from_items(&acl);
 
             // Todo: also update custom and preview roles once frontend sends these
             context.db.execute("\

--- a/backend/src/api/model/event.rs
+++ b/backend/src/api/model/event.rs
@@ -18,7 +18,7 @@ use crate::{
             acl::{self, Acl},
             realm::Realm,
             series::Series,
-            shared::{AclForDb, SearchFilter, SortDirection, ToSqlColumn, ensure_acl_assignment_allowed},
+            shared::{SearchFilter, SortDirection, ToSqlColumn, ensure_acl_assignment_allowed},
         },
         util::{OcItemId, LazyLoad},
     },
@@ -27,7 +27,7 @@ use crate::{
         types::{Credentials, EventCaption, EventSegment, EventTrack},
         util::impl_from_db,
     },
-    model::{AclItem, EventState, ExtraMetadata, Key, OpencastId, SeriesState},
+    model::{AclForDb, AclItem, EventState, ExtraMetadata, Key, OpencastId, SeriesState},
     prelude::*,
     sync::client::{AclInput, OpencastItem},
 };

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -1,14 +1,59 @@
 use meilisearch_sdk::search::{Selectors, MatchingStrategies};
 
 use crate::{
+    HasRoles,
     api::{err::ApiResult, Context},
-    model::KnownUser,
+    model::{self, KnownUser, TranslatedString},
     db::util::select,
     prelude::*,
 };
 use super::search::{handle_search_result, measure_search_duration, SearchResults, SearchUnavailable};
 
 
+
+// ===== Groups ===============================================================
+
+/// A group selectable in the ACL UI, as seen by the current user.
+#[derive(juniper::GraphQLObject)]
+pub(crate) struct KnownGroup {
+    pub role: String,
+    pub label: TranslatedString,
+    pub implies: Vec<String>,
+    pub sort_key: Option<String>,
+
+    /// List of actions that should trigger a warning when assigning this
+    /// group, e.g. because it is unusually large or broad.
+    pub warn_for_action: Vec<String>,
+
+    /// The actions the current user is allowed to assign this group for.
+    pub assignable_actions: Vec<String>,
+}
+
+/// Loads all known groups and actions the current user is allowed to assign for each.
+pub(crate) async fn known_groups_for_user(context: &Context) -> ApiResult<Vec<KnownGroup>> {
+    let user_is_tobira_admin = context.auth.is_tobira_admin(&context.config.auth);
+    let user_roles = context.auth.roles();
+
+    let groups = model::KnownGroup::load_all(context).await?;
+    let out = groups.into_iter()
+        .map(|group| {
+            let assignable_actions = group.actions_assignable_by(user_roles, user_is_tobira_admin);
+            KnownGroup {
+                role: group.role,
+                label: group.label,
+                implies: group.implies,
+                sort_key: group.sort_key,
+                warn_for_action: group.warn_for_action,
+                assignable_actions,
+            }
+        })
+        .collect();
+
+    Ok(out)
+}
+
+
+// ===== Users ===============================================================
 
 #[derive(juniper::GraphQLUnion)]
 #[graphql(Context = Context)]

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -20,10 +20,7 @@ pub(crate) struct KnownGroup {
     pub label: TranslatedString,
     pub implies: Vec<String>,
     pub sort_key: Option<String>,
-
-    /// List of actions that should trigger a warning when assigning this
-    /// group, e.g. because it is unusually large or broad.
-    pub warn_for_action: Vec<String>,
+    pub safe_actions: Vec<String>,
 
     /// The actions the current user is allowed to assign this group for.
     pub assignable_actions: Vec<String>,
@@ -42,7 +39,7 @@ pub(crate) async fn known_groups_for_user(context: &Context) -> ApiResult<Vec<Kn
                 label: group.label,
                 implies: group.implies,
                 sort_key: group.sort_key,
-                warn_for_action: group.warn_for_action,
+                safe_actions: group.safe_actions,
                 assignable_actions,
             }
         })

--- a/backend/src/api/model/known_roles.rs
+++ b/backend/src/api/model/known_roles.rs
@@ -29,7 +29,6 @@ pub(crate) struct KnownGroup {
     pub assignable_actions: Vec<String>,
 }
 
-/// Loads all known groups and actions the current user is allowed to assign for each.
 pub(crate) async fn known_groups_for_user(context: &Context) -> ApiResult<Vec<KnownGroup>> {
     let user_is_tobira_admin = context.auth.is_tobira_admin(&context.config.auth);
     let user_roles = context.auth.roles();

--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -10,6 +10,7 @@ use crate::{
             event::{Missing, VideoListEntry},
             realm::Realm,
             shared::{
+                AclForDb,
                 define_sort_column_and_order,
                 load_writable_for_user,
                 Connection,
@@ -59,8 +60,7 @@ pub(crate) struct AuthorizedPlaylist {
     thumbnail_stack: LazyLoad<ThumbnailStack>,
     has_public_videos: LazyLoad<bool>,
 
-    pub(crate) read_roles: Vec<String>,
-    write_roles: Vec<String>,
+    pub(crate) acl: AclForDb,
 }
 
 impl_from_db!(
@@ -78,8 +78,10 @@ impl_from_db!(
             title: row.title(),
             description: row.description(),
             creator: row.creator(),
-            read_roles: row.read_roles(),
-            write_roles: row.write_roles(),
+            acl: AclForDb {
+                read_roles: row.read_roles(),
+                write_roles: row.write_roles(),
+            },
             updated: row.updated(),
             is_bookmark: LazyLoad::NotLoaded,
             num_entries: LazyLoad::NotLoaded,
@@ -121,7 +123,7 @@ impl Playlist {
     }
 
     pub(crate) fn check_auth(playlist: AuthorizedPlaylist, auth: &AuthContext) -> Self {
-        if auth.overlaps_roles(&playlist.read_roles) {
+        if auth.overlaps_roles(&playlist.acl.read_roles) {
             Self::Playlist(playlist)
         } else {
             Self::NotAllowed(NotAllowed)
@@ -134,7 +136,7 @@ impl Playlist {
             .ok_or_else(|| err::invalid_input!(key = "playlist.not-found", "playlist not found"))?
             .into_result()?;
 
-        if !context.auth.overlaps_roles(&playlist.write_roles) {
+        if !context.auth.overlaps_roles(&playlist.acl.write_roles) {
             return Err(err::not_authorized!(key = "playlist.not-allowed", "playlist action not allowed"));
         }
 
@@ -278,7 +280,7 @@ impl AuthorizedPlaylist {
     /// Returns whether this playlist's RSS feed is public (i.e. the playlist itself is
     /// accessible to anonymous users, and it contains at least one public video).
     fn has_public_rss_feed(&self) -> bool {
-        self.has_public_videos() && self.read_roles.iter().any(|role| role == ROLE_ANONYMOUS)
+        self.has_public_videos() && self.acl.read_roles.iter().any(|role| role == ROLE_ANONYMOUS)
     }
 
     /// Returns `true` if the realm has a playlist block with this playlist.
@@ -323,7 +325,7 @@ impl AuthorizedPlaylist {
                 }
 
                 let event = AuthorizedEvent::from_row(&row, mapping.event);
-                if !context.auth.overlaps_roles(&event.read_roles) {
+                if !context.auth.overlaps_roles(&event.acl.read_roles) {
                     return VideoListEntry::NotAllowed(NotAllowed);
                 }
 
@@ -354,17 +356,17 @@ impl AuthorizedPlaylist {
 
     /// This doesn't contain `ROLE_ADMIN` as that is included implicitly.
     fn read_roles(&self) -> &[String] {
-        &self.read_roles
+        &self.acl.read_roles
     }
 
     /// This doesn't contain `ROLE_ADMIN` as that is included implicitly.
     fn write_roles(&self) -> &[String] {
-        &self.write_roles
+        &self.acl.write_roles
     }
 
     /// Whether the current user has write access to this playlist.
     fn can_write(&self, context: &Context) -> bool {
-        context.auth.overlaps_roles(&self.write_roles)
+        context.auth.overlaps_roles(&self.acl.write_roles)
     }
 }
 

--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -10,7 +10,6 @@ use crate::{
             event::{Missing, VideoListEntry},
             realm::Realm,
             shared::{
-                AclForDb,
                 define_sort_column_and_order,
                 load_writable_for_user,
                 Connection,
@@ -30,7 +29,7 @@ use crate::{
     },
     auth::{AuthContext, ROLE_ANONYMOUS},
     db::util::{impl_from_db, select},
-    model::{Key, OpencastId, SearchThumbnailInfo, ThumbnailInfo, ThumbnailStack},
+    model::{AclForDb, Key, OpencastId, SearchThumbnailInfo, ThumbnailInfo, ThumbnailStack},
     prelude::*,
 };
 

--- a/backend/src/api/model/playlist/mutations.rs
+++ b/backend/src/api/model/playlist/mutations.rs
@@ -4,7 +4,7 @@ use crate::{
     api::{
         err::{self, ApiResult, ApiError, ApiErrorKind},
         model::{
-            shared::{convert_acl_input, BasicMetadata},
+            shared::{convert_acl_input, ensure_acl_assignment_allowed, BasicMetadata},
         },
         Context,
         Id,
@@ -29,6 +29,7 @@ impl AuthorizedPlaylist {
         if !context.auth.can_create_playlists(&context.config.auth) {
             return Err(err::not_authorized!(key = "playlist.not-allowed", "playlist action not allowed"));
         }
+        ensure_acl_assignment_allowed(context, &acl, None).await?;
 
         let entry_ids = load_entries(entries, context).await?;
 
@@ -82,6 +83,11 @@ impl AuthorizedPlaylist {
     ) -> ApiResult<Self> {
         // `load_for_mutation` handles authorization.
         let playlist = Playlist::load_for_mutation(id, context).await?;
+
+        if let Some(acl) = &acl {
+            let previous = Some((playlist.read_roles.as_slice(), playlist.write_roles.as_slice()));
+            ensure_acl_assignment_allowed(context, acl, previous).await?;
+        }
 
         let mut entry_ids = if let Some(entries) = entries {
             Some(load_entries(entries, context).await?)

--- a/backend/src/api/model/playlist/mutations.rs
+++ b/backend/src/api/model/playlist/mutations.rs
@@ -4,7 +4,7 @@ use crate::{
     api::{
         err::{self, ApiResult, ApiError, ApiErrorKind},
         model::{
-            shared::{convert_acl_input, ensure_acl_assignment_allowed, BasicMetadata},
+            shared::{AclForDb, ensure_acl_assignment_allowed, BasicMetadata},
         },
         Context,
         Id,
@@ -47,7 +47,7 @@ impl AuthorizedPlaylist {
                 err::opencast_unavailable!("Failed to create playlist")
             })?;
 
-        let acl = convert_acl_input(&acl);
+        let acl = AclForDb::from_items(&acl);
         let selection = Self::select();
 
         let query = format!(
@@ -85,8 +85,7 @@ impl AuthorizedPlaylist {
         let playlist = Playlist::load_for_mutation(id, context).await?;
 
         if let Some(acl) = &acl {
-            let previous = Some((playlist.read_roles.as_slice(), playlist.write_roles.as_slice()));
-            ensure_acl_assignment_allowed(context, acl, previous).await?;
+            ensure_acl_assignment_allowed(context, acl, Some(&playlist.acl)).await?;
         }
 
         let mut entry_ids = if let Some(entries) = entries {
@@ -142,7 +141,7 @@ impl AuthorizedPlaylist {
             .filter(|a| a.allow)
             .map(|a| AclItem { role: a.role, actions: vec![a.action] })
             .collect();
-        let response_acl = convert_acl_input(&acl_entries);
+        let response_acl = AclForDb::from_items(&acl_entries);
 
         let selection = Self::select();
         let query = format!(

--- a/backend/src/api/model/playlist/mutations.rs
+++ b/backend/src/api/model/playlist/mutations.rs
@@ -4,12 +4,12 @@ use crate::{
     api::{
         err::{self, ApiResult, ApiError, ApiErrorKind},
         model::{
-            shared::{AclForDb, ensure_acl_assignment_allowed, BasicMetadata},
+            shared::{ensure_acl_assignment_allowed, BasicMetadata},
         },
         Context,
         Id,
     },
-    model::{AclItem, OpencastId},
+    model::{AclForDb, AclItem, OpencastId},
     prelude::*,
     sync::client::{AclInput, OpencastItem},
 };

--- a/backend/src/api/model/realm/mod.rs
+++ b/backend/src/api/model/realm/mod.rs
@@ -291,9 +291,9 @@ impl Realm {
     /// the respective actions that are necessary for UI purposes.
     async fn own_acl(&self, context: &Context) -> ApiResult<Acl> {
         let raw_roles_sql = "
-            select unnest(moderator_roles) as role, 'moderate' as action from realms where id = $1
+            select unnest(moderator_roles) as role, 'tobira:realm:moderate' as action from realms where id = $1
             union
-            select unnest(admin_roles) as role, 'admin' as action from realms where id = $1
+            select unnest(admin_roles) as role, 'tobira:realm:admin' as action from realms where id = $1
         ";
         acl::load_for(context, raw_roles_sql, dbargs![&self.key]).await
     }
@@ -305,9 +305,9 @@ impl Realm {
     /// acl.
     async fn inherited_acl(&self, context: &Context) -> ApiResult<Acl> {
         let raw_roles_sql = "
-            select unnest(flattened_moderator_roles) as role, 'moderate' as action from realms where id = $1
+            select unnest(flattened_moderator_roles) as role, 'tobira:realm:moderate' as action from realms where id = $1
             union
-            select unnest(flattened_admin_roles) as role, 'admin' as action from realms where id = $1
+            select unnest(flattened_admin_roles) as role, 'tobira:realm:admin' as action from realms where id = $1
         ";
         acl::load_for(context, raw_roles_sql, dbargs![&self.parent_key]).await
     }

--- a/backend/src/api/model/realm/mutations.rs
+++ b/backend/src/api/model/realm/mutations.rs
@@ -5,10 +5,10 @@ use crate::{
         Context,
         err::{invalid_input, map_db_err, ApiResult},
         Id,
-        model::block::RemovedBlock,
+        model::{shared::ensure_permission_change_allowed, block::RemovedBlock},
     },
     auth::AuthState,
-    model::Key,
+    model::{Key, REALM_ADMIN_ACTION, REALM_MODERATE_ACTION},
     prelude::*,
 };
 use super::{Realm, RealmOrder};
@@ -247,6 +247,23 @@ impl Realm {
         };
         realm.require_admin_rights(context)?;
         let db = &context.db;
+
+        // Make sure the user is allowed to assign these groups.
+        {
+            let mut added = HashMap::new();
+            for role in permissions.admin_roles.iter().flatten() {
+                if !realm.admin_roles.contains(role) {
+                    added.entry(role.as_str()).or_insert(vec![]).push(REALM_ADMIN_ACTION);
+                }
+            }
+            for role in permissions.moderator_roles.iter().flatten() {
+                if !realm.moderator_roles.contains(role) {
+                    added.entry(role.as_str()).or_insert(vec![]).push(REALM_MODERATE_ACTION);
+                }
+            }
+
+            ensure_permission_change_allowed(context, added.into_iter().collect()).await?;
+        }
 
         db.execute(
             "update realms set \

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -12,7 +12,7 @@ use crate::{
             acl::{self, Acl},
             event::{AuthorizedEvent, Event},
             realm::Realm,
-            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input},
+            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input, ensure_acl_assignment_allowed},
         },
         util::{OcItemId, LazyLoad},
     },
@@ -203,6 +203,7 @@ impl Series {
         if !context.auth.can_create_series(&context.config.auth) {
             return Err(err::not_authorized!(key = "series.not-allowed", "series action not allowed"));
         }
+        ensure_acl_assignment_allowed(context, &acl, None).await?;
         let response = context
             .oc_client
             .create_series(&acl, &metadata.title, metadata.description.as_deref())
@@ -417,6 +418,12 @@ impl Series {
 
     pub(crate) async fn update_acl(id: Id, acl: Vec<AclItem>, context: &Context) -> ApiResult<Series> {
         let series = Self::load_for_mutation(id, context).await?;
+
+        let previous = Some((
+            series.read_roles.as_deref().unwrap_or(&[]),
+            series.write_roles.as_deref().unwrap_or(&[]),
+        ));
+        ensure_acl_assignment_allowed(context, &acl, previous).await?;
 
         info!(
             series_id = %id,

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     db::util::{impl_from_db, select},
     model::{
+        AclForDb,
         AclItem,
         ExtraMetadata,
         Key,
@@ -46,7 +47,6 @@ use super::{
         define_sort_column_and_order,
         load_writable_for_user,
         BasicMetadata,
-        AclForDb,
         Connection,
         ConnectionQueryParts,
         PageInfo,

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -12,7 +12,7 @@ use crate::{
             acl::{self, Acl},
             event::{AuthorizedEvent, Event},
             realm::Realm,
-            shared::{SearchFilter, SortDirection, ToSqlColumn, convert_acl_input, ensure_acl_assignment_allowed},
+            shared::{SearchFilter, SortDirection, ToSqlColumn, ensure_acl_assignment_allowed},
         },
         util::{OcItemId, LazyLoad},
     },
@@ -46,7 +46,7 @@ use super::{
         define_sort_column_and_order,
         load_writable_for_user,
         BasicMetadata,
-        AclForDB,
+        AclForDb,
         Connection,
         ConnectionQueryParts,
         PageInfo,
@@ -65,9 +65,7 @@ pub(crate) struct Series {
     pub(crate) created: Option<DateTime<Utc>>,
     pub(crate) updated: Option<DateTime<Utc>>,
     pub(crate) metadata: Option<ExtraMetadata>,
-    #[allow(dead_code)]
-    pub(crate) read_roles: Option<Vec<String>>,
-    pub(crate) write_roles: Option<Vec<String>>,
+    pub(crate) acl: AclForDb,
     pub(crate) is_bookmark: LazyLoad<bool>,
     pub(crate) num_videos: LazyLoad<u32>,
     pub(crate) thumbnail_stack: LazyLoad<ThumbnailStack>,
@@ -99,8 +97,10 @@ impl_from_db!(
             created: row.created(),
             updated: row.updated(),
             metadata: row.metadata(),
-            read_roles: row.read_roles(),
-            write_roles: row.write_roles(),
+            acl: AclForDb {
+                read_roles: row.read_roles::<Option<Vec<String>>>().unwrap_or(vec![]),
+                write_roles: row.write_roles::<Option<Vec<String>>>().unwrap_or(vec![]),
+            },
             tobira_deletion_timestamp: row.tobira_deletion_timestamp(),
             description: row.description(),
             is_bookmark: LazyLoad::NotLoaded,
@@ -144,7 +144,7 @@ impl Series {
             .await?
             .ok_or_else(|| err::invalid_input!(key = "series.not-found", "series {id} not found"))?;
 
-        if !context.auth.overlaps_roles(series.write_roles.as_deref().unwrap_or(&[])) {
+        if !context.auth.overlaps_roles(&series.acl.write_roles) {
             return Err(err::not_authorized!(key = "series.not-allowed", "series action not allowed"));
         }
 
@@ -153,7 +153,7 @@ impl Series {
 
     pub(crate) async fn create(
         series: NewSeries,
-        acl: Option<AclForDB>,
+        acl: Option<AclForDb>,
         context: &Context,
         state: SeriesState,
     ) -> ApiResult<Self> {
@@ -213,7 +213,7 @@ impl Series {
                 err::opencast_unavailable!("Failed to create series")
             })?;
 
-        let db_acl = Some(convert_acl_input(&acl));
+        let db_acl = Some(AclForDb::from_items(&acl));
 
         // If the request returned an Opencast identifier, the series was created successfully.
         // The series is created in the database, so the user doesn't have to wait for sync to see
@@ -419,11 +419,7 @@ impl Series {
     pub(crate) async fn update_acl(id: Id, acl: Vec<AclItem>, context: &Context) -> ApiResult<Series> {
         let series = Self::load_for_mutation(id, context).await?;
 
-        let previous = Some((
-            series.read_roles.as_deref().unwrap_or(&[]),
-            series.write_roles.as_deref().unwrap_or(&[]),
-        ));
-        ensure_acl_assignment_allowed(context, &acl, previous).await?;
+        ensure_acl_assignment_allowed(context, &acl, Some(&series.acl)).await?;
 
         info!(
             series_id = %id,
@@ -442,7 +438,7 @@ impl Series {
 
         if response.status() == StatusCode::OK {
             // 200: The updated access control list is returned.
-            let db_acl = convert_acl_input(&acl);
+            let db_acl = AclForDb::from_items(&acl);
 
             context.db.execute("\
                 update all_series \
@@ -801,7 +797,7 @@ impl Series {
 
     /// Whether the current user has write access to this series.
     fn can_write(&self, context: &Context) -> bool {
-        self.write_roles.as_ref().is_some_and(|roles| context.auth.overlaps_roles(roles))
+        context.auth.overlaps_roles(&self.acl.write_roles)
     }
 
     fn tobira_deletion_timestamp(&self) -> &Option<DateTime<Utc>> {

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use juniper::{GraphQLEnum, GraphQLInputObject, GraphQLObject};
 use tokio_postgres::Row;
@@ -6,8 +6,8 @@ use tokio_postgres::Row;
 use crate::{
     HasRoles, api::{
         Context,
-        err::{ApiResult, invalid_input},
-    }, dbargs, model::AclItem
+        err::{ApiResult, invalid_input, not_authorized},
+    }, dbargs, model::{AclItem, KnownGroup}
 };
 
 
@@ -364,6 +364,59 @@ pub(crate) fn convert_acl_input(entries: &[AclItem]) -> AclForDB {
         // preview_roles: preview_roles.into_iter().collect(),
         // custom_action_roles,
     }
+}
+
+/// Checks that the current user is allowed to make the ACL change described
+/// by `entries`, i.e. is allowed to grant every newly added role/action
+/// combination.
+///
+/// `previous` holds the item's current roles or `None` when creating a new item
+/// (i.e. nothing granted yet).
+/// Only newly added role/action combinations are checked against each role's
+/// `assignable_by` (as of now, shrinking access is always allowed).
+pub(crate) async fn ensure_acl_assignment_allowed(
+    context: &Context,
+    entries: &[AclItem],
+    previous: Option<(&[String], &[String])>,
+) -> ApiResult<()> {
+    if context.auth.is_tobira_admin(&context.config.auth) {
+        return Ok(());
+    }
+
+    let new_acl = convert_acl_input(entries);
+    let (prev_read, prev_write) = previous.unwrap_or((&[], &[]));
+    // Todo: also check preview roles and custom actions once `convert_acl_input` returns them.
+    let added_read = new_acl.read_roles.iter()
+        .filter(|role| !prev_read.contains(role))
+        .map(|role| (role.as_str(), "read"));
+    let added_write = new_acl.write_roles.iter()
+        .filter(|role| !prev_write.contains(role))
+        .map(|role| (role.as_str(), "write"));
+    let added = added_read.chain(added_write).collect::<Vec<_>>();
+
+    if added.is_empty() {
+        return Ok(());
+    }
+
+    let roles = added.iter().map(|&(role, _)| role).collect::<Vec<_>>();
+    let groups = KnownGroup::load_by_roles(&roles, context).await?;
+    let user_roles = context.auth.roles();
+    // Admins already returned above, so `is_admin: false`.
+    let assignable = groups.iter()
+        .map(|g| (g.role.as_str(), g.actions_assignable_by(user_roles, false)))
+        .collect::<HashMap<_, _>>();
+
+    for (role, action) in added {
+        let Some(actions) = assignable.get(role) else { continue };
+        if !actions.iter().any(|a| a == action) {
+            return Err(not_authorized!(
+                key = "acl.assign-not-allowed",
+                "not allowed to assign group '{role}' for action '{action}'",
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(GraphQLInputObject)]

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -1,13 +1,16 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use juniper::{GraphQLEnum, GraphQLInputObject, GraphQLObject};
 use tokio_postgres::Row;
 
 use crate::{
-    HasRoles, api::{
+    auth::HasRoles,
+    api::{
         Context,
         err::{ApiResult, invalid_input, not_authorized},
-    }, dbargs, model::{AclItem, KnownGroup}
+    },
+    dbargs,
+    model::{AclForDb, AclItem, KnownGroup}
 };
 
 
@@ -315,67 +318,6 @@ where
         page_info,
     })
 }
-
-
-#[derive(Debug, Clone)]
-pub(crate) struct AclForDb {
-    pub(crate) read_roles: Vec<String>,
-    pub(crate) write_roles: Vec<String>,
-    // todo: add custom and preview roles for events when sent by frontend
-    // preview_roles: Option<Vec<String>>,
-    // custom_action_roles: Option<CustomActions>,
-}
-
-impl AclForDb {
-    pub(crate) fn empty() -> Self {
-        Self {
-            read_roles: Vec::new(),
-            write_roles: Vec::new(),
-        }
-    }
-
-    pub(crate) fn from_items(entries: &[AclItem]) -> Self {
-        let mut read_roles = HashSet::new();
-        let mut write_roles = HashSet::new();
-        // let mut preview_roles = HashSet::new();
-        // let mut custom_action_roles = CustomActions::default();
-
-        for entry in entries {
-            let role = &entry.role;
-            for action in &entry.actions {
-                match action.as_str() {
-                    // "preview" => { preview_roles.insert(role.clone()); }
-                    "read" => { read_roles.insert(role.clone()); }
-                    "write" => { write_roles.insert(role.clone()); }
-                    _ => {
-                        // custom_action_roles.0.entry(action)
-                        //     .or_insert_default()
-                        //     .push(role.clone());
-                        todo!();
-                    }
-                };
-            }
-        }
-
-        AclForDb {
-            read_roles: read_roles.into_iter().collect(),
-            write_roles: write_roles.into_iter().collect(),
-            // todo: add custom and preview roles when sent by frontend
-            // preview_roles: preview_roles.into_iter().collect(),
-            // custom_action_roles,
-        }
-    }
-
-    /// Returns the list of roles that are allowed to perform the given action.
-    pub(crate) fn roles_for_action(&self, action: &str) -> &[String] {
-        match action {
-            "read" => &self.read_roles,
-            "write" => &self.write_roles,
-            _ => &[],
-        }
-    }
-}
-
 
 
 /// Checks that the current user is allowed to make the ACL change described

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -317,8 +317,8 @@ where
 }
 
 
-#[derive(Debug)]
-pub(crate) struct AclForDB {
+#[derive(Debug, Clone)]
+pub(crate) struct AclForDb {
     pub(crate) read_roles: Vec<String>,
     pub(crate) write_roles: Vec<String>,
     // todo: add custom and preview roles for events when sent by frontend
@@ -326,45 +326,57 @@ pub(crate) struct AclForDB {
     // custom_action_roles: Option<CustomActions>,
 }
 
-pub(crate) fn convert_acl_input(entries: &[AclItem]) -> AclForDB {
-    let mut read_roles = HashSet::new();
-    let mut write_roles = HashSet::new();
-    // let mut preview_roles = HashSet::new();
-    // let mut custom_action_roles = CustomActions::default();
-
-    for entry in entries {
-        let role = &entry.role;
-        for action in &entry.actions {
-            match action.as_str() {
-                // "preview" => {
-                //     preview_roles.insert(role.clone());
-                // }
-                "read" => {
-                    read_roles.insert(role.clone());
-                }
-                "write" => {
-                    write_roles.insert(role.clone());
-                }
-                _ => {
-                    // custom_action_roles
-                    //     .0
-                    //     .entry(action)
-                    //     .or_insert_with(Vec::new)
-                    //     .push(role.clone());
-                    todo!();
-                }
-            };
+impl AclForDb {
+    pub(crate) fn empty() -> Self {
+        Self {
+            read_roles: Vec::new(),
+            write_roles: Vec::new(),
         }
     }
 
-    AclForDB {
-        read_roles: read_roles.into_iter().collect(),
-        write_roles: write_roles.into_iter().collect(),
-        // todo: add custom and preview roles when sent by frontend
-        // preview_roles: preview_roles.into_iter().collect(),
-        // custom_action_roles,
+    pub(crate) fn from_items(entries: &[AclItem]) -> Self {
+        let mut read_roles = HashSet::new();
+        let mut write_roles = HashSet::new();
+        // let mut preview_roles = HashSet::new();
+        // let mut custom_action_roles = CustomActions::default();
+
+        for entry in entries {
+            let role = &entry.role;
+            for action in &entry.actions {
+                match action.as_str() {
+                    // "preview" => { preview_roles.insert(role.clone()); }
+                    "read" => { read_roles.insert(role.clone()); }
+                    "write" => { write_roles.insert(role.clone()); }
+                    _ => {
+                        // custom_action_roles.0.entry(action)
+                        //     .or_insert_default()
+                        //     .push(role.clone());
+                        todo!();
+                    }
+                };
+            }
+        }
+
+        AclForDb {
+            read_roles: read_roles.into_iter().collect(),
+            write_roles: write_roles.into_iter().collect(),
+            // todo: add custom and preview roles when sent by frontend
+            // preview_roles: preview_roles.into_iter().collect(),
+            // custom_action_roles,
+        }
+    }
+
+    /// Returns the list of roles that are allowed to perform the given action.
+    pub(crate) fn roles_for_action(&self, action: &str) -> &[String] {
+        match action {
+            "read" => &self.read_roles,
+            "write" => &self.write_roles,
+            _ => &[],
+        }
     }
 }
+
+
 
 /// Checks that the current user is allowed to make the ACL change described
 /// by `entries`, i.e. is allowed to grant every newly added role/action
@@ -376,23 +388,24 @@ pub(crate) fn convert_acl_input(entries: &[AclItem]) -> AclForDB {
 /// `assignable_by` (as of now, shrinking access is always allowed).
 pub(crate) async fn ensure_acl_assignment_allowed(
     context: &Context,
-    entries: &[AclItem],
-    previous: Option<(&[String], &[String])>,
+    new: &[AclItem],
+    old: Option<&AclForDb>,
 ) -> ApiResult<()> {
     if context.auth.is_tobira_admin(&context.config.auth) {
         return Ok(());
     }
 
-    let new_acl = convert_acl_input(entries);
-    let (prev_read, prev_write) = previous.unwrap_or((&[], &[]));
-    // Todo: also check preview roles and custom actions once `convert_acl_input` returns them.
-    let added_read = new_acl.read_roles.iter()
-        .filter(|role| !prev_read.contains(role))
-        .map(|role| (role.as_str(), "read"));
-    let added_write = new_acl.write_roles.iter()
-        .filter(|role| !prev_write.contains(role))
-        .map(|role| (role.as_str(), "write"));
-    let added = added_read.chain(added_write).collect::<Vec<_>>();
+    let empty_acl = AclForDb::empty();
+    let old = old.unwrap_or(&empty_acl);
+    let added = new.iter()
+        .map(|item| (
+            item.role.as_str(),
+            item.actions.iter()
+                .filter(|action| !old.roles_for_action(action).contains(&item.role))
+                .collect::<Vec<_>>(),
+        ))
+        .filter(|(_role, actions)| !actions.is_empty())
+        .collect::<Vec<_>>();
 
     if added.is_empty() {
         return Ok(());
@@ -406,12 +419,14 @@ pub(crate) async fn ensure_acl_assignment_allowed(
         .map(|g| (g.role.as_str(), g.actions_assignable_by(user_roles, false)))
         .collect::<HashMap<_, _>>();
 
-    for (role, action) in added {
-        let Some(actions) = assignable.get(role) else { continue };
-        if !actions.iter().any(|a| a == action) {
+    for (role, requested_actions) in added {
+        // If the group isn't known, everything is allowed
+        let Some(allowed_actions) = assignable.get(role) else { continue };
+
+        if requested_actions.iter().any(|req| !allowed_actions.contains(&req)) {
             return Err(not_authorized!(
                 key = "acl.assign-not-allowed",
-                "not allowed to assign group '{role}' for action '{action}'",
+                "not allowed to assign group '{role}' for '{requested_actions:?}'",
             ));
         }
     }

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -415,9 +415,14 @@ pub(crate) async fn ensure_acl_assignment_allowed(
     let groups = KnownGroup::load_by_roles(&roles, context).await?;
     let user_roles = context.auth.roles();
     // Admins already returned above, so `is_admin: false`.
-    let assignable = groups.iter()
+    let mut assignable = groups.iter()
         .map(|g| (g.role.as_str(), g.actions_assignable_by(user_roles, false)))
         .collect::<HashMap<_, _>>();
+
+    // Insert defaults for built-in groups if not present yet.
+    // TODO: this is duplicated with frontend logic! Deduplicate
+    assignable.entry(crate::auth::ROLE_ANONYMOUS).or_insert_with(|| vec!["read".into()]);
+    assignable.entry(crate::auth::ROLE_USER).or_insert_with(|| vec!["read".into()]);
 
     for (role, requested_actions) in added {
         // If the group isn't known, everything is allowed

--- a/backend/src/api/model/shared.rs
+++ b/backend/src/api/model/shared.rs
@@ -344,11 +344,24 @@ pub(crate) async fn ensure_acl_assignment_allowed(
             item.role.as_str(),
             item.actions.iter()
                 .filter(|action| !old.roles_for_action(action).contains(&item.role))
+                .map(|a| a.as_str())
                 .collect::<Vec<_>>(),
         ))
         .filter(|(_role, actions)| !actions.is_empty())
         .collect::<Vec<_>>();
 
+    ensure_permission_change_allowed(context, added).await
+}
+
+/// Makes sure that an ACL modification is allowed by the known groups'
+/// `assignable_by`. `added` contains a list of `(role, actions)`.
+pub(crate) async fn ensure_permission_change_allowed(
+    context: &Context,
+    added: Vec<(&str, Vec<&str>)>,
+) -> ApiResult<()> {
+    if context.auth.is_tobira_admin(&context.config.auth) {
+        return Ok(());
+    }
     if added.is_empty() {
         return Ok(());
     }
@@ -370,7 +383,7 @@ pub(crate) async fn ensure_acl_assignment_allowed(
         // If the group isn't known, everything is allowed
         let Some(allowed_actions) = assignable.get(role) else { continue };
 
-        if requested_actions.iter().any(|req| !allowed_actions.contains(&req)) {
+        if requested_actions.iter().any(|req| !allowed_actions.iter().any(|a| a == *req)) {
             return Err(not_authorized!(
                 key = "acl.assign-not-allowed",
                 "not allowed to assign group '{role}' for '{requested_actions:?}'",

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -3,7 +3,7 @@ use juniper::graphql_object;
 
 use crate::{
     auth::{AuthState, User},
-    model::{OpencastId, KnownGroup},
+    model::OpencastId,
 };
 
 use super::{
@@ -13,7 +13,7 @@ use super::{
         self,
         admin::AdminInfo,
         event::Event,
-        known_roles::{self, KnownUsersSearchOutcome},
+        known_roles::{self, KnownGroup, KnownUsersSearchOutcome},
         playlist::Playlist,
         realm::Realm,
         search::{
@@ -196,9 +196,9 @@ impl Query {
         known_roles::search_known_users(query, context).await
     }
 
-    /// Returns all known groups selectable in the ACL UI.
+    /// Returns all known groups selectable in the ACL UI by the current user.
     async fn known_groups(context: &Context) -> ApiResult<Vec<KnownGroup>> {
-        KnownGroup::load_all(context).await.map_err(Into::into)
+        known_roles::known_groups_for_user(context).await
     }
 
     /// Returns information for the admin dashboard.

--- a/backend/src/api/query.rs
+++ b/backend/src/api/query.rs
@@ -196,7 +196,7 @@ impl Query {
         known_roles::search_known_users(query, context).await
     }
 
-    /// Returns all known groups selectable in the ACL UI by the current user.
+    /// Returns all known groups, with `assignableActions` for the current user.
     async fn known_groups(context: &Context) -> ApiResult<Vec<KnownGroup>> {
         known_roles::known_groups_for_user(context).await
     }

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -61,7 +61,7 @@ pub(crate) fn is_special_eth_role(role: &String, config: &Config) -> bool {
 }
 
 pub(crate) const ROLE_ANONYMOUS: &str = "ROLE_ANONYMOUS";
-const ROLE_USER: &str = "ROLE_USER";
+pub(crate) const ROLE_USER: &str = "ROLE_USER";
 
 const SESSION_COOKIE: &str = "tobira-session";
 

--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -8,7 +8,7 @@ use crate::{
     model::KnownGroup,
     config::Config,
     model::TranslatedString,
-    db,
+    db::{self, types::ActionRoleMap},
     prelude::*,
 };
 
@@ -28,7 +28,8 @@ pub(crate) enum Args {
     ///     "ROLE_LECTURER": {
     ///         "label": { "default": "Lecturer", "de": "Vortragende" },
     ///         "implies": ["ROLE_STAFF"],
-    ///         "warnForAction": ["write"]
+    ///         "warnForAction": ["write"],
+    ///         "assignableBy": { "write": ["ROLE_STAFF"] }
     ///     }
     /// }
     ///
@@ -92,7 +93,8 @@ fn print_group(group: &KnownGroup) {
         }
         print!("{}", json!(role));
     }
-    print!(r#"], "warnForAction": {} }}"#, json!(group.warn_for_action));
+    print!(r#"], "warnForAction": {}, "assignableBy": {} }}"#,
+        json!(group.warn_for_action), json!(group.assignable_by.0));
 }
 
 async fn list(tx: Transaction<'_>) -> Result<()> {
@@ -132,19 +134,22 @@ async fn upsert(file: &str, config: &Config, tx: Transaction<'_>) -> Result<()> 
     // Insert into DB
     let len = groups.len();
     for (role, info) in groups {
-        let sql = "insert into known_groups (role, label, implies, sort_key, warn_for_action) \
-            values ($1, $2, $3, $4, $5) \
+        let sql = "insert into known_groups \
+            (role, label, implies, sort_key, warn_for_action, assignable_by) \
+            values ($1, $2, $3, $4, $5, $6) \
             on conflict (role) do update set \
                 label = excluded.label, \
                 implies = excluded.implies, \
                 sort_key = excluded.sort_key, \
-                warn_for_action = excluded.warn_for_action";
+                warn_for_action = excluded.warn_for_action, \
+                assignable_by = excluded.assignable_by";
         tx.execute(sql, &[
             &role,
             &info.label,
             &info.implies,
             &info.sort_key,
             &info.warn_for_action,
+            &info.assignable_by,
         ]).await?;
     }
     tx.commit().await?;
@@ -208,6 +213,7 @@ struct GroupData {
     implies: Vec<Role>,
 
     warn_for_action: Vec<String>,
+    assignable_by: ActionRoleMap,
     sort_key: Option<String>,
 }
 

--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -28,7 +28,7 @@ pub(crate) enum Args {
     ///     "ROLE_LECTURER": {
     ///         "label": { "default": "Lecturer", "de": "Vortragende" },
     ///         "implies": ["ROLE_STAFF"],
-    ///         "large": true
+    ///         "warnForAction": ["write"]
     ///     }
     /// }
     ///
@@ -92,7 +92,7 @@ fn print_group(group: &KnownGroup) {
         }
         print!("{}", json!(role));
     }
-    print!(r#"], "large": {} }}"#, group.large);
+    print!(r#"], "warnForAction": {} }}"#, json!(group.warn_for_action));
 }
 
 async fn list(tx: Transaction<'_>) -> Result<()> {
@@ -132,14 +132,20 @@ async fn upsert(file: &str, config: &Config, tx: Transaction<'_>) -> Result<()> 
     // Insert into DB
     let len = groups.len();
     for (role, info) in groups {
-        let sql = "insert into known_groups (role, label, implies, sort_key, large) \
+        let sql = "insert into known_groups (role, label, implies, sort_key, warn_for_action) \
             values ($1, $2, $3, $4, $5) \
             on conflict (role) do update set \
                 label = excluded.label, \
                 implies = excluded.implies, \
                 sort_key = excluded.sort_key, \
-                large = excluded.large";
-        tx.execute(sql, &[&role, &info.label, &info.implies, &info.sort_key, &info.large]).await?;
+                warn_for_action = excluded.warn_for_action";
+        tx.execute(sql, &[
+            &role,
+            &info.label,
+            &info.implies,
+            &info.sort_key,
+            &info.warn_for_action,
+        ]).await?;
     }
     tx.commit().await?;
 
@@ -201,7 +207,7 @@ struct GroupData {
     #[serde(default)]
     implies: Vec<Role>,
 
-    large: bool,
+    warn_for_action: Vec<String>,
     sort_key: Option<String>,
 }
 

--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -149,7 +149,9 @@ async fn upsert(file: &str, config: &Config, tx: Transaction<'_>) -> Result<()> 
             &info.implies,
             &info.sort_key,
             &info.warn_for_action,
-            &info.assignable_by,
+            &info.assignable_by.unwrap_or_else(|| ActionRoleMap(
+                HashMap::from([("read".into(), vec![crate::auth::ROLE_USER.into()])])
+            )),
         ]).await?;
     }
     tx.commit().await?;
@@ -213,7 +215,7 @@ struct GroupData {
     implies: Vec<Role>,
 
     warn_for_action: Vec<String>,
-    assignable_by: ActionRoleMap,
+    assignable_by: Option<ActionRoleMap>,
     sort_key: Option<String>,
 }
 

--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -21,22 +21,8 @@ pub(crate) enum Args {
     /// `ROLE_ANONYMOUS` are not listed.
     List,
 
-    /// Adds new known groups and updates existing ones. The groups are
-    /// specified in a JSON file in this format:
-    ///
-    /// {
-    ///     "ROLE_LECTURER": {
-    ///         "label": { "default": "Lecturer", "de": "Vortragende" },
-    ///         "implies": ["ROLE_STAFF"],
-    ///         "warnForAction": ["write"],
-    ///         "assignableBy": { "write": ["ROLE_STAFF"] }
-    ///     }
-    /// }
-    ///
-    /// Each entry may also have a field `sortKey` which is used to sort entries
-    /// in the group selector. Entries with same `sortKey` are sorted
-    /// alphabetically. Entries without `sortKey` are sorted last. By default,
-    /// ROLE_ANONYMOUS has sortKey "_a" and ROLE_USER has "_b".
+    /// Adds new known groups and updates existing ones. See the documentation
+    /// on "known groups" for more detail in the format.
     Upsert {
         /// File to JSON file containing groups to add.
         file: String,
@@ -81,7 +67,7 @@ fn print_group(group: &KnownGroup) {
     println!("    {}: {{ ", json!(group.role));
     println!(r#"        "label": {},"#, json!(group.label));
     println!(r#"        "implies": {},"#, json!(group.implies));
-    println!(r#"        "warnForAction": {},"#, json!(group.warn_for_action));
+    println!(r#"        "safeActions": {},"#, json!(group.safe_actions));
     println!(r#"        "assignableBy": {},"#, json!(group.assignable_by));
     println!("    }},");
 }
@@ -123,20 +109,20 @@ async fn upsert(file: &str, config: &Config, tx: Transaction<'_>) -> Result<()> 
     let len = groups.len();
     for (role, info) in groups {
         let sql = "insert into known_groups \
-            (role, label, implies, sort_key, warn_for_action, assignable_by) \
+            (role, label, implies, sort_key, safe_actions, assignable_by) \
             values ($1, $2, $3, $4, $5, $6) \
             on conflict (role) do update set \
                 label = excluded.label, \
                 implies = excluded.implies, \
                 sort_key = excluded.sort_key, \
-                warn_for_action = excluded.warn_for_action, \
+                safe_actions = excluded.safe_actions, \
                 assignable_by = excluded.assignable_by";
         tx.execute(sql, &[
             &role,
             &info.label,
             &info.implies,
             &info.sort_key,
-            &info.warn_for_action,
+            &info.safe_actions.unwrap_or_else(|| vec!["read".into()]),
             &info.assignable_by.unwrap_or_else(|| ActionRoleMap(
                 HashMap::from([("read".into(), vec![crate::auth::ROLE_USER.into()])])
             )),
@@ -201,7 +187,7 @@ struct GroupData {
     #[serde(default)]
     implies: Vec<Role>,
 
-    warn_for_action: Vec<String>,
+    safe_actions: Option<Vec<String>>,
     assignable_by: Option<ActionRoleMap>,
     sort_key: Option<String>,
 }

--- a/backend/src/cmd/known_groups.rs
+++ b/backend/src/cmd/known_groups.rs
@@ -78,23 +78,12 @@ pub(crate) async fn run(config: Config, args: &Args) -> Result<()> {
 }
 
 fn print_group(group: &KnownGroup) {
-    print!(r#"    {}: {{ "label": {{"#, json!(group.role));
-
-    // Sort by key to get consistent ordering (hashmap order is random).
-    let mut labels = group.label.iter().collect::<Vec<_>>();
-    labels.sort();
-    for (lang, label) in labels {
-        print!(" {}: {}", json!(lang), json!(label));
-    }
-    print!(r#" }}, "implies": ["#);
-    for (i, role) in group.implies.iter().enumerate() {
-        if i > 0 {
-            print!(", ");
-        }
-        print!("{}", json!(role));
-    }
-    print!(r#"], "warnForAction": {}, "assignableBy": {} }}"#,
-        json!(group.warn_for_action), json!(group.assignable_by.0));
+    println!("    {}: {{ ", json!(group.role));
+    println!(r#"        "label": {},"#, json!(group.label));
+    println!(r#"        "implies": {},"#, json!(group.implies));
+    println!(r#"        "warnForAction": {},"#, json!(group.warn_for_action));
+    println!(r#"        "assignableBy": {},"#, json!(group.assignable_by));
+    println!("    }},");
 }
 
 async fn list(tx: Transaction<'_>) -> Result<()> {
@@ -107,7 +96,6 @@ async fn list(tx: Transaction<'_>) -> Result<()> {
     rows.try_for_each(|row| {
         let group = KnownGroup::from_row_start(&row);
         print_group(&group);
-        println!(",");
         future::ready(Ok(()))
     }).await?;
     println!("}}");
@@ -176,7 +164,6 @@ async fn remove(roles: &[String], tx: Transaction<'_>) -> Result<()> {
         for row in &rows {
             let group = KnownGroup::from_row_start(&row);
             print_group(&group);
-            println!(",");
         }
         println!("}}");
     }

--- a/backend/src/db/migrations.rs
+++ b/backend/src/db/migrations.rs
@@ -382,4 +382,5 @@ static MIGRATIONS: Lazy<BTreeMap<u64, Migration>> = include_migrations![
     47: "search-thumbnail-info-with-state",
     48: "user-session-timestamp-fix",
     49: "bookmarks",
+    50: "group-permissions",
 ];

--- a/backend/src/db/migrations/50-group-permissions.sql
+++ b/backend/src/db/migrations/50-group-permissions.sql
@@ -1,0 +1,58 @@
+--  Adds `assignable_by`: a mapping from action to the list of roles allowed to
+-- assign that group for that action. Empty/missing entries for actions
+-- mean that only admins can assign the group for that action (`read` is still
+-- implied by `write`)
+-- Also replaces the `large` boolean on known groups with `warn_for_action`
+-- (a list of actions that should trigger a warning when assigned).
+--
+-- Existing groups are migrated to `warn_for_action = ['write']` (iff they
+-- were `large`) and `assignable_by = { "write": ["ROLE_ANONYMOUS"] }`.
+-- This preserves today's behavior (anyone can assign any group for any action).
+-- Admins will have to manually adjust `assignable_by` after this migration (if needed).
+
+alter table known_groups add column warn_for_action text[] not null default '{}';
+update known_groups set warn_for_action = array['write'] where large;
+alter table known_groups drop column large;
+
+alter table known_groups
+    add column assignable_by jsonb not null default '{"write": ["ROLE_ANONYMOUS"]}'::jsonb;
+alter table known_groups alter column assignable_by drop default;
+
+-- Verifies that `assignable_by` follows the expected format: a JSON object
+-- mapping action names to arrays of role strings.
+create or replace function check_known_groups_assignable_by_format() returns trigger as $$
+declare
+    col text := 'known_groups.assignable_by';
+    field record;
+    element jsonb;
+begin
+    if jsonb_typeof(new.assignable_by) <> 'object' then
+        raise exception '% is %, but should be a JSON object', col, jsonb_typeof(new.assignable_by);
+    end if;
+
+    for field in select * from jsonb_each(new.assignable_by) loop
+        if jsonb_typeof(field.value) <> 'array' then
+            raise exception '%: type of field "%" is %, but should be an array',
+                col,
+                field.key,
+                jsonb_typeof(field.value);
+        end if;
+
+        for element in select * from jsonb_array_elements(field.value) loop
+            if jsonb_typeof(element) <> 'string' then
+                raise exception '%: found non-string element "%" in field "%", but that field should be a string array',
+                    col,
+                    element,
+                    field.key;
+            end if;
+        end loop;
+    end loop;
+
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger check_known_groups_assignable_by_format_on_upsert
+    before insert or update on known_groups
+    for each row
+    execute procedure check_known_groups_assignable_by_format();

--- a/backend/src/db/migrations/50-group-permissions.sql
+++ b/backend/src/db/migrations/50-group-permissions.sql
@@ -1,17 +1,14 @@
---  Adds `assignable_by`: a mapping from action to the list of roles allowed to
+-- Adds `assignable_by`: a mapping from action to the list of roles allowed to
 -- assign that group for that action. Empty/missing entries for actions
 -- mean that only admins can assign the group for that action (`read` is still
--- implied by `write`)
--- Also replaces the `large` boolean on known groups with `warn_for_action`
--- (a list of actions that should trigger a warning when assigned).
+-- implied by `write`).
 --
--- Existing groups are migrated to `warn_for_action = ['write']` (iff they
--- were `large`) and `assignable_by = { "write": ["ROLE_ANONYMOUS"] }`.
--- This preserves today's behavior (anyone can assign any group for any action).
--- Admins will have to manually adjust `assignable_by` after this migration (if needed).
+-- Also replaces the `large` boolean on known groups with `safe_actions`, a
+-- list of actions that is considered harmless to assign to that group. All
+-- other actions will show a warning in the UI.
 
-alter table known_groups add column warn_for_action text[] not null default '{}';
-update known_groups set warn_for_action = array['write'] where large;
+alter table known_groups add column safe_actions text[] not null default array['read'];
+update known_groups set safe_actions = array['read', 'write'] where not large;
 alter table known_groups drop column large;
 
 alter table known_groups

--- a/backend/src/db/migrations/50-group-permissions.sql
+++ b/backend/src/db/migrations/50-group-permissions.sql
@@ -15,8 +15,11 @@ update known_groups set warn_for_action = array['write'] where large;
 alter table known_groups drop column large;
 
 alter table known_groups
-    add column assignable_by jsonb not null default '{"write": ["ROLE_ANONYMOUS"]}'::jsonb;
+    add column assignable_by jsonb not null default '{"write": ["ROLE_USER"]}'::jsonb;
 alter table known_groups alter column assignable_by drop default;
+update known_groups
+    set assignable_by = '{"read": ["ROLE_USER"]}'::jsonb
+    where role in ('ROLE_ANONYMOUS', 'ROLE_USER');
 
 -- Verifies that `assignable_by` follows the expected format: a JSON object
 -- mapping action names to arrays of role strings.

--- a/backend/src/db/types.rs
+++ b/backend/src/db/types.rs
@@ -66,21 +66,22 @@ pub struct PlaylistEntry {
 }
 
 
-/// Represents the type for the `custom_action_roles` field from `32-custom-actions.sql`.
-/// This holds a mapping of actions to lists holding roles that are allowed
-/// to carry out the respective action.
-#[derive(Debug, Serialize, Deserialize, Default)]
+/// Represents a JSON object mapping an action (like `read` and/or `write`) to a
+/// list of roles. Used for the `custom_action_roles` field on events from
+/// `32-custom-actions.sql` and the `assignable_by` field on known groups
+/// from `49-group-permissions.sql`.
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-pub(crate) struct CustomActions(pub(crate) HashMap<String, Vec<String>>);
+pub(crate) struct ActionRoleMap(pub(crate) HashMap<String, Vec<String>>);
 
-impl ToSql for CustomActions {
+impl ToSql for ActionRoleMap {
     fn to_sql(
         &self,
         ty: &postgres_types::Type,
         out: &mut BytesMut,
     ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
         serde_json::to_value(self)
-            .expect("failed to convert `CustomActions` to JSON value")
+            .expect("failed to convert `ActionRoleMap` to JSON value")
             .to_sql(ty, out)
     }
 
@@ -91,7 +92,7 @@ impl ToSql for CustomActions {
     postgres_types::to_sql_checked!();
 }
 
-impl<'a> FromSql<'a> for CustomActions {
+impl<'a> FromSql<'a> for ActionRoleMap {
     fn from_sql(
         ty: &postgres_types::Type,
         raw: &'a [u8],

--- a/backend/src/model/acl.rs
+++ b/backend/src/model/acl.rs
@@ -3,6 +3,9 @@ use juniper::GraphQLInputObject;
 use serde::Serialize;
 
 
+pub const REALM_ADMIN_ACTION: &str = "tobira:realm:admin";
+pub const REALM_MODERATE_ACTION: &str = "tobira:realm:moderate";
+
 /// A role being granted permission to perform certain actions.
 #[derive(Debug, GraphQLInputObject, Serialize)]
 pub struct AclItem {

--- a/backend/src/model/acl.rs
+++ b/backend/src/model/acl.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use juniper::GraphQLInputObject;
 use serde::Serialize;
 
@@ -7,4 +8,64 @@ use serde::Serialize;
 pub struct AclItem {
     pub role: String,
     pub actions: Vec<String>,
+}
+
+/// ACL as stored in the DB: separate lists per action.
+#[derive(Debug, Clone)]
+pub(crate) struct AclForDb {
+    pub(crate) read_roles: Vec<String>,
+    pub(crate) write_roles: Vec<String>,
+    // todo: add custom and preview roles for events when sent by frontend
+    // preview_roles: Option<Vec<String>>,
+    // custom_action_roles: Option<CustomActions>,
+}
+
+impl AclForDb {
+    pub(crate) fn empty() -> Self {
+        Self {
+            read_roles: Vec::new(),
+            write_roles: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_items(entries: &[AclItem]) -> Self {
+        let mut read_roles = HashSet::new();
+        let mut write_roles = HashSet::new();
+        // let mut preview_roles = HashSet::new();
+        // let mut custom_action_roles = CustomActions::default();
+
+        for entry in entries {
+            let role = &entry.role;
+            for action in &entry.actions {
+                match action.as_str() {
+                    // "preview" => { preview_roles.insert(role.clone()); }
+                    "read" => { read_roles.insert(role.clone()); }
+                    "write" => { write_roles.insert(role.clone()); }
+                    _ => {
+                        // custom_action_roles.0.entry(action)
+                        //     .or_insert_default()
+                        //     .push(role.clone());
+                        todo!();
+                    }
+                };
+            }
+        }
+
+        AclForDb {
+            read_roles: read_roles.into_iter().collect(),
+            write_roles: write_roles.into_iter().collect(),
+            // todo: add custom and preview roles when sent by frontend
+            // preview_roles: preview_roles.into_iter().collect(),
+            // custom_action_roles,
+        }
+    }
+
+    /// Returns the list of roles that are allowed to perform the given action.
+    pub(crate) fn roles_for_action(&self, action: &str) -> &[String] {
+        match action {
+            "read" => &self.read_roles,
+            "write" => &self.write_roles,
+            _ => &[],
+        }
+    }
 }

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -45,6 +45,18 @@ impl KnownGroup {
         context.db.query_mapped(&query, dbargs![], |row| Self::from_row_start(&row)).await
     }
 
+    /// Loads the known-group rows matching any of the given roles. Roles with
+    /// no matching row are simply absent from the result since they are not
+    /// tracked as known groups.
+    pub(crate) async fn load_by_roles(
+        roles: &[&str],
+        context: &Context,
+    ) -> Result<Vec<Self>, tokio_postgres::Error> {
+        let selection = Self::select();
+        let query = format!("select {selection} from known_groups where role = any($1)");
+        context.db.query_mapped(&query, dbargs![&roles], |row| Self::from_row_start(&row)).await
+    }
+
     /// Returns the set of actions that the current user is allowed to hand out for a specific group.
     pub(crate) fn actions_assignable_by(
         &self,

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
+
 use serde::Deserialize;
 
-use crate::{api::Context, db::util::{impl_from_db}, prelude::*};
+use crate::{api::Context, db::{types::ActionRoleMap, util::{impl_from_db}}, prelude::*};
 
 use super::{TranslatedString};
 
@@ -9,19 +11,20 @@ use super::{TranslatedString};
 
 /// A group selectable in the ACL UI. Basically a mapping from role to a nice
 /// label and info about the relationship to other roles/groups.
-#[derive(juniper::GraphQLObject)]
+#[derive(Debug)]
 pub struct KnownGroup {
     pub role: String,
     pub label: TranslatedString,
     pub implies: Vec<String>,
     pub sort_key: Option<String>,
     pub warn_for_action: Vec<String>,
+    pub assignable_by: ActionRoleMap,
 }
 
 impl_from_db!(
     KnownGroup,
     select: {
-        known_groups.{ role, label, implies, sort_key, warn_for_action },
+        known_groups.{ role, label, implies, sort_key, warn_for_action, assignable_by },
     },
     |row| {
         KnownGroup {
@@ -30,6 +33,7 @@ impl_from_db!(
             implies: row.implies(),
             sort_key: row.sort_key(),
             warn_for_action: row.warn_for_action(),
+            assignable_by: row.assignable_by(),
         }
     },
 );
@@ -40,6 +44,37 @@ impl KnownGroup {
         let query = format!("select {selection} from known_groups");
         context.db.query_mapped(&query, dbargs![], |row| Self::from_row_start(&row)).await
     }
+
+    /// Returns the set of actions that the current user is allowed to hand out for a specific group.
+    pub(crate) fn actions_assignable_by(
+        &self,
+        user_roles: &HashSet<String>,
+        is_admin: bool,
+    ) -> Vec<String> {
+        actions_assignable_by(&self.assignable_by, user_roles, is_admin)
+    }
+}
+
+/// Returns the set of actions that the current user is allowed to hand out for a specific group.
+pub(crate) fn actions_assignable_by(
+    assignable_by: &ActionRoleMap,
+    user_roles: &HashSet<String>,
+    is_admin: bool,
+) -> Vec<String> {
+    let mut candidate_actions: HashSet<&str> = ["read", "write"].into_iter().collect();
+    candidate_actions.extend(assignable_by.0.keys().map(String::as_str));
+
+    let is_allowed_for = |action: &str| {
+        assignable_by.0.get(action)
+            .is_some_and(|roles| roles.iter().any(|role| user_roles.contains(role)))
+    };
+
+    candidate_actions.into_iter()
+        .filter(|action| {
+            is_admin || is_allowed_for(action) || (*action == "read" && is_allowed_for("write"))
+        })
+        .map(str::to_owned)
+        .collect()
 }
 
 

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -15,13 +15,13 @@ pub struct KnownGroup {
     pub label: TranslatedString,
     pub implies: Vec<String>,
     pub sort_key: Option<String>,
-    pub large: bool,
+    pub warn_for_action: Vec<String>,
 }
 
 impl_from_db!(
     KnownGroup,
     select: {
-        known_groups.{ role, label, implies, sort_key, large },
+        known_groups.{ role, label, implies, sort_key, warn_for_action },
     },
     |row| {
         KnownGroup {
@@ -29,7 +29,7 @@ impl_from_db!(
             label: row.label(),
             implies: row.implies(),
             sort_key: row.sort_key(),
-            large: row.large(),
+            warn_for_action: row.warn_for_action(),
         }
     },
 );

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -68,25 +68,28 @@ impl KnownGroup {
 }
 
 /// Returns the set of actions that the current user is allowed to hand out for a specific group.
+/// For admins, an empty list is returned, as the frontend has the logic for the special
+/// "admin can do anything".
 pub(crate) fn actions_assignable_by(
     assignable_by: &ActionRoleMap,
     user_roles: &HashSet<String>,
     is_admin: bool,
 ) -> Vec<String> {
-    let mut candidate_actions: HashSet<&str> = ["read", "write"].into_iter().collect();
-    candidate_actions.extend(assignable_by.0.keys().map(String::as_str));
+    if is_admin {
+        return Vec::new();
+    }
 
-    let is_allowed_for = |action: &str| {
-        assignable_by.0.get(action)
-            .is_some_and(|roles| roles.iter().any(|role| user_roles.contains(role)))
-    };
+    let mut out = assignable_by.0.iter()
+        .filter(|(_action, roles)| roles.iter().any(|role| user_roles.contains(role)))
+        .map(|(action, _roles)| action.as_str())
+        .collect::<Vec<_>>();
 
-    candidate_actions.into_iter()
-        .filter(|action| {
-            is_admin || is_allowed_for(action) || (*action == "read" && is_allowed_for("write"))
-        })
-        .map(str::to_owned)
-        .collect()
+    // Apply implicit rule that `write` implies `read`.
+    if out.contains(&"write") && !out.contains(&"read") {
+        out.push("read");
+    }
+
+    out.into_iter().map(str::to_owned).collect()
 }
 
 

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -17,14 +17,14 @@ pub struct KnownGroup {
     pub label: TranslatedString,
     pub implies: Vec<String>,
     pub sort_key: Option<String>,
-    pub warn_for_action: Vec<String>,
+    pub safe_actions: Vec<String>,
     pub assignable_by: ActionRoleMap,
 }
 
 impl_from_db!(
     KnownGroup,
     select: {
-        known_groups.{ role, label, implies, sort_key, warn_for_action, assignable_by },
+        known_groups.{ role, label, implies, sort_key, safe_actions, assignable_by },
     },
     |row| {
         KnownGroup {
@@ -32,7 +32,7 @@ impl_from_db!(
             label: row.label(),
             implies: row.implies(),
             sort_key: row.sort_key(),
-            warn_for_action: row.warn_for_action(),
+            safe_actions: row.safe_actions(),
             assignable_by: row.assignable_by(),
         }
     },

--- a/backend/src/model/known_roles.rs
+++ b/backend/src/model/known_roles.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use serde::Deserialize;
 
-use crate::{api::Context, db::{types::ActionRoleMap, util::{impl_from_db}}, prelude::*};
+use crate::{api::Context, db::{types::ActionRoleMap, util::impl_from_db}, model::{REALM_ADMIN_ACTION, REALM_MODERATE_ACTION}, prelude::*};
 
 use super::{TranslatedString};
 
@@ -84,9 +84,12 @@ pub(crate) fn actions_assignable_by(
         .map(|(action, _roles)| action.as_str())
         .collect::<Vec<_>>();
 
-    // Apply implicit rule that `write` implies `read`.
+    // Apply implicit rules
     if out.contains(&"write") && !out.contains(&"read") {
         out.push("read");
+    }
+    if out.contains(&REALM_ADMIN_ACTION) && !out.contains(&REALM_MODERATE_ACTION) {
+        out.push(REALM_MODERATE_ACTION);
     }
 
     out.into_iter().map(str::to_owned).collect()

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use self::{
     },
     extra_metadata::ExtraMetadata,
     key::Key,
-    known_roles::{KnownGroup, KnownUser},
+    known_roles::{actions_assignable_by, KnownGroup, KnownUser},
     misc::ByteSpan,
     series::SeriesState,
     translated_string::{LangKey, TranslatedString},

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -23,7 +23,7 @@ mod series;
 mod translated_string;
 
 pub(crate) use self::{
-    acl::AclItem,
+    acl::{AclForDb, AclItem},
     block::BlockType,
     event::{
         TextMatch, TextAssetType, TimespanText, EventState,

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -23,7 +23,7 @@ mod series;
 mod translated_string;
 
 pub(crate) use self::{
-    acl::{AclForDb, AclItem},
+    acl::{AclForDb, AclItem, REALM_ADMIN_ACTION, REALM_MODERATE_ACTION},
     block::BlockType,
     event::{
         TextMatch, TextAssetType, TimespanText, EventState,

--- a/backend/src/sync/harvest/response.rs
+++ b/backend/src/sync/harvest/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    db::types::{CustomActions, EventCaption, EventSegment, EventTrack},
+    db::types::{ActionRoleMap, EventCaption, EventSegment, EventTrack},
     model::{BlockType, ExtraMetadata},
     sync::DeletionMode,
     Config,
@@ -231,7 +231,7 @@ pub(crate) struct Acl {
     #[serde(default)]
     pub(crate) preview: Vec<String>,
     #[serde(flatten)]
-    pub(crate) custom_actions: CustomActions,
+    pub(crate) custom_actions: ActionRoleMap,
 }
 
 #[derive(Debug, Deserialize)]
@@ -276,7 +276,7 @@ mod tests {
                         preview: vec![],
                         read: vec!["ROLE_ANONYMOUS".into()],
                         write: vec!["ROLE_ANONYMOUS".into()],
-                        custom_actions: CustomActions::default(),
+                        custom_actions: ActionRoleMap::default(),
                     },
                     updated: timestamp(1727866771932),
                     created: None,
@@ -290,7 +290,7 @@ mod tests {
                         preview: vec![],
                         read: vec!["ROLE_ADMIN".into(), "ROLE_ANONYMOUS".into()],
                         write: vec!["ROLE_ADMIN".into()],
-                        custom_actions: CustomActions::default(),
+                        custom_actions: ActionRoleMap::default(),
                     },
                     updated: timestamp(1727866860840),
                     created: timestamp(1727866740000),
@@ -409,7 +409,7 @@ mod tests {
                         read: vec!["ROLE_USER_BOB".into()],
                         write: vec![],
                         preview: vec![],
-                        custom_actions: CustomActions::default(),
+                        custom_actions: ActionRoleMap::default(),
                     },
                     entries: vec![
                         PlaylistEntry {

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -41,15 +41,55 @@ To configure additional known non-user roles, these four commands exist:
 
 Groups are specified in a JSON file in this format (`list` outputs the same format):
 
-```json
+```json5
 {
-    "ROLE_STUDENT": { "label": { "default": "Students", "de": "Studierende" }, "implies": [], "sortKey": "_c", "large": true },
-    "ROLE_STAFF": { "label": { "default": "Staff", "de": "Angestellte" }, "implies": [], "large": true },
-    "ROLE_LECTURER": { "label": { "default": "Lecturers", "de": "Vortragende" }, "implies": ["ROLE_STAFF"], "large": true },
-    "ROLE_TOBIRA_MODERATOR": { "label": { "default": "Moderators", "de": "Moderierende" }, "implies": ["ROLE_STAFF"], "large": false }
+    "ROLE_STUDENT": {
+        "label": { "default": "Students", "de": "Studierende" },
+        "implies": [],
+        "sortKey": "_c",
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+    },
+    "ROLE_STAFF": {
+        "label": { "default": "Staff", "de": "Angestellte" },
+        "implies": [],
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+    },
+    "ROLE_LECTURER": {
+        "label": { "default": "Lecturers", "de": "Vortragende" },
+        "implies": ["ROLE_STAFF"],
+        "warnForAction": ["write"],
+        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+    },
+    "ROLE_TOBIRA_MODERATOR": {
+        "label": { "default": "Moderators", "de": "Moderierende" },
+        "implies": ["ROLE_STAFF"],
+        "warnForAction": [],
+        "assignableBy": {} // Only assignable by admins
+    },
+
+    // Course-scoped groups can restrict who is allowed to see and assign them.
+    // In this example, only members of the course (as students or lecturers)
+    // can grant read access, and only lecturers can grant write access.
+    // Other users won't see this group in the selector at all.
+    "ROLE_COURSE_123_STUDENTS": {
+        "label": { "default": "Course 123 (students)", "de": "Kurs 123 (Studierende)" },
+        "implies": [],
+        "warnForAction": [],
+        "assignableBy": {
+            "read": ["ROLE_COURSE_123_STUDENTS"],
+            "write": ["ROLE_COURSE_123_LECTURERS"]
+        }
+    }
 
     // You can also overwrite the label of built-in groups, if you so desire
-    // "ROLE_USER": { "label": { "default": "...", "de": "..." }, "implies": [], "large": true },
+    // "ROLE_USER": {
+    //     "label": { "default": "...", "de": "..." },
+    //     "implies": [],
+    //     "warnForAction": ["write"],
+    //     "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
+    // },
 }
 ```
 
@@ -61,8 +101,17 @@ Field explanation:
   So all users with `ROLE_LECTURER` always also have the role `ROLE_STAFF`.
   This information is used to improve the user interaction with the ACL interface.
   All roles automatically imply `ROLE_USER` and `ROLE_ANONYMOUS`.
-- `large`: set to `true` if this group is considered so large that giving write access to it is unusual enough to show a warning in the ACL interface.
-  `ROLE_USER` and `ROLE_ANONYMOUS` are both considered large.
+- `warnForAction`: a list of actions (currently `read` and/or `write` are relevant) that should
+  trigger a warning in the ACL interface when granted to this group, e.g. because it is unusually
+  large or broad. `ROLE_USER` and `ROLE_ANONYMOUS` both warn for `write` by default.
+- `assignableBy`: a mapping from action (`read`, `write`) to the list of roles allowed to assign
+  this group for that action. Being allowed to assign a group for `write` implicitly also allows
+  assigning it for `read`. An action that's missing from the map (or an empty list) means only
+  Tobira/Opencast admins can assign the group for that action. Users who cannot assign a group for
+  *any* action don't see it in the ACL selector at all — this is how "internal" groups (e.g. for
+  management staff) or course-scoped groups (many thousands of them, only relevant to their own
+  course) are kept out of everyone else's way. Groups without any matching entry in `assignableBy`
+  for a given role still show up for admins.
 - `sortKey`: optional, used to sort entries in the group selector.
   Entries with same `sortKey` are sorted alphabetically.
   Entries without `sortKey` are sorted last.

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -73,7 +73,8 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
         "safeActions": ["read", "write"],
         "assignableBy": {
             "read": ["ROLE_COURSE_123_STUDENTS"],
-            "write": ["ROLE_COURSE_123_LECTURERS"]
+            "write": ["ROLE_COURSE_123_LECTURERS"],
+            "tobira:realm:moderate": ["ROLE_COURSE_123_LECTURERS"]
         }
     }
 
@@ -97,7 +98,7 @@ Field explanation:
 - `safeActions`: a list of actions that are considered safe to assign to this group. All
   other actions will show a warning in the UI. Defaults to `["read"]` if not specified and for
   `ROLE_USER` and `ROLE_ANONYMOUS`.
-- `assignableBy`: a mapping from action (`read`, `write`) to the list of roles allowed to assign
+- `assignableBy`: a mapping from action to the list of roles allowed to assign
   this group for that action. Being allowed to assign a group for `write` implicitly also allows
   assigning it for `read`. An action that's missing from the map (or an empty list) means only
   Tobira/Opencast admins can assign the group for that action. Users who cannot assign a group for
@@ -109,6 +110,10 @@ Field explanation:
   Entries with same `sortKey` are sorted alphabetically.
   Entries without `sortKey` are sorted last.
   By default, `ROLE_ANONYMOUS` has sortKey "_a" and `ROLE_USER` has "_b".
+
+"Actions" can be anything in an Opencast ACL (though the UI currently supports only `read` and `write`) plus these Tobira-specific ones:
+- `tobira:realm:moderate`: moderator access to a realm
+- `tobira:realm:admin`: page admin access to a realm (imples `tobira:realm:moderate`)
 
 Note that `upsert` is idempotent, so you can simply call this as part of your Ansible script, for example.
 

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -47,20 +47,17 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
         "label": { "default": "Students", "de": "Studierende" },
         "implies": [],
         "sortKey": "_c",
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+        "warnForAction": ["write"]
     },
     "ROLE_STAFF": {
         "label": { "default": "Staff", "de": "Angestellte" },
         "implies": [],
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+        "warnForAction": ["write"]
     },
     "ROLE_LECTURER": {
         "label": { "default": "Lecturers", "de": "Vortragende" },
         "implies": ["ROLE_STAFF"],
-        "warnForAction": ["write"],
-        "assignableBy": { "read": ["ROLE_ANONYMOUS"] }
+        "warnForAction": ["write"]
     },
     "ROLE_TOBIRA_MODERATOR": {
         "label": { "default": "Moderators", "de": "Moderierende" },
@@ -88,7 +85,6 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
     //     "label": { "default": "...", "de": "..." },
     //     "implies": [],
     //     "warnForAction": ["write"],
-    //     "assignableBy": { "read": ["ROLE_ANONYMOUS"] },
     // },
 }
 ```
@@ -111,7 +107,7 @@ Field explanation:
   *any* action don't see it in the ACL selector at all — this is how "internal" groups (e.g. for
   management staff) or course-scoped groups (many thousands of them, only relevant to their own
   course) are kept out of everyone else's way. Groups without any matching entry in `assignableBy`
-  for a given role still show up for admins.
+  for a given role still show up for admins. Optional, defaults to `{ "read": ["ROLE_USER"] }`.
 - `sortKey`: optional, used to sort entries in the group selector.
   Entries with same `sortKey` are sorted alphabetically.
   Entries without `sortKey` are sorted last.

--- a/docs/docs/setup/config.md
+++ b/docs/docs/setup/config.md
@@ -46,23 +46,20 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
     "ROLE_STUDENT": {
         "label": { "default": "Students", "de": "Studierende" },
         "implies": [],
-        "sortKey": "_c",
-        "warnForAction": ["write"]
+        "sortKey": "_c"
     },
     "ROLE_STAFF": {
         "label": { "default": "Staff", "de": "Angestellte" },
-        "implies": [],
-        "warnForAction": ["write"]
+        "implies": []
     },
     "ROLE_LECTURER": {
         "label": { "default": "Lecturers", "de": "Vortragende" },
-        "implies": ["ROLE_STAFF"],
-        "warnForAction": ["write"]
+        "implies": ["ROLE_STAFF"]
     },
     "ROLE_TOBIRA_MODERATOR": {
         "label": { "default": "Moderators", "de": "Moderierende" },
         "implies": ["ROLE_STAFF"],
-        "warnForAction": [],
+        "safeActions": ["read", "write"],
         "assignableBy": {} // Only assignable by admins
     },
 
@@ -73,7 +70,7 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
     "ROLE_COURSE_123_STUDENTS": {
         "label": { "default": "Course 123 (students)", "de": "Kurs 123 (Studierende)" },
         "implies": [],
-        "warnForAction": [],
+        "safeActions": ["read", "write"],
         "assignableBy": {
             "read": ["ROLE_COURSE_123_STUDENTS"],
             "write": ["ROLE_COURSE_123_LECTURERS"]
@@ -84,7 +81,7 @@ Groups are specified in a JSON file in this format (`list` outputs the same form
     // "ROLE_USER": {
     //     "label": { "default": "...", "de": "..." },
     //     "implies": [],
-    //     "warnForAction": ["write"],
+    //     "safeActions": ["read"],
     // },
 }
 ```
@@ -97,9 +94,9 @@ Field explanation:
   So all users with `ROLE_LECTURER` always also have the role `ROLE_STAFF`.
   This information is used to improve the user interaction with the ACL interface.
   All roles automatically imply `ROLE_USER` and `ROLE_ANONYMOUS`.
-- `warnForAction`: a list of actions (currently `read` and/or `write` are relevant) that should
-  trigger a warning in the ACL interface when granted to this group, e.g. because it is unusually
-  large or broad. `ROLE_USER` and `ROLE_ANONYMOUS` both warn for `write` by default.
+- `safeActions`: a list of actions that are considered safe to assign to this group. All
+  other actions will show a warning in the UI. Defaults to `["read"]` if not specified and for
+  `ROLE_USER` and `ROLE_ANONYMOUS`.
 - `assignableBy`: a mapping from action (`read`, `write`) to the list of roles allowed to assign
   this group for that action. Being allowed to assign a group for `write` implicitly also allows
   assigning it for `read`. An action that's missing from the map (or an empty list) means only

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -857,3 +857,5 @@ api-remote-errors:
     not-found: "Aktion fehlgeschlagen: Playlist nicht gefunden."
     entry-not-found: Es wurde versucht, unbekannte Einträge hinzuzufügen.
     not-allowed: Sie haben nicht die Berechtigung, diese Playlist-Aktion durchzuführen.
+  acl:
+    assign-not-allowed: Sie sind nicht berechtigt, diese Berechtigung zu vergeben.

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -388,7 +388,7 @@ acl:
     admin-user: Admin
     unknown-user-note: unbekannt
     no-entries: Keine Einträge
-    subset-warning: 'Diese Auswahl ist bereits in den folgenden Gruppen enthalten: {{groups}}.'
+    subset-warning: 'Diese Auswahl ist bereits enthalten und wird durch die folgenden Gruppen überschrieben: {{groups}}.'
     inherited: 'Geerbte Berechtigungen:'
     inherited-tooltip: >
       Die folgenden Berechtigungen wurden auf einer übergeordneten Seite gewährt und werden an alle Unterseiten

--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -428,10 +428,7 @@ acl:
         Kann moderieren, Seiten löschen und Berechtigungen bearbeiten.
       realm-admin-description_other: >
         Können moderieren, Seiten löschen und Berechtigungen bearbeiten.
-      write-access: Schreibzugriff
-      moderate-access: Moderationsrechte
-      admin-access: Adminrechte
-      large-group-warning: Sie geben einer großen Gruppe {{val}}. Ist das beabsichtigt?
+      large-group-warning: Sie geben dieser ganzen Gruppe '{{val}}' Berechtigung. Ist das beabsichtigt?
   unlisted:
       note: Dieses Video ist ungelistet.
       explanation: >

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -382,7 +382,7 @@ acl:
     admin-user: Admin
     unknown-user-note: unknown
     no-entries: No entries
-    subset-warning: 'This selection is already included in the following group(s): {{groups}}.'
+    subset-warning: 'This selection is already included in and overridden by the following group(s): {{groups}}.'
     inherited: 'Inherited permissions:'
     inherited-tooltip: >
       The following permissions were granted in a higher level page and are inherited to all subpages.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -815,3 +815,5 @@ api-remote-errors:
     not-found: "Action failed: playlist not found."
     entry-not-found: Attempted to add unknown entries.
     not-allowed: You are not allowed to perform this playlist action.
+  acl:
+    assign-not-allowed: You are not allowed to grant this permission.

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -402,10 +402,7 @@ acl:
       playlist-write-description: Can delete the playlist, change metadata and add or remove videos.
       realm-moderate-description: Can edit content, add subpages and change the name and subpage order.
       realm-admin-description: Can moderate, delete pages and edit permissions.
-      write-access: write-access
-      moderate-access: moderating-rights
-      admin-access: page admin-rights
-      large-group-warning: You are giving {{val}} to a large group. Is this intentional?
+      large-group-warning: You are giving '{{val}}' permissions to this whole group. Is this intentional?
   unlisted:
     note: This video is unlisted.
     explanation: >

--- a/frontend/src/i18n/locales/fr.yaml
+++ b/frontend/src/i18n/locales/fr.yaml
@@ -421,10 +421,7 @@ acl:
       realm-admin-description: Peut modérer, supprimer des pages et modifier les autorisations.
       realm-admin-description_one: Peut modérer, supprimer des pages et modifier les autorisations.
       realm-admin-description_other: Peuvent modérer, supprimer des pages et modifier les autorisations.
-      write-access: Droit d’écriture
-      moderate-access: Droits de modération
-      admin-access: Droits d'administration
-      large-group-warning: Vous donnez {{val}} à un grand groupe. Est-ce volontaire ?
+      large-group-warning: Vous donnez l'autorisation '{{val}}' à tout ce groupe. Est-ce volontaire ? # needs verification
   unlisted:
     note: Cette vidéo n'est pas répertoriée.
     explanation: >

--- a/frontend/src/i18n/locales/it.yaml
+++ b/frontend/src/i18n/locales/it.yaml
@@ -432,10 +432,7 @@ acl:
       realm-admin-description: —
       realm-admin-description_one: Può moderare, cancellare pagine e modificare le autorizzazioni.
       realm-admin-description_other: Possono moderare, cancellare pagine e modificare le autorizzazioni.
-      write-access: accesso in scrittura
-      moderate-access: diritti di moderazione
-      admin-access: pagina diritti-amministratore
-      large-group-warning: State dando {{val}} a un gruppo numeroso. È una cosa intenzionale?
+      large-group-warning: State dando a questo intero gruppo l'autorizzazione '{{val}}'. È una cosa intenzionale? #needs verification
   unlisted:
     note: Questo video non è in elenco.
     explanation: >

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -95,7 +95,7 @@ const query = graphql`
             description
             created
             canWrite
-            acl { role actions info { label implies large } }
+            acl { role actions info { label implies warnForAction } }
         }
     }
 `;
@@ -823,7 +823,7 @@ const SeriesAclQuery = graphql`
     query UploadSeriesAclQuery($seriesId: String!) {
         series: seriesByOpencastId(id: $seriesId) {
             id
-            acl { role actions info { label implies large } }
+            acl { role actions info { label implies warnForAction } }
         }
     }
 `;

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -95,7 +95,7 @@ const query = graphql`
             description
             created
             canWrite
-            acl { role actions info { label implies warnForAction } }
+            acl { role actions info { label implies warnForAction assignableActions } }
         }
     }
 `;
@@ -823,7 +823,7 @@ const SeriesAclQuery = graphql`
     query UploadSeriesAclQuery($seriesId: String!) {
         series: seriesByOpencastId(id: $seriesId) {
             id
-            acl { role actions info { label implies warnForAction } }
+            acl { role actions info { label implies warnForAction assignableActions } }
         }
     }
 `;

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -908,7 +908,7 @@ const MetaDataEdit: React.FC<MetaDataEditProps> = ({
 
     const formMethods = useForm<Metadata>({
         mode: "onChange",
-        defaultValues: { acl: defaultAclMap(user) },
+        defaultValues: { acl: defaultAclMap(user, knownRoles) },
     });
     const { handleSubmit, control, formState: { isValid, errors } } = formMethods;
 

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -95,7 +95,7 @@ const query = graphql`
             description
             created
             canWrite
-            acl { role actions info { label implies warnForAction assignableActions } }
+            acl { role actions info { label implies safeActions assignableActions } }
         }
     }
 `;
@@ -823,7 +823,7 @@ const SeriesAclQuery = graphql`
     query UploadSeriesAclQuery($seriesId: String!) {
         series: seriesByOpencastId(id: $seriesId) {
             id
-            acl { role actions info { label implies warnForAction assignableActions } }
+            acl { role actions info { label implies safeActions assignableActions } }
         }
     }
 `;

--- a/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
+++ b/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
@@ -29,7 +29,7 @@ const updatePlaylistAcl = graphql`
     mutation PlaylistAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updatePlaylist(id: $id, acl: $acl) {
             ...on AuthorizedPlaylist {
-                acl { role actions info { label implies warnForAction } }
+                acl { role actions info { label implies warnForAction assignableActions } }
             }
         }
     }

--- a/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
+++ b/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
@@ -29,7 +29,7 @@ const updatePlaylistAcl = graphql`
     mutation PlaylistAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updatePlaylist(id: $id, acl: $acl) {
             ...on AuthorizedPlaylist {
-                acl { role actions info { label implies large } }
+                acl { role actions info { label implies warnForAction } }
             }
         }
     }

--- a/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
+++ b/frontend/src/routes/manage/Playlist/PlaylistAccess.tsx
@@ -29,7 +29,7 @@ const updatePlaylistAcl = graphql`
     mutation PlaylistAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updatePlaylist(id: $id, acl: $acl) {
             ...on AuthorizedPlaylist {
-                acl { role actions info { label implies warnForAction assignableActions } }
+                acl { role actions info { label implies safeActions assignableActions } }
             }
         }
     }

--- a/frontend/src/routes/manage/Playlist/Shared.tsx
+++ b/frontend/src/routes/manage/Playlist/Shared.tsx
@@ -90,7 +90,7 @@ const query = graphql`
                 readRoles
                 writeRoles
                 hasPublicRssFeed
-                acl { role actions info { label implies large } }
+                acl { role actions info { label implies warnForAction } }
                 updated
                 thumbnailStack { thumbnails { url live audioOnly state }}
                 entries {

--- a/frontend/src/routes/manage/Playlist/Shared.tsx
+++ b/frontend/src/routes/manage/Playlist/Shared.tsx
@@ -90,7 +90,7 @@ const query = graphql`
                 readRoles
                 writeRoles
                 hasPublicRssFeed
-                acl { role actions info { label implies warnForAction } }
+                acl { role actions info { label implies warnForAction assignableActions } }
                 updated
                 thumbnailStack { thumbnails { url live audioOnly state }}
                 entries {

--- a/frontend/src/routes/manage/Playlist/Shared.tsx
+++ b/frontend/src/routes/manage/Playlist/Shared.tsx
@@ -90,7 +90,7 @@ const query = graphql`
                 readRoles
                 writeRoles
                 hasPublicRssFeed
-                acl { role actions info { label implies warnForAction assignableActions } }
+                acl { role actions info { label implies safeActions assignableActions } }
                 updated
                 thumbnailStack { thumbnails { url live audioOnly state }}
                 entries {

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -17,8 +17,8 @@ import { aclArrayToMap } from "../../util";
 const fragment = graphql`
     fragment RealmPermissionsData on Realm {
         id
-        ownAcl { role actions info { label implies large } }
-        inheritedAcl { role actions info { label implies large } }
+        ownAcl { role actions info { label implies warnForAction } }
+        inheritedAcl { role actions info { label implies warnForAction } }
         ownerDisplayName
         ancestors { ownerDisplayName }
     }
@@ -45,7 +45,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const [commit, inFlight] = useMutation<RealmPermissionsMutation>(graphql`
         mutation RealmPermissionsMutation($id: ID!, $permissions: UpdatedPermissions!) {
             updatePermissions(id: $id, permissions: $permissions) {
-                ownAcl { role actions info { label implies large } }
+                ownAcl { role actions info { label implies warnForAction } }
                 isCurrentUserPageAdmin
                 canCurrentUserModerate
                 ... GeneralRealmData

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -17,8 +17,8 @@ import { aclArrayToMap } from "../../util";
 const fragment = graphql`
     fragment RealmPermissionsData on Realm {
         id
-        ownAcl { role actions info { label implies warnForAction } }
-        inheritedAcl { role actions info { label implies warnForAction } }
+        ownAcl { role actions info { label implies warnForAction assignableActions } }
+        inheritedAcl { role actions info { label implies warnForAction assignableActions } }
         ownerDisplayName
         ancestors { ownerDisplayName }
     }
@@ -45,7 +45,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const [commit, inFlight] = useMutation<RealmPermissionsMutation>(graphql`
         mutation RealmPermissionsMutation($id: ID!, $permissions: UpdatedPermissions!) {
             updatePermissions(id: $id, permissions: $permissions) {
-                ownAcl { role actions info { label implies warnForAction } }
+                ownAcl { role actions info { label implies warnForAction assignableActions } }
                 isCurrentUserPageAdmin
                 canCurrentUserModerate
                 ... GeneralRealmData

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -94,7 +94,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclEditButtons
             userIsOwner={!!ownerDisplayName}
             css={{ marginTop: 16 }}
-            kind="admin"
+            warnIfActionLost="admin"
             {...{
                 selections,
                 setSelections,

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -10,7 +10,9 @@ import { ConfirmationModalHandle } from "../../../ui/Modal";
 import { boxError } from "@opencast/appkit";
 import { displayCommitError } from "./util";
 import { currentRef } from "../../../util";
-import { MODERATE_ADMIN_ACTIONS } from "../../../util/permissionLevels";
+import {
+    MODERATE_ADMIN_ACTIONS, REALM_ADMIN_ACTION, REALM_MODERATE_ACTION,
+} from "../../../util/permissionLevels";
 import { aclArrayToMap } from "../../util";
 
 
@@ -57,11 +59,11 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         const [moderatorRoles, adminRoles]: string[][] = [[], []];
 
         for (const [role, { actions }] of selections) {
-            if (actions.has("moderate")) {
+            if (actions.has(REALM_MODERATE_ACTION)) {
                 moderatorRoles.push(role);
             }
 
-            if (actions.has("admin")) {
+            if (actions.has(REALM_ADMIN_ACTION)) {
                 adminRoles.push(role);
             }
         }
@@ -94,7 +96,8 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
         <AclEditButtons
             userIsOwner={!!ownerDisplayName}
             css={{ marginTop: 16 }}
-            warnIfActionLost="admin"
+            warnIfActionLost={REALM_ADMIN_ACTION}
+            warningText={t("acl.save-modal.disclaimer-admin")}
             {...{
                 selections,
                 setSelections,

--- a/frontend/src/routes/manage/Realm/RealmPermissions.tsx
+++ b/frontend/src/routes/manage/Realm/RealmPermissions.tsx
@@ -17,8 +17,8 @@ import { aclArrayToMap } from "../../util";
 const fragment = graphql`
     fragment RealmPermissionsData on Realm {
         id
-        ownAcl { role actions info { label implies warnForAction assignableActions } }
-        inheritedAcl { role actions info { label implies warnForAction assignableActions } }
+        ownAcl { role actions info { label implies safeActions assignableActions } }
+        inheritedAcl { role actions info { label implies safeActions assignableActions } }
         ownerDisplayName
         ancestors { ownerDisplayName }
     }
@@ -45,7 +45,7 @@ export const RealmPermissions: React.FC<Props> = ({ fragRef, data }) => {
     const [commit, inFlight] = useMutation<RealmPermissionsMutation>(graphql`
         mutation RealmPermissionsMutation($id: ID!, $permissions: UpdatedPermissions!) {
             updatePermissions(id: $id, permissions: $permissions) {
-                ownAcl { role actions info { label implies warnForAction assignableActions } }
+                ownAcl { role actions info { label implies safeActions assignableActions } }
                 isCurrentUserPageAdmin
                 canCurrentUserModerate
                 ... GeneralRealmData

--- a/frontend/src/routes/manage/Series/SeriesAccess.tsx
+++ b/frontend/src/routes/manage/Series/SeriesAccess.tsx
@@ -30,7 +30,7 @@ const updateSeriesAcl = graphql`
     mutation SeriesAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateSeriesAcl(id: $id, acl: $acl) {
             ...on Series {
-                acl { role actions info { label implies warnForAction } }
+                acl { role actions info { label implies warnForAction assignableActions } }
             }
         }
     }

--- a/frontend/src/routes/manage/Series/SeriesAccess.tsx
+++ b/frontend/src/routes/manage/Series/SeriesAccess.tsx
@@ -30,7 +30,7 @@ const updateSeriesAcl = graphql`
     mutation SeriesAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateSeriesAcl(id: $id, acl: $acl) {
             ...on Series {
-                acl { role actions info { label implies large } }
+                acl { role actions info { label implies warnForAction } }
             }
         }
     }

--- a/frontend/src/routes/manage/Series/SeriesAccess.tsx
+++ b/frontend/src/routes/manage/Series/SeriesAccess.tsx
@@ -30,7 +30,7 @@ const updateSeriesAcl = graphql`
     mutation SeriesAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateSeriesAcl(id: $id, acl: $acl) {
             ...on Series {
-                acl { role actions info { label implies warnForAction assignableActions } }
+                acl { role actions info { label implies safeActions assignableActions } }
             }
         }
     }

--- a/frontend/src/routes/manage/Series/Shared.tsx
+++ b/frontend/src/routes/manage/Series/Shared.tsx
@@ -85,7 +85,7 @@ const query = graphql`
             title
             created
             updated
-            acl { role actions info { label implies warnForAction } }
+            acl { role actions info { label implies warnForAction assignableActions } }
             canWrite
             description
             state

--- a/frontend/src/routes/manage/Series/Shared.tsx
+++ b/frontend/src/routes/manage/Series/Shared.tsx
@@ -85,7 +85,7 @@ const query = graphql`
             title
             created
             updated
-            acl { role actions info { label implies large } }
+            acl { role actions info { label implies warnForAction } }
             canWrite
             description
             state

--- a/frontend/src/routes/manage/Series/Shared.tsx
+++ b/frontend/src/routes/manage/Series/Shared.tsx
@@ -85,7 +85,7 @@ const query = graphql`
             title
             created
             updated
-            acl { role actions info { label implies warnForAction assignableActions } }
+            acl { role actions info { label implies safeActions assignableActions } }
             canWrite
             description
             state

--- a/frontend/src/routes/manage/Shared/Access.tsx
+++ b/frontend/src/routes/manage/Shared/Access.tsx
@@ -75,6 +75,7 @@ export const AccessEditor: React.FC<AccessEditorProps> = ({
     editingBlocked = false,
     itemType,
 }) => {
+    const { t } = useTranslation();
     const knownRoles = useFragment(knownRolesFragment, data);
     const saveModalRef = useRef<ConfirmationModalHandle>(null);
     const acl = aclArrayToMap(rawAcl);
@@ -98,6 +99,7 @@ export const AccessEditor: React.FC<AccessEditorProps> = ({
                 saveModalRef={saveModalRef}
                 onSubmit={() => onSubmit({ selections, saveModalRef, setCommitError })}
                 warnIfActionLost="write"
+                warningText={t("acl.save-modal.disclaimer-write")}
             />
         </Inertable>
         {boxError(commitError)}

--- a/frontend/src/routes/manage/Shared/Access.tsx
+++ b/frontend/src/routes/manage/Shared/Access.tsx
@@ -97,7 +97,7 @@ export const AccessEditor: React.FC<AccessEditorProps> = ({
                 inFlight={inFlight}
                 saveModalRef={saveModalRef}
                 onSubmit={() => onSubmit({ selections, saveModalRef, setCommitError })}
-                kind="write"
+                warnIfActionLost="write"
             />
         </Inertable>
         {boxError(commitError)}

--- a/frontend/src/routes/manage/Shared/Create.tsx
+++ b/frontend/src/routes/manage/Shared/Create.tsx
@@ -66,7 +66,7 @@ export const CreateVideoList = <TMutation extends MutationParameters>({
         formState: { errors, isValid, isDirty },
     } = useForm<Metadata>({
         mode: "onChange",
-        defaultValues: { acl: isRealUser(user) ? defaultAclMap(user) : [] },
+        defaultValues: { acl: isRealUser(user) ? defaultAclMap(user, knownRoles) : [] },
     });
 
     if (!isRealUser(user) || !canUserCreateList(user)) {

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -93,7 +93,7 @@ const query = graphql`
                 canWrite
                 isLive
                 workflowStatus @include(if: $fetchWorkflowState)
-                acl { role actions info { label implies large } }
+                acl { role actions info { label implies warnForAction } }
                 syncedData {
                     duration
                     updated

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -93,7 +93,7 @@ const query = graphql`
                 canWrite
                 isLive
                 workflowStatus @include(if: $fetchWorkflowState)
-                acl { role actions info { label implies warnForAction } }
+                acl { role actions info { label implies warnForAction assignableActions } }
                 syncedData {
                     duration
                     updated

--- a/frontend/src/routes/manage/Video/Shared.tsx
+++ b/frontend/src/routes/manage/Video/Shared.tsx
@@ -93,7 +93,7 @@ const query = graphql`
                 canWrite
                 isLive
                 workflowStatus @include(if: $fetchWorkflowState)
-                acl { role actions info { label implies warnForAction assignableActions } }
+                acl { role actions info { label implies safeActions assignableActions } }
                 syncedData {
                     duration
                     updated

--- a/frontend/src/routes/manage/Video/VideoAccess.tsx
+++ b/frontend/src/routes/manage/Video/VideoAccess.tsx
@@ -47,7 +47,7 @@ const updateVideoAcl = graphql`
     mutation VideoAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateEventAcl(id: $id, acl: $acl) {
             ...on AuthorizedEvent {
-                acl { role actions info { label implies warnForAction } }
+                acl { role actions info { label implies warnForAction assignableActions } }
                 workflowStatus
             }
         }

--- a/frontend/src/routes/manage/Video/VideoAccess.tsx
+++ b/frontend/src/routes/manage/Video/VideoAccess.tsx
@@ -47,7 +47,7 @@ const updateVideoAcl = graphql`
     mutation VideoAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateEventAcl(id: $id, acl: $acl) {
             ...on AuthorizedEvent {
-                acl { role actions info { label implies large } }
+                acl { role actions info { label implies warnForAction } }
                 workflowStatus
             }
         }

--- a/frontend/src/routes/manage/Video/VideoAccess.tsx
+++ b/frontend/src/routes/manage/Video/VideoAccess.tsx
@@ -47,7 +47,7 @@ const updateVideoAcl = graphql`
     mutation VideoAccessAclMutation($id: ID!, $acl: [AclItem!]!) {
         updateEventAcl(id: $id, acl: $acl) {
             ...on AuthorizedEvent {
-                acl { role actions info { label implies warnForAction assignableActions } }
+                acl { role actions info { label implies safeActions assignableActions } }
                 workflowStatus
             }
         }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -575,7 +575,7 @@ type KnownGroup {
   label: TranslatedString!
   implies: [String!]!
   sortKey: String
-  large: Boolean!
+  warnForAction: [String!]!
 }
 
 type KnownUser {
@@ -1055,10 +1055,11 @@ type RoleInfo {
   """
   implies: [String!]
   """
-    Is `true` if this role represents a large group. Used to warn users
-    accidentally giving write access to large groups.
+    List of actions that should trigger a warning when assigning this
+    role, e.g. because it represents an unusually large or broad group.
+    Always empty for roles that are not a known group.
   """
-  large: Boolean!
+  warnForAction: [String!]!
 }
 
 type SearchEvent implements Node {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -566,16 +566,19 @@ type InaccessibleBookmarkItem {
   id: ID!
 }
 
-"""
-  A group selectable in the ACL UI. Basically a mapping from role to a nice
-  label and info about the relationship to other roles/groups.
-"""
+"A group selectable in the ACL UI, as seen by the current user."
 type KnownGroup {
   role: String!
   label: TranslatedString!
   implies: [String!]!
   sortKey: String
+  """
+    List of actions that should trigger a warning when assigning this
+    group, e.g. because it is unusually large or broad.
+  """
   warnForAction: [String!]!
+  "The actions the current user is allowed to assign this group for."
+  assignableActions: [String!]!
 }
 
 type KnownUser {
@@ -897,7 +900,7 @@ type Query {
     results is limited to some fixed value.
   """
   searchKnownUsers(query: String!): KnownUsersSearchOutcome!
-  "Returns all known groups selectable in the ACL UI."
+  "Returns all known groups selectable in the ACL UI by the current user."
   knownGroups: [KnownGroup!]!
   "Returns information for the admin dashboard."
   adminDashboardInfo: AdminInfo

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -1063,6 +1063,12 @@ type RoleInfo {
     Always empty for roles that are not a known group.
   """
   warnForAction: [String!]!
+  """
+    Actions the current user is allowed to assign this role for.
+    `null` if the role is not a known group (like free-text roles added in the ACL selector).
+    In that case the assignment is unrestricted.
+  """
+  assignableActions: [String!]
 }
 
 type SearchEvent implements Node {

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -900,7 +900,7 @@ type Query {
     results is limited to some fixed value.
   """
   searchKnownUsers(query: String!): KnownUsersSearchOutcome!
-  "Returns all known groups selectable in the ACL UI by the current user."
+  "Returns all known groups, with `assignableActions` for the current user."
   knownGroups: [KnownGroup!]!
   "Returns information for the admin dashboard."
   adminDashboardInfo: AdminInfo

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -572,11 +572,7 @@ type KnownGroup {
   label: TranslatedString!
   implies: [String!]!
   sortKey: String
-  """
-    List of actions that should trigger a warning when assigning this
-    group, e.g. because it is unusually large or broad.
-  """
-  warnForAction: [String!]!
+  safeActions: [String!]!
   "The actions the current user is allowed to assign this group for."
   assignableActions: [String!]!
 }
@@ -1058,11 +1054,12 @@ type RoleInfo {
   """
   implies: [String!]
   """
-    List of actions that should trigger a warning when assigning this
-    role, e.g. because it represents an unusually large or broad group.
+    List of actions that are considered harmless to assign to this group.
+    All other actions will show a warning, as assigning it is considered
+    questionable, e.g. because the group is very large.
     Always empty for roles that are not a known group.
   """
-  warnForAction: [String!]!
+  safeActions: [String!]!
   """
     Actions the current user is allowed to assign this role for.
     `null` if the role is not a known group (like free-text roles added in the ACL selector).

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -58,6 +58,7 @@ export type RoleInfo = {
     label: TranslatedLabel;
     implies?: readonly string[] | null;
     warnForAction: readonly string[];
+    assignableActions?: readonly string[] | null;
 };
 
 type SelectOption = {
@@ -79,6 +80,7 @@ type AclContext = {
         implies: Set<string>;
         sortKey: string | null;
         warnForAction: readonly string[];
+        assignableActions: readonly string[];
     }>;
     groupDag: GroupDag;
 }
@@ -146,6 +148,7 @@ export const AclSelector: React.FC<AclSelectorProps> = ({
             implies: new Set(g.implies),
             sortKey: g.sortKey ?? null,
             warnForAction: g.warnForAction,
+            assignableActions: g.assignableActions,
         }])),
     };
 
@@ -166,7 +169,7 @@ type RoleKind = "group" | "user";
 
 export const knownRolesFragment = graphql`
     fragment AccessKnownRolesData on Query {
-        knownGroups { role label implies sortKey warnForAction }
+        knownGroups { role label implies sortKey warnForAction assignableActions }
     }
 `;
 
@@ -186,6 +189,9 @@ type Entry = {
 
     /** Actions that should trigger a warning when assigned. Empty for unknown roles. */
     warnForAction: readonly string[];
+
+    /** Actions the current user may assign this role for. `undefined` means unrestricted. */
+    assignableActions?: readonly string[] | null;
 };
 
 type AclSelectProps = SelectProps & {
@@ -210,6 +216,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         actions,
         label: getLabel(role, info?.label, i18n),
         warnForAction: info?.warnForAction ?? [],
+        assignableActions: info?.assignableActions,
     }));
     let groupSelectorEntries: { role: string, label: string, sortKey: string | null }[] = [];
     if (kind === "group") {
@@ -217,11 +224,16 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         entries = groupDag.sort(entries);
 
         // In the group selector, sort groups by the sortKey and then alphabetically.
-        groupSelectorEntries = [...knownGroups.entries()].map(([role, { label, sortKey }]) => ({
-            role,
-            label: getLabel(role, label, i18n),
-            sortKey,
-        }));
+        // Non-assignable roles for any action are not offered. The backend
+        // already filters those out, except for built-in groups. Those are always
+        // sent so that "not configured" can be told apart from "not assignable".
+        groupSelectorEntries = [...knownGroups.entries()]
+            .filter(([, { assignableActions }]) => assignableActions.length > 0)
+            .map(([role, { label, sortKey }]) => ({
+                role,
+                label: getLabel(role, label, i18n),
+                sortKey,
+            }));
         groupSelectorEntries.sort((a, b) => {
             if (a.sortKey === b.sortKey) {
                 return a.label.localeCompare(b.label, i18n.language);
@@ -265,6 +277,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             label: getLabel(role, info?.label, i18n),
             // Don't show any warning on inherited entries as they can't be changed.
             warnForAction: [],
+            assignableActions: info?.assignableActions,
         }));
 
     const showUserEntry = (kind === "user" && ownerDisplayName);
@@ -292,6 +305,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                         label: info?.label ?? { "default": option.label },
                         implies: [...info?.implies ?? new Set()],
                         warnForAction: info?.warnForAction ?? [],
+                        assignableActions: info?.assignableActions,
                     },
                 });
             });
@@ -655,6 +669,17 @@ const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
     const allLabels = Object.keys(permissionLevels.all) as PermissionLevel[];
     const currentActionOption = getActionLabel(item, permissionLevels);
 
+    // Restrict the offered options to the ones the current user is allowed
+    // to assign this role for. `null` or `undefined` means unrestricted.
+    // (This is for entries that are already present in the ACL)
+    const { assignableActions } = item;
+    const allowedLabels = assignableActions == null
+        ? allLabels
+        : allLabels.filter(level => {
+            const actions = permissionLevels.all[level]?.actions;
+            return actions && [...actions].every(action => assignableActions.includes(action));
+        });
+
     const changeOption = (newOption: PermissionLevel) => change(prev => {
         notNullish(prev.get(item.role)).actions
             = notNullish(permissionLevels.all[newOption]).actions;
@@ -715,7 +740,7 @@ const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
                         margin: 0,
                         padding: 0,
                     }}>
-                        {allLabels.map(actionOption => <ActionMenuItem
+                        {allowedLabels.map(actionOption => <ActionMenuItem
                             key={actionOption}
                             disabled={actionOption === currentActionOption}
                             label={t(`acl.table.permissions.${actionOption}`)}
@@ -964,6 +989,7 @@ const insertBuiltinRoleInfo = (
             implies: [],
             label: keyToTranslatedString("acl.groups.everyone"),
             warnForAction: ["write"],
+            assignableActions: ["read"],
             sortKey: "_a",
         };
         knownGroups.push(anonymousInfo);
@@ -975,6 +1001,7 @@ const insertBuiltinRoleInfo = (
             implies: [COMMON_ROLES.ANONYMOUS],
             label: keyToTranslatedString("acl.groups.logged-in-users"),
             warnForAction: ["write"],
+            assignableActions: ["read"],
             sortKey: "_b",
         };
         knownGroups.push(userInfo);

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -57,7 +57,7 @@ export type Acl = Map<string, {
 export type RoleInfo = {
     label: TranslatedLabel;
     implies?: readonly string[] | null;
-    large: boolean;
+    warnForAction: readonly string[];
 };
 
 type SelectOption = {
@@ -78,7 +78,7 @@ type AclContext = {
         label: TranslatedLabel;
         implies: Set<string>;
         sortKey: string | null;
-        large: boolean;
+        warnForAction: readonly string[];
     }>;
     groupDag: GroupDag;
 }
@@ -145,7 +145,7 @@ export const AclSelector: React.FC<AclSelectorProps> = ({
             label: g.label,
             implies: new Set(g.implies),
             sortKey: g.sortKey ?? null,
-            large: g.large,
+            warnForAction: g.warnForAction,
         }])),
     };
 
@@ -166,7 +166,7 @@ type RoleKind = "group" | "user";
 
 export const knownRolesFragment = graphql`
     fragment AccessKnownRolesData on Query {
-        knownGroups { role label implies sortKey large }
+        knownGroups { role label implies sortKey warnForAction }
     }
 `;
 
@@ -184,8 +184,8 @@ type Entry = {
      */
     label: string;
 
-    /** Whether this is a large group. `false` for unknown roles. */
-    large: boolean;
+    /** Actions that should trigger a warning when assigned. Empty for unknown roles. */
+    warnForAction: readonly string[];
 };
 
 type AclSelectProps = SelectProps & {
@@ -209,7 +209,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         role,
         actions,
         label: getLabel(role, info?.label, i18n),
-        large: info?.large ?? false,
+        warnForAction: info?.warnForAction ?? [],
     }));
     let groupSelectorEntries: { role: string, label: string, sortKey: string | null }[] = [];
     if (kind === "group") {
@@ -263,7 +263,8 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             role,
             actions,
             label: getLabel(role, info?.label, i18n),
-            large: false, // Don't show any warning on inherited entries as they can't be changed.
+            // Don't show any warning on inherited entries as they can't be changed.
+            warnForAction: [],
         }));
 
     const showUserEntry = (kind === "user" && ownerDisplayName);
@@ -290,7 +291,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                     info: {
                         label: info?.label ?? { "default": option.label },
                         implies: [...info?.implies ?? new Set()],
-                        large: info?.large ?? false,
+                        warnForAction: info?.warnForAction ?? [],
                     },
                 });
             });
@@ -564,7 +565,7 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
             ? <UnchangeableAllActions permission={getActionLabel(item, permissionLevels)} />
             : <>
                 <ActionsMenu {...{ item, kind }} />
-                {item.large && noteworthyAccessType
+                {noteworthyAccessType && item.warnForAction.includes(noteworthyAccessType)
                     ? <IconWithTooltip
                         mode="warning"
                         tooltip={t("acl.table.permissions.large-group-warning", {
@@ -962,7 +963,7 @@ const insertBuiltinRoleInfo = (
             role: COMMON_ROLES.ANONYMOUS,
             implies: [],
             label: keyToTranslatedString("acl.groups.everyone"),
-            large: true,
+            warnForAction: ["write"],
             sortKey: "_a",
         };
         knownGroups.push(anonymousInfo);
@@ -973,7 +974,7 @@ const insertBuiltinRoleInfo = (
             role: COMMON_ROLES.USER,
             implies: [COMMON_ROLES.ANONYMOUS],
             label: keyToTranslatedString("acl.groups.logged-in-users"),
-            large: true,
+            warnForAction: ["write"],
             sortKey: "_b",
         };
         knownGroups.push(userInfo);

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -9,6 +9,7 @@ import {
     Button,
     Card,
     Spinner,
+    unreachable,
 } from "@opencast/appkit";
 import {
     createContext,
@@ -29,7 +30,7 @@ import { graphql } from "react-relay";
 import { i18n, ParseKeys } from "i18next";
 
 import { IconWithTooltip, focusStyle } from ".";
-import { useUser, isRealUser } from "../User";
+import { useUser, isRealUser, User } from "../User";
 import { COLORS } from "../color";
 import { COMMON_ROLES } from "../util/roles";
 import { SelectProps } from "./Input";
@@ -207,8 +208,11 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
     const { t, i18n } = useTranslation();
     const { change, knownGroups, groupDag, permissionLevels, ownerDisplayName } = useAclContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean>(false);
-    const userIsOwner = isRealUser(user) && user.displayName === ownerDisplayName;
     const [error, setError] = useState<ReactNode>(null);
+    if (!isRealUser(user)) {
+        return bug("<AclSelect> used without user session");
+    }
+    const userIsOwner = user.displayName === ownerDisplayName;
 
     // Sort the active ACL entries (and put them into a new variable for that).
     let entries: Entry[] = [...acl.entries()].map(([role, { actions, info }]) => ({
@@ -227,7 +231,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         // We filter out all groups that the user cannot assign any permission level to.
         groupSelectorEntries = [...knownGroups.entries()]
             .filter(([, { assignableActions }]) => (
-                filterPermissionLevels(permissionLevels, assignableActions).length > 0
+                filterPermissionLevels(permissionLevels, assignableActions, user).length > 0
             ))
             .map(([role, { label, sortKey }]) => ({
                 role,
@@ -664,8 +668,9 @@ const UnchangeableAllActions: React.FC<{ permission?: PermissionLevel }> = ({ pe
 const filterPermissionLevels = (
     permissionLevels: PermissionLevels,
     assignableActions: readonly string[] | null | undefined,
+    user: User,
 ): PermissionLevel[] => {
-    if (assignableActions == null) {
+    if (user.isTobiraAdmin || assignableActions == null) {
         return Object.keys(permissionLevels.all) as PermissionLevel[];
     }
 
@@ -677,16 +682,20 @@ const filterPermissionLevels = (
 
 const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
     const { isDark } = useColorScheme();
+    const user = useUser();
     const ref = useRef<FloatingHandle>(null);
     const { t } = useTranslation();
     const { change, permissionLevels, itemType } = useAclContext();
     const currentActionOption = getActionLabel(item, permissionLevels);
+    if (!isRealUser(user)) {
+        return unreachable();
+    }
 
     // Restrict the offered options to the ones the current user is allowed
     // to assign this role for. `null` or `undefined` means unrestricted.
     // (This is for entries that are already present in the ACL)
     const { assignableActions } = item;
-    const allowedLabels = filterPermissionLevels(permissionLevels, assignableActions);
+    const allowedLabels = filterPermissionLevels(permissionLevels, assignableActions, user);
 
     const changeOption = (newOption: PermissionLevel) => change(prev => {
         notNullish(prev.get(item.role)).actions

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -228,7 +228,9 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         // already filters those out, except for built-in groups. Those are always
         // sent so that "not configured" can be told apart from "not assignable".
         groupSelectorEntries = [...knownGroups.entries()]
-            .filter(([, { assignableActions }]) => assignableActions.length > 0)
+            .filter(([, { assignableActions }]) => (
+                filterPermissionLevels(permissionLevels, assignableActions).length > 0
+            ))
             .map(([role, { label, sortKey }]) => ({
                 role,
                 label: getLabel(role, label, i18n),
@@ -661,24 +663,32 @@ const UnchangeableAllActions: React.FC<{ permission?: PermissionLevel }> = ({ pe
     return <span css={{ marginLeft: 8 }}>{t(`acl.table.permissions.${label}`)}</span>;
 };
 
+const filterPermissionLevels = (
+    permissionLevels: PermissionLevels,
+    assignableActions: readonly string[] | null | undefined,
+): PermissionLevel[] => {
+    if (assignableActions == null) {
+        return Object.keys(permissionLevels.all) as PermissionLevel[];
+    }
+
+    const allowed = new Set(assignableActions);
+    return Object.entries(permissionLevels.all)
+        .filter(([_key, level]) => level.actions.isSubsetOf(allowed))
+        .map(([key, _level]) => key as PermissionLevel);
+};
+
 const ActionsMenu: React.FC<ItemProps> = ({ item, kind }) => {
     const { isDark } = useColorScheme();
     const ref = useRef<FloatingHandle>(null);
     const { t } = useTranslation();
     const { change, permissionLevels, itemType } = useAclContext();
-    const allLabels = Object.keys(permissionLevels.all) as PermissionLevel[];
     const currentActionOption = getActionLabel(item, permissionLevels);
 
     // Restrict the offered options to the ones the current user is allowed
     // to assign this role for. `null` or `undefined` means unrestricted.
     // (This is for entries that are already present in the ACL)
     const { assignableActions } = item;
-    const allowedLabels = assignableActions == null
-        ? allLabels
-        : allLabels.filter(level => {
-            const actions = permissionLevels.all[level]?.actions;
-            return actions && [...actions].every(action => assignableActions.includes(action));
-        });
+    const allowedLabels = filterPermissionLevels(permissionLevels, assignableActions);
 
     const changeOption = (newOption: PermissionLevel) => change(prev => {
         notNullish(prev.get(item.role)).actions

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -43,7 +43,7 @@ import { ErrorDisplay } from "../util/err";
 import { useNavBlocker } from "../routes/util";
 import { currentRef, OcEntity } from "../util";
 import { ModalHandle, Modal, ConfirmationModal, ConfirmationModalHandle } from "./Modal";
-import { PermissionLevel, PermissionLevels } from "../util/permissionLevels";
+import { AclActions, PermissionLevel, PermissionLevels } from "../util/permissionLevels";
 import { languages } from "../i18n";
 import { fetchQuery } from "../relay";
 
@@ -294,7 +294,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             // If "create" is called, a new option is created, meaning that we
             // don't know the role.
             info: null,
-            actions: new Set([permissionLevels.default]),
+            actions: notNullish(permissionLevels.all[permissionLevels.default]).actions,
         });
     });
 
@@ -304,7 +304,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             .forEach(option => {
                 const info = knownGroups.get(option.role);
                 prev.set(option.role, {
-                    actions: new Set([permissionLevels.default]),
+                    actions: notNullish(permissionLevels.all[permissionLevels.default]).actions,
                     info: {
                         label: info?.label ?? { "default": option.label },
                         implies: [...info?.implies ?? new Set()],
@@ -453,7 +453,7 @@ type TableProps = PropsWithChildren<{
 
 const Table: React.FC<TableProps> = ({ children, header }) => {
     const { i18n } = useTranslation();
-    const { permissionLevels } = useAclContext();
+    const { itemType } = useAclContext();
 
     return (
         <table css={{
@@ -489,7 +489,7 @@ const Table: React.FC<TableProps> = ({ children, header }) => {
                     // labels altogether, this needs yet another check.
                     // This will of course become even more complicated once more languages are
                     // added.
-                    width: permissionLevels.highest === "admin"
+                    width: itemType === "realm"
                         ? i18n.resolvedLanguage === "en" ? 160 : 165
                         : i18n.resolvedLanguage === "en" ? 190 : 224,
                 }} />
@@ -842,7 +842,8 @@ type AclEditButtonsProps = {
     inheritedAcl?: Acl;
     userIsOwner?: boolean;
     /** Checks if the user loses permissions to perform this action, and warns in that case. */
-    warnIfActionLost: "write" | "admin";
+    warnIfActionLost: AclActions;
+    warningText: string;
     saveModalRef: React.RefObject<ConfirmationModalHandle>;
 }
 
@@ -857,16 +858,17 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
     userIsOwner,
     saveModalRef,
     warnIfActionLost,
+    warningText,
 }) => {
     const { t } = useTranslation();
     const user = useUser();
     const resetModalRef = useRef<ModalHandle>(null);
 
     const containsUser = (acl: Acl) => isRealUser(user) && (
-        userIsOwner || user.isAdmin || user.roles.some(r =>
+        userIsOwner || user.isAdmin || user.roles.some(r => (
             acl.get(r)?.actions.has(warnIfActionLost)
                 || inheritedAcl?.get(r)?.actions.has(warnIfActionLost)
-        )
+        ))
     );
 
     const selectionIsInitial = selections.size === initialAcl.size
@@ -933,7 +935,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
                 buttonContent={t("acl.save-modal.confirm")}
                 onSubmit={() => submit(selections)}
             >
-                <p>{t(`acl.save-modal.disclaimer-${warnIfActionLost}`)}</p>
+                <p>{warningText}</p>
             </ConfirmationModal>
         </div>
     );

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -841,7 +841,8 @@ type AclEditButtonsProps = {
     inFlight?: boolean;
     inheritedAcl?: Acl;
     userIsOwner?: boolean;
-    kind: "write" | "admin";
+    /** Checks if the user loses permissions to perform this action, and warns in that case. */
+    warnIfActionLost: "write" | "admin";
     saveModalRef: React.RefObject<ConfirmationModalHandle>;
 }
 
@@ -855,7 +856,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
     inheritedAcl,
     userIsOwner,
     saveModalRef,
-    kind,
+    warnIfActionLost,
 }) => {
     const { t } = useTranslation();
     const user = useUser();
@@ -863,7 +864,9 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
 
     const containsUser = (acl: Acl) => isRealUser(user) && (
         userIsOwner || user.isAdmin || user.roles.some(r =>
-            acl.get(r)?.actions.has(kind) || inheritedAcl?.get(r)?.actions.has(kind))
+            acl.get(r)?.actions.has(warnIfActionLost)
+                || inheritedAcl?.get(r)?.actions.has(warnIfActionLost)
+        )
     );
 
     const selectionIsInitial = selections.size === initialAcl.size
@@ -930,7 +933,7 @@ export const AclEditButtons: React.FC<AclEditButtonsProps> = ({
                 buttonContent={t("acl.save-modal.confirm")}
                 onSubmit={() => submit(selections)}
             >
-                <p>{t(`acl.save-modal.disclaimer-${kind}`)}</p>
+                <p>{t(`acl.save-modal.disclaimer-${warnIfActionLost}`)}</p>
             </ConfirmationModal>
         </div>
     );

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -224,9 +224,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         entries = groupDag.sort(entries);
 
         // In the group selector, sort groups by the sortKey and then alphabetically.
-        // Non-assignable roles for any action are not offered. The backend
-        // already filters those out, except for built-in groups. Those are always
-        // sent so that "not configured" can be told apart from "not assignable".
+        // We filter out all groups that the user cannot assign any permission level to.
         groupSelectorEntries = [...knownGroups.entries()]
             .filter(([, { assignableActions }]) => (
                 filterPermissionLevels(permissionLevels, assignableActions).length > 0

--- a/frontend/src/ui/Access.tsx
+++ b/frontend/src/ui/Access.tsx
@@ -58,7 +58,7 @@ export type Acl = Map<string, {
 export type RoleInfo = {
     label: TranslatedLabel;
     implies?: readonly string[] | null;
-    warnForAction: readonly string[];
+    safeActions?: readonly string[];
     assignableActions?: readonly string[] | null;
 };
 
@@ -80,7 +80,7 @@ type AclContext = {
         label: TranslatedLabel;
         implies: Set<string>;
         sortKey: string | null;
-        warnForAction: readonly string[];
+        safeActions: readonly string[];
         assignableActions: readonly string[];
     }>;
     groupDag: GroupDag;
@@ -148,7 +148,7 @@ export const AclSelector: React.FC<AclSelectorProps> = ({
             label: g.label,
             implies: new Set(g.implies),
             sortKey: g.sortKey ?? null,
-            warnForAction: g.warnForAction,
+            safeActions: g.safeActions,
             assignableActions: g.assignableActions,
         }])),
     };
@@ -170,7 +170,7 @@ type RoleKind = "group" | "user";
 
 export const knownRolesFragment = graphql`
     fragment AccessKnownRolesData on Query {
-        knownGroups { role label implies sortKey warnForAction assignableActions }
+        knownGroups { role label implies sortKey safeActions assignableActions }
     }
 `;
 
@@ -189,7 +189,7 @@ type Entry = {
     label: string;
 
     /** Actions that should trigger a warning when assigned. Empty for unknown roles. */
-    warnForAction: readonly string[];
+    safeActions?: readonly string[];
 
     /** Actions the current user may assign this role for. `undefined` means unrestricted. */
     assignableActions?: readonly string[] | null;
@@ -219,7 +219,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
         role,
         actions,
         label: getLabel(role, info?.label, i18n),
-        warnForAction: info?.warnForAction ?? [],
+        safeActions: info?.safeActions,
         assignableActions: info?.assignableActions,
     }));
     let groupSelectorEntries: { role: string, label: string, sortKey: string | null }[] = [];
@@ -280,7 +280,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
             actions,
             label: getLabel(role, info?.label, i18n),
             // Don't show any warning on inherited entries as they can't be changed.
-            warnForAction: [],
+            safeActions: [],
             assignableActions: info?.assignableActions,
         }));
 
@@ -308,7 +308,7 @@ const AclSelect: React.FC<AclSelectProps> = ({ acl, inheritedAcl, kind }) => {
                     info: {
                         label: info?.label ?? { "default": option.label },
                         implies: [...info?.implies ?? new Set()],
-                        warnForAction: info?.warnForAction ?? [],
+                        safeActions: info?.safeActions,
                         assignableActions: info?.assignableActions,
                     },
                 });
@@ -531,18 +531,6 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
     const { t, i18n } = useTranslation();
     const { userIsRequired, acl, groupDag, permissionLevels } = useAclContext();
 
-    const entryContainsActions = (actions: PermissionLevel[]) =>
-        actions.every(action => item.actions.has(action));
-
-    let noteworthyAccessType: PermissionLevel | null = null;
-    if (entryContainsActions(["write"])) {
-        noteworthyAccessType = "write";
-    } else if (entryContainsActions(["admin"])) {
-        noteworthyAccessType = "admin";
-    } else if (entryContainsActions(["moderate"]) && !entryContainsActions(["admin"])) {
-        noteworthyAccessType = "moderate";
-    }
-
     const supersets = kind === "user" ? [] : groupDag
         .supersetsOf(item.role)
         .filter(role => {
@@ -571,6 +559,10 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
         label = <>{item.label}</>;
     }
 
+    // For unknown groups, we just say "read" is safe.
+    const safeActions = new Set(item.safeActions ?? ["read"]);
+    const currentLevel = getActionLabel(item, permissionLevels);
+
     return <TableRow
         labelCol={<>
             {label}
@@ -580,14 +572,14 @@ const ListEntry: React.FC<ListEntryProps> = ({ remove, item, kind, inherited = f
         </>}
         mutedLabel={isSubset || inherited}
         actionCol={immutable
-            ? <UnchangeableAllActions permission={getActionLabel(item, permissionLevels)} />
+            ? <UnchangeableAllActions permission={currentLevel} />
             : <>
                 <ActionsMenu {...{ item, kind }} />
-                {noteworthyAccessType && item.warnForAction.includes(noteworthyAccessType)
+                {kind === "group" && !item.actions.isSubsetOf(safeActions)
                     ? <IconWithTooltip
                         mode="warning"
                         tooltip={t("acl.table.permissions.large-group-warning", {
-                            val: t(`acl.table.permissions.${noteworthyAccessType}-access`),
+                            val: t(`acl.table.permissions.${currentLevel}`),
                         })}
                     />
                     : <div css={{ width: 22 }} />
@@ -1005,7 +997,7 @@ const insertBuiltinRoleInfo = (
             role: COMMON_ROLES.ANONYMOUS,
             implies: [],
             label: keyToTranslatedString("acl.groups.everyone"),
-            warnForAction: ["write"],
+            safeActions: ["read"],
             assignableActions: ["read"],
             sortKey: "_a",
         };
@@ -1017,7 +1009,7 @@ const insertBuiltinRoleInfo = (
             role: COMMON_ROLES.USER,
             implies: [COMMON_ROLES.ANONYMOUS],
             label: keyToTranslatedString("acl.groups.logged-in-users"),
-            warnForAction: ["write"],
+            safeActions: ["read"],
             assignableActions: ["read"],
             sortKey: "_b",
         };

--- a/frontend/src/util/permissionLevels.tsx
+++ b/frontend/src/util/permissionLevels.tsx
@@ -1,7 +1,13 @@
+
+export const REALM_MODERATE_ACTION = "tobira:realm:moderate";
+export const REALM_ADMIN_ACTION = "tobira:realm:admin";
+
+export type AclActions = "read" | "write"
+    | typeof REALM_MODERATE_ACTION | typeof REALM_ADMIN_ACTION | "unknown";
 export type PermissionLevel = "read" | "write" | "moderate" | "admin" | "unknown";
 export type PermissionLevels = {
     /** Must include the below `default` and `highest` values. */
-    all: Partial<Record<PermissionLevel, { actions: Set<PermissionLevel> }>>;
+    all: Partial<Record<PermissionLevel, { actions: Set<AclActions> }>>;
     /** Default action for new entries. */
     default: PermissionLevel;
     /** Most privileged action, usually includes every other action. */
@@ -19,10 +25,9 @@ export const READ_WRITE_ACTIONS: PermissionLevels = {
 
 export const MODERATE_ADMIN_ACTIONS: PermissionLevels = {
     all: {
-        "moderate": { actions: new Set(["moderate"]) },
-        "admin": { actions: new Set(["moderate", "admin"]) },
+        "moderate": { actions: new Set([REALM_MODERATE_ACTION]) },
+        "admin": { actions: new Set([REALM_MODERATE_ACTION, REALM_ADMIN_ACTION]) },
     },
     default: "moderate",
     highest: "admin",
 };
-

--- a/frontend/src/util/roles.tsx
+++ b/frontend/src/util/roles.tsx
@@ -17,7 +17,7 @@ export const defaultAclMap = (user: User): Acl => new Map([
         info: {
             label: { "default": user.displayName },
             implies: null,
-            large: false,
+            warnForAction: [],
         },
     }],
     [COMMON_ROLES.ANONYMOUS, {

--- a/frontend/src/util/roles.tsx
+++ b/frontend/src/util/roles.tsx
@@ -1,6 +1,7 @@
 import CONFIG from "../config";
 import { Acl } from "../ui/Access";
 import { User } from "../User";
+import { AccessKnownRolesData$data } from "../ui/__generated__/AccessKnownRolesData.graphql";
 
 export const COMMON_ROLES = {
     ANONYMOUS: "ROLE_ANONYMOUS",
@@ -11,18 +12,27 @@ export const COMMON_ROLES = {
     TOBIRA_GLOBAL_PAGE_MODERATOR: CONFIG.auth.globalPageModeratorRole,
 };
 
-export const defaultAclMap = (user: User): Acl => new Map([
-    [user.userRole, {
-        actions: new Set(["read", "write"]),
-        info: {
-            label: { "default": user.displayName },
-            implies: null,
-            warnForAction: [],
-        },
-    }],
-    [COMMON_ROLES.ANONYMOUS, {
-        actions: new Set(["read"]),
-        info: null,
-    }],
-]);
+export const defaultAclMap = (user: User, knownRoles: AccessKnownRolesData$data): Acl => {
+    const acl: Acl = new Map([
+        [user.userRole, {
+            actions: new Set(["read", "write"]),
+            info: {
+                label: { "default": user.displayName },
+                implies: null,
+                warnForAction: [],
+            },
+        }],
+    ]);
+
+    // Only default to public read access if the user is actually allowed to grant it.
+    const anonymousGroup = knownRoles.knownGroups.find(g => g.role === COMMON_ROLES.ANONYMOUS);
+    if (!anonymousGroup || anonymousGroup.assignableActions.includes("read")) {
+        acl.set(COMMON_ROLES.ANONYMOUS, {
+            actions: new Set(["read"]),
+            info: null,
+        });
+    }
+
+    return acl;
+};
 

--- a/frontend/src/util/roles.tsx
+++ b/frontend/src/util/roles.tsx
@@ -19,7 +19,7 @@ export const defaultAclMap = (user: User, knownRoles: AccessKnownRolesData$data)
             info: {
                 label: { "default": user.displayName },
                 implies: null,
-                warnForAction: [],
+                safeActions: [],
             },
         }],
     ]);
@@ -35,4 +35,3 @@ export const defaultAclMap = (user: User, knownRoles: AccessKnownRolesData$data)
 
     return acl;
 };
-

--- a/util/known-groups.sql
+++ b/util/known-groups.sql
@@ -1,26 +1,37 @@
 -- Inserts some known groups into the DB. Three large ones and then roughly 2k
 -- ones taken from the realm tree, representing individual courses.
 
-insert into known_groups (role, label, implies, large)
-values 
-    ('ROLE_STUDENTS', hstore(array['en', 'Students', 'de', 'Studierende']), '{}', true),
-    ('ROLE_STAFF', hstore(array['en', 'Staff', 'de', 'Angestellte']), '{}', true),
-    ('ROLE_LECTURER', hstore(array['en', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'], true);
+insert into known_groups (role, label, implies, warn_for_action, assignable_by)
+values
+    ('ROLE_STUDENTS', hstore(array['default', 'Students', 'de', 'Studierende']), '{}',
+        array['write'], '{"read": ["ROLE_ANONYMOUS"], "write": ["ROLE_INSTRUCTOR"]}'),
+    ('ROLE_STAFF', hstore(array['default', 'Staff', 'de', 'Angestellte']), '{}',
+        array['write'], '{"read": ["ROLE_ANONYMOUS"]}'),
+    ('ROLE_LECTURER', hstore(array['default', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'],
+        array['write'], '{"read": ["ROLE_ANONYMOUS"]}');
 
-insert into known_groups (role, label, implies, large)
-select 
+-- Only the course's own students/assistants/instructors can see and assign
+-- its group (instructors can grant write, everyone in the course can grant
+-- read), demonstrating how `assignable_by` scopes course groups to their
+-- course instead of showing all ~2k of them to everyone.
+insert into known_groups (role, label, implies, warn_for_action, assignable_by)
+select
     'ROLE_COURSE_' || path_segment || '_' || kind,
-    hstore(array['en', 'de'], array[
+    hstore(array['default', 'de'], array[
         label_en || ' of „' || name || '“',
         label_de || ' von „' || name || '“'
     ]),
-    case 
+    case
         when kind = 'STUDENTS' then array[]::text[]
         when kind = 'ASSISTANTS' then array['ROLE_COURSE_' || path_segment || '_STUDENTS']
         when kind = 'INSTRUCTORS' then array['ROLE_COURSE_' || path_segment || '_ASSISTANTS']
     end,
-    false
-from realms, 
+    '{}',
+    jsonb_build_object(
+        'read', array['ROLE_COURSE_' || path_segment || '_STUDENTS'],
+        'write', array['ROLE_COURSE_' || path_segment || '_INSTRUCTORS']
+    )
+from realms,
     (values 
         ('STUDENTS', 'Studierende', 'Students'), 
         ('ASSISTANTS', 'Assistierende', 'Assistants'), 

--- a/util/known-groups.sql
+++ b/util/known-groups.sql
@@ -1,20 +1,20 @@
 -- Inserts some known groups into the DB. Three large ones and then roughly 2k
 -- ones taken from the realm tree, representing individual courses.
 
-insert into known_groups (role, label, implies, warn_for_action, assignable_by)
+insert into known_groups (role, label, implies, safe_actions, assignable_by)
 values
     ('ROLE_STUDENTS', hstore(array['default', 'Students', 'de', 'Studierende']), '{}',
-        array['write'], '{"read": ["ROLE_ANONYMOUS"], "write": ["ROLE_INSTRUCTOR"]}'),
+        array['read'], '{"read": ["ROLE_ANONYMOUS"], "write": ["ROLE_INSTRUCTOR"]}'),
     ('ROLE_STAFF', hstore(array['default', 'Staff', 'de', 'Angestellte']), '{}',
-        array['write'], '{"read": ["ROLE_ANONYMOUS"]}'),
+        array['read'], '{"read": ["ROLE_ANONYMOUS"]}'),
     ('ROLE_LECTURER', hstore(array['default', 'Lecturers', 'de', 'Vortragende']), array['ROLE_STAFF'],
-        array['write'], '{"read": ["ROLE_ANONYMOUS"]}');
+        array['read'], '{"read": ["ROLE_ANONYMOUS"]}');
 
 -- Only the course's own students/assistants/instructors can see and assign
 -- its group (instructors can grant write, everyone in the course can grant
 -- read), demonstrating how `assignable_by` scopes course groups to their
 -- course instead of showing all ~2k of them to everyone.
-insert into known_groups (role, label, implies, warn_for_action, assignable_by)
+insert into known_groups (role, label, implies, safe_actions, assignable_by)
 select
     'ROLE_COURSE_' || path_segment || '_' || kind,
     hstore(array['default', 'de'], array[
@@ -26,15 +26,15 @@ select
         when kind = 'ASSISTANTS' then array['ROLE_COURSE_' || path_segment || '_STUDENTS']
         when kind = 'INSTRUCTORS' then array['ROLE_COURSE_' || path_segment || '_ASSISTANTS']
     end,
-    '{}',
+    '{read}',
     jsonb_build_object(
         'read', array['ROLE_COURSE_' || path_segment || '_STUDENTS'],
         'write', array['ROLE_COURSE_' || path_segment || '_INSTRUCTORS']
     )
 from realms,
-    (values 
-        ('STUDENTS', 'Studierende', 'Students'), 
-        ('ASSISTANTS', 'Assistierende', 'Assistants'), 
+    (values
+        ('STUDENTS', 'Studierende', 'Students'),
+        ('ASSISTANTS', 'Assistierende', 'Assistants'),
         ('INSTRUCTORS', 'Lehrende', 'Instructors')
     ) as tmp (kind, label_de, label_en)
 where full_path similar to '/lectures/[^/]+/2020/(autumn|spring)/%'


### PR DESCRIPTION
Closes #1287 
Closes #1528

This adds the proposed fields from https://github.com/elan-ev/tobira/issues/1287#issuecomment-5239736543 to the `known_groups` table:
- `assignableBy` -> mapping of permissions to roles (for example `assignableBy: { "read": ["ROLE_STUDENT"]}`, which would mean that the group this is specified for may only by granted read access by users with `ROLE_STUDENT` (or admins, because admins can always grant any permission). When users can't assign a specific action for a role, that option will be omitted in the actions selector, and when a user can't assign *any* action for a role, that role won't be present in the selector at all.
- `warnForAction` -> replaces the former `large` boolean field with a more powerful list approach (for example `warnForAction: { "write" }`, which is used as a condition in frontend to show a warning when assigning write access to the group this is specified for).

As suggested in the linked comment, old group data is migrated to preserve their old behaviour with `assignableBy: { write: ["ROLE_ANONYMOUS"]}` and groups that were marked as `large` are migrated to have `warnForAction: ["write"]`.
That means that admins need to manually adjust the permissions for `ROLE_ANONYMOUS` (i.e. everyone) if they want them restricted (the same is true for `ROLE_USER` (i.e. logged-in users).

Review commit by commit.