### PR TITLE
Fix bug in `{Series/Playlist}::load` for Opencast IDs

### DIFF
--- a/backend/src/api/model/playlist/mod.rs
+++ b/backend/src/api/model/playlist/mod.rs
@@ -108,7 +108,7 @@ impl Playlist {
 
         let (selection, mapping) = select!(
             playlist: AuthorizedPlaylist,
-            is_bookmark: "exists(select from bookmarks where playlist = $1 and username = $2)",
+            is_bookmark: "exists(select from bookmarks where playlist = playlists.id and username = $2)",
             has_public_videos: "exists(\
                 select from events \
                 where opencast_id = any(event_entry_ids(playlists.entries)) \

--- a/backend/src/api/model/series.rs
+++ b/backend/src/api/model/series.rs
@@ -122,7 +122,7 @@ impl Series {
 
         let (selection, mapping) = select!(
             series: Series,
-            is_bookmark: "exists(select from bookmarks where series = $1 and username = $2)",
+            is_bookmark: "exists(select from bookmarks where series = series.id and username = $2)",
             has_public_videos: "exists(\
                 select from events \
                 where events.series = series.id and 'ROLE_ANONYMOUS' = any(events.read_roles)\


### PR DESCRIPTION
Just a simple SQL bug that we didn't test before. This breaks opencast-ID routes as well as the uploader when selecting a series and if `lock_acl_to_series = true`. This kind of bugs really should be caught by automated tests. 