### PR TITLE
Use display- instead of username when creating playlists

### DIFF
--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -157,6 +157,7 @@ impl Series {
     pub(crate) async fn create(
         series: NewSeries,
         acl: Option<AclForDb>,
+        metadata: ExtraMetadata,
         context: &Context,
         state: SeriesState,
     ) -> ApiResult<Self> {
@@ -175,9 +176,9 @@ impl Series {
         let query = format!(
             "insert into all_series ( \
                 opencast_id, title, description, state, \
-                created, updated, read_roles, write_roles \
+                created, updated, read_roles, write_roles, metadata \
             ) \
-            values ($1, $2, $3, $4, now(), {updated}, $5, $6) \
+            values ($1, $2, $3, $4, now(), {updated}, $5, $6, $7) \
             returning {selection}",
         );
 
@@ -190,6 +191,7 @@ impl Series {
                     &state,
                     &read_roles,
                     &write_roles,
+                    &metadata,
                 ]).await?
                 .pipe(|row| Self::from_row_start(&row))
                 .pipe(Ok)
@@ -220,6 +222,10 @@ impl Series {
             })?;
 
         let db_acl = Some(AclForDb::from_items(&acl));
+        let extra_metadata = ExtraMetadata {
+            dcterms: HashMap::from([("creator".into(), vec![creator])]),
+            extended: HashMap::new(),
+        };
 
         // If the request returned an Opencast identifier, the series was created successfully.
         // The series is created in the database, so the user doesn't have to wait for sync to see
@@ -231,6 +237,7 @@ impl Series {
                 description: metadata.description,
             },
             db_acl,
+            extra_metadata,
             context,
             SeriesState::Ready,
         ).await?;
