### PR TITLE
Update Paella dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "linkify-it": "^5.0.2",
         "lucide-react": "^1.7.0",
         "paella-basic-plugins": "1.44.10",
-        "paella-core": "1.50.2",
+        "paella-core": "1.50.5",
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.1",
         "paella-slide-plugins": "1.50.1",
@@ -8005,9 +8005,9 @@
       }
     },
     "node_modules/paella-core": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.50.2.tgz",
-      "integrity": "sha512-uh6WvxgyKkoIQ4vwe0TIlvaG7zVFyZhYVLmTG+8+qLd2eiWPoobH7N+t9Om41i2apbuqq6jGAv8UH+ZIUzZ5Rg==",
+      "version": "1.50.5",
+      "resolved": "https://registry.npmjs.org/paella-core/-/paella-core-1.50.5.tgz",
+      "integrity": "sha512-RUIEDX/efdxP8rEXw47UZn6Ue5MHzivNtQZc6smMmGwR3Q5BuvNVi4QiRx3h4eLUycgv/xwYV2bHZ3fSfJxLag==",
       "license": "ECL-2.0",
       "dependencies": {
         "core-js": "^3.8.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "linkify-it": "^5.0.2",
         "lucide-react": "^1.7.0",
-        "paella-basic-plugins": "1.44.10",
+        "paella-basic-plugins": "1.50.3",
         "paella-core": "1.50.5",
         "paella-mp4multiquality-plugin": "1.47.1",
         "paella-skins": "1.48.1",
@@ -7996,12 +7996,12 @@
       }
     },
     "node_modules/paella-basic-plugins": {
-      "version": "1.44.10",
-      "resolved": "https://registry.npmjs.org/paella-basic-plugins/-/paella-basic-plugins-1.44.10.tgz",
-      "integrity": "sha512-BLzf1iX3b0XudCa3frVwk9zliynh8/CS2x2meE+CZ+28BDLPLoXU8VM1rD/aFn6RzGFGY1pMQ424zBWLv3cfqA==",
+      "version": "1.50.3",
+      "resolved": "https://registry.npmjs.org/paella-basic-plugins/-/paella-basic-plugins-1.50.3.tgz",
+      "integrity": "sha512-xdqz6vERKOO/8mgtRfljPC8+mnuNGHAs6OWFJJ692339OBHXXmNwkkCIxZO9CKRsn5tx92AiRadjwIkCoM3JsA==",
       "license": "SEE LICENSE IN license.txt",
       "dependencies": {
-        "paella-core": "^1.46.6"
+        "paella-core": "^1.50.2"
       }
     },
     "node_modules/paella-core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "linkify-it": "^5.0.2",
     "lucide-react": "^1.7.0",
-    "paella-basic-plugins": "1.44.10",
+    "paella-basic-plugins": "1.50.3",
     "paella-core": "1.50.5",
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "linkify-it": "^5.0.2",
     "lucide-react": "^1.7.0",
     "paella-basic-plugins": "1.44.10",
-    "paella-core": "1.50.2",
+    "paella-core": "1.50.5",
     "paella-mp4multiquality-plugin": "1.47.1",
     "paella-skins": "1.48.1",
     "paella-slide-plugins": "1.50.1",


### PR DESCRIPTION
- Updates `paella-core` from 1.50.2 to 1.50.5
- and `paella-basic-plugins` from 1.44.10 to 1.50.3

This includes the current fix for https://github.com/opencast/opencast/security/advisories/GHSA-m6c8-jcw2-5r25