### PR TITLE
Invalidate relay store when bookmark is removed

### DIFF
--- a/frontend/src/i18n/locales/de.yaml
+++ b/frontend/src/i18n/locales/de.yaml
@@ -243,6 +243,7 @@ bookmark:
   add: Lesezeichen hinzufügen
   remove: Lesezeichen entfernen
   manage: Lesezeichen verwalten
+  show-bookmarks: Lesezeichen anzeigen
   no-bookmarks-yet: Sie haben noch keine Lesezeichen.
   failed-to-add: Lesezeichen hinzufügen fehlgeschlagen
   failed-to-remove: Lesezeichen entfernen fehlgeschlagen

--- a/frontend/src/i18n/locales/en.yaml
+++ b/frontend/src/i18n/locales/en.yaml
@@ -240,6 +240,7 @@ bookmark:
   add: Add bookmark
   remove: Remove bookmark
   manage: Manage bookmarks
+  show-bookmarks: Show bookmarks
   no-bookmarks-yet: You haven't bookmarked anything yet.
   failed-to-add: Failed to add bookmark
   failed-to-remove: Failed to remove bookmark

--- a/frontend/src/routes/manage/Bookmarks.tsx
+++ b/frontend/src/routes/manage/Bookmarks.tsx
@@ -22,6 +22,8 @@ import { DirectSeriesRoute } from "../Series";
 import { COLORS } from "../../color";
 import { Creators } from "../../ui/Video";
 import { DateAndCreators } from "../../ui/metadata";
+import { LinkButton } from "../../ui/LinkButton";
+import { BookmarksRoute } from "../Bookmarks";
 
 
 export const PATH = "/~manage/bookmarks" as const;
@@ -77,11 +79,25 @@ const ManageBookmarks: React.FC<Props> = ({ queryData }) => {
             display: "flex",
             flexDirection: "column",
         }}>
-            <Breadcrumbs tail={t("bookmark.main-label")} path={[{
-                label: t("user.manage"),
-                link: ManageRoute.url,
-            }]} />
-            <PageTitle title={t("bookmark.manage")} />
+            <div css={{
+                marginBottom: 12,
+                display: "flex",
+                justifyContent: "space-between",
+                flexWrap: "wrap",
+            }}>
+                <div>
+                    <Breadcrumbs tail={t("bookmark.main-label")} path={[{
+                        label: t("user.manage"),
+                        link: ManageRoute.url,
+                    }]} />
+                    <PageTitle title={t("bookmark.manage")} />
+                </div>
+                <div>
+                    <LinkButton to={BookmarksRoute.url({})}>
+                        {t("bookmark.show-bookmarks")}
+                    </LinkButton>
+                </div>
+            </div>
 
             <ul css={{
                 maxWidth: 700,

--- a/frontend/src/routes/manage/Bookmarks.tsx
+++ b/frontend/src/routes/manage/Bookmarks.tsx
@@ -149,6 +149,7 @@ const ListItem: React.FC<ListItemProps> = ({ fav }) => {
         commit({
             variables: { id: fav.id },
             onCompleted: () => setIsDeleted(true),
+            updater: store => store.invalidateStore(),
         });
     };
 


### PR DESCRIPTION
This was previously missing, requiring a manual page reload for the changes to become visible.
Invalidating the store means that data is refetched on button press.

Also adds a link button to take you back to the bookmarks overview from "manage bookmarks"

Closes #1785 