@@ -240,7 +247,7 @@ impl Series {
 
     pub(crate) async fn announce(series: NewSeries, context: &Context) -> ApiResult<Self> {
         context.require_trusted_external_auth()?;
-        Self::create(series, None, context, SeriesState::Waiting).await
+        Self::create(series, None, ExtraMetadata::default(), context, SeriesState::Waiting).await
     }
 
     pub(crate) async fn add_mount_point(
@@ -361,7 +368,9 @@ impl Series {
         }
 
         // Create series
-        let series = Series::create(series, None, context, SeriesState::Waiting).await?;
+        let series = Series::create(
+            series, None, ExtraMetadata::default(), context, SeriesState::Waiting,
+        ).await?;
 
         // Create realms
         let target_realm = {

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -201,6 +201,7 @@ impl Series {
     pub(crate) async fn create_in_oc(
         metadata: BasicMetadata,
         acl: Vec<AclItem>,
+        creator: String,
         context: &Context,
     ) -> ApiResult<Self> {
         if !context.auth.can_create_series(&context.config.auth) {
@@ -211,7 +212,7 @@ impl Series {
 
         let response = context
             .oc_client
-            .create_series(&acl, &metadata.title, metadata.description.as_deref())
+            .create_series(&acl, &metadata.title, metadata.description.as_deref(), &creator)
             .await
             .map_err(|e| {
                 error!("Failed to create series in Opencast: {}", e);

--- a/backend/src/api/mutation.rs
+++ b/backend/src/api/mutation.rs
@@ -145,9 +145,10 @@ impl Mutation {
     async fn create_series(
         metadata: BasicMetadata,
         acl: Vec<AclItem>,
+        creator: String,
         context: &Context,
     ) -> ApiResult<Series> {
-        Series::create_in_oc(metadata, acl, context).await
+        Series::create_in_oc(metadata, acl, creator, context).await
     }
 
     /// Creates a new playlist in Opencast and stores it in Tobira's DB.

--- a/backend/src/sync/client.rs
+++ b/backend/src/sync/client.rs
@@ -229,6 +229,7 @@ impl OcClient {
         acl: &[AclItem],
         title: &str,
         description: Option<&str>,
+        creator: &str,
     ) -> Result<CreateSeriesResponse> {
         let access_policy = build_access_policy(acl);
 
@@ -242,6 +243,10 @@ impl OcClient {
                 {
                     "id": "description",
                     "value": description
+                },
+                {
+                    "id": "creator",
+                    "value": [creator]
                 },
             ]
         }]);

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -199,8 +199,12 @@ const createPlaceholderMutation = graphql`
 `;
 
 const createSeriesMutation = graphql`
-    mutation UploadCreateSeriesMutation($metadata: BasicMetadata!, $acl: [AclItem!]!) {
-        createSeries(metadata: $metadata, acl: $acl) { id }
+    mutation UploadCreateSeriesMutation(
+        $metadata: BasicMetadata!,
+        $acl: [AclItem!]!,
+        $creator: String!,
+    ) {
+        createSeries(metadata: $metadata, acl: $acl, creator: $creator) { id }
     }
 `;
 
@@ -392,6 +396,9 @@ const SeriesCreationStep: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) 
             {...{ commit, inFlight, knownRolesRef }}
             canUserCreateList={user => user.canCreateSeries}
             kind="series"
+            buildVariables={({ displayName }) => ({
+                creator: displayName,
+            })}
             returnPath={response => UploadRoute.url({
                 seriesId: keyOfId(response.createSeries.id),
             })}

--- a/frontend/src/routes/manage/Playlist/Create.tsx
+++ b/frontend/src/routes/manage/Playlist/Create.tsx
@@ -75,8 +75,8 @@ const CreatePlaylistPage: React.FC<CreatePlaylistPageProps> = ({ knownRolesRef }
         <CreateVideoList
             {...{ commit, inFlight, knownRolesRef, canUserCreateList }}
             kind="playlist"
-            buildVariables={({ username }) => ({
-                creator: username,
+            buildVariables={({ displayName }) => ({
+                creator: displayName,
                 entries: items.map(e => e.id),
             })}
             returnPath={response =>

--- a/frontend/src/routes/manage/Series/Create.tsx
+++ b/frontend/src/routes/manage/Series/Create.tsx
@@ -43,8 +43,12 @@ const query = graphql`
 `;
 
 const createSeriesMutation = graphql`
-    mutation CreateSeriesMutation($metadata: BasicMetadata!, $acl: [AclItem!]!) {
-        createSeries(metadata: $metadata, acl: $acl) { id }
+    mutation CreateSeriesMutation(
+        $metadata: BasicMetadata!,
+        $acl: [AclItem!]!,
+        $creator: String!,
+    ) {
+        createSeries(metadata: $metadata, acl: $acl, creator: $creator) { id }
     }
 `;
 
@@ -60,6 +64,9 @@ const CreateSeriesPage: React.FC<CreateSeriesPageProps> = ({ knownRolesRef }) =>
     return <CreateVideoList
         {...{ commit, inFlight, knownRolesRef, canUserCreateList }}
         kind="series"
+        buildVariables={({ displayName }) => ({
+            creator: displayName,
+        })}
         returnPath={response =>
             ManageSeriesDetailsRoute.url({ id: response.createSeries.id })
         }

--- a/frontend/src/routes/manage/Shared/Create.tsx
+++ b/frontend/src/routes/manage/Shared/Create.tsx
@@ -36,7 +36,7 @@ export type CreateVideoListProps<TMutation extends MutationParameters> = PropsWi
     kind: "series" | "playlist";
     showTitle?: boolean;
     buildVariables?: (args: {
-        username: string;
+        displayName: string;
     }) => Omit<TMutation["variables"], "metadata" | "acl">;
 }>;
 
@@ -74,7 +74,7 @@ export const CreateVideoList = <TMutation extends MutationParameters>({
     }
 
     const create = (data: Metadata) => {
-        const rest = buildVariables?.({ username: user.username });
+        const rest = buildVariables?.({ displayName: user.displayName });
         const base = {
             metadata: { title: data.title, description: data.description },
             acl: aclMapToArray(data.acl),

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -670,7 +670,7 @@ type Mutation {
     Sends an http request to Opencast to create a new series,
     and stores the series in Tobira's DB.
   """
-  createSeries(metadata: BasicMetadata!, acl: [AclItem!]!): Series!
+  createSeries(metadata: BasicMetadata!, acl: [AclItem!]!, creator: String!): Series!
   "Creates a new playlist in Opencast and stores it in Tobira's DB."
   createPlaylist(metadata: BasicMetadata!, creator: String!, entries: [ID!]!, acl: [AclItem!]!): AuthorizedPlaylist!
   """


### PR DESCRIPTION
This was previously using the username, which wasn't an issue in our test environment. However, it became apparent that certain™ institutions use opaque usernames likes 12345@me or something, which isn't nice to display as creator name.